### PR TITLE
Add translations to workspace invitation page

### DIFF
--- a/apps/upskii/src/components/notifications/WorkspaceInviteSnippet.tsx
+++ b/apps/upskii/src/components/notifications/WorkspaceInviteSnippet.tsx
@@ -87,7 +87,10 @@ const WorkspaceInviteSnippet = ({ ws, transparent = true }: Props) => {
     >
       <div className="cursor-default font-semibold transition duration-150">
         <span className="text-foreground/60">{invitedTo} </span>
-        <Link href={`/${ws.id}`} className="text-foreground hover:underline">
+        <Link
+          href={`/${ws.id}/home`}
+          className="text-foreground hover:underline"
+        >
           {ws?.name || `Unnamed Workspace`}
         </Link>
         {ws?.created_at ? (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- All workspace invitation notifications now support multiple languages, displaying text according to your selected locale.
	- Workspace invitation links now direct you to the workspace home page for quicker access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->