### PR TITLE
Fix code scanning alert no. 91: Incomplete string escaping or encoding

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(ai)/datasets/[datasetId]/explore/crawlers/html-crawler.ts
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(ai)/datasets/[datasetId]/explore/crawlers/html-crawler.ts
@@ -274,7 +274,7 @@ export class HtmlCrawler {
         const href = element.getAttribute('href');
         if (href) {
           return href.startsWith('..')
-            ? new URL(href.replace('..', ''), this.baseUrl).toString()
+            ? new URL(href.replace(/\.\./g, ''), this.baseUrl).toString()
             : new URL(href, this.baseUrl).toString();
         }
       }


### PR DESCRIPTION
Fixes [https://github.com/tutur3u/platform/security/code-scanning/91](https://github.com/tutur3u/platform/security/code-scanning/91)

To fix the problem, we need to ensure that all occurrences of `'..'` in the `href` attribute are replaced. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of `'..'` is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
