### PR TITLE
User Priviliges Clash

### DIFF
--- a/packages/ui/src/components/ui/legacy/tumeet/planId/agenda-details.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/agenda-details.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { MeetTogetherPlan } from '@tuturuuu/types/primitives/MeetTogetherPlan';
-import type { User } from '@tuturuuu/types/primitives/User';
 import { Button } from '@tuturuuu/ui/button';
 import { useTimeBlocking } from '@tuturuuu/ui/hooks/time-blocking-provider';
 import { ClipboardList, Pencil, Plus } from '@tuturuuu/ui/icons';

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/agenda-details.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/agenda-details.tsx
@@ -3,6 +3,7 @@
 import type { MeetTogetherPlan } from '@tuturuuu/types/primitives/MeetTogetherPlan';
 import type { User } from '@tuturuuu/types/primitives/User';
 import { Button } from '@tuturuuu/ui/button';
+import { useTimeBlocking } from '@tuturuuu/ui/hooks/time-blocking-provider';
 import { ClipboardList, Pencil, Plus } from '@tuturuuu/ui/icons';
 import { RichTextEditor } from '@tuturuuu/ui/text-editor/editor';
 import { type JSONContent } from '@tuturuuu/ui/tiptap';
@@ -12,15 +13,12 @@ import { useCallback, useState } from 'react';
 
 interface AgendaDetailsProps {
   plan: MeetTogetherPlan;
-  platformUser: User | null;
 }
 
