### PR TITLE
Get name for cert details

### DIFF
--- a/apps/upskii/src/app/api/v1/certificates/[certId]/generate/route.ts
+++ b/apps/upskii/src/app/api/v1/certificates/[certId]/generate/route.ts
@@ -1,5 +1,6 @@
 import { CertificateProps } from '@/app/[locale]/(dashboard)/[wsId]/certificate/[certID]/page';
 import { DEV_MODE } from '@/constants/common';
+import { getCurrentUser } from '@tuturuuu/utils/user-helper';
 import { NextRequest } from 'next/server';
 import puppeteer from 'puppeteer';
 
@@ -21,7 +22,17 @@ const getCertificateData = async (certID: string) => {
     throw new Error('Failed to fetch certificate data');
   }
 
-  return response.json();
+  const userDetails = await getCurrentUser();
+
+  const certDetails = await response.json();
+
+  // Replace the student name in the response with the user's name
+
+  if (userDetails) {
+    certDetails.studentName = userDetails.display_name;
+  }
+
+  return certDetails;
 };
 
 const renderHTML = (data: {


### PR DESCRIPTION
Fix certificate details to fetch from currentUser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Certificate generation now personalizes the student name field with the current user's display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->