### PR TITLE
(Background sync) Remove utc() as not imported

### DIFF
--- a/packages/trigger/google-calendar-sync.ts
+++ b/packages/trigger/google-calendar-sync.ts
@@ -162,7 +162,7 @@ export const syncGoogleCalendarEvents = async () => {
       try {
         const calendar = google.calendar({ version: 'v3', auth });
 
-        const now = dayjs().utc();
+        const now = dayjs();
         const timeMin = now.toDate();
         const timeMax = now.add(BACKGROUND_SYNC_RANGE, 'day');
 


### PR DESCRIPTION
Please merge this commit but avoid deploying as there is no improvements on the efficiency. I just fixed the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved time zone handling for Google Calendar event synchronization to use local time instead of UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->