### PR TITLE
feat(navigation): Add new product links for Mira, Nova, and Rewise

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -270,7 +270,10 @@
     "error_updating_visibility": "Error updating visibility",
     "error_deleting": "Error deleting document",
     "domain_added": "Domain added",
-    "error_adding_domain": "Failed to add domain"
+    "error_adding_domain": "Failed to add domain",
+    "rewise-description": "Access a wide-range of enterprise AI-powered tools.",
+    "nova-description": "Prompt engineering playground for everyone.",
+    "waitlist": "Waitlist"
   },
   "date_helper": {
     "time-unit": "Time unit",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -270,7 +270,10 @@
     "error_updating_visibility": "Lỗi khi cập nhật quyền truy cập",
     "error_deleting": "Lỗi khi xoá tài liệu",
     "domain_added": "Tên miền được thêm vào",
-    "error_adding_domain": "Không thể thêm miền"
+    "error_adding_domain": "Không thể thêm miền",
+    "rewise-description": "Truy cập một loạt các công cụ hỗ trợ AI dành cho doanh nghiệp.",
+    "nova-description": "Sân chơi prompt engineering cho mọi người.",
+    "waitlist": "Danh sách chờ"
   },
   "date_helper": {
     "time-unit": "Đơn vị thời gian",

--- a/apps/web/src/app/[locale]/navigation-menu.tsx
+++ b/apps/web/src/app/[locale]/navigation-menu.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { DEV_MODE } from '@/constants/common';
 import { Badge } from '@tuturuuu/ui/badge';
 import { Card } from '@tuturuuu/ui/card';
 import {
@@ -32,10 +33,12 @@ import {
   Pill,
   Presentation,
   Shield,
+  Sparkles,
   Store,
   Users,
   UsersRound,
   Utensils,
+  WandSparkles,
   Workflow,
   Zap,
 } from 'lucide-react';
@@ -129,6 +132,24 @@ export function MainNavigationMenu() {
       description: t('common.workflows-description'),
       icon: <Workflow className="h-4 w-4" />,
       badge: t('common.coming_soon'),
+    },
+    {
+      title: 'Mira',
+      href: DEV_MODE ? 'http://localhost:7806' : 'https://mira.tuturuuu.com',
+      description: t('common.workflows-description'),
+      icon: <Factory className="h-4 w-4" />,
+    },
+    {
+      title: 'Nova',
+      href: DEV_MODE ? 'http://localhost:7805' : 'https://nova.tuturuuu.com',
+      description: t('common.workflows-description'),
+      icon: <WandSparkles className="h-4 w-4" />,
+    },
+    {
+      title: 'Rewise',
+      href: DEV_MODE ? 'http://localhost:7804' : 'https://rewise.me',
+      description: t('common.workflows-description'),
+      icon: <Sparkles className="h-4 w-4" />,
     },
   ];
 
@@ -233,18 +254,18 @@ export function MainNavigationMenu() {
     <NavigationMenu className="flex w-full max-w-none">
       <NavigationMenuList className="flex w-full justify-between">
         <NavigationMenuItem>
-          <NavigationMenuTrigger className="group bg-gradient-to-r font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5">
+          <NavigationMenuTrigger className="hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r font-semibold transition-all duration-300">
             <span className="flex items-center gap-2">
               {t('common.products')}
               <span className="relative flex h-2 w-2">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/50 opacity-75"></span>
-                <span className="relative inline-flex h-2 w-2 rounded-full bg-primary"></span>
+                <span className="bg-primary/50 absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"></span>
+                <span className="bg-primary relative inline-flex h-2 w-2 rounded-full"></span>
               </span>
             </span>
           </NavigationMenuTrigger>
           <NavigationMenuContent>
-            <ul className="grid w-[400px] gap-3 bg-gradient-to-br from-background via-background/95 to-background/90 p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px] xl:w-[1000px] xl:grid-cols-3">
-              <Card className="col-span-full mb-2 bg-primary/5 p-4">
+            <ul className="from-background via-background/95 to-background/90 grid w-[400px] gap-3 bg-gradient-to-br p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px] xl:w-[1000px] xl:grid-cols-3">
+              <Card className="bg-primary/5 col-span-full mb-2 p-4">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <Zap className="h-4 w-4" />
                   <span>Featured Products</span>
@@ -266,17 +287,17 @@ export function MainNavigationMenu() {
         </NavigationMenuItem>
 
         <NavigationMenuItem>
-          <NavigationMenuTrigger className="group bg-gradient-to-r font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5">
+          <NavigationMenuTrigger className="hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r font-semibold transition-all duration-300">
             <span className="flex items-center gap-2">
               {t('common.solutions')}
-              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary">
+              <span className="bg-primary/10 text-primary rounded-full px-2 py-0.5 text-xs">
                 {t('common.new')}
               </span>
             </span>
           </NavigationMenuTrigger>
           <NavigationMenuContent>
-            <ul className="grid w-[400px] gap-3 bg-gradient-to-br from-background via-background/95 to-background/90 p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px]">
-              <Card className="col-span-full mb-2 bg-primary/5 p-4">
+            <ul className="from-background via-background/95 to-background/90 grid w-[400px] gap-3 bg-gradient-to-br p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px]">
+              <Card className="bg-primary/5 col-span-full mb-2 p-4">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <Building className="h-4 w-4" />
                   <span>Industry Solutions</span>
@@ -297,12 +318,12 @@ export function MainNavigationMenu() {
         </NavigationMenuItem>
 
         <NavigationMenuItem>
-          <NavigationMenuTrigger className="group bg-gradient-to-r font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5">
+          <NavigationMenuTrigger className="hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r font-semibold transition-all duration-300">
             {t('common.resources')}
           </NavigationMenuTrigger>
           <NavigationMenuContent>
-            <ul className="grid w-[400px] gap-3 bg-gradient-to-br from-background via-background/95 to-background/90 p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px]">
-              <Card className="col-span-full mb-2 bg-primary/5 p-4">
+            <ul className="from-background via-background/95 to-background/90 grid w-[400px] gap-3 bg-gradient-to-br p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px]">
+              <Card className="bg-primary/5 col-span-full mb-2 p-4">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <BookText className="h-4 w-4" />
                   <span>Learning Resources</span>
@@ -328,7 +349,7 @@ export function MainNavigationMenu() {
             <NavigationMenuLink
               className={cn(
                 navigationMenuTriggerStyle(),
-                'group bg-gradient-to-r px-6 font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5'
+                'hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r px-6 font-semibold transition-all duration-300'
               )}
             >
               <span className="flex items-center gap-2">
@@ -343,7 +364,7 @@ export function MainNavigationMenu() {
             <NavigationMenuLink
               className={cn(
                 navigationMenuTriggerStyle(),
-                'bg-gradient-to-r px-6 font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5'
+                'hover:from-primary/10 hover:to-primary/5 bg-gradient-to-r px-6 font-semibold transition-all duration-300'
               )}
             >
               {t('common.about')}
@@ -356,7 +377,7 @@ export function MainNavigationMenu() {
             <NavigationMenuLink
               className={cn(
                 navigationMenuTriggerStyle(),
-                'group bg-gradient-to-r px-6 font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5'
+                'hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r px-6 font-semibold transition-all duration-300'
               )}
             >
               <span className="flex items-center gap-2">
@@ -371,7 +392,7 @@ export function MainNavigationMenu() {
             <NavigationMenuLink
               className={cn(
                 navigationMenuTriggerStyle(),
-                'bg-gradient-to-r px-6 font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5'
+                'hover:from-primary/10 hover:to-primary/5 bg-gradient-to-r px-6 font-semibold transition-all duration-300'
               )}
             >
               {t('common.contact')}
@@ -398,7 +419,7 @@ const ListItem = React.forwardRef<
         <a
           ref={ref}
           className={cn(
-            'group relative block h-full space-y-1 rounded-md p-4 leading-none no-underline outline-hidden transition-all duration-300 select-none',
+            'outline-hidden group relative block h-full select-none space-y-1 rounded-md p-4 leading-none no-underline transition-all duration-300',
             'via-primary/10 to-primary/5 hover:bg-gradient-to-br',
             'opacity-90 hover:opacity-100',
             'hover:scale-[1.02] hover:shadow-lg active:scale-[0.98]',
@@ -409,10 +430,10 @@ const ListItem = React.forwardRef<
         >
           <div className="relative">
             <div className="flex items-center gap-2">
-              <div className="text-primary transition-transform duration-300 group-hover:scale-110 group-hover:rotate-3">
+              <div className="text-primary transition-transform duration-300 group-hover:rotate-3 group-hover:scale-110">
                 {icon}
               </div>
-              <div className="text-sm leading-none font-semibold">{title}</div>
+              <div className="text-sm font-semibold leading-none">{title}</div>
               {badge && (
                 <Badge
                   variant="secondary"
@@ -422,7 +443,7 @@ const ListItem = React.forwardRef<
                 </Badge>
               )}
             </div>
-            <p className="mt-2 line-clamp-2 text-sm leading-snug text-muted-foreground opacity-80 transition-opacity duration-300 group-hover:opacity-100">
+            <p className="text-muted-foreground mt-2 line-clamp-2 text-sm leading-snug opacity-80 transition-opacity duration-300 group-hover:opacity-100">
               {children}
             </p>
           </div>

--- a/apps/web/src/app/[locale]/navigation-menu.tsx
+++ b/apps/web/src/app/[locale]/navigation-menu.tsx
@@ -14,32 +14,23 @@ import {
 } from '@tuturuuu/ui/navigation-menu';
 import { cn } from '@tuturuuu/utils/format';
 import {
-  Archive,
-  Banknote,
   BookText,
-  Brain,
   Building,
-  Calendar,
-  CircleCheck,
   Factory,
   FileText,
   Github,
   GraduationCap,
-  HardDrive,
   HardHat,
   Hotel,
-  Mail,
   Paintbrush,
   Pill,
   Presentation,
   Shield,
   Sparkles,
   Store,
-  Users,
   UsersRound,
   Utensils,
   WandSparkles,
-  Workflow,
   Zap,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -56,100 +47,102 @@ export function MainNavigationMenu() {
       description: t('common.meet-together-description'),
       icon: <UsersRound className="h-4 w-4" />,
     },
+    // {
+    //   title: t('common.ai-assistant'),
+    //   href: '/products/ai',
+    //   description: t('common.ai-assistant-description'),
+    //   icon: <Brain className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.lms'),
+    //   href: '/products/lms',
+    //   description: t('common.lms-description'),
+    //   icon: <GraduationCap className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.calendar'),
+    //   href: '/products/calendar',
+    //   description: t('common.calendar-description'),
+    //   icon: <Calendar className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.documents'),
+    //   href: '/products/documents',
+    //   description: t('common.documents-description'),
+    //   icon: <FileText className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.drive'),
+    //   href: '/products/drive',
+    //   description: t('common.drive-description'),
+    //   icon: <HardDrive className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.crm'),
+    //   href: '/products/crm',
+    //   description: t('common.crm-description'),
+    //   icon: <Users className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.inventory'),
+    //   href: '/products/inventory',
+    //   description: t('common.inventory-description'),
+    //   icon: <Archive className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.finance'),
+    //   href: '/products/finance',
+    //   description: t('common.finance-description'),
+    //   icon: <Banknote className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.mail'),
+    //   href: '/products/mail',
+    //   description: t('common.mail-description'),
+    //   icon: <Mail className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.tasks'),
+    //   href: '/products/tasks',
+    //   description: t('common.tasks-description'),
+    //   icon: <CircleCheck className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: t('common.workflows'),
+    //   href: '/products/workflows',
+    //   description: t('common.workflows-description'),
+    //   icon: <Workflow className="h-4 w-4" />,
+    //   badge: t('common.coming_soon'),
+    // },
+    // {
+    //   title: 'Mira',
+    //   href: DEV_MODE ? 'http://localhost:7806' : 'https://mira.tuturuuu.com',
+    //   description: t('common.workflows-description'),
+    //   icon: <Factory className="h-4 w-4" />,
+    // },
     {
-      title: t('common.ai-assistant'),
-      href: '/products/ai',
-      description: t('common.ai-assistant-description'),
-      icon: <Brain className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.lms'),
-      href: '/products/lms',
-      description: t('common.lms-description'),
-      icon: <GraduationCap className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.calendar'),
-      href: '/products/calendar',
-      description: t('common.calendar-description'),
-      icon: <Calendar className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.documents'),
-      href: '/products/documents',
-      description: t('common.documents-description'),
-      icon: <FileText className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.drive'),
-      href: '/products/drive',
-      description: t('common.drive-description'),
-      icon: <HardDrive className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.crm'),
-      href: '/products/crm',
-      description: t('common.crm-description'),
-      icon: <Users className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.inventory'),
-      href: '/products/inventory',
-      description: t('common.inventory-description'),
-      icon: <Archive className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.finance'),
-      href: '/products/finance',
-      description: t('common.finance-description'),
-      icon: <Banknote className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.mail'),
-      href: '/products/mail',
-      description: t('common.mail-description'),
-      icon: <Mail className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.tasks'),
-      href: '/products/tasks',
-      description: t('common.tasks-description'),
-      icon: <CircleCheck className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: t('common.workflows'),
-      href: '/products/workflows',
-      description: t('common.workflows-description'),
-      icon: <Workflow className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
-    },
-    {
-      title: 'Mira',
-      href: DEV_MODE ? 'http://localhost:7806' : 'https://mira.tuturuuu.com',
-      description: t('common.workflows-description'),
-      icon: <Factory className="h-4 w-4" />,
+      title: 'Rewise',
+      href: DEV_MODE ? 'http://localhost:7804' : 'https://rewise.me',
+      description: t('common.rewise-description'),
+      icon: <Sparkles className="h-4 w-4" />,
+      badge: t('common.waitlist'),
     },
     {
       title: 'Nova',
       href: DEV_MODE ? 'http://localhost:7805' : 'https://nova.tuturuuu.com',
-      description: t('common.workflows-description'),
+      description: t('common.nova-description'),
       icon: <WandSparkles className="h-4 w-4" />,
-    },
-    {
-      title: 'Rewise',
-      href: DEV_MODE ? 'http://localhost:7804' : 'https://rewise.me',
-      description: t('common.workflows-description'),
-      icon: <Sparkles className="h-4 w-4" />,
+      badge: t('common.coming_soon'),
     },
   ];
 
@@ -210,7 +203,6 @@ export function MainNavigationMenu() {
       href: '/blog',
       description: t('common.blog-description'),
       icon: <BookText className="h-4 w-4" />,
-      badge: t('common.coming_soon'),
     },
     {
       title: t('common.changelog'),
@@ -254,18 +246,18 @@ export function MainNavigationMenu() {
     <NavigationMenu className="flex w-full max-w-none">
       <NavigationMenuList className="flex w-full justify-between">
         <NavigationMenuItem>
-          <NavigationMenuTrigger className="hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r font-semibold transition-all duration-300">
+          <NavigationMenuTrigger className="group bg-gradient-to-r font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5">
             <span className="flex items-center gap-2">
               {t('common.products')}
               <span className="relative flex h-2 w-2">
-                <span className="bg-primary/50 absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"></span>
-                <span className="bg-primary relative inline-flex h-2 w-2 rounded-full"></span>
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/50 opacity-75"></span>
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-primary"></span>
               </span>
             </span>
           </NavigationMenuTrigger>
           <NavigationMenuContent>
-            <ul className="from-background via-background/95 to-background/90 grid w-[400px] gap-3 bg-gradient-to-br p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px] xl:w-[1000px] xl:grid-cols-3">
-              <Card className="bg-primary/5 col-span-full mb-2 p-4">
+            <ul className="grid w-[400px] gap-3 bg-gradient-to-br from-background via-background/95 to-background/90 p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px] xl:w-[1000px] xl:grid-cols-3">
+              <Card className="col-span-full mb-2 bg-primary/5 p-4">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <Zap className="h-4 w-4" />
                   <span>Featured Products</span>
@@ -287,17 +279,17 @@ export function MainNavigationMenu() {
         </NavigationMenuItem>
 
         <NavigationMenuItem>
-          <NavigationMenuTrigger className="hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r font-semibold transition-all duration-300">
+          <NavigationMenuTrigger className="group bg-gradient-to-r font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5">
             <span className="flex items-center gap-2">
               {t('common.solutions')}
-              <span className="bg-primary/10 text-primary rounded-full px-2 py-0.5 text-xs">
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary">
                 {t('common.new')}
               </span>
             </span>
           </NavigationMenuTrigger>
           <NavigationMenuContent>
-            <ul className="from-background via-background/95 to-background/90 grid w-[400px] gap-3 bg-gradient-to-br p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px]">
-              <Card className="bg-primary/5 col-span-full mb-2 p-4">
+            <ul className="grid w-[400px] gap-3 bg-gradient-to-br from-background via-background/95 to-background/90 p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px]">
+              <Card className="col-span-full mb-2 bg-primary/5 p-4">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <Building className="h-4 w-4" />
                   <span>Industry Solutions</span>
@@ -318,12 +310,12 @@ export function MainNavigationMenu() {
         </NavigationMenuItem>
 
         <NavigationMenuItem>
-          <NavigationMenuTrigger className="hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r font-semibold transition-all duration-300">
+          <NavigationMenuTrigger className="group bg-gradient-to-r font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5">
             {t('common.resources')}
           </NavigationMenuTrigger>
           <NavigationMenuContent>
-            <ul className="from-background via-background/95 to-background/90 grid w-[400px] gap-3 bg-gradient-to-br p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px]">
-              <Card className="bg-primary/5 col-span-full mb-2 p-4">
+            <ul className="grid w-[400px] gap-3 bg-gradient-to-br from-background via-background/95 to-background/90 p-6 backdrop-blur-sm md:w-[500px] md:grid-cols-2 lg:w-[800px]">
+              <Card className="col-span-full mb-2 bg-primary/5 p-4">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <BookText className="h-4 w-4" />
                   <span>Learning Resources</span>
@@ -335,7 +327,7 @@ export function MainNavigationMenu() {
                   title={resource.title}
                   href={resource.href}
                   icon={resource.icon}
-                  badge={resource.badge}
+                  // badge={resource.badge}
                 >
                   {resource.description}
                 </ListItem>
@@ -349,7 +341,7 @@ export function MainNavigationMenu() {
             <NavigationMenuLink
               className={cn(
                 navigationMenuTriggerStyle(),
-                'hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r px-6 font-semibold transition-all duration-300'
+                'group bg-gradient-to-r px-6 font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5'
               )}
             >
               <span className="flex items-center gap-2">
@@ -364,7 +356,7 @@ export function MainNavigationMenu() {
             <NavigationMenuLink
               className={cn(
                 navigationMenuTriggerStyle(),
-                'hover:from-primary/10 hover:to-primary/5 bg-gradient-to-r px-6 font-semibold transition-all duration-300'
+                'bg-gradient-to-r px-6 font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5'
               )}
             >
               {t('common.about')}
@@ -377,7 +369,7 @@ export function MainNavigationMenu() {
             <NavigationMenuLink
               className={cn(
                 navigationMenuTriggerStyle(),
-                'hover:from-primary/10 hover:to-primary/5 group bg-gradient-to-r px-6 font-semibold transition-all duration-300'
+                'group bg-gradient-to-r px-6 font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5'
               )}
             >
               <span className="flex items-center gap-2">
@@ -392,7 +384,7 @@ export function MainNavigationMenu() {
             <NavigationMenuLink
               className={cn(
                 navigationMenuTriggerStyle(),
-                'hover:from-primary/10 hover:to-primary/5 bg-gradient-to-r px-6 font-semibold transition-all duration-300'
+                'bg-gradient-to-r px-6 font-semibold transition-all duration-300 hover:from-primary/10 hover:to-primary/5'
               )}
             >
               {t('common.contact')}
@@ -419,7 +411,7 @@ const ListItem = React.forwardRef<
         <a
           ref={ref}
           className={cn(
-            'outline-hidden group relative block h-full select-none space-y-1 rounded-md p-4 leading-none no-underline transition-all duration-300',
+            'group relative block h-full space-y-1 rounded-md p-4 leading-none no-underline outline-hidden transition-all duration-300 select-none',
             'via-primary/10 to-primary/5 hover:bg-gradient-to-br',
             'opacity-90 hover:opacity-100',
             'hover:scale-[1.02] hover:shadow-lg active:scale-[0.98]',
@@ -430,10 +422,10 @@ const ListItem = React.forwardRef<
         >
           <div className="relative">
             <div className="flex items-center gap-2">
-              <div className="text-primary transition-transform duration-300 group-hover:rotate-3 group-hover:scale-110">
+              <div className="text-primary transition-transform duration-300 group-hover:scale-110 group-hover:rotate-3">
                 {icon}
               </div>
-              <div className="text-sm font-semibold leading-none">{title}</div>
+              <div className="text-sm leading-none font-semibold">{title}</div>
               {badge && (
                 <Badge
                   variant="secondary"
@@ -443,7 +435,7 @@ const ListItem = React.forwardRef<
                 </Badge>
               )}
             </div>
-            <p className="text-muted-foreground mt-2 line-clamp-2 text-sm leading-snug opacity-80 transition-opacity duration-300 group-hover:opacity-100">
+            <p className="mt-2 line-clamp-2 text-sm leading-snug text-muted-foreground opacity-80 transition-opacity duration-300 group-hover:opacity-100">
               {children}
             </p>
           </div>


### PR DESCRIPTION
I have added new product links for Mira, Nova, and Rewise, please check their corresponding URLs, icons to assess their suitability with the app. However, their descriptions are just temporarily filled with the one in Workflows tab and should be replaced with suitable contents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced two new product navigation options: Nova and Rewise, with dynamic links based on the environment.
  - Updated product descriptions and badges for the new entries.

- **Bug Fixes**
  - Removed outdated product entries from the navigation menu.

- **Documentation**
  - Expanded localization support with new descriptions and waitlist messaging in English and Vietnamese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->