### PR TITLE
Fix code scanning alert no. 93: Incomplete string escaping or encoding

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(ai)/datasets/[datasetId]/explore/crawlers/html-crawler.ts
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(ai)/datasets/[datasetId]/explore/crawlers/html-crawler.ts
@@ -421,7 +421,7 @@ export class HtmlCrawler {
               const href = item.getAttribute('href');
               if (href) {
                 const fullUrl = href.startsWith('..')
-                  ? new URL(href.replace('..', ''), this.baseUrl).toString()
+                  ? new URL(href.replace(/\.\./g, ''), this.baseUrl).toString()
                   : new URL(href, this.baseUrl).toString();
                 previewData.sampleData?.push(fullUrl);
               }
@@ -447,7 +447,7 @@ export class HtmlCrawler {
             if (!href) continue;
 
             const articleUrl = href.startsWith('..')
-              ? new URL(href.replace('..', ''), this.baseUrl).toString()
+              ? new URL(href.replace(/\.\./g, ''), this.baseUrl).toString()
               : new URL(href, this.baseUrl).toString();
 
             const articleData = await this.getArticlePreview(articleUrl, [


### PR DESCRIPTION
Fixes [https://github.com/tutur3u/platform/security/code-scanning/93](https://github.com/tutur3u/platform/security/code-scanning/93)

To fix the problem, we should use a regular expression with the global flag to ensure that all occurrences of `'..'` are replaced in the `href` string. This will ensure that the URL is constructed correctly even if there are multiple occurrences of `'..'`.

We will replace the `href.replace('..', '')` with `href.replace(/\.\./g, '')` to achieve this.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
