### PR TITLE
Add reauthentication feature for password change

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit",
-    "source.organizeImports": "always"
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
@@ -13,18 +12,8 @@
     "**/components/**/index.tsx": "${dirname} - Component"
   },
   "tailwindCSS.experimental.configFile": "packages/ui/src/globals.css",
-  "i18n-ally.enabledFrameworks": ["next-intl"],
-  "i18n-ally.localesPaths": [
-    "apps/calendar/messages",
-    "apps/web/messages",
-    "apps/rewise/messages",
-    "apps/nova/messages",
-    "apps/upskii/messages"
-  ],
-  "i18n-ally.autoDetection": true,
-  "i18n-ally.keystyle": "nested",
   "[xml]": {
-    "editor.defaultFormatter": "redhat.vscode-xml"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
@@ -44,11 +33,5 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "codeQL.githubDatabase.update": "never",
-  "codeQL.githubDatabase.download": "never",
-  "IDX.aI.enableInlineCompletion": true,
-  "IDX.aI.enableCodebaseIndexing": true,
-  "i18n-ally.sourceLanguage": "en",
-  "typescript.experimental.useTsgo": false,
-  "cSpell.words": ["tuturuuu"]
+  "typescript.experimental.useTsgo": false
 }

--- a/apps/calendar/messages/en.json
+++ b/apps/calendar/messages/en.json
@@ -1672,7 +1672,7 @@
     "logout-description": "Log out of your account.",
     "confirm-account-deletion": "Confirm account deletion",
     "change-password": "Change password",
-    "change-password-description": "Change your pasword",
+    "change-password-description": "Change your password",
     "delete-account": "Delete account",
     "delete-account-description": "Delete your account",
     "delete-account-message": "This will permanently delete your account and cannot be undone. Type your email address to confirm deletion.",

--- a/apps/db/supabase/config.toml
+++ b/apps/db/supabase/config.toml
@@ -97,6 +97,8 @@ enable_signup = true
 # If enabled, a user will be required to confirm any email change on both the old, and new email
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
+# If enabled, requires the user's current password to be provided when changing to a new password.
+secure_password_change = true
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = true
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.

--- a/apps/famigo/messages/en.json
+++ b/apps/famigo/messages/en.json
@@ -2320,7 +2320,7 @@
     "logout-description": "Log out of your account.",
     "confirm-account-deletion": "Confirm account deletion",
     "change-password": "Change password",
-    "change-password-description": "Change your pasword",
+    "change-password-description": "Change your password",
     "delete-account": "Delete account",
     "delete-account-description": "Delete your account",
     "delete-account-message": "This will permanently delete your account and cannot be undone. Type your email address to confirm deletion.",

--- a/apps/nova/messages/en.json
+++ b/apps/nova/messages/en.json
@@ -2392,7 +2392,7 @@
     "logout-description": "Log out of your account.",
     "confirm-account-deletion": "Confirm account deletion",
     "change-password": "Change password",
-    "change-password-description": "Change your pasword",
+    "change-password-description": "Change your password",
     "delete-account": "Delete account",
     "delete-account-description": "Delete your account",
     "delete-account-message": "This will permanently delete your account and cannot be undone. Type your email address to confirm deletion.",

--- a/apps/rewise/messages/en.json
+++ b/apps/rewise/messages/en.json
@@ -1356,7 +1356,7 @@
     "logout-description": "Log out of your account.",
     "confirm-account-deletion": "Confirm account deletion",
     "change-password": "Change password",
-    "change-password-description": "Change your pasword",
+    "change-password-description": "Change your password",
     "delete-account": "Delete account",
     "delete-account-description": "Delete your account",
     "delete-account-message": "This will permanently delete your account and cannot be undone. Type your email address to confirm deletion."

--- a/apps/upskii/messages/en.json
+++ b/apps/upskii/messages/en.json
@@ -2901,7 +2901,7 @@
     "logout-description": "Log out of your account.",
     "confirm-account-deletion": "Confirm account deletion",
     "change-password": "Change password",
-    "change-password-description": "Change your pasword",
+    "change-password-description": "Change your password",
     "delete-account": "Delete account",
     "delete-account-description": "Delete your account",
     "delete-account-message": "This will permanently delete your account and cannot be undone. Type your email address to confirm deletion.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1718,7 +1718,7 @@
     "logout-description": "Log out of your account.",
     "confirm-account-deletion": "Confirm account deletion",
     "change-password": "Change password",
-    "change-password-description": "Change your pasword",
+    "change-password-description": "Change your password",
     "delete-account": "Delete account",
     "delete-account-description": "Delete your account",
     "delete-account-message": "This will permanently delete your account and cannot be undone. Type your email address to confirm deletion.",

