### PR TITLE
Restrict Access to Agenda edit button

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/meet-together/plans/[planId]/agenda-details.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/meet-together/plans/[planId]/agenda-details.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTimeBlocking } from './time-blocking-provider';
 import type { MeetTogetherPlan } from '@tuturuuu/types/primitives/MeetTogetherPlan';
 import { Button } from '@tuturuuu/ui/button';
 import { ClipboardList, Pencil, Plus } from '@tuturuuu/ui/icons';
@@ -16,7 +17,7 @@ interface AgendaDetailsProps {
 export default function AgendaDetails({ plan }: AgendaDetailsProps) {
   const t = useTranslations('meet-together');
   const router = useRouter();
-
+  const { user } = useTimeBlocking();
   const [editContent, setEditContent] = useState<JSONContent | null>(
     plan.agenda_content || null
   );
@@ -87,17 +88,19 @@ export default function AgendaDetails({ plan }: AgendaDetailsProps) {
               {isLoading ? 'Saving...' : 'Save'}
             </Button>
           </div>
-        ) : plan.agenda_content ? (
-          <Button onClick={handleEdit} variant="outline" size="lg">
-            <Pencil size={16} />
-            Edit
-          </Button>
-        ) : (
-          <Button onClick={handleEdit} variant="default" size="lg">
-            <Plus size={16} />
-            Add Agenda
-          </Button>
-        )}
+        ) : user ? (
+          plan.agenda_content ? (
+            <Button onClick={handleEdit} variant="outline" size="lg">
+              <Pencil size={16} />
+              Edit
+            </Button>
+          ) : (
+            <Button onClick={handleEdit} variant="default" size="lg">
+              <Plus size={16} />
+              Add Agenda
+            </Button>
+          )
+        ) : null}
       </div>
 
       {plan.agenda_content || isEditing ? (

--- a/apps/web/src/app/[locale]/(marketing)/meet-together/plans/[planId]/agenda-details.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/meet-together/plans/[planId]/agenda-details.tsx
@@ -2,6 +2,7 @@
 
 import { useTimeBlocking } from './time-blocking-provider';
 import type { MeetTogetherPlan } from '@tuturuuu/types/primitives/MeetTogetherPlan';
+import type { User } from '@tuturuuu/types/primitives/User';
 import { Button } from '@tuturuuu/ui/button';
 import { ClipboardList, Pencil, Plus } from '@tuturuuu/ui/icons';
 import { RichTextEditor } from '@tuturuuu/ui/text-editor/editor';
@@ -12,9 +13,13 @@ import { useCallback, useState } from 'react';
 
 interface AgendaDetailsProps {
   plan: MeetTogetherPlan;
+  platformUser: User | null;
 }
 
-export default function AgendaDetails({ plan }: AgendaDetailsProps) {
+export default function AgendaDetails({
+  plan,
+  platformUser,
+}: AgendaDetailsProps) {
   const t = useTranslations('meet-together');
   const router = useRouter();
   const { user } = useTimeBlocking();
@@ -65,6 +70,9 @@ export default function AgendaDetails({ plan }: AgendaDetailsProps) {
     setEditContent(content || null);
   }, []);
 
+  // Only allow platform users to edit (not guest users)
+  const canEdit = !!platformUser;
+
   return (
     <div className="w-full space-y-8">
       <div className="flex flex-col items-start justify-between gap-4 md:flex-row">
@@ -88,7 +96,7 @@ export default function AgendaDetails({ plan }: AgendaDetailsProps) {
               {isLoading ? 'Saving...' : 'Save'}
             </Button>
           </div>
-        ) : user ? (
+        ) : canEdit ? (
           plan.agenda_content ? (
             <Button onClick={handleEdit} variant="outline" size="lg">
               <Pencil size={16} />

--- a/apps/web/src/app/[locale]/(marketing)/meet-together/plans/[planId]/agenda-details.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/meet-together/plans/[planId]/agenda-details.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useTimeBlocking } from './time-blocking-provider';
 import type { MeetTogetherPlan } from '@tuturuuu/types/primitives/MeetTogetherPlan';
 import type { User } from '@tuturuuu/types/primitives/User';
 import { Button } from '@tuturuuu/ui/button';
@@ -22,7 +21,6 @@ export default function AgendaDetails({
 }: AgendaDetailsProps) {
   const t = useTranslations('meet-together');
   const router = useRouter();
-  const { user } = useTimeBlocking();
   const [editContent, setEditContent] = useState<JSONContent | null>(
     plan.agenda_content || null
   );

--- a/apps/web/src/app/[locale]/(marketing)/meet-together/plans/[planId]/plan-details-client.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/meet-together/plans/[planId]/plan-details-client.tsx
@@ -199,7 +199,7 @@ export default function PlanDetailsClient({
 
           <Separator className="my-8" />
 
-          <AgendaDetails plan={plan} />
+          <AgendaDetails plan={plan} platformUser={platformUser} />
         </div>
       </div>
       {users.length > 0 && (

--- a/apps/web/src/app/api/meet-together/plans/[planId]/route.ts
+++ b/apps/web/src/app/api/meet-together/plans/[planId]/route.ts
@@ -1,4 +1,7 @@
-import { createAdminClient } from '@tuturuuu/supabase/next/server';
+import {
+  createAdminClient,
+  createClient,
+} from '@tuturuuu/supabase/next/server';
 import { NextResponse } from 'next/server';
 
 interface Params {
@@ -8,6 +11,13 @@ interface Params {
 }
 
 export async function PUT(req: Request, { params }: Params) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ message: 'Not authenticated' }, { status: 401 });
+  }
   const sbAdmin = await createAdminClient();
   const { planId: id } = await params;
 


### PR DESCRIPTION
No longer renders edit button to anonymous users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edit and Add Agenda buttons are now only visible to logged-in users, ensuring only authenticated users can modify agenda content.
  * API updates now require user authentication for updating plans, improving security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->