### PR TITLE
Store user-provided API Key in cookie

### DIFF
--- a/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/ai-chat/chat.tsx
+++ b/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/ai-chat/chat.tsx
@@ -24,6 +24,7 @@ export interface ChatProps extends React.ComponentProps<'div'> {
   locale: string;
   noEmptyPage?: boolean;
   disabled?: boolean;
+  initialApiKey?: string | null;
 }
 
 const Chat = ({
@@ -36,6 +37,7 @@ const Chat = ({
   locale,
   noEmptyPage,
   disabled,
+  initialApiKey,
 }: ChatProps) => {
   const t = useTranslations();
 
@@ -47,17 +49,6 @@ const Chat = ({
   const [model, setModel] = useState<Model | undefined>(inputModel);
   const [mode, setMode] = useState<ResponseMode>('medium');
   const [currentUserId, setCurrentUserId] = useState<string>();
-
-  const [apiKey, setApiKey] = useState<string | null>(null);
-  const [apiKeyProvided, setApiKeyProvided] = useState(false);
-
-  useEffect(() => {
-    const storedApiKey = localStorage.getItem('google_api_key');
-    if (storedApiKey) {
-      setApiKey(storedApiKey);
-      setApiKeyProvided(true);
-    }
-  }, []);
 
   const { messages, append, reload, stop, isLoading, input, setInput } =
     useChat({
@@ -77,7 +68,7 @@ const Chat = ({
         id: chat?.id,
         model: chat?.model || model?.value,
         mode,
-        previewToken: apiKey,
+        previewToken: initialApiKey,
       },
       onResponse(response) {
         console.log('Response:', response);
@@ -146,7 +137,7 @@ const Chat = ({
           body: JSON.stringify({
             id: chat.id,
             model: chat.model,
-            previewToken: apiKey,
+            previewToken: initialApiKey,
           }),
         }
       );
@@ -248,7 +239,7 @@ const Chat = ({
         body: JSON.stringify({
           model: model.value,
           message: input,
-          previewToken: apiKey,
+          previewToken: initialApiKey,
         }),
       }
     );
@@ -385,8 +376,7 @@ const Chat = ({
         setMode={setMode}
         disabled={disabled}
         currentUserId={currentUserId}
-        apiKey={apiKey ?? undefined}
-        apiKeyProvided={apiKeyProvided}
+        apiKey={initialApiKey ?? undefined}
       />
     </div>
   );

--- a/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/ai-chat/page.tsx
+++ b/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/ai-chat/page.tsx
@@ -3,6 +3,7 @@ import { getChats } from './helper';
 import { createAdminClient } from '@tuturuuu/supabase/next/server';
 import { getCurrentUser } from '@tuturuuu/utils/user-helper';
 import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
 
 interface Props {
   searchParams: Promise<{
@@ -14,8 +15,8 @@ export default async function AIPage({ searchParams }: Props) {
   const { lang: locale } = await searchParams;
   const { data: chats, count } = await getChats();
 
-  // const cookiesStore = await cookies();
-  // const apiKey = cookiesStore.get('apiKey');
+  const cookieStore = await cookies();
+  const apiKey = cookieStore.get('google_api_key')?.value;
 
   const user = await getCurrentUser();
   if (!user?.email) redirect('/login');
@@ -30,5 +31,5 @@ export default async function AIPage({ searchParams }: Props) {
 
   if (error || !whitelisted?.enabled) redirect('/not-whitelisted');
 
-  return <Chat chats={chats} count={count} locale={locale} />;
+  return <Chat chats={chats} count={count} locale={locale} initialApiKey={apiKey} />;
 }

--- a/apps/upskii/src/app/api/ai/chat/google/key/route.ts
+++ b/apps/upskii/src/app/api/ai/chat/google/key/route.ts
@@ -1,0 +1,50 @@
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const { apiKey } = await request.json();
+    
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'API key is required' },
+        { status: 400 }
+      );
+    }
+
+    const cookieStore = await cookies();
+    cookieStore.set('google_api_key', apiKey, {
+      maxAge: 30 * 24 * 60 * 60, // 30 days
+      path: '/',
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      httpOnly: true
+    });
+
+    revalidatePath('/ai-chat');
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to set API key' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE() {
+  try {
+    const cookieStore = await cookies();
+    cookieStore.delete('google_api_key');
+
+    revalidatePath('/ai-chat');
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to delete API key' },
+      { status: 500 }
+    );
+  }
+} 

--- a/apps/upskii/src/components/chat-panel.tsx
+++ b/apps/upskii/src/components/chat-panel.tsx
@@ -86,7 +86,6 @@ export function ChatPanel({
   disabled,
   currentUserId,
   apiKey,
-  apiKeyProvided,
 }: ChatPanelProps) {
   const t = useTranslations('ai_chat');
 
@@ -185,7 +184,6 @@ export function ChatPanel({
               setMode={setMode}
               disabled={disabled}
               apiKey={apiKey}
-              apiKeyProvided={apiKeyProvided}
             />
           </div>
         </div>

--- a/apps/upskii/src/components/prompt-form.tsx
+++ b/apps/upskii/src/components/prompt-form.tsx
@@ -8,7 +8,6 @@ import { Dialog } from '@tuturuuu/ui/dialog';
 import {
   Bolt,
   Cat,
-  Check,
   File,
   FileText,
   Globe,
@@ -62,7 +61,6 @@ export interface PromptProps
   setMode: (mode: ResponseMode) => void;
   disabled?: boolean;
   apiKey?: string | null;
-  apiKeyProvided?: boolean;
 }
 
 export function PromptForm({
@@ -85,7 +83,7 @@ export function PromptForm({
   mode,
   setMode,
   disabled,
-  apiKeyProvided,
+  apiKey,
 }: PromptProps) {
   const t = useTranslations();
 
@@ -251,18 +249,6 @@ export function PromptForm({
       >
         <div className="mb-2 flex items-center justify-between gap-2">
           <div className="scrollbar-none flex w-full items-center gap-2 overflow-x-auto font-semibold">
-            {apiKeyProvided ? (
-              <>
-                <div className="border-dynamic-green/20 bg-dynamic-green/10 text-dynamic-green flex shrink-0 items-center gap-1 rounded border px-2 py-1.5 text-xs font-semibold">
-                  <Check className="h-3 w-3" />
-                </div>
-                {disabled || (
-                  <Separator orientation="vertical" className="h-4" />
-                )}
-              </>
-            ) : (
-              <></>
-            )}
             {model && (
               <>
                 <div className="border-dynamic-orange/20 bg-dynamic-orange/10 text-dynamic-orange flex shrink-0 items-center gap-1 rounded border px-2 py-1 text-xs font-semibold">
@@ -809,14 +795,14 @@ export function PromptForm({
             // value={[input, caption || ''].filter(Boolean).join(' ')}
             onChange={(e) => setInput(e.target.value)}
             placeholder={
-              disabled || !apiKeyProvided
+              disabled || !apiKey
                 ? t('ai_chat.imagine_placeholder')
                 : `${t('ai_chat.send_message')}.`
             }
             spellCheck={false}
             maxRows={7}
             className="scrollbar-none placeholder-foreground/50 focus-within:outline-hidden w-full resize-none bg-transparent py-2 sm:text-sm"
-            disabled={disabled || !apiKeyProvided}
+            disabled={disabled || !apiKey}
           />
         </div>
       </form>


### PR DESCRIPTION
Store API key in Cookie instead of local storage
No longer needs to manually refresh page after api key input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure server-side API endpoints for saving and deleting your Google API key, ensuring better security and integration.
  - The chat interface now automatically uses your saved API key from cookies for AI interactions.

- **Improvements**
  - Enhanced user feedback with clearer success and error messages when saving or deleting your API key.
  - Simplified the chat and prompt forms by removing redundant indicators and streamlining how the API key is managed.

- **Bug Fixes**
  - Fixed issues related to inconsistent API key handling by removing reliance on local storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->