### PR TITLE
(Active sync) Pass timezone to fetch google events API call

### DIFF
--- a/apps/web/src/__tests__/calendar-fetch-format.test.ts
+++ b/apps/web/src/__tests__/calendar-fetch-format.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import { convertGoogleAllDayEvent } from '@tuturuuu/ui/hooks/calendar-utils';
 
 // Extend dayjs with required plugins for timezone handling
@@ -9,9 +9,9 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 
 describe('convertGoogleAllDayEvent', () => {
-  test('converts all-day (date-only) event to midnight in user timezone', () => {
+  test('converts all-day (date-only) event to local timezone midnight', () => {
     const result = convertGoogleAllDayEvent('2024-01-01', '2024-01-02', 'Asia/Ho_Chi_Minh');
-    // The function converts to user timezone midnight but returns in UTC
+    // The function now stores local timezone midnight times
     expect(result.start_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     expect(result.end_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     // Verify the dates are different (start and end dates)
@@ -32,7 +32,7 @@ describe('convertGoogleAllDayEvent', () => {
 
   test('handles auto timezone', () => {
     const result = convertGoogleAllDayEvent('2024-01-01', '2024-01-02', 'auto');
-    // The function converts to user timezone midnight but returns in UTC
+    // The function now stores local timezone midnight times
     expect(result.start_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     expect(result.end_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     // Verify the dates are different (start and end dates)
@@ -43,5 +43,23 @@ describe('convertGoogleAllDayEvent', () => {
     const result = convertGoogleAllDayEvent('invalid', 'invalid', 'Asia/Ho_Chi_Minh');
     expect(result.start_at).toBeDefined();
     expect(result.end_at).toBeDefined();
+  });
+
+  test('handles multi-day all-day events', () => {
+    const result = convertGoogleAllDayEvent('2024-01-01', '2024-01-05', 'Asia/Ho_Chi_Minh');
+    expect(result.start_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(result.end_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    // Verify the dates are different (start and end dates)
+    expect(result.start_at).not.toBe(result.end_at);
+  });
+
+  test('timezone plugin is properly loaded', () => {
+    // Test that dayjs timezone functions work
+    expect(typeof dayjs.tz).toBe('function');
+    
+    // Test that we can create a timezone-aware date
+    const tzDate = dayjs.tz('2024-01-01T00:00:00', 'Asia/Ho_Chi_Minh');
+    expect(tzDate.isValid()).toBe(true);
+    expect(tzDate.toISOString()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   });
 }); 

--- a/apps/web/src/app/api/v1/calendar/auth/fetch/route.ts
+++ b/apps/web/src/app/api/v1/calendar/auth/fetch/route.ts
@@ -180,13 +180,14 @@ export async function GET(request: Request) {
 
       // format the events to match the expected structure
       const formattedEvents = events.map((event) => {
+        // Get timezone from query parameters, fallback to 'auto' for backward compatibility
+        const userTimezone = url.searchParams.get('timezone') || 'auto';
+        
         // Use the new timezone-aware conversion for all-day events
         const { start_at, end_at } = convertGoogleAllDayEvent(
           event.start?.dateTime || event.start?.date || '',
           event.end?.dateTime || event.end?.date || '',
-          // Use the user's browser timezone which is available in the process.env.TZ or system default
-          // This will be enhanced later to use actual user preferences
-          'auto'
+          userTimezone
         );
 
         return {

--- a/packages/ui/src/hooks/calendar-utils.ts
+++ b/packages/ui/src/hooks/calendar-utils.ts
@@ -1,7 +1,9 @@
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import type { CalendarEvent } from '@tuturuuu/types/primitives/calendar-event';
 
+dayjs.extend(utc);
 dayjs.extend(timezone);
 
 export function isAllDayEvent(event: Pick<CalendarEvent, 'start_at' | 'end_at'>, userTimezone?: string): boolean {
@@ -78,7 +80,7 @@ export function createAllDayEvent(
     : userTimezone;
   
   const startAtMidnight = tz 
-    ? dayjs(date).tz(tz).startOf('day')
+    ? dayjs.tz(date, tz).startOf('day')
     : dayjs(date).startOf('day');
   
   const endAtMidnight = startAtMidnight.add(durationDays, 'day');

--- a/packages/ui/src/hooks/use-calendar.tsx
+++ b/packages/ui/src/hooks/use-calendar.tsx
@@ -813,7 +813,11 @@ export const CalendarProvider = ({
     if (!ws?.id) {
       throw new Error('No workspace selected');
     }
-    const response = await fetch(`/api/v1/calendar/auth/fetch?wsId=${ws.id}`);
+    
+    // Get timezone from settings
+    const userTimezone = settings?.timezone?.timezone || 'auto';
+    
+    const response = await fetch(`/api/v1/calendar/auth/fetch?wsId=${ws.id}&timezone=${userTimezone}`);
     if (!response.ok) {
       throw new Error('Failed to fetch Google Calendar events');
     }
@@ -1239,8 +1243,11 @@ export const CalendarProvider = ({
 
         // Force fetch the latest events from Google with a cache-busting parameter
         try {
+          // Get timezone from settings
+          const userTimezone = settings?.timezone?.timezone || 'auto';
+          
           const response = await fetch(
-            `/api/v1/calendar/auth/fetch?wsId=${ws.id}&force=true&t=${Date.now()}`
+            `/api/v1/calendar/auth/fetch?wsId=${ws.id}&force=true&t=${Date.now()}&timezone=${userTimezone}`
           );
           const data = await response.json();
 


### PR DESCRIPTION
Error for all day events in active sync may happen when the API is called in the server and the location of the server affect the timezone sync.

#### Fix
* Instead of using `auto` we pass the user `timezone` from the settings on the client side