### PR TITLE
(Background sync) Change to 10 mins cron temporarily 

### DIFF
--- a/packages/trigger/google-calendar-background-sync.ts
+++ b/packages/trigger/google-calendar-background-sync.ts
@@ -6,7 +6,7 @@ export const googleCalendarBackgroundSync = schedules.task({
   id: 'google-calendar-background-sync',
   cron: {
     // every minute
-    pattern: '* * * * *',
+    pattern: '*/10 * * * *',
   },
   run: async () => {
     await syncGoogleCalendarEvents();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the schedule for Google Calendar background sync to run every 10 minutes instead of every minute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->