### PR TITLE
feat(drive): implement dropdown actions and folder create

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -746,7 +746,10 @@
     "total_files": "Total Files",
     "total_size": "Total Size",
     "largest_file": "Largest File",
-    "smallest_file": "Smallest File"
+    "smallest_file": "Smallest File",
+    "files": "Files",
+    "folder": "Folder",
+    "folder_create": "Create folder"
   },
   "ws-ai-workflows": {
     "module": "Workflows",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -148,7 +148,8 @@
     "option": "Option",
     "correct": "Correct",
     "add_option": "Add option",
-    "question": "Question"
+    "question": "Question",
+    "create_new": "Create new"
   },
   "date_helper": {
     "time-unit": "Time unit",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -737,7 +737,11 @@
     "ai_chat_playground_discontinued_p2": "has been temporarily disabled for improvement and further testing. Don't worry! We are working on exciting features to bring you a better experience. Stay tuned for a comeback with more features and functionalities. Thank you for your patience and understanding.\n\nBest regards,\nTuturuuu"
   },
   "ws-storage-objects": {
-    "module": "Tuturuuu Drive",
+    "name": "Tuturuuu Drive",
+    "plural": "Tuturuuu Drive",
+    "singular": "Tuturuuu Drive",
+    "upload": "Upload",
+    "upload_description": "Upload multiple files to Tuturuuu Drive",
     "description": "Store workspace files securely, and access them from anywhere.",
     "total_files": "Total Files",
     "total_size": "Total Size",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -737,7 +737,11 @@
     "ai_chat_playground_discontinued_p2": "tạm thời bị vô hiệu hóa để tiến hành cải thiện và kiểm tra thêm. Đừng lo lắng! Chúng tôi đang phát triển thêm nhiều tính năng thú vị để mang lại trải nghiệm tốt hơn cho bạn. Hãy chờ đợi sự trở lại với nhiều tính năng vượt trội hơn. Cảm ơn bạn đã kiên nhẫn và thấu hiểu cho chúng tôi.\n\nTrân trọng,\nTuturuuu"
   },
   "ws-storage-objects": {
-    "module": "Tuturuuu Drive",
+    "name": "Tuturuuu Drive",
+    "plural": "Tuturuuu Drive",
+    "singular": "Tuturuuu Drive",
+    "upload": "Tải lên",
+    "upload_description": "Tải tệp tin lên Tuturuuu Drive",
     "description": "Lưu trữ tệp làm việc một cách an toàn và truy cập chúng từ bất kỳ nơi nào.",
     "total_files": "Tổng số tệp",
     "total_size": "Tổng dung lượng",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -148,7 +148,8 @@
     "option": "Lựa chọn",
     "correct": "Chính xác",
     "add_option": "Thêm tùy chọn",
-    "question": "Câu hỏi"
+    "question": "Câu hỏi",
+    "create_new": "Tạo mới"
   },
   "date_helper": {
     "time-unit": "Đơn vị thời gian",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -746,7 +746,10 @@
     "total_files": "Tổng số tệp",
     "total_size": "Tổng dung lượng",
     "largest_file": "Tệp lớn nhất",
-    "smallest_file": "Tệp nhỏ nhất"
+    "smallest_file": "Tệp nhỏ nhất",
+    "files": "Tệp tin",
+    "folder": "Thư mục",
+    "folder_create": "Tạo thư mục mới"
   },
   "ws-ai-workflows": {
     "module": "Quy trình",

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/drive/new-actions.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/drive/new-actions.tsx
@@ -27,9 +27,9 @@ export default function NewActions({ wsId }: Props) {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button className="cursor-pointer">
-            <Plus className="mr-2 h-4 w-4" />
-            <span>{t('common.new')}</span>
+          <Button size="xs" className="cursor-pointer">
+            <Plus className="h-4 w-4" />
+            <span>{t('common.create_new')}</span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/drive/new-actions.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/drive/new-actions.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { StorageFolderForm, StorageObjectForm } from './form';
+import { Button } from '@repo/ui/components/ui/button';
+import ModifiableDialogTrigger from '@repo/ui/components/ui/custom/modifiable-dialog-trigger';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@repo/ui/components/ui/dropdown-menu';
+import { File, Folder, Plus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+interface Props {
+  wsId: string;
+}
+
+export default function NewActions({ wsId }: Props) {
+  const t = useTranslations();
+
+  const [showFileUploadDialog, setFileUploadDialog] = useState(false);
+  const [showFolderCreateDialog, setFolderCreateDialog] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button className="cursor-pointer">
+            <Plus className="mr-2 h-4 w-4" />
+            <span>{t('common.new')}</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={() => setFileUploadDialog(true)}>
+            <File className="mr-2 h-4 w-4" />
+            {t('ws-storage-objects.files')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setFolderCreateDialog(true)}>
+            <Folder className="mr-2 h-4 w-4" />
+            {t('ws-storage-objects.folder')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ModifiableDialogTrigger
+        open={showFileUploadDialog}
+        setOpen={setFileUploadDialog}
+        title={t('ws-storage-objects.upload')}
+        form={
+          <StorageObjectForm wsId={wsId} submitLabel={t('common.upload')} />
+        }
+      />
+
+      <ModifiableDialogTrigger
+        open={showFolderCreateDialog}
+        title={t('ws-storage-objects.folder_create')}
+        setOpen={setFolderCreateDialog}
+        form={<StorageFolderForm wsId={wsId} />}
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/drive/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/drive/page.tsx
@@ -1,4 +1,4 @@
-import { StorageObjectForm } from './form';
+import NewActions from './new-actions';
 import StorageObjectsTable from './table';
 import { getPermissions, verifyHasSecrets } from '@/lib/workspace-helper';
 import {
@@ -53,9 +53,7 @@ export default async function WorkspaceStorageObjectsPage({
         description={t('ws-storage-objects.description')}
         createTitle={t('ws-storage-objects.upload')}
         createDescription={t('ws-storage-objects.upload_description')}
-        form={
-          <StorageObjectForm wsId={wsId} submitLabel={t('common.upload')} />
-        }
+        action={<NewActions wsId={wsId} />}
       />
 
       <div className="mb-8 mt-4 grid gap-4 text-center md:grid-cols-2 xl:grid-cols-4">

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/drive/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/drive/page.tsx
@@ -1,3 +1,4 @@
+import { StorageObjectForm } from './form';
 import StorageObjectsTable from './table';
 import { getPermissions, verifyHasSecrets } from '@/lib/workspace-helper';
 import {
@@ -6,6 +7,7 @@ import {
 } from '@/types/primitives/StorageObject';
 import { formatBytes } from '@/utils/file-helper';
 import { createClient, createDynamicClient } from '@/utils/supabase/server';
+import FeatureSummary from '@repo/ui/components/ui/custom/feature-summary';
 import { Separator } from '@repo/ui/components/ui/separator';
 import { getTranslations } from 'next-intl/server';
 import { redirect } from 'next/navigation';
@@ -27,7 +29,7 @@ export default async function WorkspaceStorageObjectsPage({
   searchParams,
 }: Props) {
   const { wsId } = await params;
-  const t = await getTranslations('ws-storage-objects');
+  const t = await getTranslations();
 
   const { withoutPermission } = await getPermissions({
     wsId,
@@ -45,28 +47,38 @@ export default async function WorkspaceStorageObjectsPage({
 
   return (
     <>
-      <div className="border-border bg-foreground/5 flex flex-col justify-between gap-4 rounded-lg border p-4 md:flex-row md:items-start">
-        <div>
-          <h1 className="text-2xl font-bold">{t('module')}</h1>
-          <p className="text-foreground/80">{t('description')}</p>
-        </div>
-      </div>
+      <FeatureSummary
+        pluralTitle={t('ws-storage-objects.plural')}
+        singularTitle={t('ws-storage-objects.singular')}
+        description={t('ws-storage-objects.description')}
+        createTitle={t('ws-storage-objects.upload')}
+        createDescription={t('ws-storage-objects.upload_description')}
+        form={
+          <StorageObjectForm wsId={wsId} submitLabel={t('common.upload')} />
+        }
+      />
 
       <div className="mb-8 mt-4 grid gap-4 text-center md:grid-cols-2 xl:grid-cols-4">
         <div className="border-border bg-foreground/5 rounded-lg border p-4">
-          <h2 className="text-lg font-semibold">{t('total_files')}</h2>
+          <h2 className="text-lg font-semibold">
+            {t('ws-storage-objects.total_files')}
+          </h2>
           <Separator className="my-2" />
           <div className="text-3xl font-bold">{count}</div>
         </div>
 
         <div className="border-border bg-foreground/5 rounded-lg border p-4">
-          <h2 className="text-lg font-semibold">{t('total_size')}</h2>
+          <h2 className="text-lg font-semibold">
+            {t('ws-storage-objects.total_size')}
+          </h2>
           <Separator className="my-2" />
           <div className="text-3xl font-bold">{formatBytes(totalSize)}</div>
         </div>
 
         <div className="border-border bg-foreground/5 rounded-lg border p-4">
-          <h2 className="text-lg font-semibold">{t('largest_file')}</h2>
+          <h2 className="text-lg font-semibold">
+            {t('ws-storage-objects.largest_file')}
+          </h2>
           <Separator className="my-2" />
           <div className="text-3xl font-bold">
             {data.length > 0 ? formatBytes(largestFile?.size as number) : '-'}
@@ -74,7 +86,9 @@ export default async function WorkspaceStorageObjectsPage({
         </div>
 
         <div className="border-border bg-foreground/5 rounded-lg border p-4">
-          <h2 className="text-lg font-semibold">{t('smallest_file')}</h2>
+          <h2 className="text-lg font-semibold">
+            {t('ws-storage-objects.smallest_file')}
+          </h2>
           <Separator className="my-2" />
           <div className="text-3xl font-bold">
             {data.length > 0 ? formatBytes(smallestFile?.size as number) : '-'}


### PR DESCRIPTION
dropdown was implemented similar to Google Drive's "new" dropdown. closes #1902 

| <img width="198" alt="image" src="https://github.com/user-attachments/assets/5b99c5f6-45c4-47fd-b9de-8008ab9749af" align="left"> | <img width="340" alt="image" src="https://github.com/user-attachments/assets/335c9f3e-5353-474a-92ad-e23004bbea48" align="right"> |
|---|---|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new component, `NewActions`, for creating storage objects and folders.
	- Enhanced file management capabilities with new options for uploading files and creating folders.
  
- **Improvements**
	- Updated localization keys for better clarity and usability across multiple languages.
	- Streamlined the presentation of storage object information with the new `FeatureSummary` component.

- **Bug Fixes**
	- Adjusted localization retrieval methods to ensure consistent text display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->