### PR TITLE
Fix code scanning alert no. 90: Incomplete string escaping or encoding

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(ai)/datasets/[datasetId]/explore/html-crawler.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(ai)/datasets/[datasetId]/explore/html-crawler.tsx
@@ -382,7 +382,7 @@ export class HtmlCrawler {
       if (!href) continue;
 
       const articleUrl = href.startsWith('..')
-        ? new URL(href.replace('..', ''), this.baseUrl).toString()
+        ? new URL(href.replace(/\.\./g, ''), this.baseUrl).toString()
         : new URL(href, this.baseUrl).toString();
 
       uniqueUrls.add(articleUrl);


### PR DESCRIPTION
Fixes [https://github.com/tutur3u/platform/security/code-scanning/90](https://github.com/tutur3u/platform/security/code-scanning/90)

To fix the problem, we need to ensure that all occurrences of `'..'` in the `href` string are replaced. This can be achieved by using a regular expression with the global flag (`g`). This will ensure that every instance of `'..'` is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