--- a/apps/web/src/app/[locale]/(dashboard)/settings/account/components/security-settings-card.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/account/components/security-settings-card.tsx
@@ -1,4 +1,4 @@
-import ResetPasswordForm from '../reset-password-form';
+import ResetPasswordDialog from '../reset-password-dialog';
 import type { WorkspaceUser } from '@tuturuuu/types/primitives/WorkspaceUser';
 import {
   Card,
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@tuturuuu/ui/card';
+import { SettingItemTab } from '@tuturuuu/ui/custom/settings-item-tab';
 import { Shield } from '@tuturuuu/ui/icons';
 import { getTranslations } from 'next-intl/server';
 
@@ -37,7 +38,12 @@ export default async function SecuritySettingsCard({
         </div>
       </CardHeader>
       <CardContent className="p-6">
-        <ResetPasswordForm user={user} />
+        <SettingItemTab
+          title={t('change-password')}
+          description={t('change-password-description')}
+        >
+          <ResetPasswordDialog user={user} />
+        </SettingItemTab>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/app/[locale]/(dashboard)/settings/account/reauthenticate-form.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/account/reauthenticate-form.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { Button } from '@tuturuuu/ui/button';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@tuturuuu/ui/form';
+import { useForm } from '@tuturuuu/ui/hooks/use-form';
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@tuturuuu/ui/input-otp';
+import { zodResolver } from '@tuturuuu/ui/resolvers';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+import * as z from 'zod';
+
+const formSchema = z.object({
+  otp: z.string().min(6, {
+    message: 'OTP must be 6 digits',
+  }),
+});
+
+export type ReauthenticateFormData = z.infer<typeof formSchema>;
+
+export default function ReauthenticateForm({
+  onSubmit,
+  onResend,
+  loading,
+}: {
+  onSubmit: (data: ReauthenticateFormData) => Promise<void>;
+  onResend: () => Promise<void>;
+  loading: boolean;
+}) {
+  const t = useTranslations();
+  const [resendCooldown, setResendCooldown] = useState(0);
+
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      otp: '',
+    },
+  });
+
+  const handleResend = async () => {
+    await onResend();
+    setResendCooldown(60);
+
+    // Countdown timer
+    const timer = setInterval(() => {
+      setResendCooldown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground">
+            For security, please enter the verification code sent to your email
+            to continue with the password change.
+          </p>
+        </div>
+
+        <FormField
+          control={form.control}
+          name="otp"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('login.verification_code')}</FormLabel>
+              <FormControl>
+                <div className="flex justify-center">
+                  <InputOTP
+                    maxLength={6}
+                    {...field}
+                    onChange={(value) => {
+                      form.setValue('otp', value);
+                      if (value.length === 6) {
+                        form.handleSubmit(onSubmit)();
+                      }
+                    }}
+                    disabled={loading}
+                  >
+                    <InputOTPGroup>
+                      {Array.from({ length: 6 }).map((_, index) => (
+                        <InputOTPSlot key={index} index={index} />
+                      ))}
+                    </InputOTPGroup>
+                  </InputOTP>
+                </div>
+              </FormControl>
+              <FormDescription className="text-center">
+                Enter the 6-digit code sent to your email
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex flex-col gap-2">
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={loading || form.watch('otp').length < 6}
+          >
+            {loading ? 'Verifying...' : 'Verify Code'}
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={handleResend}
+            disabled={loading || resendCooldown > 0}
+          >
+            {resendCooldown > 0
+              ? `Resend Code (${resendCooldown}s)`
+              : 'Resend Code'}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/apps/web/src/app/[locale]/(dashboard)/settings/account/reset-password-dialog.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/account/reset-password-dialog.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import ReauthenticateForm, {
+  type ReauthenticateFormData,
+} from './reauthenticate-form';
+import ResetPasswordForm, {
+  type ResetPasswordFormData,
+} from './reset-password-form';
+import { createClient } from '@tuturuuu/supabase/next/client';
+import type { WorkspaceUser } from '@tuturuuu/types/primitives/WorkspaceUser';
+import { Button } from '@tuturuuu/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@tuturuuu/ui/dialog';
+import { toast } from '@tuturuuu/ui/hooks/use-toast';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+export default function ResetPasswordDialog({
+  user,
+}: {
+  user: WorkspaceUser | null;
+}) {
+  const t = useTranslations();
+
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [needsReauth, setNeedsReauth] = useState(false);
+  const [passwordData, setPasswordData] =
+    useState<ResetPasswordFormData | null>(null);
+
+  const onSubmit = async (data: ResetPasswordFormData) => {
+    if (!user?.email) return;
+
+    setLoading(true);
+    try {
+      const supabase = createClient();
+
+      const { error } = await supabase.auth.updateUser({
+        password: data.password,
+      });
+
+      if (error) {
+        // Check if reauthentication is needed
+        if (
+          error.message.includes('reauthentication_needed') ||
+          error.message.includes('reauthentication') ||
+          error.code === 'reauthentication_needed'
+        ) {
+          // Store password data and trigger reauthentication flow
+          setPasswordData(data);
+
+          // Send reauthentication OTP
+          const { error: reauthError } = await supabase.auth.reauthenticate();
+
+          if (reauthError) {
+            throw reauthError;
+          }
+
+          setNeedsReauth(true);
+          toast({
+            title: 'Verification Required',
+            description:
+              "For security, we've sent a verification code to your email. Please enter it to continue.",
+          });
+
+          setLoading(false);
+          return;
+        }
+
+        throw error;
+      }
+
+      toast({
+        title: t('common.success'),
+        description: 'Password has been updated successfully.',
+      });
+
+      // Close the dialog
+      setOpen(false);
+    } catch (error) {
+      console.error('Error resetting password:', error);
+      toast({
+        title: t('common.error'),
+        description:
+          'An error occurred while resetting your password. Please try again later.',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onReauthSubmit = async (data: ReauthenticateFormData) => {
+    if (!passwordData) return;
+
+    setLoading(true);
+    try {
+      const supabase = createClient();
+
+      const { error } = await supabase.auth.updateUser({
+        password: passwordData.password,
+        nonce: data.otp,
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      toast({
+        title: t('common.success'),
+        description: 'Password has been updated successfully.',
+      });
+
+      // Reset state and close the dialog
+      setNeedsReauth(false);
+      setPasswordData(null);
+      setOpen(false);
+    } catch (error) {
+      console.error('Error updating password with nonce:', error);
+      toast({
+        title: t('common.error'),
+        description:
+          'Invalid verification code or an error occurred. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onResendReauth = async () => {
+    try {
+      const supabase = createClient();
+
+      const { error } = await supabase.auth.reauthenticate();
+
+      if (error) {
+        throw error;
+      }
+
+      toast({
+        title: t('common.success'),
+        description: 'Verification code has been resent to your email.',
+      });
+    } catch (error) {
+      console.error('Error resending reauthentication code:', error);
+      toast({
+        title: t('common.error'),
+        description: 'Failed to resend verification code. Please try again.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button className="w-full">
+          {t('settings-account.reset-password')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {needsReauth
+              ? 'Verify Your Identity'
+              : t('reset-password.reset-password')}
+          </DialogTitle>
+        </DialogHeader>
+
+        {needsReauth ? (
+          <ReauthenticateForm
+            onSubmit={onReauthSubmit}
+            onResend={onResendReauth}
+            loading={loading}
+          />
+        ) : (
+          <ResetPasswordForm onSubmit={onSubmit} loading={loading} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/[locale]/(dashboard)/settings/account/reset-password-form.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/account/reset-password-form.tsx
@@ -1,17 +1,7 @@
 'use client';
 
-import { createClient } from '@tuturuuu/supabase/next/client';
-import type { WorkspaceUser } from '@tuturuuu/types/primitives/WorkspaceUser';
 import { Button } from '@tuturuuu/ui/button';
 import { LoadingIndicator } from '@tuturuuu/ui/custom/loading-indicator';
-import { SettingItemTab } from '@tuturuuu/ui/custom/settings-item-tab';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@tuturuuu/ui/dialog';
 import {
   Form,
   FormControl,
@@ -21,20 +11,27 @@ import {
   FormMessage,
 } from '@tuturuuu/ui/form';
 import { useForm } from '@tuturuuu/ui/hooks/use-form';
-import { toast } from '@tuturuuu/ui/hooks/use-toast';
 import { Eye, EyeOff, Lock } from '@tuturuuu/ui/icons';
 import { Input } from '@tuturuuu/ui/input';
 import { zodResolver } from '@tuturuuu/ui/resolvers';
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import * as z from 'zod';
 
 const formSchema = z
   .object({
-    password: z.string().min(8, {
-      message: 'Password must be at least 8 characters',
-    }),
+    password: z
+      .string()
+      .min(8, {
+        message: 'Password must be at least 8 characters',
+      })
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/,
+        {
+          message:
+            'Password must contain at least one lowercase letter, one uppercase letter, one number, and one special character',
+        }
+      ),
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -42,16 +39,17 @@ const formSchema = z
     path: ['confirmPassword'],
   });
 
+export type ResetPasswordFormData = z.infer<typeof formSchema>;
+
 export default function ResetPasswordForm({
-  user,
+  onSubmit,
+  loading,
 }: {
-  user: WorkspaceUser | null;
+  onSubmit: (data: ResetPasswordFormData) => Promise<void>;
+  loading: boolean;
 }) {
   const t = useTranslations();
-  const router = useRouter();
 
-  const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
@@ -63,153 +61,90 @@ export default function ResetPasswordForm({
     },
   });
 
-  const onSubmit = async (data: z.infer<typeof formSchema>) => {
-    if (!user?.email) return;
-
-    setLoading(true);
-    try {
-      const supabase = createClient();
-
-      const { error } = await supabase.auth.updateUser({
-        password: data.password,
-      });
-
-      if (error) {
-        throw error;
-      }
-
-      toast({
-        title: t('common.success'),
-        description:
-          'Password has been updated successfully. You can now log in with your new password.',
-      });
-
-      // Close the dialog
-      setOpen(false);
-
-      await supabase.auth.signOut();
-      router.push('/login?passwordless=false');
-      router.refresh();
-
-      // Reset the form
-      form.reset();
-    } catch (error) {
-      console.error('Error resetting password:', error);
-      toast({
-        title: t('common.error'),
-        description:
-          'An error occurred while resetting your password. Please try again later.',
-        variant: 'destructive',
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
-    <SettingItemTab
-      title={t('settings-account.change-password')}
-      description={t('settings-account.change-password-description')}
-    >
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>
-          <Button className="w-full">
-            {t('settings-account.reset-password')}
-          </Button>
-        </DialogTrigger>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('reset-password.reset-password')}</DialogTitle>
-          </DialogHeader>
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('login.password')}</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <Lock className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    className="pr-10 pl-10"
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder="Enter new password"
+                    {...field}
+                    disabled={loading}
+                  />
+                  <button
+                    tabIndex={-1}
+                    type="button"
+                    className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground"
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="size-4" />
+                    ) : (
+                      <Eye className="size-4" />
+                    )}
+                  </button>
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-              <FormField
-                control={form.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('login.password')}</FormLabel>
-                    <FormControl>
-                      <div className="relative">
-                        <Lock className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-                        <Input
-                          className="pr-10 pl-10"
-                          type={showPassword ? 'text' : 'password'}
-                          placeholder="Enter new password"
-                          {...field}
-                          disabled={loading}
-                        />
-                        <button
-                          tabIndex={-1}
-                          type="button"
-                          className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground"
-                          onClick={() => setShowPassword(!showPassword)}
-                        >
-                          {showPassword ? (
-                            <EyeOff className="size-4" />
-                          ) : (
-                            <Eye className="size-4" />
-                          )}
-                        </button>
-                      </div>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Confirm Password</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <Lock className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    className="pr-10 pl-10"
+                    type={showConfirmPassword ? 'text' : 'password'}
+                    placeholder="Confirm your password"
+                    {...field}
+                    disabled={loading}
+                  />
+                  <button
+                    tabIndex={-1}
+                    type="button"
+                    className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className="size-4" />
+                    ) : (
+                      <Eye className="size-4" />
+                    )}
+                  </button>
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
-              <FormField
-                control={form.control}
-                name="confirmPassword"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Confirm Password</FormLabel>
-                    <FormControl>
-                      <div className="relative">
-                        <Lock className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-                        <Input
-                          className="pr-10 pl-10"
-                          type={showConfirmPassword ? 'text' : 'password'}
-                          placeholder="Confirm your password"
-                          {...field}
-                          disabled={loading}
-                        />
-                        <button
-                          tabIndex={-1}
-                          type="button"
-                          className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground"
-                          onClick={() =>
-                            setShowConfirmPassword(!showConfirmPassword)
-                          }
-                        >
-                          {showConfirmPassword ? (
-                            <EyeOff className="size-4" />
-                          ) : (
-                            <Eye className="size-4" />
-                          )}
-                        </button>
-                      </div>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? (
-                  <>
-                    <LoadingIndicator className="mr-2 h-4 w-4" />
-                    {t('reset-password.resetting')}
-                  </>
-                ) : (
-                  t('reset-password.reset-password')
-                )}
-              </Button>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-    </SettingItemTab>
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? (
+            <>
+              <LoadingIndicator className="mr-2 h-4 w-4" />
+              {t('reset-password.resetting')}
+            </>
+          ) : (
+            t('reset-password.reset-password')
+          )}
+        </Button>
+      </form>
+    </Form>
   );
 }


### PR DESCRIPTION
This should be done via OTP confirmation only when users are logged in for more than 24 hours upon changing the password. The email template sending OTP could be customized in production database as its option might not be available in local development one.