### PR TITLE
Change API Key Form Behaviour

### DIFF
--- a/apps/upskii/src/components/form-apikey.tsx
+++ b/apps/upskii/src/components/form-apikey.tsx
@@ -170,6 +170,7 @@ export default function ApiKeyInput({
                       placeholder={t('enter-api-key')}
                       type={showApiKey ? 'text' : 'password'}
                       {...field}
+                      disabled={saving || validated}
                     />
                   </FormControl>
                   <button


### PR DESCRIPTION
Disable the form when a key is already inputted and the user wants to delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The API key input field is now automatically disabled while saving or after successful validation, improving user experience by preventing further edits during these states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->