### PR TITLE
Downgrade default model to gemini-2.0-flash-lite-preview-02-05

### DIFF
--- a/apps/nova/src/constants/configs.ts
+++ b/apps/nova/src/constants/configs.ts
@@ -59,5 +59,5 @@ export const appConfig: AppConfig = {
     privateKeyId: process.env.GOOGLE_VERTEX_PRIVATE_KEY_ID,
     credentials: process.env.GOOGLE_APPLICATION_CREDENTIALS,
   },
-  defaultModel: process.env.DEFAULT_AI_MODEL || 'gemini-2.0-flash-001',
+  defaultModel: process.env.DEFAULT_AI_MODEL || 'gemini-2.0-flash-lite-preview-02-05',
 };


### PR DESCRIPTION
downgrade the AI model from
  defaultModel: process.env.DEFAULT_AI_MODEL || 'gemini-2.0-flash-001',
to
defaultModel: process.env.DEFAULT_AI_MODEL || 'gemini-2.0-flash-lite-preview-02-05'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the default AI model to a newer version for improved performance when no custom model is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->