### PR TITLE
Move the hsl wrappers and use @theme inline

### DIFF
--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -6,97 +6,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-@theme {
-  --color-background: hsl(var(--background));
-  --color-foreground: hsl(var(--foreground));
-
-  --color-card: hsl(var(--card));
-  --color-card-foreground: hsl(var(--card-foreground));
-
-  --color-popover: hsl(var(--popover));
-  --color-popover-foreground: hsl(var(--popover-foreground));
-
-  --color-primary: hsl(var(--primary));
-  --color-primary-foreground: hsl(var(--primary-foreground));
-
-  --color-secondary: hsl(var(--secondary));
-  --color-secondary-foreground: hsl(var(--secondary-foreground));
-
-  --color-muted: hsl(var(--muted));
-  --color-muted-foreground: hsl(var(--muted-foreground));
-
-  --color-accent: hsl(var(--accent));
-  --color-accent-foreground: hsl(var(--accent-foreground));
-
-  --color-destructive: hsl(var(--destructive));
-  --color-destructive-foreground: hsl(var(--destructive-foreground));
-
-  --color-border: hsl(var(--border));
-  --color-input: hsl(var(--input));
-  --color-ring: hsl(var(--ring));
-
-  --color-chart-1: hsl(var(--chart-1));
-  --color-chart-2: hsl(var(--chart-2));
-  --color-chart-3: hsl(var(--chart-3));
-  --color-chart-4: hsl(var(--chart-4));
-  --color-chart-5: hsl(var(--chart-5));
-
-  --color-sidebar: hsl(var(--sidebar-background));
-  --color-sidebar-foreground: hsl(var(--sidebar-foreground));
-  --color-sidebar-primary: hsl(var(--sidebar-primary));
-  --color-sidebar-primary-foreground: hsl(var(--sidebar-primary-foreground));
-  --color-sidebar-accent: hsl(var(--sidebar-accent));
-  --color-sidebar-accent-foreground: hsl(var(--sidebar-accent-foreground));
-  --color-sidebar-border: hsl(var(--sidebar-border));
-  --color-sidebar-ring: hsl(var(--sidebar-ring));
-
-  --radius-lg: var(--radius);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-sm: calc(var(--radius) - 4px);
-
-  --animate-accordion-down: accordion-down 0.2s ease-out;
-  --animate-accordion-up: accordion-up 0.2s ease-out;
-
-  --color-dynamic-lime: hsl(var(--lime));
-  --color-dynamic-purple: hsl(var(--purple));
-  --color-dynamic-blue: hsl(var(--blue));
-  --color-dynamic-sky: hsl(var(--sky));
-  --color-dynamic-green: hsl(var(--green));
-  --color-dynamic-yellow: hsl(var(--yellow));
-  --color-dynamic-orange: hsl(var(--orange));
-  --color-dynamic-red: hsl(var(--red));
-  --color-deep-blue: #0b1023;
-  --color-midnight-blue: #1e2240;
-  --color-dark-purple: #2c124b;
-  --color-dynamic-light-lime: hsl(var(--light-lime));
-  --color-dynamic-light-purple: hsl(var(--light-purple));
-  --color-dynamic-light-pink: hsl(var(--light-pink));
-  --color-dynamic-light-blue: hsl(var(--light-blue));
-  --color-dynamic-light-sky: hsl(var(--light-sky));
-  --dynamic-light-green: hsl(var(--light-green));
-  --color-dynamic-light-yellow: hsl(var(--light-yellow));
-  --color-dynamic-light-orange: hsl(var(--light-orange));
-  --color-dynamic-light-red: hsl(var(--light-red));
-
-  @keyframes accordion-down {
-    from {
-      height: 0;
-    }
-    to {
-      height: var(--radix-accordion-content-height);
-    }
-  }
-
-  @keyframes accordion-up {
-    from {
-      height: var(--radix-accordion-content-height);
-    }
-    to {
-      height: 0;
-    }
-  }
-}
-
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still
@@ -124,116 +33,207 @@
   }
 }
 
