### PR TITLE
Potential fix for code scanning alert no. 103: Incomplete multi-character sanitization

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "@octokit/rest": "^22.0.0",
     "@tanstack/react-query": "^5.81.5",
     "@tanstack/react-table": "^8.21.3",
+    "@testing-library/jest-dom": "^6.6.3",
     "@tldraw/sync": "^3.13.4",
     "@trpc/client": "^11.4.3",
     "@trpc/react-query": "^11.4.3",
@@ -89,6 +90,7 @@
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "sanitize-html": "^2.17.0",
     "server-only": "^0.0.1",
     "sharp": "^0.34.2",
     "swr": "^2.3.3",
@@ -96,8 +98,7 @@
     "use-debounce": "^10.0.5",
     "uuid": "^11.1.0",
     "xlsx": "file:vendor/xlsx-0.20.3.tgz",
-    "zod": "^3.25.67",
-    "sanitize-html": "^2.17.0"
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "15.3.4",
@@ -112,6 +113,7 @@
     "@types/papaparse": "^5.3.16",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/sanitize-html": "^2.16.0",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.6.0",
     "autoprefixer": "^10.4.21",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -96,7 +96,8 @@
     "use-debounce": "^10.0.5",
     "uuid": "^11.1.0",
     "xlsx": "file:vendor/xlsx-0.20.3.tgz",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "15.3.4",

