### PR TITLE
Fix for auth flow 

### DIFF
--- a/apps/upskii/src/app/[locale]/(dashboard)/onboarding/workspace-invites.tsx
+++ b/apps/upskii/src/app/[locale]/(dashboard)/onboarding/workspace-invites.tsx
@@ -9,7 +9,7 @@ export default async function WorkspaceInvites() {
   const workspaces = await getWorkspaces();
   const workspaceInvites = await getWorkspaceInvites();
 
-  if (workspaces?.[0]?.id) redirect(`/${workspaces[0].id}`);
+  if (workspaces?.[0]?.id) redirect(`/${workspaces[0].id}/home`);
 
   return (
     <div className="scrollbar-none grid h-full w-full gap-4 overflow-y-auto">

--- a/apps/upskii/src/app/[locale]/(marketing)/navbar-actions.tsx
+++ b/apps/upskii/src/app/[locale]/(marketing)/navbar-actions.tsx
@@ -1,7 +1,6 @@
 import { UserNavWrapper } from './user-nav-wrapper';
 import { LOCALE_COOKIE_NAME } from '@/constants/common';
 import { defaultLocale, supportedLocales } from '@/i18n/routing';
-import { getWorkspaces } from '@/lib/workspace-helper';
 import { createClient } from '@tuturuuu/supabase/next/server';
 import { GetStartedButton } from '@tuturuuu/ui/custom/get-started-button';
 import { LanguageWrapper } from '@tuturuuu/ui/custom/language-wrapper';

--- a/apps/upskii/src/app/[locale]/(marketing)/navbar-actions.tsx
+++ b/apps/upskii/src/app/[locale]/(marketing)/navbar-actions.tsx
@@ -1,6 +1,7 @@
 import { UserNavWrapper } from './user-nav-wrapper';
 import { LOCALE_COOKIE_NAME } from '@/constants/common';
 import { defaultLocale, supportedLocales } from '@/i18n/routing';
+import { getWorkspaces } from '@/lib/workspace-helper';
 import { createClient } from '@tuturuuu/supabase/next/server';
 import { GetStartedButton } from '@tuturuuu/ui/custom/get-started-button';
 import { LanguageWrapper } from '@tuturuuu/ui/custom/language-wrapper';
@@ -19,6 +20,7 @@ export default async function NavbarActions({
     data: { user: sbUser },
   } = await supabase.auth.getUser();
 
+
   return (
     <div className="relative">
       <div className="flex items-center gap-1">
@@ -28,7 +30,10 @@ export default async function NavbarActions({
           </>
         ) : (
           <>
-            <GetStartedButton text={t('home.get-started')} href="/home" />
+            <GetStartedButton
+              text={t('home.get-started')}
+              href="/onboarding"
+            />
             <LanguageWrapper
               cookieName={LOCALE_COOKIE_NAME}
               defaultLocale={defaultLocale}

--- a/apps/upskii/src/app/[locale]/(marketing)/user-nav-client.tsx
+++ b/apps/upskii/src/app/[locale]/(marketing)/user-nav-client.tsx
@@ -41,13 +41,16 @@ export default function UserNavClient({
   user,
   locale,
   hideMetadata = false,
+  wsId,
 }: {
   user: WorkspaceUser | null;
   locale: string | undefined;
   hideMetadata?: boolean;
+  wsId?: string;
 }) {
   const t = useTranslations();
   const [open, setOpen] = useState(false);
+
 
   return (
     <>
@@ -114,7 +117,7 @@ export default function UserNavClient({
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
-            <Link href="/home">
+            <Link href={wsId ? `/${wsId}/home` : '/onboarding'}>
               <DropdownMenuItem className="flex cursor-pointer gap-4">
                 <Home className="h-4 w-4" />
                 <span>{t('common.home')}</span>

--- a/apps/upskii/src/app/[locale]/(marketing)/user-nav.tsx
+++ b/apps/upskii/src/app/[locale]/(marketing)/user-nav.tsx
@@ -13,7 +13,7 @@ export async function UserNav({
   const user = await getCurrentUser();
   const currentLocale = cookies.get(LOCALE_COOKIE_NAME)?.value;
 
-  const workspaces = await getWorkspaces();
+  const workspaces = await getWorkspaces(true);
   const wsId = workspaces?.[0]?.id;
 
   return (

--- a/apps/upskii/src/app/[locale]/(marketing)/user-nav.tsx
+++ b/apps/upskii/src/app/[locale]/(marketing)/user-nav.tsx
@@ -1,6 +1,8 @@
 import UserNavClient from './user-nav-client';
 import { LOCALE_COOKIE_NAME } from '@/constants/common';
+
 import { getCurrentUser } from '@tuturuuu/utils/user-helper';
+import { getWorkspaces } from '@/lib/workspace-helper';
 import { cookies as c } from 'next/headers';
 
 export async function UserNav({
@@ -12,11 +14,15 @@ export async function UserNav({
   const user = await getCurrentUser();
   const currentLocale = cookies.get(LOCALE_COOKIE_NAME)?.value;
 
+  const workspaces = await getWorkspaces();
+  const wsId = workspaces?.[0]?.id;
+
   return (
     <UserNavClient
       user={user}
       locale={currentLocale}
       hideMetadata={hideMetadata}
+      wsId={wsId}
     />
   );
 }


### PR DESCRIPTION
Badabing badaboom
Get started link now redirects to onboarding
Onboarding handles redirect to correct wsId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "Home" link in the user navigation now directs users to their specific workspace home if available, or to onboarding if not.
- **Improvements**
  - The "Get Started" button for unauthenticated users now redirects to the onboarding page instead of the home page.
  - Users with an existing workspace are now redirected to the workspace home page upon onboarding completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->