### PR TITLE
Change isAllDayEvent to check all day without timezone

### DIFF
--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -8824,11 +8824,11 @@ export type Database = {
     };
     Functions: {
       add_board_tags: {
-        Args: { new_tags: string[]; board_id: string };
+        Args: { board_id: string; new_tags: string[] };
         Returns: Json;
       };
       calculate_productivity_score: {
-        Args: { category_color: string; duration_seconds: number };
+        Args: { duration_seconds: number; category_color: string };
         Returns: number;
       };
       check_ws_creator: {
@@ -8845,14 +8845,14 @@ export type Database = {
       };
       count_search_users: {
         Args: {
-          role_filter?: string;
           search_query: string;
+          role_filter?: string;
           enabled_filter?: boolean;
         };
         Returns: number;
       };
       create_ai_chat: {
-        Args: { model: string; message: string; title: string };
+        Args: { title: string; message: string; model: string };
         Returns: string;
       };
       extract_domain: {
@@ -8866,22 +8866,22 @@ export type Database = {
       generate_cross_app_token: {
         Args:
           | {
-              p_origin_app: string;
               p_user_id: string;
+              p_origin_app: string;
               p_target_app: string;
               p_expiry_seconds?: number;
             }
           | {
-              p_target_app: string;
-              p_session_data?: Json;
-              p_expiry_seconds?: number;
-              p_origin_app: string;
               p_user_id: string;
+              p_origin_app: string;
+              p_target_app: string;
+              p_expiry_seconds?: number;
+              p_session_data?: Json;
             };
         Returns: string;
       };
       get_browsers: {
-        Args: { p_limit?: number; p_link_id: string };
+        Args: { p_link_id: string; p_limit?: number };
         Returns: {
           browser: string;
           count: number;
@@ -8890,8 +8890,8 @@ export type Database = {
       get_challenge_stats: {
         Args: { challenge_id_param: string; user_id_param: string };
         Returns: {
-          problems_attempted: number;
           total_score: number;
+          problems_attempted: number;
         }[];
       };
       get_clicks_by_day: {
@@ -8912,24 +8912,24 @@ export type Database = {
       get_clicks_by_hour: {
         Args: { p_link_id: string };
         Returns: {
-          clicks: number;
           hour: number;
+          clicks: number;
         }[];
       };
       get_daily_income_expense: {
-        Args: { past_days?: number; _ws_id: string };
+        Args: { _ws_id: string; past_days?: number };
         Returns: {
           day: string;
-          total_expense: number;
           total_income: number;
+          total_expense: number;
         }[];
       };
       get_daily_prompt_completion_tokens: {
         Args: { past_days?: number };
         Returns: {
-          total_completion_tokens: number;
-          total_prompt_tokens: number;
           day: string;
+          total_prompt_tokens: number;
+          total_completion_tokens: number;
         }[];
       };
       get_device_types: {
@@ -8977,22 +8977,22 @@ export type Database = {
       };
       get_inventory_products: {
         Args: {
-          _has_unit?: boolean;
-          _warehouse_ids?: string[];
-          _ws_id?: string;
           _category_ids?: string[];
+          _ws_id?: string;
+          _warehouse_ids?: string[];
+          _has_unit?: boolean;
         };
         Returns: {
-          created_at: string;
-          ws_id: string;
-          amount: number;
-          price: number;
-          category: string;
-          unit_id: string;
-          unit: string;
-          manufacturer: string;
-          name: string;
           id: string;
+          name: string;
+          manufacturer: string;
+          unit: string;
+          unit_id: string;
+          category: string;
+          price: number;
+          amount: number;
+          ws_id: string;
+          created_at: string;
         }[];
       };
       get_inventory_products_count: {
@@ -9015,20 +9015,20 @@ export type Database = {
         Args: { _ws_id: string; past_months?: number };
         Returns: {
           month: string;
-          total_expense: number;
           total_income: number;
+          total_expense: number;
         }[];
       };
       get_monthly_prompt_completion_tokens: {
         Args: { past_months?: number };
         Returns: {
-          total_completion_tokens: number;
-          total_prompt_tokens: number;
           month: string;
+          total_prompt_tokens: number;
+          total_completion_tokens: number;
         }[];
       };
       get_operating_systems: {
-        Args: { p_limit?: number; p_link_id: string };
+        Args: { p_link_id: string; p_limit?: number };
         Returns: {
           os: string;
           count: number;
@@ -9041,10 +9041,10 @@ export type Database = {
       get_possible_excluded_groups: {
         Args: { _ws_id: string; included_groups: string[] };
         Returns: {
-          name: string;
           id: string;
-          amount: number;
+          name: string;
           ws_id: string;
+          amount: number;
         }[];
       };
       get_possible_excluded_tags: {
@@ -9059,10 +9059,10 @@ export type Database = {
       get_session_statistics: {
         Args: Record<PropertyKey, never>;
         Returns: {
+          total_count: number;
+          unique_users_count: number;
           active_count: number;
           completed_count: number;
-          unique_users_count: number;
-          total_count: number;
           latest_session_date: string;
         }[];
       };
@@ -9073,6 +9073,10 @@ export type Database = {
           limit_count?: number;
         };
         Returns: {
+          title: string;
+          description: string;
+          category_id: string;
+          task_id: string;
           tags: string[];
           category_name: string;
           category_color: string;
@@ -9080,18 +9084,14 @@ export type Database = {
           usage_count: number;
           avg_duration: number;
           last_used: string;
-          category_id: string;
-          task_id: string;
-          title: string;
-          description: string;
         }[];
       };
       get_submission_statistics: {
         Args: Record<PropertyKey, never>;
         Returns: {
+          total_count: number;
           latest_submission_date: string;
           unique_users_count: number;
-          total_count: number;
         }[];
       };
       get_top_cities: {
@@ -9103,14 +9103,14 @@ export type Database = {
         }[];
       };
       get_top_countries: {
-        Args: { p_limit?: number; p_link_id: string };
+        Args: { p_link_id: string; p_limit?: number };
         Returns: {
           country: string;
           count: number;
         }[];
       };
       get_top_referrers: {
-        Args: { p_limit?: number; p_link_id: string };
+        Args: { p_link_id: string; p_limit?: number };
         Returns: {
           domain: string;
           count: number;
@@ -9119,59 +9119,59 @@ export type Database = {
       get_transaction_categories_with_amount: {
         Args: Record<PropertyKey, never>;
         Returns: {
-          is_expense: boolean;
-          name: string;
-          ws_id: string;
           id: string;
+          name: string;
+          is_expense: boolean;
+          ws_id: string;
           created_at: string;
           amount: number;
         }[];
       };
       get_user_role: {
-        Args: { ws_id: string; user_id: string };
+        Args: { user_id: string; ws_id: string };
         Returns: string;
       };
       get_user_session_stats: {
         Args: { user_id: string };
         Returns: {
           total_sessions: number;
-          current_session_age: unknown;
           active_sessions: number;
+          current_session_age: unknown;
         }[];
       };
       get_user_sessions: {
         Args: { user_id: string };
         Returns: {
-          is_current: boolean;
+          session_id: string;
+          created_at: string;
           updated_at: string;
           user_agent: string;
           ip: string;
-          session_id: string;
-          created_at: string;
+          is_current: boolean;
         }[];
       };
       get_user_tasks: {
         Args: { _board_id: string };
         Returns: {
-          completed: boolean;
-          description: string;
           id: string;
           name: string;
-          end_date: string;
-          start_date: string;
+          description: string;
           priority: number;
-          board_id: string;
+          completed: boolean;
+          start_date: string;
+          end_date: string;
           list_id: string;
+          board_id: string;
         }[];
       };
       get_user_whitelist_status: {
         Args: { user_id_param: string };
         Returns: {
+          is_whitelisted: boolean;
           enabled: boolean;
+          allow_challenge_management: boolean;
           allow_manage_all_challenges: boolean;
           allow_role_management: boolean;
-          is_whitelisted: boolean;
-          allow_challenge_management: boolean;
         }[];
       };
       get_workspace_drive_size: {
@@ -9191,24 +9191,24 @@ export type Database = {
         Returns: number;
       };
       get_workspace_transactions_count: {
-        Args: { ws_id: string; end_date?: string; start_date?: string };
+        Args: { ws_id: string; start_date?: string; end_date?: string };
         Returns: number;
       };
       get_workspace_user_groups: {
         Args: {
-          search_query: string;
-          excluded_tags: string[];
-          included_tags: string[];
           _ws_id: string;
+          included_tags: string[];
+          excluded_tags: string[];
+          search_query: string;
         };
         Returns: {
-          ws_id: string;
-          notes: string;
-          name: string;
           id: string;
-          created_at: string;
-          tag_count: number;
+          name: string;
+          notes: string;
+          ws_id: string;
           tags: string[];
+          tag_count: number;
+          created_at: string;
         }[];
       };
       get_workspace_user_groups_count: {
@@ -9223,6 +9223,12 @@ export type Database = {
           search_query: string;
         };
         Returns: {
+          id: string;
+          avatar_url: string;
+          full_name: string;
+          display_name: string;
+          email: string;
+          phone: string;
           gender: string;
           birthday: string;
           ethnicity: string;
@@ -9232,17 +9238,11 @@ export type Database = {
           note: string;
           balance: number;
           ws_id: string;
+          groups: string[];
           group_count: number;
           linked_users: Json;
           created_at: string;
-          groups: string[];
           updated_at: string;
-          id: string;
-          avatar_url: string;
-          full_name: string;
-          display_name: string;
-          email: string;
-          phone: string;
         }[];
       };
       get_workspace_users_count: {
@@ -9254,11 +9254,11 @@ export type Database = {
         Returns: number;
       };
       get_workspace_wallets_expense: {
-        Args: { end_date?: string; start_date?: string; ws_id: string };
+        Args: { ws_id: string; start_date?: string; end_date?: string };
         Returns: number;
       };
       get_workspace_wallets_income: {
-        Args: { start_date?: string; ws_id: string; end_date?: string };
+        Args: { ws_id: string; start_date?: string; end_date?: string };
         Returns: number;
       };
       gtrgm_compress: {
@@ -9282,11 +9282,11 @@ export type Database = {
         Returns: unknown;
       };
       has_other_owner: {
-        Args: { _user_id: string; _ws_id: string };
+        Args: { _ws_id: string; _user_id: string };
         Returns: boolean;
       };
       insert_ai_chat_message: {
-        Args: { message: string; source: string; chat_id: string };
+        Args: { message: string; chat_id: string; source: string };
         Returns: undefined;
       };
       is_list_accessible: {
@@ -9310,7 +9310,7 @@ export type Database = {
         Returns: boolean;
       };
       is_nova_user_id_in_team: {
-        Args: { _team_id: string; _user_id: string };
+        Args: { _user_id: string; _team_id: string };
         Returns: boolean;
       };
       is_org_member: {
@@ -9346,11 +9346,11 @@ export type Database = {
         Returns: Json;
       };
       nova_get_user_daily_sessions: {
-        Args: { user_id: string; challenge_id: string };
+        Args: { challenge_id: string; user_id: string };
         Returns: number;
       };
       nova_get_user_total_sessions: {
-        Args: { user_id: string; challenge_id: string };
+        Args: { challenge_id: string; user_id: string };
         Returns: number;
       };
       parse_user_agent: {
@@ -9362,7 +9362,7 @@ export type Database = {
         }[];
       };
       remove_board_tags: {
-        Args: { tags_to_remove: string[]; board_id: string };
+        Args: { board_id: string; tags_to_remove: string[] };
         Returns: Json;
       };
       revoke_all_cross_app_tokens: {
@@ -9374,19 +9374,19 @@ export type Database = {
         Returns: number;
       };
       revoke_user_session: {
-        Args: { session_id: string; target_user_id: string };
+        Args: { target_user_id: string; session_id: string };
         Returns: boolean;
       };
       search_boards_by_tags: {
         Args: {
           workspace_id: string;
-          match_all?: boolean;
           search_tags: string[];
+          match_all?: boolean;
         };
         Returns: {
-          board_tags: Json;
-          board_name: string;
           board_id: string;
+          board_name: string;
+          board_tags: Json;
         }[];
       };
       search_users: {
@@ -9398,14 +9398,6 @@ export type Database = {
           enabled_filter?: boolean;
         };
         Returns: {
-          enabled: boolean;
-          team_name: string[];
-          full_name: string;
-          birthday: string;
-          new_email: string;
-          email: string;
-          allow_role_management: boolean;
-          allow_manage_all_challenges: boolean;
           id: string;
           display_name: string;
           deleted: boolean;
@@ -9414,21 +9406,29 @@ export type Database = {
           bio: string;
           created_at: string;
           user_id: string;
+          enabled: boolean;
           allow_challenge_management: boolean;
+          allow_manage_all_challenges: boolean;
+          allow_role_management: boolean;
+          email: string;
+          new_email: string;
+          birthday: string;
+          full_name: string;
+          team_name: string[];
         }[];
       };
       search_users_by_name: {
         Args: {
-          min_similarity?: number;
           search_query: string;
           result_limit?: number;
+          min_similarity?: number;
         };
         Returns: {
-          avatar_url: string;
-          relevance: number;
           id: string;
           handle: string;
           display_name: string;
+          avatar_url: string;
+          relevance: number;
         }[];
       };
       set_limit: {
@@ -9450,11 +9450,11 @@ export type Database = {
         }[];
       };
       transactions_have_same_abs_amount: {
-        Args: { transaction_id_2: string; transaction_id_1: string };
+        Args: { transaction_id_1: string; transaction_id_2: string };
         Returns: boolean;
       };
       transactions_have_same_amount: {
-        Args: { transaction_id_2: string; transaction_id_1: string };
+        Args: { transaction_id_1: string; transaction_id_2: string };
         Returns: boolean;
       };
       update_expired_sessions: {
@@ -9474,14 +9474,14 @@ export type Database = {
         Returns: boolean;
       };
       validate_cross_app_token: {
-        Args: { p_target_app: string; p_token: string };
+        Args: { p_token: string; p_target_app: string };
         Returns: string;
       };
       validate_cross_app_token_with_session: {
         Args: { p_token: string; p_target_app: string };
         Returns: {
-          session_data: Json;
           user_id: string;
+          session_data: Json;
         }[];
       };
     };

--- a/packages/ui/src/hooks/calendar-utils.test.ts
+++ b/packages/ui/src/hooks/calendar-utils.test.ts
@@ -22,15 +22,6 @@ describe('calendar-utils', () => {
       expect(isAllDayEvent(event)).toBe(true);
     });
 
-    it('should detect single-day all-day events', () => {
-      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
-        start_at: '2024-01-01T00:00:00.000Z',
-        end_at: '2024-01-01T00:00:00.000Z' // Same day
-      };
-      
-      expect(isAllDayEvent(event)).toBe(true);
-    });
-
     it('should reject timed events', () => {
       const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
         start_at: '2024-01-01T10:00:00.000Z',

--- a/packages/ui/src/hooks/calendar-utils.test.ts
+++ b/packages/ui/src/hooks/calendar-utils.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { isAllDayEvent, convertGoogleAllDayEvent, createAllDayEvent } from './calendar-utils';
+import type { CalendarEvent } from '@tuturuuu/types/primitives/calendar-event';
+
+describe('calendar-utils', () => {
+  describe('isAllDayEvent', () => {
+    it('should detect all-day events with date-only format', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T00:00:00.000Z',
+        end_at: '2024-01-02T00:00:00.000Z'
+      };
+      
+      expect(isAllDayEvent(event)).toBe(true);
+    });
+
+    it('should detect all-day events spanning multiple days', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T00:00:00.000Z',
+        end_at: '2024-01-03T00:00:00.000Z' // 48 hours
+      };
+      
+      expect(isAllDayEvent(event)).toBe(true);
+    });
+
+    it('should detect single-day all-day events', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T00:00:00.000Z',
+        end_at: '2024-01-01T00:00:00.000Z' // Same day
+      };
+      
+      expect(isAllDayEvent(event)).toBe(true);
+    });
+
+    it('should reject timed events', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T10:00:00.000Z',
+        end_at: '2024-01-01T11:00:00.000Z'
+      };
+      
+      expect(isAllDayEvent(event)).toBe(false);
+    });
+
+    it('should reject events not starting at midnight', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T01:00:00.000Z',
+        end_at: '2024-01-02T00:00:00.000Z'
+      };
+      
+      expect(isAllDayEvent(event)).toBe(false);
+    });
+
+    it('should reject events not ending at midnight', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T00:00:00.000Z',
+        end_at: '2024-01-02T01:00:00.000Z'
+      };
+      
+      expect(isAllDayEvent(event)).toBe(false);
+    });
+
+    it('should reject events with non-24-hour duration', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T00:00:00.000Z',
+        end_at: '2024-01-01T12:00:00.000Z' // 12 hours
+      };
+      
+      expect(isAllDayEvent(event)).toBe(false);
+    });
+
+    it('should reject events with 0 duration', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T00:00:00.000Z',
+        end_at: '2024-01-01T00:00:00.000Z' // Same time
+      };
+      
+      expect(isAllDayEvent(event)).toBe(false);
+    });
+
+    it('should handle events with seconds and milliseconds', () => {
+      const event: Pick<CalendarEvent, 'start_at' | 'end_at'> = {
+        start_at: '2024-01-01T00:00:00.123Z',
+        end_at: '2024-01-02T00:00:00.456Z'
+      };
+      
+      expect(isAllDayEvent(event)).toBe(false);
+    });
+  });
+
+  describe('convertGoogleAllDayEvent', () => {
+    it('should convert Google date-only format to user timezone midnight', () => {
+      const result = convertGoogleAllDayEvent('2024-01-01', '2024-01-02', 'America/New_York');
+      
+      // Should convert to timezone midnight
+      expect(result.start_at).toMatch(/2024-01-01T05:00:00\.000Z/); // UTC equivalent of midnight EST
+      expect(result.end_at).toMatch(/2024-01-02T05:00:00\.000Z/);
+    });
+
+    it('should handle missing dates by using current time', () => {
+      const result = convertGoogleAllDayEvent(undefined, undefined, 'America/New_York');
+      
+      expect(result.start_at).toBeDefined();
+      expect(result.end_at).toBeDefined();
+      expect(new Date(result.end_at).getTime() - new Date(result.start_at).getTime()).toBe(60 * 60 * 1000); // 1 hour
+    });
+
+    it('should pass through existing dateTime format unchanged', () => {
+      const result = convertGoogleAllDayEvent(
+        '2024-01-01T10:00:00Z',
+        '2024-01-01T11:00:00Z',
+        'America/New_York'
+      );
+      
+      expect(result.start_at).toBe('2024-01-01T10:00:00Z');
+      expect(result.end_at).toBe('2024-01-01T11:00:00Z');
+    });
+
+    it('should handle mixed date formats', () => {
+      const result = convertGoogleAllDayEvent(
+        '2024-01-01',
+        '2024-01-01T11:00:00Z',
+        'America/New_York'
+      );
+      
+      // Should pass through as-is since not both are date-only
+      expect(result.start_at).toBe('2024-01-01');
+      expect(result.end_at).toBe('2024-01-01T11:00:00Z');
+    });
+  });
+
+  describe('createAllDayEvent', () => {
+    it('should create all-day event in user timezone', () => {
+      const date = new Date('2024-01-01T10:00:00Z');
+      const result = createAllDayEvent(date, 'America/New_York');
+      
+      expect(result.start_at).toMatch(/2024-01-01T05:00:00\.000Z/); // UTC equivalent of midnight EST
+      expect(result.end_at).toMatch(/2024-01-02T05:00:00\.000Z/);
+    });
+
+    it('should create multi-day all-day event', () => {
+      const date = new Date('2024-01-01T10:00:00Z');
+      const result = createAllDayEvent(date, 'America/New_York', 3);
+      
+      expect(result.start_at).toMatch(/2024-01-01T05:00:00\.000Z/);
+      expect(result.end_at).toMatch(/2024-01-04T05:00:00\.000Z/); // 3 days later
+    });
+
+    it('should handle undefined timezone', () => {
+      const date = new Date('2024-01-01T10:00:00Z');
+      const result = createAllDayEvent(date, undefined);
+      
+      expect(result.start_at).toMatch(/2024-01-01T00:00:00\.000Z/);
+      expect(result.end_at).toMatch(/2024-01-02T00:00:00\.000Z/);
+    });
+  });
+}); 

--- a/packages/ui/src/hooks/calendar-utils.ts
+++ b/packages/ui/src/hooks/calendar-utils.ts
@@ -71,7 +71,7 @@ export function createAllDayEvent(
     : userTimezone;
   
   const startAtMidnight = tz 
-    ? dayjs(date).tz(tz).startOf('day')
+    ? dayjs.tz(date, tz).startOf('day')
     : dayjs(date).startOf('day');
   
   const endAtMidnight = startAtMidnight.add(durationDays, 'day');

--- a/packages/ui/src/hooks/calendar-utils.ts
+++ b/packages/ui/src/hooks/calendar-utils.ts
@@ -8,8 +8,8 @@ export function isAllDayEvent(event: Pick<CalendarEvent, 'start_at' | 'end_at'>,
   const start = dayjs(event.start_at);
   const end = dayjs(event.end_at);
   
-  const isStartAtMidnight = start.hour() === 0 && start.minute() === 0 && start.second() === 0;
-  const isEndAtMidnight = end.hour() === 0 && end.minute() === 0 && end.second() === 0;
+  const isStartAtMidnight = start.hour() === 0 && start.minute() === 0 && start.second() === 0 && start.millisecond() === 0;
+  const isEndAtMidnight = end.hour() === 0 && end.minute() === 0 && end.second() === 0 && end.millisecond() === 0;
   const durationHours = end.diff(start, 'hour');
   const isMultipleOf24Hours = durationHours > 0 && durationHours % 24 === 0;
   

--- a/packages/ui/src/hooks/calendar-utils.ts
+++ b/packages/ui/src/hooks/calendar-utils.ts
@@ -8,16 +8,9 @@ export function isAllDayEvent(event: Pick<CalendarEvent, 'start_at' | 'end_at'>,
   const start = dayjs(event.start_at);
   const end = dayjs(event.end_at);
   
-  // Handle timezone-aware checking
-  const tz = userTimezone === 'auto' ? 
-    (typeof window !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().timeZone : undefined) 
-    : userTimezone;
-  const startInTz = tz ? start.tz(tz) : start;
-  const endInTz = tz ? end.tz(tz) : end;
-  
-  const isStartAtMidnight = startInTz.hour() === 0 && startInTz.minute() === 0 && startInTz.second() === 0;
-  const isEndAtMidnight = endInTz.hour() === 0 && endInTz.minute() === 0 && endInTz.second() === 0;
-  const durationHours = endInTz.diff(startInTz, 'hour');
+  const isStartAtMidnight = start.hour() === 0 && start.minute() === 0 && start.second() === 0;
+  const isEndAtMidnight = end.hour() === 0 && end.minute() === 0 && end.second() === 0;
+  const durationHours = end.diff(start, 'hour');
   const isMultipleOf24Hours = durationHours > 0 && durationHours % 24 === 0;
   
   return isStartAtMidnight && isEndAtMidnight && isMultipleOf24Hours;

--- a/packages/ui/src/hooks/calendar-utils.ts
+++ b/packages/ui/src/hooks/calendar-utils.ts
@@ -1,8 +1,10 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import type { CalendarEvent } from '@tuturuuu/types/primitives/calendar-event';
 
 dayjs.extend(timezone);
+dayjs.extend(utc);
 
 export function isAllDayEvent(event: Pick<CalendarEvent, 'start_at' | 'end_at'>, userTimezone?: string): boolean {
   const start = dayjs(event.start_at);


### PR DESCRIPTION
As `convertGoogleAllDayEvent` now only used the `auto` timezone, al the all day events are saved as 00-00 hours in UTC and not in the user timezone.

I think we don't need to change this as per Google Calendar, all day events are saved as date only and the dates are not changed in any timezones.

This PR changes the `isAllDayEvent` filtering logic so that it checks for the time right away without converting to the user's timezone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for calendar event utilities, including detection and creation of all-day events and conversion of Google Calendar events.

* **Refactor**
  * Simplified all-day event detection logic by removing timezone-aware checks and streamlining calculations.
  * Updated timezone application method when creating all-day events for improved consistency.

* **Chores**
  * Updated type property ordering for improved consistency and clarity; no functional changes to features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->