### PR TITLE
Add toggle debug calendar

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/calendar/active-sync.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/calendar/active-sync.tsx
@@ -2,7 +2,9 @@
 
 import { useCalendarSync } from '@tuturuuu/ui/hooks/use-calendar-sync';
 import { Separator } from '@tuturuuu/ui/separator';
+import { Switch } from '@tuturuuu/ui/switch';
 import dayjs from 'dayjs';
+import { useState } from 'react';
 
 const InnerComponent = () => {
   const { data, googleData, dates, error } = useCalendarSync();
@@ -56,5 +58,18 @@ const InnerComponent = () => {
 };
 
 export const CalendarActiveSyncDebugger = () => {
-  return <InnerComponent />;
+  const [isDebuggingOpen, setIsDebuggingOpen] = useState(false);
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={isDebuggingOpen}
+          onCheckedChange={setIsDebuggingOpen}
+        />
+        <span>Active Sync</span>
+      </div>
+      {isDebuggingOpen && <InnerComponent />}
+    </>
+  );
 };

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/calendar/active-sync.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/calendar/active-sync.tsx
@@ -1,116 +1,14 @@
 'use client';
 
-import { Button } from '@tuturuuu/ui/button';
 import { useCalendarSync } from '@tuturuuu/ui/hooks/use-calendar-sync';
-import { Progress } from '@tuturuuu/ui/progress';
 import { Separator } from '@tuturuuu/ui/separator';
 import dayjs from 'dayjs';
-import { useState } from 'react';
 
 const InnerComponent = () => {
-  const {
-    data,
-    googleData,
-    dates,
-    error,
-    currentView,
-    syncToTuturuuu,
-    setCurrentView,
-  } = useCalendarSync();
-
-  const [isSyncing, setIsSyncing] = useState(false);
-  const [syncProgress, setSyncProgress] = useState<{
-    phase: 'get' | 'fetch' | 'delete' | 'upsert' | 'complete';
-    percentage: number;
-    statusMessage: string;
-    changesMade: boolean;
-  }>({
-    phase: 'complete',
-    percentage: 100,
-    statusMessage: '',
-    changesMade: false,
-  });
-
-  const handleSyncToTuturuuu = async () => {
-    setIsSyncing(true);
-    setSyncProgress({
-      phase: 'get',
-      percentage: 0,
-      statusMessage: 'Starting sync...',
-      changesMade: false,
-    });
-
-    try {
-      await syncToTuturuuu((progress) => {
-        setSyncProgress({
-          phase: progress.phase,
-          percentage: progress.percentage,
-          statusMessage: progress.statusMessage,
-          changesMade: progress.changesMade,
-        });
-      });
-    } finally {
-      setIsSyncing(false);
-    }
-  };
+  const { data, googleData, dates, error } = useCalendarSync();
 
   return (
     <div>
-      <div className="mb-4 flex gap-2">
-        <Button
-          variant={currentView === 'day' ? undefined : 'outline'}
-          onClick={() => setCurrentView('day')}
-          disabled={currentView === 'day'}
-        >
-          Switch to day
-        </Button>
-        <Button
-          variant={currentView === '4-day' ? undefined : 'outline'}
-          onClick={() => setCurrentView('4-day')}
-          disabled={currentView === '4-day'}
-        >
-          Switch to 4-day
-        </Button>
-        <Button
-          variant={currentView === 'week' ? undefined : 'outline'}
-          onClick={() => setCurrentView('week')}
-          disabled={currentView === 'week'}
-        >
-          Switch to week
-        </Button>
-        <Button
-          variant={currentView === 'month' ? undefined : 'outline'}
-          onClick={() => setCurrentView('month')}
-          disabled={currentView === 'month'}
-        >
-          Switch to month
-        </Button>
-      </div>
-
-      {/* Add sync progress bar when syncing */}
-      {isSyncing && (
-        <>
-          <Separator className="my-2" />
-          <div className="mt-3 space-y-2">
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-green-700 dark:text-green-400">
-                {syncProgress.statusMessage}
-              </span>
-              <span className="text-green-700 dark:text-green-400">
-                {Math.round(syncProgress.percentage)}%
-              </span>
-            </div>
-            <Progress
-              value={syncProgress.percentage}
-              className="h-1.5 w-full"
-            />
-          </div>
-          <Separator className="my-2" />
-        </>
-      )}
-
-      <Button onClick={handleSyncToTuturuuu}>Sync to Tuturuuu</Button>
-
       {data && (
         <>
           <Separator className="my-2" />

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/calendar/active-sync.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/calendar/active-sync.tsx
@@ -63,11 +63,13 @@ export const CalendarActiveSyncDebugger = () => {
   return (
     <>
       <div className="flex items-center gap-2">
-        <Switch
-          checked={isDebuggingOpen}
-          onCheckedChange={setIsDebuggingOpen}
-        />
-        <span>Active Sync</span>
+        <label className="flex cursor-pointer items-center gap-2">
+          <Switch
+            checked={isDebuggingOpen}
+            onCheckedChange={setIsDebuggingOpen}
+          />
+          <span>Show Debugger</span>
+        </label>
       </div>
       {isDebuggingOpen && <InnerComponent />}
     </>


### PR DESCRIPTION
<img width="1439" height="360" alt="image" src="https://github.com/user-attachments/assets/d82f3106-b1d6-40d5-a516-23c858eccae2" />
<img width="1442" height="534" alt="image" src="https://github.com/user-attachments/assets/967de443-084a-4009-9ee7-18b4092789d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle switch to show or hide calendar sync details in the dashboard.

* **Refactor**
  * Simplified the calendar sync view by removing the sync button, progress bar, and related interactive controls. Only sync data and errors are now displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->