### PR TITLE
Change GMT references to UTC

### DIFF
--- a/packages/ui/src/components/ui/legacy/tumeet/create-plan-dialog.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/create-plan-dialog.tsx
@@ -63,7 +63,18 @@ const convertToTimetz = (
   utcOffset: number | undefined
 ) => {
   if (!time || utcOffset === undefined) return undefined;
-  return `${time}:00${utcOffset < 0 ? '-' : '+'}${Math.abs(utcOffset)}`;
+
+  // Convert decimal offset to HH:MM format for PostgreSQL
+  const hours = Math.floor(Math.abs(utcOffset));
+  const minutes = Math.round((Math.abs(utcOffset) - hours) * 60);
+
+  // Format time as HH:MM
+  const timeStr = time.toString().padStart(2, '0') + ':00';
+
+  // Format offset as +/-HH:MM
+  const offsetStr = `${utcOffset < 0 ? '-' : '+'}${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+
+  return `${timeStr}${offsetStr}`;  
 };
 
 export default function CreatePlanDialog({ plan }: Props) {

--- a/packages/ui/src/components/ui/legacy/tumeet/plans-grid.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/plans-grid.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { formatTimezoneOffset } from '../../../../utils/date-helper';
 import EditPlanDialog from './edit-plan-dialog';
 import type { MeetTogetherPlanWithParticipants } from './page';
 import UserTime from './user-time';
@@ -56,13 +57,7 @@ export function PlansGrid({
             </h3>
             {plan.start_time && (
               <div className="rounded-full bg-foreground/10 px-3 py-1 text-xs font-medium whitespace-nowrap text-foreground/80">
-                UTC
-                {Intl.NumberFormat('en-US', {
-                  signDisplay: 'always',
-                }).format(
-                  parseInt(plan.start_time?.split(/[+-]/)?.[1] ?? '0') *
-                    (plan.start_time?.includes('-') ? -1 : 1)
-                )}
+                {formatTimezoneOffset(plan.start_time)}
               </div>
             )}
             <div onClick={handleDialogClick}>

--- a/packages/ui/src/components/ui/legacy/tumeet/plans-grid.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/plans-grid.tsx
@@ -56,7 +56,7 @@ export function PlansGrid({
             </h3>
             {plan.start_time && (
               <div className="rounded-full bg-foreground/10 px-3 py-1 text-xs font-medium whitespace-nowrap text-foreground/80">
-                GMT
+                UTC
                 {Intl.NumberFormat('en-US', {
                   signDisplay: 'always',
                 }).format(

--- a/packages/ui/src/components/ui/legacy/tumeet/plans-list-view.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/plans-list-view.tsx
@@ -70,7 +70,7 @@ export function PlansListView({
                 </h3>
                 {plan.start_time && (
                   <div className="rounded-full bg-foreground/10 px-3 py-1 text-xs font-medium whitespace-nowrap text-foreground/80">
-                    GMT
+                    UTC
                     {Intl.NumberFormat('en-US', {
                       signDisplay: 'always',
                     }).format(

--- a/packages/ui/src/components/ui/legacy/tumeet/plans-list-view.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/plans-list-view.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { formatTimezoneOffset } from '../../../../utils/date-helper';
 import EditPlanDialog from './edit-plan-dialog';
 import type { MeetTogetherPlanWithParticipants } from './page';
 import UserTime from './user-time';
@@ -70,14 +71,7 @@ export function PlansListView({
                 </h3>
                 {plan.start_time && (
                   <div className="rounded-full bg-foreground/10 px-3 py-1 text-xs font-medium whitespace-nowrap text-foreground/80">
-                    UTC
-                    {Intl.NumberFormat('en-US', {
-                      signDisplay: 'always',
-                    }).format(
-                      Number.parseInt(
-                        plan.start_time?.split(/[+-]/)?.[1] ?? '0'
-                      ) * (plan.start_time?.includes('-') ? -1 : 1)
-                    )}
+                    {formatTimezoneOffset(plan.start_time)}
                   </div>
                 )}
               </div>

--- a/packages/ui/src/utils/date-helper.ts
+++ b/packages/ui/src/utils/date-helper.ts
@@ -54,3 +54,66 @@ export function minTimetz(timetz1: string, timetz2: string) {
 export function maxTimetz(timetz1: string, timetz2: string) {
   return compareTimetz(timetz1, timetz2) > 0 ? timetz1 : timetz2;
 }
+
+/**
+ * Parses timezone offset from a time string and returns a formatted offset string
+ * @param timeString - String like "11:00:00+07:00" or "14:30:00-05:30"
+ * @returns Formatted offset string like "+07:00" or "-05:30"
+ */
+export function parseTimezoneOffset(timeString: string): string {
+  if (!timeString) return '';
+
+  // Find the last occurrence of '+' or '-' which indicates the timezone offset
+  const lastPlusIndex = timeString.lastIndexOf('+');
+  const lastMinusIndex = timeString.lastIndexOf('-');
+
+  // If no offset found, return empty string
+  if (lastPlusIndex === -1 && lastMinusIndex === -1) {
+    return '';
+  }
+
+  // Determine which offset to use (take the last one if both exist)
+  const offsetIndex = Math.max(lastPlusIndex, lastMinusIndex);
+
+  // Extract the offset part
+  const offsetPart = timeString.substring(offsetIndex);
+
+  // Handle cases where the offset is already in HH:MM format like "+05:30"
+  if (offsetPart.includes(':')) {
+    // Already in HH:MM format, return as-is
+    return offsetPart;
+  }
+
+  // Handle legacy decimal format like "+5.5" (for backward compatibility)
+  const offset = parseFloat(offsetPart);
+
+  // Handle NaN case
+  if (isNaN(offset)) {
+    return '';
+  }
+
+  // Convert decimal hours to HH:MM format
+  const hours = Math.floor(Math.abs(offset));
+  const minutes = Math.round((Math.abs(offset) - hours) * 60);
+
+  // Format as HH:MM
+  const formattedHours = hours.toString().padStart(2, '0');
+  const formattedMinutes = minutes.toString().padStart(2, '0');
+
+  const sign = offset >= 0 ? '+' : '-';
+  return `${sign}${formattedHours}:${formattedMinutes}`;
+}
+
+/**
+ * Formats timezone offset for display in UI
+ * @param timeString - String like "11:00:00+07" or "14:30:00-05"
+ * @returns Formatted string like "UTC+07:00" or "UTC-05:30"
+ */
+export function formatTimezoneOffset(timeString: string): string {
+  if (!timeString) return '';
+
+  const offset = parseTimezoneOffset(timeString);
+  if (!offset) return '';
+
+  return `UTC${offset}`;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved display of time zone offsets for plans, now showing them in a standardized "UTC±HH:MM" format for better clarity.
* **Refactor**
  * Centralized and simplified time zone offset formatting across the app, ensuring consistency and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->