--- a/apps/web/src/__tests__/mail-display-sanitization.test.tsx
+++ b/apps/web/src/__tests__/mail-display-sanitization.test.tsx
@@ -1,0 +1,748 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MailDisplay } from '../app/[locale]/(dashboard)/[wsId]/mail/_components/mail-display';
+import type { Mail } from '../app/[locale]/(dashboard)/[wsId]/mail/client';
+import '@testing-library/jest-dom/vitest';
+
+// Mock next-intl
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+}));
+
+// Mock dayjs
+vi.mock('dayjs', () => {
+  const mockDayjs = Object.assign(
+    vi.fn(() => ({
+      locale: vi.fn().mockReturnThis(),
+      format: vi.fn().mockReturnValue('January 1, 2024 12:00 AM'),
+    })),
+    {
+      extend: vi.fn(),
+      locale: vi.fn(),
+    }
+  );
+  return { default: mockDayjs };
+});
+
+// Mock dayjs plugins
+vi.mock('dayjs/locale/vi', () => ({}));
+vi.mock('dayjs/plugin/localizedFormat', () => ({ default: vi.fn() }));
+vi.mock('dayjs/plugin/relativeTime', () => ({ default: vi.fn() }));
+
+// Mock DOMPurify
+const mockDOMPurify = {
+  sanitize: vi.fn(),
+};
+
+// Mock sanitize-html
+const mockSanitizeHtml = vi.fn();
+
+// Setup dynamic imports
+vi.mock('dompurify', () => ({
+  default: mockDOMPurify,
+}));
+
+vi.mock('sanitize-html', () => ({
+  default: mockSanitizeHtml,
+}));
+
+describe('MailDisplay - HTML Sanitization', () => {
+  const createMockMail = (overrides: Partial<Mail> = {}): Mail => ({
+    id: '1',
+    name: 'John Doe',
+    email: 'john@example.com',
+    recipient: 'jane@example.com',
+    subject: 'Test Subject',
+    text: '<p>Test content</p>',
+    date: '2024-01-01T12:00:00Z',
+    read: false,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDOMPurify.sanitize.mockReturnValue('<p>Sanitized content</p>');
+    mockSanitizeHtml.mockReturnValue('<p>Fallback sanitized content</p>');
+  });
+
+  describe('HTML Sanitization', () => {
+    it('should sanitize HTML content using DOMPurify', async () => {
+      const mailWithHtml = createMockMail({
+        text: '<p>Hello <script>alert("xss")</script>World</p>',
+      });
+
+      mockDOMPurify.sanitize.mockReturnValue('<p>Hello World</p>');
+
+      render(<MailDisplay mail={mailWithHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(
+          '<p>Hello <script>alert("xss")</script>World</p>'
+        );
+      });
+
+      expect(screen.queryByText('loading_email_content')).toBeNull();
+    });
+
+    it('should fall back to sanitize-html when DOMPurify fails', async () => {
+      const mailWithHtml = createMockMail({
+        text: '<p>Content with potential issues</p>',
+      });
+
+      // Make DOMPurify throw an error
+      mockDOMPurify.sanitize.mockImplementation(() => {
+        throw new Error('DOMPurify failed');
+      });
+
+      mockSanitizeHtml.mockReturnValue('<p>Content with potential issues</p>');
+
+      render(<MailDisplay mail={mailWithHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalled();
+        expect(mockSanitizeHtml).toHaveBeenCalledWith(
+          '<p>Content with potential issues</p>'
+        );
+      });
+    });
+
+    it('should handle various types of malicious HTML', async () => {
+      const maliciousHtml = `
+        <p>Normal content</p>
+        <script>alert('xss')</script>
+        <img src="x" onerror="alert('xss')">
+        <a href="javascript:alert('xss')">Click me</a>
+        <iframe src="javascript:alert('xss')"></iframe>
+        <object data="javascript:alert('xss')"></object>
+      `;
+
+      const mailWithMaliciousHtml = createMockMail({
+        text: maliciousHtml,
+      });
+
+      const sanitizedHtml = '<p>Normal content</p><a>Click me</a>';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedHtml);
+
+      render(<MailDisplay mail={mailWithMaliciousHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(maliciousHtml);
+      });
+
+      // Verify loading state is gone
+      expect(screen.queryByText('loading_email_content')).toBeNull();
+    });
+
+    it('should handle HTML with style attributes and CSS injection attempts', async () => {
+      const htmlWithStyles = `
+        <p style="color: red; background: url(javascript:alert('xss'))">Styled text</p>
+        <div style="expression(alert('xss'))">IE specific attack</div>
+        <span style="color: blue;">Safe styling</span>
+      `;
+
+      const mailWithStyledHtml = createMockMail({
+        text: htmlWithStyles,
+      });
+
+      const sanitizedHtml = '<p style="color: red;">Styled text</p><span style="color: blue;">Safe styling</span>';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedHtml);
+
+      render(<MailDisplay mail={mailWithStyledHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithStyles);
+      });
+    });
+
+    it('should handle empty or null content gracefully', async () => {
+      const mailWithEmptyText = createMockMail({
+        text: '',
+      });
+
+      render(<MailDisplay mail={mailWithEmptyText} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).not.toHaveBeenCalled();
+        expect(mockSanitizeHtml).not.toHaveBeenCalled();
+      });
+
+      expect(screen.queryByText('loading_email_content')).toBeNull();
+    });
+
+    it('should handle null mail gracefully', () => {
+      render(<MailDisplay mail={null} />);
+
+      expect(screen.getByText('no_email_selected')).toBeDefined();
+      expect(screen.getByText('choose_email_message')).toBeDefined();
+      expect(mockDOMPurify.sanitize).not.toHaveBeenCalled();
+      expect(mockSanitizeHtml).not.toHaveBeenCalled();
+    });
+
+    it('should preserve safe HTML formatting', async () => {
+      const safeHtml = `
+        <h1>Email Subject</h1>
+        <p>This is a <strong>bold</strong> and <em>italic</em> text.</p>
+        <ul>
+          <li>List item 1</li>
+          <li>List item 2</li>
+        </ul>
+        <blockquote>This is a quote</blockquote>
+        <code>console.log('code')</code>
+      `;
+
+      const mailWithSafeHtml = createMockMail({
+        text: safeHtml,
+      });
+
+      mockDOMPurify.sanitize.mockReturnValue(safeHtml);
+
+      render(<MailDisplay mail={mailWithSafeHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(safeHtml);
+      });
+    });
+
+    it('should handle complex nested HTML structures', async () => {
+      const complexHtml = `
+        <div class="email-content">
+          <table>
+            <tr>
+              <td>
+                <div>
+                  <p>Nested <span>content</span> with <a href="https://example.com">links</a></p>
+                  <img src="https://example.com/image.jpg" alt="Test image">
+                </div>
+              </td>
+            </tr>
+          </table>
+        </div>
+      `;
+
+      const mailWithComplexHtml = createMockMail({
+        text: complexHtml,
+      });
+
+      const sanitizedComplexHtml = `
+        <div>
+          <table>
+            <tr>
+              <td>
+                <div>
+                  <p>Nested <span>content</span> with <a href="https://example.com">links</a></p>
+                  <img src="https://example.com/image.jpg" alt="Test image">
+                </div>
+              </td>
+            </tr>
+          </table>
+        </div>
+      `;
+
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedComplexHtml);
+
+      render(<MailDisplay mail={mailWithComplexHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(complexHtml);
+      });
+    });
+
+    it('should display loading state while sanitizing', () => {
+      const mailWithHtml = createMockMail({
+        text: '<p>Content being sanitized</p>',
+      });
+
+      render(<MailDisplay mail={mailWithHtml} />);
+
+      // Initially should show loading
+      expect(screen.getByText('loading_email_content')).toBeDefined();
+    });
+
+    it('should handle URLs with potential XSS in href attributes', async () => {
+      const htmlWithMaliciousUrls = `
+        <a href="javascript:alert('xss')">Malicious link</a>
+        <a href="data:text/html,<script>alert('xss')</script>">Data URL attack</a>
+        <a href="https://example.com">Safe link</a>
+        <form action="javascript:alert('xss')">
+          <input type="submit" value="Submit">
+        </form>
+      `;
+
+      const mailWithMaliciousUrls = createMockMail({
+        text: htmlWithMaliciousUrls,
+      });
+
+      const sanitizedUrls = '<a>Malicious link</a><a>Data URL attack</a><a href="https://example.com">Safe link</a>';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedUrls);
+
+      render(<MailDisplay mail={mailWithMaliciousUrls} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithMaliciousUrls);
+      });
+    });
+
+    it('should handle SVG with potential script injection', async () => {
+      const htmlWithSvg = `
+        <svg>
+          <script>alert('xss')</script>
+          <circle cx="50" cy="50" r="40" stroke="black" fill="red" />
+        </svg>
+        <svg onload="alert('xss')">
+          <rect width="100" height="100" />
+        </svg>
+      `;
+
+      const mailWithSvg = createMockMail({
+        text: htmlWithSvg,
+      });
+
+      const sanitizedSvg = `
+        <svg>
+          <circle cx="50" cy="50" r="40" stroke="black" fill="red" />
+        </svg>
+        <svg>
+          <rect width="100" height="100" />
+        </svg>
+      `;
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedSvg);
+
+      render(<MailDisplay mail={mailWithSvg} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithSvg);
+      });
+    });
+
+    it('should handle both DOMPurify and sanitize-html failures gracefully', async () => {
+      const mailWithHtml = createMockMail({
+        text: '<p>Content that causes both sanitizers to fail</p>',
+      });
+
+      // Make both sanitizers fail
+      mockDOMPurify.sanitize.mockImplementation(() => {
+        throw new Error('DOMPurify failed');
+      });
+
+      mockSanitizeHtml.mockImplementation(() => {
+        throw new Error('sanitize-html failed');
+      });
+
+      // Suppress console.error for this test
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      render(<MailDisplay mail={mailWithHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalled();
+      });
+
+      // Wait for the fallback attempt
+      await waitFor(() => {
+        expect(mockSanitizeHtml).toHaveBeenCalled();
+      });
+
+      // Should log the error
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to sanitize HTML:', expect.any(Error));
+      });
+
+      // Should not crash and should finish loading
+      await waitFor(() => {
+        expect(screen.queryByText('loading_email_content')).toBeNull();
+      });
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Advanced Security Scenarios', () => {
+    it('should handle HTML entities that could decode to malicious content', async () => {
+      const htmlWithEntities = `
+        &lt;script&gt;alert('xss')&lt;/script&gt;
+        &#60;img src=x onerror=alert('xss')&#62;
+        &#x3C;iframe src=javascript:alert('xss')&#x3E;
+        <p>Normal &amp; safe content</p>
+      `;
+
+      const mailWithEntities = createMockMail({
+        text: htmlWithEntities,
+      });
+
+      const sanitizedEntities = '<p>Normal &amp; safe content</p>';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedEntities);
+
+      render(<MailDisplay mail={mailWithEntities} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithEntities);
+      });
+    });
+
+    it('should handle meta refresh redirects and CSP bypass attempts', async () => {
+      const htmlWithMetaRefresh = `
+        <meta http-equiv="refresh" content="0;url=javascript:alert('xss')">
+        <meta http-equiv="refresh" content="0;url=data:text/html,<script>alert('xss')</script>">
+        <meta charset="utf-8">
+        <style>@import "javascript:alert('xss')";</style>
+        <link rel="stylesheet" href="javascript:alert('xss')">
+      `;
+
+      const mailWithMetaRefresh = createMockMail({
+        text: htmlWithMetaRefresh,
+      });
+
+      const sanitizedMeta = '<meta charset="utf-8">';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedMeta);
+
+      render(<MailDisplay mail={mailWithMetaRefresh} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithMetaRefresh);
+      });
+    });
+
+    it('should handle comprehensive event handler injection attempts', async () => {
+      const htmlWithEventHandlers = `
+        <div onclick="alert('xss')" onmouseover="alert('xss')" onload="alert('xss')">
+          <p onmouseout="alert('xss')" onfocus="alert('xss')">Text</p>
+          <img src="valid.jpg" onerror="alert('xss')" onload="alert('xss')">
+          <input type="text" onfocus="alert('xss')" onchange="alert('xss')">
+          <form onsubmit="alert('xss')">
+            <button onclick="alert('xss')">Click</button>
+          </form>
+          <body onload="alert('xss')">
+          <iframe onload="alert('xss')" src="about:blank"></iframe>
+        </div>
+      `;
+
+      const mailWithEventHandlers = createMockMail({
+        text: htmlWithEventHandlers,
+      });
+
+      const sanitizedEventHandlers = `
+        <div>
+          <p>Text</p>
+          <img src="valid.jpg">
+          <input type="text">
+          <form>
+            <button>Click</button>
+          </form>
+          <iframe src="about:blank"></iframe>
+        </div>
+      `;
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedEventHandlers);
+
+      render(<MailDisplay mail={mailWithEventHandlers} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithEventHandlers);
+      });
+    });
+
+    it('should handle base64 encoded malicious content', async () => {
+      const htmlWithBase64 = `
+        <img src="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoJ3hzcycpPjwvc3ZnPg==">
+        <iframe src="data:text/html;base64,PHNjcmlwdD5hbGVydCgneHNzJyk8L3NjcmlwdD4="></iframe>
+        <a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgneHNzJyk8L3NjcmlwdD4=">Click</a>
+        <object data="data:text/html;base64,PHNjcmlwdD5hbGVydCgneHNzJyk8L3NjcmlwdD4="></object>
+      `;
+
+      const mailWithBase64 = createMockMail({
+        text: htmlWithBase64,
+      });
+
+      const sanitizedBase64 = '<a>Click</a>';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedBase64);
+
+      render(<MailDisplay mail={mailWithBase64} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithBase64);
+      });
+    });
+
+    it('should handle CSS injection and expression attacks', async () => {
+      const htmlWithCssInjection = `
+        <style>
+          body { background: url(javascript:alert('xss')); }
+          .evil { behavior: url(evil.htc); }
+          .expression { width: expression(alert('xss')); }
+          @import "javascript:alert('xss')";
+        </style>
+        <div style="background: url('javascript:alert(\\'xss\\')'); behavior: url(evil.htc);">
+          <p style="color: -moz-binding:url(xss.xml#xss);">Text</p>
+        </div>
+      `;
+
+      const mailWithCssInjection = createMockMail({
+        text: htmlWithCssInjection,
+      });
+
+      const sanitizedCss = '<div><p>Text</p></div>';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedCss);
+
+      render(<MailDisplay mail={mailWithCssInjection} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithCssInjection);
+      });
+    });
+
+    it('should handle iframe, object, and embed tag injection', async () => {
+      const htmlWithEmbeds = `
+        <iframe src="javascript:alert('xss')"></iframe>
+        <iframe srcdoc="<script>alert('xss')</script>"></iframe>
+        <object data="javascript:alert('xss')"></object>
+        <object data="data:text/html,<script>alert('xss')</script>"></object>
+        <embed src="javascript:alert('xss')">
+        <embed src="data:text/html,<script>alert('xss')</script>">
+        <applet code="javascript:alert('xss')"></applet>
+      `;
+
+      const mailWithEmbeds = createMockMail({
+        text: htmlWithEmbeds,
+      });
+
+      const sanitizedEmbeds = '';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedEmbeds);
+
+      render(<MailDisplay mail={mailWithEmbeds} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithEmbeds);
+      });
+    });
+
+    it('should handle form injection and redirect attacks', async () => {
+      const htmlWithForms = `
+        <form action="javascript:alert('xss')" method="get">
+          <input type="hidden" name="redirect" value="javascript:alert('xss')">
+          <input type="submit" value="Submit">
+        </form>
+        <form action="data:text/html,<script>alert('xss')</script>">
+          <button formaction="javascript:alert('xss')">Click</button>
+        </form>
+        <input type="image" src="x" formaction="javascript:alert('xss')">
+      `;
+
+      const mailWithForms = createMockMail({
+        text: htmlWithForms,
+      });
+
+      const sanitizedForms = `
+        <form>
+          <input type="hidden" name="redirect">
+          <input type="submit" value="Submit">
+        </form>
+        <form>
+          <button>Click</button>
+        </form>
+        <input type="image" src="x">
+      `;
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedForms);
+
+      render(<MailDisplay mail={mailWithForms} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithForms);
+      });
+    });
+
+    it('should handle Unicode and encoding-based attacks', async () => {
+      const htmlWithUnicode = `
+        <script>alert(\u0027xss\u0027)</script>
+        <img src=\u0078 onerror=\u0061lert(\u0027xss\u0027)>
+        <a href=\u006A\u0061\u0076\u0061\u0073\u0063\u0072\u0069\u0070\u0074:\u0061\u006C\u0065\u0072\u0074(\u0027\u0078\u0073\u0073\u0027)>Link</a>
+        <%2Fscript><%2Fscript>alert('xss')<%2Fscript>
+      `;
+
+      const mailWithUnicode = createMockMail({
+        text: htmlWithUnicode,
+      });
+
+      const sanitizedUnicode = '<a>Link</a>';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedUnicode);
+
+      render(<MailDisplay mail={mailWithUnicode} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithUnicode);
+      });
+    });
+
+    it('should handle large content performance and potential DoS attacks', async () => {
+      // Create a large HTML content that could cause performance issues
+      const largeHtml = `
+        <div>
+          ${'<p>Repeated content</p>'.repeat(1000)}
+          <script>alert('xss')</script>
+          ${'<span>More content</span>'.repeat(1000)}
+        </div>
+      `;
+
+      const mailWithLargeHtml = createMockMail({
+        text: largeHtml,
+      });
+
+      const sanitizedLarge = '<div>' + '<p>Repeated content</p>'.repeat(1000) + '<span>More content</span>'.repeat(1000) + '</div>';
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedLarge);
+
+      render(<MailDisplay mail={mailWithLargeHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(largeHtml);
+      });
+    });
+
+    it('should handle realistic email HTML content with tracking pixels and external resources', async () => {
+      const realisticEmailHtml = `
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <style>
+              .email-content { font-family: Arial, sans-serif; }
+              .header { background: #f0f0f0; padding: 20px; }
+            </style>
+          </head>
+          <body>
+            <div class="email-content">
+              <div class="header">
+                <h1>Newsletter</h1>
+              </div>
+              <p>Dear Customer,</p>
+              <p>Check out our latest offers!</p>
+              <img src="https://example.com/tracking-pixel.gif?user=123" width="1" height="1">
+              <a href="https://example.com/click?id=456">Click here</a>
+              <img src="https://cdn.example.com/images/product.jpg" alt="Product">
+              <table border="0" cellpadding="10">
+                <tr>
+                  <td>Product Name</td>
+                  <td>$99.99</td>
+                </tr>
+              </table>
+            </div>
+          </body>
+        </html>
+      `;
+
+      const mailWithRealisticHtml = createMockMail({
+        text: realisticEmailHtml,
+      });
+
+      const sanitizedRealistic = `
+        <div>
+          <div>
+            <h1>Newsletter</h1>
+          </div>
+          <p>Dear Customer,</p>
+          <p>Check out our latest offers!</p>
+          <img src="https://example.com/tracking-pixel.gif?user=123" width="1" height="1">
+          <a href="https://example.com/click?id=456">Click here</a>
+          <img src="https://cdn.example.com/images/product.jpg" alt="Product">
+          <table border="0" cellpadding="10">
+            <tr>
+              <td>Product Name</td>
+              <td>$99.99</td>
+            </tr>
+          </table>
+        </div>
+      `;
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedRealistic);
+
+      render(<MailDisplay mail={mailWithRealisticHtml} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(realisticEmailHtml);
+      });
+    });
+
+    it('should handle mutation XSS and DOM clobbering attempts', async () => {
+      const htmlWithMutation = `
+        <div id="getElementById"></div>
+        <img name="body">
+        <form name="createElement">
+          <input name="appendChild">
+        </form>
+        <div><div><div><div><div>
+          <script>
+            // This would normally attempt to manipulate the DOM
+            document.getElementById = null;
+          </script>
+        </div></div></div></div></div>
+      `;
+
+      const mailWithMutation = createMockMail({
+        text: htmlWithMutation,
+      });
+
+      const sanitizedMutation = `
+        <div id="getElementById"></div>
+        <img name="body">
+        <form name="createElement">
+          <input name="appendChild">
+        </form>
+        <div><div><div><div><div>
+        </div></div></div></div></div>
+      `;
+      mockDOMPurify.sanitize.mockReturnValue(sanitizedMutation);
+
+      render(<MailDisplay mail={mailWithMutation} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith(htmlWithMutation);
+      });
+    });
+  });
+
+  describe('Component Integration', () => {
+    it('should render mail metadata correctly with sanitized content', async () => {
+      const mail = createMockMail({
+        name: 'Jane Smith',
+        email: 'jane@example.com',
+        recipient: 'john@example.com',
+        subject: 'Important Message',
+        text: '<p>Hello <script>alert("xss")</script>there!</p>',
+      });
+
+      mockDOMPurify.sanitize.mockReturnValue('<p>Hello there!</p>');
+
+      render(<MailDisplay mail={mail} />);
+
+      // Check mail metadata
+      expect(screen.getByText('Jane Smith')).toBeDefined();
+      expect(screen.getByText('Important Message')).toBeDefined();
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalled();
+      });
+    });
+
+    it('should handle mail text changes and re-sanitize', async () => {
+      const initialMail = createMockMail({
+        text: '<p>Initial content</p>',
+      });
+
+      const { rerender } = render(<MailDisplay mail={initialMail} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith('<p>Initial content</p>');
+      });
+
+      // Clear the mock calls
+      mockDOMPurify.sanitize.mockClear();
+
+      // Update with new content
+      const updatedMail = createMockMail({
+        text: '<p>Updated content</p>',
+      });
+
+      rerender(<MailDisplay mail={updatedMail} />);
+
+      await waitFor(() => {
+        expect(mockDOMPurify.sanitize).toHaveBeenCalledWith('<p>Updated content</p>');
+      });
+    });
+  });
+}); 

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/mail/_components/mail-display.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/mail/_components/mail-display.tsx
@@ -68,7 +68,8 @@ export function MailDisplay({ mail }: MailDisplayProps) {
       } catch (error) {
         console.error('Failed to sanitize HTML:', error);
         // Fallback to plain text if DOMPurify fails
-        setSanitizedHtml(mail.text.replace(/<[^>]*>/g, ''));
+        const sanitizeHtml = (await import('sanitize-html')).default;
+        setSanitizedHtml(sanitizeHtml(mail.text));
       } finally {
         setIsLoading(false);
       }

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/mail/_components/mail-display.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/mail/_components/mail-display.tsx
@@ -67,9 +67,15 @@ export function MailDisplay({ mail }: MailDisplayProps) {
         setSanitizedHtml(sanitized);
       } catch (error) {
         console.error('Failed to sanitize HTML:', error);
-        // Fallback to plain text if DOMPurify fails
-        const sanitizeHtml = (await import('sanitize-html')).default;
-        setSanitizedHtml(sanitizeHtml(mail.text));
+        try {
+          // Fallback to sanitize-html if DOMPurify fails
+          const sanitizeHtml = (await import('sanitize-html')).default;
+          setSanitizedHtml(sanitizeHtml(mail.text));
+        } catch (fallbackError) {
+          console.error('Failed to sanitize HTML:', fallbackError);
+          // If both sanitizers fail, show plain text
+          setSanitizedHtml(mail.text.replace(/<[^>]*>?/g, ''));
+        }
       } finally {
         setIsLoading(false);
       }

