### PR TITLE
fix (FAQ Translation)(Upskii): translation not displayed

### DIFF
--- a/apps/upskii/messages/vi.json
+++ b/apps/upskii/messages/vi.json
@@ -1083,6 +1083,7 @@
       }
     },
     "faq": {
+      "badge": "Câu Hỏi Thường Gặp",
       "title": "Câu Hỏi Thường Gặp",
       "subtitle": "Tìm câu trả lời cho những câu hỏi phổ biến nhất về nền tảng giáo dục của chúng tôi.",
       "still-have-questions": "Vẫn còn thắc mắc?",

--- a/apps/upskii/src/app/[locale]/(marketing)/faq/page.tsx
+++ b/apps/upskii/src/app/[locale]/(marketing)/faq/page.tsx
@@ -117,7 +117,7 @@ export default function FAQPage() {
             {t('title')}
           </h1>
           <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
-            {t('description')}
+            {t('subtitle')}
           </p>
         </motion.div>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a badge label for the FAQ section in the Vietnamese language.

- **Style**
  - Updated the subtitle text displayed on the FAQ page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->