-@layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 240 5.9% 10%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 240 4.8% 95.9%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+:root {
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(0 0% 3.9%);
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(0 0% 3.9%);
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(0 0% 3.9%);
+  --primary: hsl(0 0% 9%);
+  --primary-foreground: hsl(0 0% 98%);
+  --secondary: hsl(0 0% 96.1%);
+  --secondary-foreground: hsl(0 0% 9%);
+  --muted: hsl(0 0% 96.1%);
+  --muted-foreground: hsl(0 0% 45.1%);
+  --accent: hsl(0 0% 96.1%);
+  --accent-foreground: hsl(0 0% 9%);
+  --destructive: hsl(0 84.2% 60.2%);
+  --destructive-foreground: hsl(0 0% 98%);
+  --border: hsl(0 0% 89.8%);
+  --input: hsl(0 0% 89.8%);
+  --ring: hsl(0 0% 3.9%);
+  --chart-1: hsl(12 76% 61%);
+  --chart-2: hsl(173 58% 39%);
+  --chart-3: hsl(197 37% 24%);
+  --chart-4: hsl(43 74% 66%);
+  --chart-5: hsl(27 87% 67%);
+  --radius: 0.5rem;
+  --sidebar-background: hsl(0 0% 98%);
+  --sidebar-foreground: hsl(240 5.3% 26.1%);
+  --sidebar-primary: hsl(240 5.9% 10%);
+  --sidebar-primary-foreground: hsl(0 0% 98%);
+  --sidebar-accent: hsl(240 4.8% 95.9%);
+  --sidebar-accent-foreground: hsl(240 5.9% 10%);
+  --sidebar-border: hsl(220 13% 91%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
 
-    /* Custom colors */
-    --lime: 90 40% 30%;
-    --purple: 270 40% 30%;
-    --blue: 220 40% 30%;
-    --sky: 200 40% 30%;
-    --green: 140 40% 30%;
-    --yellow: 40 40% 30%;
-    --orange: 25 40% 30%;
-    --red: 0 40% 30%;
+  /* Custom colors */
+  --lime: hsl(90 40% 30%);
+  --purple: hsl(270 40% 30%);
+  --blue: hsl(220 40% 30%);
+  --sky: hsl(200 40% 30%);
+  --green: hsl(140 40% 30%);
+  --yellow: hsl(40 40% 30%);
+  --orange: hsl(25 40% 30%);
+  --red: hsl(0 40% 30%);
 
-    --light-lime: 90 80% 60%;
-    --light-purple: 240 70% 60%;
-    --light-pink: 330 70% 60%;
-    --light-blue: 220 80% 60%;
-    --light-sky: 200 80% 60%;
-    --light-green: 140 80% 60%;
-    --light-yellow: 40 80% 60%;
-    --light-orange: 25 80% 60%;
-    --light-red: 0 70% 80%;
+  --light-lime: hsl(90 80% 60%);
+  --light-purple: hsl(240 70% 60%);
+  --light-pink: hsl(330 70% 60%);
+  --light-blue: hsl(220 80% 60%);
+  --light-sky: hsl(200 80% 60%);
+  --light-green: hsl(140 80% 60%);
+  --light-yellow: hsl(40 80% 60%);
+  --light-orange: hsl(25 80% 60%);
+  --light-red: hsl(0 70% 80%);
+}
+
+.dark {
+  --background: hsl(0 0% 3.9%);
+  --foreground: hsl(0 0% 98%);
+  --card: hsl(0 0% 3.9%);
+  --card-foreground: hsl(0 0% 98%);
+  --popover: hsl(0 0% 3.9%);
+  --popover-foreground: hsl(0 0% 98%);
+  --primary: hsl(0 0% 98%);
+  --primary-foreground: hsl(0 0% 9%);
+  --secondary: hsl(0 0% 14.9%);
+  --secondary-foreground: hsl(0 0% 98%);
+  --muted: hsl(0 0% 14.9%);
+  --muted-foreground: hsl(0 0% 63.9%);
+  --accent: hsl(0 0% 14.9%);
+  --accent-foreground: hsl(0 0% 98%);
+  --destructive: hsl(0 62.8% 30.6%);
+  --destructive-foreground: hsl(0 0% 98%);
+  --border: hsl(0 0% 14.9%);
+  --input: hsl(0 0% 14.9%);
+  --ring: hsl(0 0% 83.1%);
+  --chart-1: hsl(220 70% 50%);
+  --chart-2: hsl(160 60% 45%);
+  --chart-3: hsl(30 80% 55%);
+  --chart-4: hsl(280 65% 60%);
+  --chart-5: hsl(340 75% 55%);
+  --sidebar-background: hsl(240 5.9% 10%);
+  --sidebar-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-primary: hsl(224.3 76.3% 48%);
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(240 3.7% 15.9%);
+  --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-border: hsl(240 3.7% 15.9%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+
+  /* Custom colors */
+  --lime: hsl(90 50% 70%);
+  --purple: hsl(270 50% 70%);
+  --blue: hsl(220 50% 70%);
+  --sky: hsl(200 70% 80%);
+  --green: hsl(160 50% 70%);
+  --yellow: hsl(40 50% 70%);
+  --orange: hsl(25 50% 70%);
+  --red: hsl(0 50% 70%);
+
+  --light-lime: hsl(90 60% 75%);
+  --light-purple: hsl(270 60% 75%);
+  --light-pink: hsl(330 60% 75%);
+  --light-blue: hsl(220 60% 75%);
+  --light-sky: hsl(200 70% 80%);
+  --light-green: hsl(160 60% 75%);
+  --light-yellow: hsl(40 60% 75%);
+  --light-orange: hsl(25 60% 75%);
+  --light-red: hsl(0 60% 75%);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+
+  --color-sidebar: var(--sidebar-background);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  --radius-lg: var(--radius);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 4px);
+
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
+
+  --color-deep-blue: #0b1023;
+  --color-midnight-blue: #1e2240;
+  --color-dark-purple: #2c124b;
+
+  --color-dynamic-lime: var(--lime);
+  --color-dynamic-purple: var(--purple);
+  --color-dynamic-blue: var(--blue);
+  --color-dynamic-sky: var(--sky);
+  --color-dynamic-green: var(--green);
+  --color-dynamic-yellow: var(--yellow);
+  --color-dynamic-orange: var(--orange);
+  --color-dynamic-red: var(--red);
+
+  --color-dynamic-light-lime: var(--light-lime);
+  --color-dynamic-light-purple: var(--light-purple);
+  --color-dynamic-light-pink: var(--light-pink);
+  --color-dynamic-light-blue: var(--light-blue);
+  --color-dynamic-light-sky: var(--light-sky);
+  --color-dynamic-light-green: var(--light-green);
+  --color-dynamic-light-yellow: var(--light-yellow);
+  --color-dynamic-light-orange: var(--light-orange);
+  --color-dynamic-light-red: var(--light-red);
+
+  @keyframes accordion-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--radix-accordion-content-height);
+    }
   }
 
