### PR TITLE
Fix the submission updates when user moves to problems in the challenge

### DIFF
--- a/apps/nova/src/app/[locale]/(dashboard)/(admin)/problems/[problemId]/prompt-form.tsx
+++ b/apps/nova/src/app/[locale]/(dashboard)/(admin)/problems/[problemId]/prompt-form.tsx
@@ -3,6 +3,7 @@
 import { ExtendedNovaSubmission, fetchSubmissions } from './actions';
 import ScoreBadge from '@/components/common/ScoreBadge';
 import { NovaProblem, NovaProblemTestCase } from '@tuturuuu/types/db';
+import { Badge } from '@tuturuuu/ui/badge';
 import { Button } from '@tuturuuu/ui/button';
 import {
   Card,
@@ -47,9 +48,7 @@ export default function PromptForm({ problem }: Props) {
 
   const getSubmissions = useCallback(async () => {
     const submissions = await fetchSubmissions(problem.id);
-    if (submissions.length > 0) {
-      setSubmissions(submissions);
-    }
+    setSubmissions(submissions);
   }, [problem.id]);
 
   useEffect(() => {
@@ -216,7 +215,14 @@ export default function PromptForm({ problem }: Props) {
       <TabsList className="mb-4 grid w-full grid-cols-3">
         <TabsTrigger value="prompt">Prompt</TabsTrigger>
         <TabsTrigger value="test">Test</TabsTrigger>
-        <TabsTrigger value="submissions">Submissions</TabsTrigger>
+        <TabsTrigger value="submissions">
+          Submissions
+          {submissions.length > 0 && (
+            <Badge variant="secondary" className="ml-2">
+              {submissions.length}
+            </Badge>
+          )}
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="prompt" className="space-y-4">

--- a/apps/nova/src/app/[locale]/(dashboard)/challenges/[challengeId]/prompt-form.tsx
+++ b/apps/nova/src/app/[locale]/(dashboard)/challenges/[challengeId]/prompt-form.tsx
@@ -53,17 +53,15 @@ export default function PromptForm({ problem, session }: Props) {
 
   const getSubmissions = useCallback(async () => {
     const submissions = await fetchSubmissions(problem.id);
-    if (submissions.length > 0) {
-      setSubmissions(submissions);
+    setSubmissions(submissions);
 
-      // Split submissions between current and past sessions
-      const current = submissions.filter((s) => s.session_id === session.id);
-      const past = submissions.filter((s) => s.session_id !== session.id);
+    // Split submissions between current and past sessions
+    const current = submissions.filter((s) => s.session_id === session.id);
+    const past = submissions.filter((s) => s.session_id !== session.id);
 
-      setCurrentSubmissions(current);
-      setPastSubmissions(past);
-      setAttempts(current.length);
-    }
+    setCurrentSubmissions(current);
+    setPastSubmissions(past);
+    setAttempts(current.length);
   }, [problem.id, session.id]);
 
   useEffect(() => {
@@ -150,8 +148,7 @@ export default function PromptForm({ problem, session }: Props) {
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
           <TabsList className="mb-4 grid w-full grid-cols-2">
             <TabsTrigger value="prompt">Prompt</TabsTrigger>
-            {/* <TabsTrigger value="test">Test</TabsTrigger> */}
-            <TabsTrigger value="submissions" className="relative">
+            <TabsTrigger value="submissions">
               Submissions
               {submissions.length > 0 && (
                 <Badge variant="secondary" className="ml-2">


### PR DESCRIPTION
The bug lies in the nonsense logic of checking if fetch submissions are not empty before displaying to users, which are not correct. I hope this fix can be patched ASAP before the official test begins tmr!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a badge to the "Submissions" tab to display the count of submissions when available.

- **Style**
  - Adjusted spacing and removed unused CSS classes from the "Submissions" tab.

- **Refactor**
  - Improved how submission data is handled to ensure the state is always updated, regardless of the number of submissions.
  - Removed a commented-out "Test" tab for cleaner navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->