-export default function AgendaDetails({
-  plan,
-  platformUser,
-}: AgendaDetailsProps) {
+export default function AgendaDetails({ plan }: AgendaDetailsProps) {
   const t = useTranslations('meet-together');
   const router = useRouter();
+  const { user } = useTimeBlocking();
   const [editContent, setEditContent] = useState<JSONContent | null>(
     plan.agenda_content || null
   );
@@ -69,7 +67,7 @@ export default function AgendaDetails({
   }, []);
 
   // Only allow platform users to edit (not guest users)
-  const canEdit = !!platformUser;
+  const canEdit = !!user && !user.is_guest;
 
   return (
     <div className="w-full space-y-8">

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/logged-in-as-button.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/logged-in-as-button.tsx
@@ -5,15 +5,15 @@ import { useTimeBlocking } from '@tuturuuu/ui/hooks/time-blocking-provider';
 import { Separator } from '@tuturuuu/ui/separator';
 import { useTranslations } from 'next-intl';
 
-export default function LoggedInAsButton({
-  platformUser,
-}: {
-  platformUser: PlatformUser | null;
-}) {
+export default function LoggedInAsButton() {
   const t = useTranslations();
-  const { user: guestUser, setDisplayMode } = useTimeBlocking();
+  const {
+    user: guestUser,
+    originalPlatformUser,
+    setDisplayMode,
+  } = useTimeBlocking();
 
-  const user = guestUser ?? platformUser;
+  const user = guestUser ?? originalPlatformUser;
 
   return (
     <div className="w-full rounded border border-foreground/20 bg-foreground/5 p-2 text-center md:w-fit md:min-w-64">
@@ -26,7 +26,7 @@ export default function LoggedInAsButton({
         className={`${user?.id ? '' : 'opacity-50'} line-clamp-1 font-semibold break-all`}
       >
         {user?.display_name ||
-          platformUser?.email ||
+          originalPlatformUser?.email ||
           t('meet-together-plan-details.anonymous')}{' '}
       </div>
 
@@ -35,7 +35,7 @@ export default function LoggedInAsButton({
           type={
             user?.is_guest === true
               ? 'GUEST'
-              : platformUser?.id
+              : originalPlatformUser?.id
                 ? 'PLATFORM'
                 : 'GUEST'
           }

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/logged-in-as-button.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/logged-in-as-button.tsx
@@ -1,5 +1,4 @@
 import AccountBadge from './account-badge';
-import type { User as PlatformUser } from '@tuturuuu/types/primitives/User';
 import { Button } from '@tuturuuu/ui/button';
 import { useTimeBlocking } from '@tuturuuu/ui/hooks/time-blocking-provider';
 import { Separator } from '@tuturuuu/ui/separator';

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/page.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/page.tsx
@@ -31,9 +31,9 @@ export default async function MeetTogetherPlanDetailsPage({
   const users: PlanUser[] = await getUsers(planId);
   const polls = await getPollsForPlan(planId);
   const timeblocks = await getTimeBlocks(planId);
-  const isCreator = Boolean(
-    platformUser?.id && plan?.creator_id && platformUser.id === plan.creator_id
-  );
+  // const isCreator = Boolean(
+  //   platformUser?.id && plan?.creator_id && platformUser.id === plan.creator_id
+  // );
 
   return (
     <div className="flex min-h-screen w-full flex-col items-center">
@@ -48,9 +48,8 @@ export default async function MeetTogetherPlanDetailsPage({
           >
             <PlanDetailsClient
               plan={plan}
-              isCreator={isCreator}
+              // isCreator={isCreator}
               polls={polls}
-              platformUser={platformUser}
               users={users}
               timeblocks={timeblocks}
               baseUrl={baseUrl}

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/plan-details-client.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/plan-details-client.tsx
@@ -28,8 +28,8 @@ import { useCallback, useEffect, useState } from 'react';
 interface PlanDetailsClientProps {
   plan: MeetTogetherPlan;
   polls: GetPollsForPlanResult | null;
-  platformUser: User | null;
-  isCreator: boolean;
+  // platformUser: User | null;
+  // isCreator: boolean;
   users: PlanUser[];
   timeblocks: Timeblock[];
   baseUrl: string;
@@ -37,8 +37,8 @@ interface PlanDetailsClientProps {
 
 export default function PlanDetailsClient({
   plan,
-  platformUser,
-  isCreator,
+  // platformUser,
+  // isCreator,
   users,
   polls,
   timeblocks,
@@ -46,7 +46,8 @@ export default function PlanDetailsClient({
 }: PlanDetailsClientProps) {
   const { resolvedTheme } = useTheme();
   const [showBestTimes, setShowBestTimes] = useState(false);
-  const { filteredUserIds, isDirty, resetLocalTimeblocks } = useTimeBlocking();
+  const { filteredUserIds, isDirty, resetLocalTimeblocks, user } =
+    useTimeBlocking();
 
   // If user filter is active, force best times off
   const isUserFilterActive = filteredUserIds && filteredUserIds.length > 0;
@@ -104,16 +105,12 @@ export default function PlanDetailsClient({
     <>
       <div className="flex w-full max-w-7xl flex-col gap-6 p-4 text-foreground md:px-6 lg:gap-14 lg:px-10">
         <div className="flex w-full flex-col items-center">
-          <UtilityButtons
-            plan={plan}
-            platformUser={platformUser}
-            handlePNG={downloadAsPNG}
-          />
+          <UtilityButtons plan={plan} handlePNG={downloadAsPNG} />
 
           <div id="plan-ref" className="flex w-full flex-col items-center">
             <p className="my-4 flex max-w-xl items-center gap-2 text-center text-2xl leading-tight! font-semibold text-balance md:mb-4 lg:text-3xl">
               {plan.name}{' '}
-              {platformUser?.id === plan.creator_id ? (
+              {user?.id === plan.creator_id ? (
                 <EditPlanDialog
                   plan={plan}
                   onSuccess={() => {
@@ -190,18 +187,12 @@ export default function PlanDetailsClient({
                   onBestTimesStatusByDateAction={setBestTimesStatusByDate}
                 />
               </div>
-              <SidebarDisplay
-                plan={plan}
-                polls={polls}
-                isCreator={isCreator}
-                platformUser={platformUser}
-                users={users}
-              />
+              <SidebarDisplay plan={plan} polls={polls} users={users} />
             </div>
 
             <Separator className="my-8" />
 
-            <AgendaDetails plan={plan} platformUser={platformUser} />
+            <AgendaDetails plan={plan} />
           </div>
         </div>
       </div>
@@ -209,7 +200,7 @@ export default function PlanDetailsClient({
       {/* Discord-style sticky bottom indicator for unsaved changes */}
       {isDirty && <StickyBottomIndicator />}
 
-      <PlanLogin plan={plan} platformUser={platformUser} baseUrl={baseUrl} />
+      <PlanLogin plan={plan} baseUrl={baseUrl} />
     </>
   );
 }

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/plan-details-client.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/plan-details-client.tsx
@@ -12,7 +12,6 @@ import type {
 } from '@tuturuuu/types/primitives/MeetTogetherPlan';
 import type { GetPollsForPlanResult } from '@tuturuuu/types/primitives/Poll';
 import type { Timeblock } from '@tuturuuu/types/primitives/Timeblock';
-import type { User } from '@tuturuuu/types/primitives/User';
 import { useTimeBlocking } from '@tuturuuu/ui/hooks/time-blocking-provider';
 import { CircleQuestionMark } from '@tuturuuu/ui/icons';
 import { Label } from '@tuturuuu/ui/label';

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/plan-login.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/plan-login.tsx
@@ -41,11 +41,9 @@ const GUEST_CREDENTIALS_KEY_PREFIX = 'meet_together_guest_';
 
 export default function PlanLogin({
   plan,
-  platformUser,
   baseUrl,
 }: {
   plan: MeetTogetherPlan;
-  platformUser: User | null;
   baseUrl: string;
 }) {
   const pathname = usePathname();
@@ -53,7 +51,8 @@ export default function PlanLogin({
 
   const t = useTranslations();
 
-  const { user, displayMode, setUser, setDisplayMode } = useTimeBlocking();
+  const { user, originalPlatformUser, displayMode, setUser, setDisplayMode } =
+    useTimeBlocking();
 
   const [loading, setLoading] = useState(false);
 

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/plan-login.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/plan-login.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { MeetTogetherPlan } from '@tuturuuu/types/primitives/MeetTogetherPlan';
-import type { User } from '@tuturuuu/types/primitives/User';
 import { Button } from '@tuturuuu/ui/button';
 import { Checkbox } from '@tuturuuu/ui/checkbox';
 import {

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/plan-login.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/plan-login.tsx
@@ -221,22 +221,24 @@ export default function PlanLogin({
               onClick={() => {
                 if (!plan.id) return;
 
-                if (!platformUser) {
+                if (!originalPlatformUser) {
                   router.push(
                     `${baseUrl}/login?nextUrl=${encodeURIComponent(pathname)}`
                   );
                   return;
                 }
 
-                setUser(plan.id, platformUser);
+                setUser(plan.id, originalPlatformUser);
                 setDisplayMode();
               }}
               disabled={
                 !plan.id ||
-                (!!platformUser && (!user?.id || platformUser?.id === user?.id))
+                (!!originalPlatformUser &&
+                  (!user?.id || originalPlatformUser?.id === user?.id))
               }
             >
-              {!!platformUser && (!user?.id || platformUser?.id === user?.id)
+              {!!originalPlatformUser &&
+              (!user?.id || originalPlatformUser?.id === user?.id)
                 ? t('meet-together-plan-details.using_tuturuuu_account')
                 : t('meet-together-plan-details.use_tuturuuu_account')}
             </Button>

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/sidebar-display.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/sidebar-display.tsx
@@ -7,7 +7,6 @@ import type {
   PlanUser,
 } from '@tuturuuu/types/primitives/MeetTogetherPlan';
 import type { GetPollsForPlanResult } from '@tuturuuu/types/primitives/Poll';
-import type { User } from '@tuturuuu/types/primitives/User';
 import {
   Accordion,
   AccordionContent,

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/sidebar-display.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/sidebar-display.tsx
@@ -14,24 +14,25 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@tuturuuu/ui/accordion';
+import { useTimeBlocking } from '@tuturuuu/ui/hooks/time-blocking-provider';
 import { useTranslations } from 'next-intl';
 
 export interface SidebarDisplayProps {
   plan: MeetTogetherPlan;
-  isCreator: boolean;
-  platformUser: User | null;
   polls: GetPollsForPlanResult | null;
   users: PlanUser[];
 }
 
 export default function SidebarDisplay({
   plan,
-  isCreator,
-  platformUser,
   polls,
   users,
 }: SidebarDisplayProps) {
   const t = useTranslations('ws-polls');
+  const { user, originalPlatformUser } = useTimeBlocking();
+
+  // Determine if the current user is the creator
+  const isCreator = user?.id === plan.creator_id;
 
   return (
     <Accordion
@@ -47,7 +48,7 @@ export default function SidebarDisplay({
           <PlanDetailsPollContent
             plan={plan}
             isCreator={isCreator}
-            platformUser={platformUser}
+            platformUser={originalPlatformUser}
             polls={polls}
           />
         </AccordionContent>

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/utility-buttons.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/utility-buttons.tsx
@@ -6,8 +6,6 @@ import EmailButton from './email-button';
 import LoggedInAsButton from './logged-in-as-button';
 import ShowQRButton from './show-qr-button';
 import type { MeetTogetherPlan } from '@tuturuuu/types/primitives/MeetTogetherPlan';
-import type { User } from '@tuturuuu/types/primitives/User';
-import { useTimeBlocking } from '@tuturuuu/ui/hooks/time-blocking-provider';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -24,7 +22,6 @@ export default function UtilityButtons({
 }: UtilityButtonsProps) {
   const pathname = usePathname();
   const [url, setUrl] = useState('');
-  const { user } = useTimeBlocking();
 
   useEffect(() => {
     setUrl(`${window.location.origin}${pathname}`);

--- a/packages/ui/src/components/ui/legacy/tumeet/planId/utility-buttons.tsx
+++ b/packages/ui/src/components/ui/legacy/tumeet/planId/utility-buttons.tsx
@@ -7,22 +7,24 @@ import LoggedInAsButton from './logged-in-as-button';
 import ShowQRButton from './show-qr-button';
 import type { MeetTogetherPlan } from '@tuturuuu/types/primitives/MeetTogetherPlan';
 import type { User } from '@tuturuuu/types/primitives/User';
+import { useTimeBlocking } from '@tuturuuu/ui/hooks/time-blocking-provider';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 interface UtilityButtonsProps {
   plan: MeetTogetherPlan;
-  platformUser: User | null;
+  // platformUser: User | null;
   handlePNG: () => Promise<void>;
 }
 
 export default function UtilityButtons({
   plan,
-  platformUser,
+  // platformUser,
   handlePNG,
 }: UtilityButtonsProps) {
   const pathname = usePathname();
   const [url, setUrl] = useState('');
+  const { user } = useTimeBlocking();
 
   useEffect(() => {
     setUrl(`${window.location.origin}${pathname}`);
@@ -40,7 +42,7 @@ export default function UtilityButtons({
         <EmailButton plan={plan} url={tumeetMeUrl} />
         <DownloadAsPNG onClick={handlePNG} />
       </div>
-      <LoggedInAsButton platformUser={platformUser} />
+      <LoggedInAsButton />
     </div>
   );
 }

--- a/packages/ui/src/hooks/time-blocking-provider.tsx
+++ b/packages/ui/src/hooks/time-blocking-provider.tsx
@@ -85,6 +85,7 @@ const findTimeBlocksToAdd = (
 
 const TimeBlockContext = createContext({
   user: null as PlatformUser | GuestUser | null,
+  originalPlatformUser: null as PlatformUser | null,
   planUsers: [] as (PlatformUser | GuestUser)[],
   filteredUserIds: [] as string[],
   previewDate: null as Date | null,
@@ -699,6 +700,7 @@ const TimeBlockingProvider = ({
     <TimeBlockContext.Provider
       value={{
         user,
+        originalPlatformUser: platformUser,
         planUsers,
         filteredUserIds,
         previewDate,


### PR DESCRIPTION
Fixes this edge case: "if I were to logged into Tuturuuu, then when I switch into a guest account in TuMeet, the permissions I have in the plan is respective to my Tuturuu account. 
E.g. My Tuturuu account is the creator, but If i switch to my guest account "Henry", this account can also edit the plan like a creator because my Tuturuu account is not signed off."