-  .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-
-    /* Custom colors */
-    --lime: 90 50% 70%;
-    --purple: 270 50% 70%;
-    --blue: 220 50% 70%;
-    --sky: 200 70% 80%;
-    --green: 160 50% 70%;
-    --yellow: 40 50% 70%;
-    --orange: 25 50% 70%;
-    --red: 0 50% 70%;
-
-    --light-lime: 90 60% 75%;
-    --light-purple: 270 60% 75%;
-    --light-pink: 330 60% 75%;
-    --light-blue: 220 60% 75%;
-    --light-sky: 200 70% 80%;
-    --light-green: 160 60% 75%;
-    --light-yellow: 40 60% 75%;
-    --light-orange: 25 60% 75%;
-    --light-red: 0 60% 75%;
+  @keyframes accordion-up {
+    from {
+      height: var(--radix-accordion-content-height);
+    }
+    to {
+      height: 0;
+    }
   }
 }
 

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -192,13 +192,6 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
 
-  --animate-accordion-down: accordion-down 0.2s ease-out;
-  --animate-accordion-up: accordion-up 0.2s ease-out;
-
-  --color-deep-blue: #0b1023;
-  --color-midnight-blue: #1e2240;
-  --color-dark-purple: #2c124b;
-
   --color-dynamic-lime: var(--lime);
   --color-dynamic-purple: var(--purple);
   --color-dynamic-blue: var(--blue);
@@ -217,6 +210,9 @@
   --color-dynamic-light-yellow: var(--light-yellow);
   --color-dynamic-light-orange: var(--light-orange);
   --color-dynamic-light-red: var(--light-red);
+
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
 
   @keyframes accordion-down {
     from {


### PR DESCRIPTION
Move :root and .dark out of the @layer base.
Wrap the color values in hsl()
Add the inline option to @theme i.e @theme inline
Remove the hsl() wrappers from @theme

This change makes it much simpler to access your theme variables in both utility classes and outside of CSS for eg. using color values in JavaScript.

References: https://ui.shadcn.com/docs/tailwind-v4#2-update-your-css-variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined global theming with an expanded color palette for enhanced consistency across light and dark modes.
	- Improved border, accent, and typography styles for a more cohesive visual design.
	- Streamlined color management to simplify future style adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->