### PR TITLE
feat: add keyboard shortcuts to switch calendar views (d, 4, w, m)

### DIFF
--- a/packages/ui/src/components/ui/legacy/calendar/calendar-content.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/calendar-content.tsx
@@ -342,6 +342,37 @@ export const CalendarContent = ({
     return () => window.removeEventListener('resize', handleResize);
   }, [enableDayView, enableWeekView, view]);
 
+  // Keyboard shortcut to change view
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      ) {
+        return; 
+        // Ignore if typing in a form field
+      }
+
+      switch (e.key.toLowerCase()) {
+        case 'd':
+          enableDayView();
+          break;
+        case '4':
+          enable4DayView();
+          break;
+        case 'w':
+          enableWeekView();
+          break;
+        case 'm':
+          enableMonthView();
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [enableDayView, enable4DayView, enableWeekView, enableMonthView]);
+
   if (!initialized || !view || !dates.length) return null;
 
   return (


### PR DESCRIPTION
Added global keyboard shortcuts for quickly switching between calendar views:
- Press "d" to switch to Day view
- Press "4" to switch to 4-Days view
- Press "w" to switch to Week view
- Press "m" to switch to Month view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added keyboard shortcuts for switching calendar views using the 'd', '4', 'w', and 'm' keys. These shortcuts allow users to quickly change between day, 4-day, week, and month views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->