### PR TITLE
Fixed event locked

### DIFF
--- a/packages/ui/src/components/ui/legacy/calendar/EventFormComponents.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/EventFormComponents.tsx
@@ -187,7 +187,6 @@ export const EventLocationInput = ({
             onClick={openGoogleMaps}
             className="absolute top-1/2 right-2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             title="Open in Google Maps"
-            disabled={disabled}
           >
             <MapPin className="h-4 w-4" />
           </button>

--- a/packages/ui/src/components/ui/legacy/calendar/UnifiedEventModal.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/UnifiedEventModal.tsx
@@ -236,6 +236,7 @@ export function UnifiedEventModal({
       setEvent({
         ...eventData,
         priority: eventData.priority || 'medium',
+        locked: eventData.locked
       });
 
       // Check if this is an all-day event (no time component)
@@ -343,11 +344,17 @@ export function UnifiedEventModal({
     try {
       let savedEvent: CalendarEvent;
       if (activeEvent?.id === 'new') {
-        savedEvent = await addEvent(event as Omit<CalendarEvent, 'id'>);
+        savedEvent = await addEvent({
+          ...event,
+          locked: event.locked || false
+        } as Omit<CalendarEvent, 'id'>);
       } else if (activeEvent?.id) {
         const originalId = activeEvent.id;
         if (originalId) {
-          savedEvent = await updateEvent(originalId, event);
+          savedEvent = await updateEvent(originalId, {
+            ...event,
+            locked: event.locked || false
+          });
         } else {
           throw new Error('Invalid event ID');
         }
@@ -808,6 +815,37 @@ export function UnifiedEventModal({
     }
   };
 
+  // Handle lock toggle
+  const handleLockToggle = async (checked: boolean) => {
+    if (!activeEvent?.id) return;
+
+    setIsSaving(true);
+    try {
+      const originalId = activeEvent.id;
+      const updatedEvent = await updateEvent(originalId, {
+        ...event,
+        locked: checked
+      });
+
+      setEvent(updatedEvent);
+      toast({
+        title: 'Success',
+        description: `Event ${checked ? 'locked' : 'unlocked'} successfully`,
+      });
+    } catch (error) {
+      console.error('Error updating event lock status:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to update event lock status',
+        variant: 'destructive',
+      });
+      // Revert the toggle if update fails
+      setEvent(prev => ({ ...prev, locked: !checked }));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   return (
     <Dialog open={isModalOpen} onOpenChange={(open) => !open && closeModal()}>
       <DialogContent className="max-h-[90vh] max-w-3xl overflow-hidden p-0">
@@ -971,9 +1009,7 @@ export function UnifiedEventModal({
                                   label="Lock Event"
                                   description="Locked events cannot be modified accidentally"
                                   checked={event.locked || false}
-                                  onChange={(checked) =>
-                                    setEvent({ ...event, locked: checked })
-                                  }
+                                  onChange={handleLockToggle}
                                 />
                                 <div className="mt-1 flex items-center gap-2">
                                   {event.locked ? (


### PR DESCRIPTION
When you clicked the button of event locked of events, it didn't save.

Therefore I fixed the event locked when saving events and now you can lock events successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The map-access button in event location input now remains active, providing immediate access to directions.
  - A new event lock toggle has been added, allowing you to prevent unintended modifications with instant feedback on status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->