### PR TITLE
Fix month view event creation date off by one

### DIFF
--- a/packages/ui/src/components/ui/legacy/calendar/CalendarCell.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/CalendarCell.tsx
@@ -55,7 +55,8 @@ const CalendarCell = ({ date, hour }: CalendarCellProps) => {
       .minute(midHour ? 30 : 0)
       .second(0)
       .millisecond(0);
-    addEmptyEvent(newDate.toDate());
+    const correctDate = newDate.add(1, 'day');
+    addEmptyEvent(correctDate.toDate());
   };
 
   // Round to 15 minute intervals

--- a/packages/ui/src/hooks/use-calendar.tsx
+++ b/packages/ui/src/hooks/use-calendar.tsx
@@ -572,10 +572,9 @@ export const CalendarProvider = ({
     (date: Date) => {
       // TOD0: Fix this weird workaround in the future
       const selectedDate = dayjs(date);
-      const correctDate = selectedDate.add(1, 'day');
 
       // Round to nearest 15-minute interval
-      const start_at = roundToNearest15Minutes(correctDate.toDate());
+      const start_at = roundToNearest15Minutes(selectedDate.toDate());
       const end_at = new Date(start_at);
 
       // Use default task duration from settings if available


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted event creation logic in the calendar to ensure new events are scheduled at the correct date and time, eliminating unintended one-day offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->