### PR TITLE
fix(calendar): resolve TypeError and ReferenceError & better time block

### DIFF
--- a/packages/ui/src/components/ui/legacy/calendar/settings/TimeRangePicker.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/settings/TimeRangePicker.tsx
@@ -8,6 +8,18 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import { cn } from '@tuturuuu/utils/format';
 import { Copy, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '@tuturuuu/ui/alert-dialog';
 
 export type TimeBlock = {
   startTime: string;
@@ -72,6 +84,185 @@ export function TimeRangePicker({
   compact = false,
 }: TimeRangePickerProps) {
   const [activeDay, setActiveDay] = useState<keyof WeekTimeRanges>('monday');
+  const [showCopyDialog, setShowCopyDialog] = useState(false);
+  const [pendingCopy, setPendingCopy] = useState(false);
+
+  // Use defaultWeekTimeRanges if value is null
+  const timeRanges = value || defaultWeekTimeRanges;
+
+  // Ensure each day has a valid timeBlocks array
+  const safeTimeRanges = Object.entries(timeRanges).reduce((acc, [day, dayRange]) => {
+    acc[day as keyof WeekTimeRanges] = {
+      enabled: dayRange?.enabled ?? false,
+      timeBlocks: dayRange?.timeBlocks ?? [{ ...defaultTimeBlock }],
+    };
+    return acc;
+  }, {} as WeekTimeRanges);
+
+  // Helper to convert time string to minutes
+  const timeToMinutes = (t: string) => {
+    const [h, m] = t.split(':').map(Number);
+    return h * 60 + m;
+  };
+  // Helper to convert minutes to time string
+  const minutesToTime = (min: number) => {
+    const h = Math.floor(min / 60);
+    const m = min % 60;
+    return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+  };
+
+  // Validation for a single block
+  const validateTimeRange = (startTime: string, endTime: string, prevEnd?: string, nextStart?: string): { isValid: boolean; message?: string; correctedEnd?: string; correctedStart?: string } => {
+    const startMin = timeToMinutes(startTime);
+    const endMin = timeToMinutes(endTime);
+    if (endMin <= startMin) {
+      return { isValid: false, message: 'End time must be after start time' };
+    }
+    if (endMin - startMin < 30) {
+      return { isValid: false, message: 'Time block must be at least 30 minutes' };
+    }
+    if (startMin < 0) {
+      return { isValid: false, message: 'Start time cannot be before 12:00 AM' };
+    }
+    if (endMin > 1439) {
+      return { isValid: false, message: 'End time cannot be after 11:59 PM' };
+    }
+    if (prevEnd && startMin < timeToMinutes(prevEnd)) {
+      return { isValid: false, message: 'Start time overlaps with previous block', correctedStart: prevEnd };
+    }
+    if (nextStart && endMin > timeToMinutes(nextStart)) {
+      return { isValid: false, message: 'End time overlaps with next block', correctedEnd: nextStart };
+    }
+    return { isValid: true };
+  };
+
+  // Can we add another block?
+  const canAddMoreBlocks = (day: keyof WeekTimeRanges) => {
+    const blocks = safeTimeRanges[day]?.timeBlocks || [];
+    if (blocks.length === 0) return true;
+    const lastBlock = blocks[blocks.length - 1];
+    const lastEnd = timeToMinutes(lastBlock.endTime);
+    // If less than 30 min left in the day, can't add
+    return lastEnd <= 1409; // 1409 = 23*60+29
+  };
+
+  // Reason for disabling add button
+  const addBlockDisabledReason = (day: keyof WeekTimeRanges) => {
+    const blocks = safeTimeRanges[day]?.timeBlocks || [];
+    if (blocks.length === 0) return '';
+    const lastBlock = blocks[blocks.length - 1];
+    const lastEnd = timeToMinutes(lastBlock.endTime);
+    if (lastEnd > 1409) return 'No time left in the day for a 30-minute block';
+    return '';
+  };
+
+  // Add a new time block
+  const addTimeBlock = (day: keyof WeekTimeRanges) => {
+    const newTimeRanges = { ...safeTimeRanges };
+    const blocks = newTimeRanges[day]?.timeBlocks || [];
+    const lastBlock = blocks[blocks.length - 1];
+    let newStartMin = lastBlock ? timeToMinutes(lastBlock.endTime) : 540; // 09:00
+    let newEndMin = newStartMin + 30;
+    if (newEndMin > 1439) newEndMin = 1439; // Clamp to 11:59 PM
+    if (newEndMin - newStartMin < 30) {
+      toast.error('Not enough time left in the day for a 30-minute block');
+      return;
+    }
+    const newStartTime = minutesToTime(newStartMin);
+    const newEndTime = minutesToTime(newEndMin);
+    // Prevent overlap
+    if (blocks.length > 0 && newStartTime < blocks[blocks.length - 1].endTime) {
+      toast.error('New block overlaps with previous block');
+      return;
+    }
+    newTimeRanges[day].timeBlocks.push({
+      startTime: newStartTime,
+      endTime: newEndTime,
+    });
+    onChange(newTimeRanges as WeekTimeRanges);
+  };
+
+  // Handle time input changes with validation and auto-correction
+  const handleTimeChange = (
+    day: keyof WeekTimeRanges,
+    blockIndex: number,
+    field: keyof TimeBlock,
+    newValue: string
+  ) => {
+    const newTimeRanges = { ...safeTimeRanges };
+    const blocks = newTimeRanges[day].timeBlocks;
+    const prevEnd = blockIndex > 0 ? blocks[blockIndex - 1].endTime : undefined;
+    const nextStart = blockIndex < blocks.length - 1 ? blocks[blockIndex + 1].startTime : undefined;
+    let updatedBlock = {
+      ...blocks[blockIndex],
+      [field]: newValue,
+    };
+    const { isValid, message, correctedEnd, correctedStart } = validateTimeRange(
+      field === 'startTime' ? newValue : updatedBlock.startTime,
+      field === 'endTime' ? newValue : updatedBlock.endTime,
+      prevEnd,
+      nextStart
+    );
+    if (!isValid) {
+      // Auto-correct if possible
+      if (correctedEnd) {
+        updatedBlock.endTime = correctedEnd;
+        toast.error(message + '. Auto-corrected end time.');
+      } else if (correctedStart) {
+        updatedBlock.startTime = correctedStart;
+        toast.error(message + '. Auto-corrected start time.');
+      } else {
+        toast.error(message);
+        return;
+      }
+    }
+    blocks[blockIndex] = updatedBlock;
+    onChange(newTimeRanges as WeekTimeRanges);
+  };
+
+  const handleDayToggle = (day: keyof WeekTimeRanges, enabled: boolean) => {
+    const newTimeRanges = { ...safeTimeRanges };
+    if (!newTimeRanges[day]) {
+      newTimeRanges[day] = { ...defaultTimeRange };
+    }
+    newTimeRanges[day] = {
+      ...newTimeRanges[day],
+      enabled,
+    };
+    onChange(newTimeRanges as WeekTimeRanges);
+  };
+
+  const removeTimeBlock = (day: keyof WeekTimeRanges, blockIndex: number) => {
+    const newTimeRanges = { ...safeTimeRanges };
+
+    // Don't remove the last block
+    if ((newTimeRanges?.[day]?.timeBlocks?.length || 0) <= 1) return;
+
+    newTimeRanges[day]?.timeBlocks?.splice(blockIndex, 1);
+    onChange(newTimeRanges as WeekTimeRanges);
+  };
+
+  const handleCopyToAllDays = () => {
+    setShowCopyDialog(true);
+  };
+
+  const confirmCopyToAllDays = () => {
+    setShowCopyDialog(false);
+    setPendingCopy(true);
+    // Actually perform the copy
+    const currentDaySettings = safeTimeRanges[activeDay];
+    const newTimeRanges = { ...safeTimeRanges };
+    days.forEach(({ key }) => {
+      if (key !== activeDay) {
+        newTimeRanges[key] = {
+          ...newTimeRanges[key], // preserve enabled status
+          timeBlocks: currentDaySettings.timeBlocks.map(block => ({ ...block })),
+        };
+      }
+    });
+    onChange(newTimeRanges as WeekTimeRanges);
+    setPendingCopy(false);
+  };
 
   const days: Array<{
     key: keyof WeekTimeRanges;
@@ -94,101 +285,31 @@ export function TimeRangePicker({
     return day.type === dayFilter;
   });
 
-  const handleTimeChange = (
-    day: keyof WeekTimeRanges,
-    blockIndex: number,
-    field: keyof TimeBlock,
-    newValue: string
-  ) => {
-    const newTimeRanges = { ...value };
-    if (newTimeRanges[day]?.timeBlocks?.[blockIndex]) {
-      newTimeRanges[day].timeBlocks[blockIndex] = {
-        ...newTimeRanges[day].timeBlocks[blockIndex],
-        [field]: newValue,
-      };
-      onChange(newTimeRanges as WeekTimeRanges);
-    }
-  };
-
-  const handleDayToggle = (day: keyof WeekTimeRanges, enabled: boolean) => {
-    const newTimeRanges = { ...value };
-    if (!newTimeRanges[day]) {
-      newTimeRanges[day] = { ...defaultTimeRange };
-    }
-    newTimeRanges[day] = {
-      ...newTimeRanges[day],
-      enabled,
-    };
-    onChange(newTimeRanges as WeekTimeRanges);
-  };
-
-  const addTimeBlock = (day: keyof WeekTimeRanges) => {
-    const newTimeRanges = { ...value };
-    const lastBlock =
-      newTimeRanges[day]?.timeBlocks?.[
-        newTimeRanges[day].timeBlocks.length - 1
-      ];
-
-    // Create a new block starting 1 hour after the last block ends
-    const lastEndTime = lastBlock ? lastBlock.endTime : '17:00';
-    const parts = lastEndTime.split(':');
-    const hours = parseInt(parts[0] || '0', 10);
-    const minutes = parseInt(parts[1] || '0', 10);
-
-    const newStartHour = (hours + 1) % 24;
-    const newEndHour = (newStartHour + 1) % 24;
-
-    const newStartTime = `${newStartHour.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
-    const newEndTime = `${newEndHour.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
-
-    if (newTimeRanges[day]?.timeBlocks) {
-      newTimeRanges[day].timeBlocks.push({
-        startTime: newStartTime,
-        endTime: newEndTime,
-      });
-      onChange(newTimeRanges as WeekTimeRanges);
-    }
-  };
-
-  const removeTimeBlock = (day: keyof WeekTimeRanges, blockIndex: number) => {
-    const newTimeRanges = { ...value };
-
-    // Don't remove the last block
-    if ((newTimeRanges?.[day]?.timeBlocks?.length || 0) <= 1) return;
-
-    newTimeRanges[day]?.timeBlocks?.splice(blockIndex, 1);
-    onChange(newTimeRanges as WeekTimeRanges);
-  };
-
-  const copyToAllDays = () => {
-    const currentDaySettings = value?.[activeDay];
-    const newTimeRanges = { ...value };
-
-    days.forEach(({ key }) => {
-      if (key !== activeDay) {
-        newTimeRanges[key] = { ...currentDaySettings } as DayTimeRange;
-      }
-    });
-
-    onChange(newTimeRanges as WeekTimeRanges);
-  };
-
   return (
     <div className="space-y-4">
       {showDaySelector && !compact && (
         <div className="flex items-center justify-between">
           {label && <Label className="text-base">{label}</Label>}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button variant="outline" onClick={copyToAllDays}>
+          <AlertDialog open={showCopyDialog} onOpenChange={setShowCopyDialog}>
+            <AlertDialogTrigger asChild>
+              <Button variant="outline" onClick={handleCopyToAllDays} disabled={pendingCopy}>
                 <Copy className="h-4 w-4" />
                 <span>Copy to all days</span>
               </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              Copy current day settings to all days
-            </TooltipContent>
-          </Tooltip>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Copy to all days?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will overwrite the hours for all days with the current day's settings. Are you sure you want to continue?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={confirmCopyToAllDays}>Yes, copy to all days</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       )}
 
@@ -204,7 +325,7 @@ export function TimeRangePicker({
                     size="sm"
                     className={cn(
                       'h-9 w-9 p-0',
-                      !value?.[key]?.enabled && 'opacity-50'
+                      !safeTimeRanges[key]?.enabled && 'opacity-50'
                     )}
                     onClick={() => setActiveDay(key)}
                   >
@@ -213,7 +334,7 @@ export function TimeRangePicker({
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
                   {fullLabel}
-                  {!value?.[key]?.enabled && ' (Disabled)'}
+                  {!safeTimeRanges[key]?.enabled && ' (Disabled)'}
                 </TooltipContent>
               </Tooltip>
             ))}
@@ -234,44 +355,60 @@ export function TimeRangePicker({
               <div className="flex items-center gap-2">
                 <Switch
                   id={`enable-${key}`}
-                  checked={value?.[key]?.enabled || false}
+                  checked={safeTimeRanges[key]?.enabled || false}
                   onCheckedChange={(checked) => handleDayToggle(key, checked)}
                 />
                 <Label
                   htmlFor={`enable-${key}`}
                   className={cn(
                     'font-medium',
-                    !value?.[key]?.enabled && 'text-muted-foreground',
+                    !safeTimeRanges[key]?.enabled && 'text-muted-foreground',
                     compact && 'text-sm'
                   )}
                 >
                   {fullLabel}
                 </Label>
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                className={cn('gap-1', compact && 'h-6 text-xs')}
-                onClick={() => addTimeBlock(key)}
-                disabled={!value?.[key]?.enabled}
-              >
-                <Plus className={cn('h-3.5 w-3.5', compact && 'h-3 w-3')} />
-                <span className="text-xs">Add Time Block</span>
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className={cn('gap-1', compact && 'h-6 text-xs')}
+                      onClick={() => addTimeBlock(key)}
+                      disabled={!safeTimeRanges[key]?.enabled || !canAddMoreBlocks(key)}
+                      aria-disabled={!safeTimeRanges[key]?.enabled || !canAddMoreBlocks(key)}
+                    >
+                      <Plus className={cn('h-3.5 w-3.5', compact && 'h-3 w-3')} />
+                      <span className="text-xs">
+                        {!canAddMoreBlocks(key)
+                          ? 'Maximum blocks reached'
+                          : 'Add Time Block'}
+                      </span>
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {!canAddMoreBlocks(key)
+                    ? addBlockDisabledReason(key) || 'No time left in the day for a 30-minute block'
+                    : 'Add a new time block'}
+                </TooltipContent>
+              </Tooltip>
             </div>
 
-            {/* Time block inputs */}
-            {value?.[key]?.enabled && (
+            {/* Time block inputs with improved visual separation */}
+            {safeTimeRanges[key]?.enabled && (
               <div
                 className={cn(
                   'space-y-2',
                   compact && 'max-h-[150px] overflow-y-auto pr-1'
                 )}
               >
-                {value[key]?.timeBlocks.map((block, blockIndex) => (
+                {safeTimeRanges[key]?.timeBlocks?.map((block, blockIndex) => (
                   <div
                     key={blockIndex}
-                    className="hover:bg-muted/30 flex items-center gap-2 rounded-md border p-2 transition-colors"
+                    className="hover:bg-muted/30 flex items-center gap-2 rounded-md border border-muted bg-muted/10 p-3 transition-colors shadow-sm"
                   >
                     <div className="grid flex-1 grid-cols-2 gap-2">
                       <div className="space-y-1">
@@ -285,6 +422,9 @@ export function TimeRangePicker({
                           id={`${key}-start-${blockIndex}`}
                           type="time"
                           value={block.startTime}
+                          min={blockIndex > 0 ? safeTimeRanges[key].timeBlocks[blockIndex - 1].endTime : '00:00'}
+                          max={block.endTime}
+                          step="60"
                           onChange={(e) =>
                             handleTimeChange(
                               key,
@@ -293,7 +433,17 @@ export function TimeRangePicker({
                               e.target.value
                             )
                           }
-                          className={cn('h-8', compact && 'h-7 text-xs')}
+                          className={cn(
+                            'h-8',
+                            compact && 'h-7 text-xs',
+                            'bg-background text-foreground',
+                            'appearance-none',
+                            'border border-muted',
+                            'focus:outline-none focus:ring-2 focus:ring-primary',
+                          )}
+                          autoComplete="off"
+                          spellCheck={false}
+                          inputMode="numeric"
                         />
                       </div>
                       <div className="space-y-1">
@@ -307,6 +457,9 @@ export function TimeRangePicker({
                           id={`${key}-end-${blockIndex}`}
                           type="time"
                           value={block.endTime}
+                          min={block.startTime}
+                          max={blockIndex < safeTimeRanges[key].timeBlocks.length - 1 ? safeTimeRanges[key].timeBlocks[blockIndex + 1].startTime : '23:59'}
+                          step="60"
                           onChange={(e) =>
                             handleTimeChange(
                               key,
@@ -315,7 +468,17 @@ export function TimeRangePicker({
                               e.target.value
                             )
                           }
-                          className={cn('h-8', compact && 'h-7 text-xs')}
+                          className={cn(
+                            'h-8',
+                            compact && 'h-7 text-xs',
+                            'bg-background text-foreground',
+                            'appearance-none',
+                            'border border-muted',
+                            'focus:outline-none focus:ring-2 focus:ring-primary',
+                          )}
+                          autoComplete="off"
+                          spellCheck={false}
+                          inputMode="numeric"
                         />
                       </div>
                     </div>
@@ -324,7 +487,7 @@ export function TimeRangePicker({
                         variant="ghost"
                         size="icon"
                         onClick={() => removeTimeBlock(key, blockIndex)}
-                        disabled={value[key]?.timeBlocks.length <= 1}
+                        disabled={safeTimeRanges[key]?.timeBlocks?.length <= 1}
                         className={cn('h-8 w-8', compact && 'h-7 w-7')}
                       >
                         <Trash2


### PR DESCRIPTION
- Fix TypeError by using defaultWeekTimeRanges when value is null
- Resolve ReferenceError by correctly importing defaultWeekTimeRanges
- Limit "+ Add time block" button to max 4 blocks per day and ensure valid time ranges
- Switch from react-hot-toast to sonner for toast notifications
- Remove hard limit on time blocks, allowing blocks to end before 11:59 PM
- Enforce min/max on time inputs and provide user feedback
- Add spacing, borders, and tooltips for better UI clarity
- Add confirmation dialog for "Copy to all days" button
- Ensure consistent styling for time inputs, supporting AM/PM selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of hour settings by automatically creating default time ranges if none exist for personal, work, or meeting types.
  - Added confirmation dialog before copying time blocks to all days in the time range picker.

- **Bug Fixes**
  - Enhanced validation and error handling for time range inputs, preventing invalid or overlapping time blocks.
  - Disabled the "Add Time Block" button and provided tooltips when no more blocks can be added.

- **User Experience**
  - Improved error reporting with clearer toast notifications and error messages.
  - Enhanced accessibility and input constraints for time selection.
  - Streamlined UI for managing and updating hour settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->