--- a/bun.lock
+++ b/bun.lock
@@ -344,6 +344,7 @@
         "@octokit/rest": "^22.0.0",
         "@tanstack/react-query": "^5.81.5",
         "@tanstack/react-table": "^8.21.3",
+        "@testing-library/jest-dom": "^6.6.3",
         "@tldraw/sync": "^3.13.4",
         "@trpc/client": "^11.4.3",
         "@trpc/react-query": "^11.4.3",
@@ -395,6 +396,7 @@
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
+        "sanitize-html": "^2.17.0",
         "server-only": "^0.0.1",
         "sharp": "^0.34.2",
         "swr": "^2.3.3",
@@ -417,6 +419,7 @@
         "@types/papaparse": "^5.3.16",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/sanitize-html": "^2.16.0",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.6.0",
         "autoprefixer": "^10.4.21",
@@ -705,6 +708,8 @@
     "supabase",
   ],
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.3", "", {}, "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA=="],
+
     "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@2.2.11", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-tZmJbOhihNfkhDnL4sVyscYiMXadXOoZ8QCqU3NVi7kho6czbNal05QZA+EMv1QL87NJAd0FZwcDIy60tor4SQ=="],
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@1.2.12", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ=="],
@@ -1693,6 +1698,8 @@
 
     "@testing-library/dom": ["@testing-library/dom@10.4.0", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "chalk": "^4.1.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "pretty-format": "^27.0.2" } }, "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ=="],
 
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.6.3", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "chalk": "^3.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "lodash": "^4.17.21", "redent": "^3.0.0" } }, "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA=="],
+
     "@testing-library/react": ["@testing-library/react@16.3.0", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw=="],
 
     "@tiptap/core": ["@tiptap/core@2.23.1", "", { "peerDependencies": { "@tiptap/pm": "^2.7.0" } }, "sha512-EURGKGsEPrwxvOPi9gA+BsczvsECJNV+xgTAGWHmEtU4YJ0AulYrCX3b7FK+aiduVhThIHDoG/Mmvmb/HPLRhQ=="],
@@ -1957,6 +1964,8 @@
 
     "@types/react-syntax-highlighter": ["@types/react-syntax-highlighter@15.5.13", "", { "dependencies": { "@types/react": "*" } }, "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA=="],
 
+    "@types/sanitize-html": ["@types/sanitize-html@2.16.0", "", { "dependencies": { "htmlparser2": "^8.0.0" } }, "sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw=="],
+
     "@types/shimmer": ["@types/shimmer@1.2.0", "", {}, "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
@@ -2211,6 +2220,8 @@
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
@@ -2337,7 +2348,7 @@
 
     "dodopayments-checkout": ["dodopayments-checkout@1.0.1", "", {}, "sha512-4eisos7D8Fr7aUD4gQ1ZA7bfNB910IAPJty5nPsle9Hh+tqZAwCQLyYyM4lMvSDbxdRD314OPOMNbBLNBExEWw=="],
 
-    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -2573,7 +2584,7 @@
 
     "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
 
-    "htmlparser2": ["htmlparser2@10.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.1", "entities": "^6.0.0" } }, "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g=="],
+    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -2600,6 +2611,8 @@
     "import-in-the-middle": ["import-in-the-middle@1.14.2", "", { "dependencies": { "acorn": "^8.14.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^1.2.2", "module-details-from-path": "^1.0.3" } }, "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -2913,6 +2926,8 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
     "minimal-polyfills": ["minimal-polyfills@2.2.3", "", {}, "sha512-oxdmJ9cL+xV72h0xYxp4tP2d5/fTBpP45H8DIOn9pASuF8a3IYTf+25fMGDYGiWW+MFsuog6KD6nfmhZJQ+uUw=="],
 
     "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
@@ -3012,6 +3027,8 @@
     "parse-entities": ["parse-entities@2.0.0", "", { "dependencies": { "character-entities": "^1.0.0", "character-entities-legacy": "^1.0.0", "character-reference-invalid": "^1.0.0", "is-alphanumerical": "^1.0.0", "is-decimal": "^1.0.0", "is-hexadecimal": "^1.0.0" } }, "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ=="],
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
 
     "parse-svg-path": ["parse-svg-path@0.1.2", "", {}, "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="],
 
@@ -3199,6 +3216,8 @@
 
     "recharts": ["recharts@3.0.2", "", { "dependencies": { "@reduxjs/toolkit": "1.x.x || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-eDc3ile9qJU9Dp/EekSthQPhAVPG48/uM47jk+PF7VBQngxeW3cwQpPHb/GHC1uqwyCRWXcIrDzuHRVrnRryoQ=="],
 
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
@@ -3258,6 +3277,8 @@
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sanitize-html": ["sanitize-html@2.17.0", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^8.0.0", "is-plain-object": "^5.0.0", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
@@ -3356,6 +3377,8 @@
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-literal": ["strip-literal@3.0.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA=="],
 
@@ -3735,6 +3758,10 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "@testing-library/jest-dom/chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
+
     "@tldraw/editor/@tiptap/core": ["@tiptap/core@2.23.0", "", { "peerDependencies": { "@tiptap/pm": "^2.7.0" } }, "sha512-Cdfhd0Po1cKMYqHtyv/3XATXpf2Kjo8fuau/QJwrml0NpM18/XX9mAgp2NJ/QaiQ3vi8vDandg7RmZ5OrApglQ=="],
 
     "@tldraw/editor/@tiptap/pm": ["@tiptap/pm@2.23.0", "", { "dependencies": { "prosemirror-changeset": "^2.3.0", "prosemirror-collab": "^1.3.1", "prosemirror-commands": "^1.6.2", "prosemirror-dropcursor": "^1.8.1", "prosemirror-gapcursor": "^1.3.2", "prosemirror-history": "^1.4.1", "prosemirror-inputrules": "^1.4.0", "prosemirror-keymap": "^1.2.2", "prosemirror-markdown": "^1.13.1", "prosemirror-menu": "^1.2.4", "prosemirror-model": "^1.23.0", "prosemirror-schema-basic": "^1.2.3", "prosemirror-schema-list": "^1.4.1", "prosemirror-state": "^1.4.3", "prosemirror-tables": "^1.6.4", "prosemirror-trailing-node": "^3.0.0", "prosemirror-transform": "^1.10.2", "prosemirror-view": "^1.37.0" } }, "sha512-PQFi8H+OrcaNXNGxbXSjJmZFh1wxiFMbUg25LjOX148d7i+21uWKy6avsr5rsBQNBAKIIMB6PQY61Lhv5r61uA=="],
@@ -3766,6 +3793,8 @@
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "cheerio/htmlparser2": ["htmlparser2@10.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.1", "entities": "^6.0.0" } }, "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -3822,10 +3851,6 @@
     "hastscript/property-information": ["property-information@5.6.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA=="],
 
     "hastscript/space-separated-tokens": ["space-separated-tokens@1.1.5", "", {}, "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="],
-
-    "html-to-text/htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
-
-    "htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -3967,11 +3992,15 @@
 
     "@supabase/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "@testing-library/jest-dom/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "@tldraw/editor/@tiptap/react/@tiptap/extension-bubble-menu": ["@tiptap/extension-bubble-menu@2.23.0", "", { "dependencies": { "tippy.js": "^6.3.7" }, "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0" } }, "sha512-4CZxcVj/0ZetEiWgiP31xTHgaQ7Hr3Ad36cAEza/nGYifaztuPjLO2Y9qdnC1iJHIxttnX6GVRnCMRmZMfhgHg=="],
 
     "@tldraw/editor/@tiptap/react/@tiptap/extension-floating-menu": ["@tiptap/extension-floating-menu@2.23.0", "", { "dependencies": { "tippy.js": "^6.3.7" }, "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0" } }, "sha512-MvwDMhO5o5NciE+wc6B9dQgTFzmPjtB1o3S+HTdlGzGFGgx9PsNikK5BkqMit9j2NnrqyHnOf88QK/wZR5fqGA=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "cheerio/htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "cross-fetch/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 


### PR DESCRIPTION
Potential fix for [https://github.com/tutur3u/platform/security/code-scanning/103](https://github.com/tutur3u/platform/security/code-scanning/103)

To address the issue, we should improve the fallback sanitization logic to ensure it effectively removes all potentially unsafe content. Instead of relying on a simple regular expression, we can use a more robust approach, such as repeatedly applying the regular expression until no matches remain. Alternatively, we could use a library like `sanitize-html` as a fallback, which is specifically designed for this purpose.

The best fix here is to use the `sanitize-html` library as a fallback. This ensures that even if `DOMPurify` fails, the fallback logic will still provide comprehensive sanitization. The changes involve:
1. Adding the `sanitize-html` library as a dependency.
2. Replacing the current fallback logic with a call to `sanitize-html`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback HTML sanitization in mail display for enhanced security and robustness.

* **Chores**
  * Added new dependencies to support advanced HTML sanitization.

* **Tests**
  * Introduced comprehensive tests to ensure secure and reliable HTML sanitization in mail display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->