### PR TITLE
Fix translations for row actions (courses, modules)

### DIFF
--- a/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/courses/[courseId]/row-actions.tsx
+++ b/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/courses/[courseId]/row-actions.tsx
@@ -93,8 +93,8 @@ export function WorkspaceCourseModuleRowActions({
       <ModifiableDialogTrigger
         data={data}
         open={showEditDialog}
-        title={t('ws-flashcards.edit')}
-        editDescription={t('ws-flashcards.edit_description')}
+        title={t('ws-course-modules.edit')}
+        editDescription={t('ws-course-modules.edit_description')}
         setOpen={setShowEditDialog}
         form={
           <WorkspaceCourseModuleForm

--- a/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/courses/row-actions.tsx
+++ b/apps/upskii/src/app/[locale]/(dashboard)/[wsId]/courses/row-actions.tsx
@@ -98,8 +98,8 @@ export function WorkspaceCourseRowActions({
       <ModifiableDialogTrigger
         data={data}
         open={showEditDialog}
-        title={t('ws-flashcards.edit')}
-        editDescription={t('ws-flashcards.edit_description')}
+        title={t('ws-courses.edit')}
+        editDescription={t('ws-courses.edit_description')}
         setOpen={setShowEditDialog}
         form={
           <WorkspaceCourseForm


### PR DESCRIPTION
Courses and Modules Edit dialog currently using flashcards titles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated translation keys for editing course and course module dialogs to improve language consistency. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->