### PR TITLE
feat(hide module content)(upskii): add hide module sub content 

### DIFF
--- a/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/courses/[courseId]/modules/[moduleId]/page.tsx
+++ b/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/courses/[courseId]/modules/[moduleId]/page.tsx
@@ -142,7 +142,7 @@ export default async function UserGroupDetailsPage({ params }: Props) {
           ) : undefined
         }
       />
-      <CourseSection
+      {/* <CourseSection
         href={`/${wsId}/courses/${courseId}/modules/${moduleId}/quiz-sets`}
         title={t('ws-quiz-sets.plural')}
         icon={<ListTodo className="h-5 w-5" />}
@@ -158,7 +158,7 @@ export default async function UserGroupDetailsPage({ params }: Props) {
             </div>
           ) : undefined
         }
-      />
+      /> */}
       <CourseSection
         href={`/${wsId}/courses/${courseId}/modules/${moduleId}/flashcards`}
         title={t('ws-flashcards.plural')}

--- a/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/courses/[courseId]/section.tsx
+++ b/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/courses/[courseId]/section.tsx
@@ -36,30 +36,34 @@ export async function CourseSection({
 
   return (
     <div className="border-foreground/10 bg-foreground/5 rounded-lg border p-4">
-      {href ? (
-        <Link
-          href={href}
-          className="flex w-fit items-center gap-2 text-lg font-semibold hover:underline md:text-2xl"
-        >
-          {icon}
-          {title}
-        </Link>
-      ) : (
-        <div className="flex items-center gap-2 text-lg font-semibold md:text-2xl">
-          {icon}
-          {title}
-        </div>
-      )}
-      {hideContent || (
-        <>
-          <Separator className="my-2" />
-          {isContentEmpty ? (
-            <div className="opacity-50">{t('common.no_content_yet')}.</div>
+      <details open>
+        <summary className="group flex justify-between">
+          {href ? (
+            <Link
+              href={href}
+              className="flex w-fit items-center gap-2 text-lg font-semibold hover:underline md:text-2xl"
+            >
+              {icon}
+              {title}
+            </Link>
           ) : (
-            content
+            <div className="flex items-center gap-2 text-lg font-semibold md:text-2xl">
+              {icon}
+              {title}
+            </div>
           )}
-        </>
-      )}
+        </summary>
+        {hideContent || (
+          <>
+            <Separator className="my-2" />
+            {isContentEmpty ? (
+              <div className="opacity-50">{t('common.no_content_yet')}.</div>
+            ) : (
+              content
+            )}
+          </>
+        )}
+      </details>
     </div>
   );
 }


### PR DESCRIPTION
This PR
This pull request introduces changes to the `CourseSection` components in the `apps/upskii` project. The modifications include commenting out a specific `CourseSection` instance in `UserGroupDetailsPage` and enhancing the `CourseSection` component with collapsible functionality using the `<details>` and `<summary>` HTML elements.

### Enhancements to `CourseSection`:

* **Added collapsible functionality**: Wrapped the `CourseSection` content in a `<details>` element with an open state by default, and introduced a `<summary>` element for toggling the collapsible section. This allows users to expand or collapse the section for better content organization. 