### PR TITLE
Add secondary calendar UI

### DIFF
--- a/packages/ui/src/components/ui/legacy/calendar/all-day-event-bar.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/all-day-event-bar.tsx
@@ -82,6 +82,9 @@ export const AllDayEventBar = ({ dates }: { dates: Date[] }) => {
   const { allDayEvents } = useCalendarSync();
   const showWeekends = settings.appearance.showWeekends;
   const tz = settings?.timezone?.timezone;
+  const secondaryTz = settings?.timezone?.secondaryTimezone;
+  const showSecondary =
+    settings?.timezone?.showSecondaryTimezone && secondaryTz;
   const [expandedDates, setExpandedDates] = useState<string[]>([]);
 
   // Drag and drop state
@@ -640,9 +643,19 @@ export const AllDayEventBar = ({ dates }: { dates: Date[] }) => {
 
   return (
     <div className="flex">
-      {/* Label column */}
-      <div className="flex w-16 items-center justify-center border-b border-l bg-muted/30 p-2 font-medium">
-        <Calendar className="h-4 w-4 text-muted-foreground" />
+      {/* Time column headers - matching the main calendar layout */}
+      <div className="flex">
+        {/* Secondary timezone header (shows on left when enabled) */}
+        {showSecondary && (
+          <div className="flex w-16 items-center justify-center border-b border-l bg-muted/20 p-2 font-medium">
+            <div className="h-4 w-4" /> {/* Spacer to maintain alignment */}
+          </div>
+        )}
+
+        {/* Primary timezone header with calendar icon */}
+        <div className="flex w-16 items-center justify-center border-b border-l bg-muted/30 p-2 font-medium">
+          <Calendar className="h-4 w-4 text-muted-foreground" />
+        </div>
       </div>
 
       {/* All-day event columns with relative positioning for spanning events */}

--- a/packages/ui/src/components/ui/legacy/calendar/time-indicator-text.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/time-indicator-text.tsx
@@ -9,6 +9,9 @@ dayjs.extend(timezone);
 export const TimeIndicatorText = ({ columnIndex }: { columnIndex: number }) => {
   const { settings } = useCalendar();
   const tz = settings?.timezone?.timezone;
+  const secondaryTz = settings?.timezone?.secondaryTimezone;
+  const showSecondary =
+    settings?.timezone?.showSecondaryTimezone && secondaryTz;
   const [now, setNow] = useState(tz === 'auto' ? dayjs() : dayjs().tz(tz));
 
   // Update the time every minute
@@ -24,9 +27,9 @@ export const TimeIndicatorText = ({ columnIndex }: { columnIndex: number }) => {
     const interval = setInterval(updateTime, 60000);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [tz]);
 
-  // Use selected timezone
+  // Use selected timezone for primary
   const nowTz = tz === 'auto' ? now : now.tz(tz);
   const hours = nowTz.hour();
   const minutes = nowTz.minute();
@@ -35,27 +38,65 @@ export const TimeIndicatorText = ({ columnIndex }: { columnIndex: number }) => {
   // Calculate total hours with decimal for precise positioning
   const totalHours = hours + minutes / 60 + seconds / 3600;
 
-  // Format the current time
+  // Format the current time for primary timezone
   const formattedTime = nowTz.format(
     settings?.appearance?.timeFormat === '24h' ? 'HH:mm' : 'h:mm a'
   );
+
+  // Secondary timezone time
+  let secondaryFormattedTime = '';
+  let secondaryTotalHours = 0;
+  if (showSecondary && secondaryTz) {
+    const secondaryNow = now.tz(secondaryTz);
+    const secHours = secondaryNow.hour();
+    const secMinutes = secondaryNow.minute();
+    const secSeconds = secondaryNow.second();
+    secondaryTotalHours = secHours + secMinutes / 60 + secSeconds / 3600;
+    secondaryFormattedTime = secondaryNow.format(
+      settings?.appearance?.timeFormat === '24h' ? 'HH:mm' : 'h:mm a'
+    );
+  }
 
   // Only show the time indicator text for the first column (when columnIndex is 0)
   // This prevents duplicate time indicators when multiple days are visible
   if (columnIndex > 0) return null;
 
+  // Calculate positioning based on whether secondary timezone is shown
+  const leftOffset = showSecondary ? -134 : -70; // Adjust for dual timezone layout
+
   return (
-    <div
-      className="pointer-events-none absolute top-[-0.075rem] -left-[70px] z-100 flex items-center"
-      style={{
-        transform: `translateY(${totalHours * HOUR_HEIGHT - 10}px)`,
-        transition: 'transform 0.3s ease-out',
-      }}
-    >
-      <div className="rounded-md bg-dynamic-light-red px-2 py-1 text-xs font-semibold text-black">
-        {formattedTime}
+    <>
+      {/* Secondary timezone indicator (shows on left when enabled) */}
+      {showSecondary && (
+        <div
+          className="pointer-events-none absolute top-[-0.075rem] z-100 flex items-center"
+          style={{
+            left: '-70px',
+            transform: `translateY(${secondaryTotalHours * HOUR_HEIGHT - 10}px)`,
+            transition: 'transform 0.3s ease-out',
+          }}
+        >
+          <div className="rounded-md bg-blue-500/80 px-2 py-1 text-xs font-semibold text-white shadow-sm">
+            {secondaryFormattedTime}
+          </div>
+          <div className="h-0 w-0 border-y-[6px] border-l-[6px] border-y-transparent border-l-blue-500/80" />
+        </div>
+      )}
+
+      {/* Primary timezone indicator */}
+      <div
+        className="pointer-events-none absolute top-[-0.075rem] z-100 flex items-center"
+        style={{
+          left: `${leftOffset}px`,
+          transform: `translateY(${totalHours * HOUR_HEIGHT - 10}px)`,
+          transition: 'transform 0.3s ease-out',
+        }}
+      >
+        <div className="rounded-md bg-dynamic-light-red px-2 py-1 text-xs font-semibold text-black">
+          {formattedTime}
+        </div>
+        <div className="h-0 w-0 border-y-[6px] border-l-[6px] border-y-transparent border-l-dynamic-light-red" />
       </div>
-      <div className="h-0 w-0 border-y-[6px] border-l-[6px] border-y-transparent border-l-dynamic-light-red" />
-    </div>
+    </>
   );
 };

--- a/packages/ui/src/components/ui/legacy/calendar/time-trail.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/time-trail.tsx
@@ -10,43 +10,82 @@ export const TimeTrail = () => {
   // Get settings from context
   const { settings } = useCalendar();
   const tz = settings?.timezone?.timezone;
+  const secondaryTz = settings?.timezone?.secondaryTimezone;
+  const showSecondary =
+    settings?.timezone?.showSecondaryTimezone && secondaryTz;
 
   // Only show hours (not every half hour)
   const hours = Array.from(Array(24).keys());
 
   // Format time for display - only show hour
-  const formatTime = (hour: number) => {
+  const formatTime = (hour: number, timezone?: string) => {
     let date = dayjs();
-    date =
-      tz === 'auto'
-        ? date.hour(hour).minute(0).second(0).millisecond(0)
-        : date.tz(tz).hour(hour).minute(0).second(0).millisecond(0);
+
+    if (timezone) {
+      // Use specific timezone
+      date = date.tz(timezone).hour(hour).minute(0).second(0).millisecond(0);
+    } else {
+      // Use primary timezone logic
+      date =
+        tz === 'auto'
+          ? date.hour(hour).minute(0).second(0).millisecond(0)
+          : date.tz(tz).hour(hour).minute(0).second(0).millisecond(0);
+    }
+
     const timeFormat =
       settings?.appearance?.timeFormat === '24h' ? 'HH:mm' : 'h a';
     return date.format(timeFormat);
   };
 
   return (
-    <div
-      className="relative w-16 border-r border-border dark:border-zinc-800"
-      style={{ height: DAY_HEIGHT }}
-    >
-      {hours.map((hour) => (
+    <div className="flex">
+      {/* Secondary timezone column (shows on left when enabled) */}
+      {showSecondary && (
         <div
-          key={`trail-hour-${hour}`}
-          className="absolute flex h-20 w-full items-center justify-end pr-2"
-          style={{ top: `${(hour - 0.65) * HOUR_HEIGHT}px` }}
+          className="relative w-16 border-r border-border/30 dark:border-zinc-700/50"
+          style={{ height: DAY_HEIGHT }}
         >
-          <span
-            className={cn(
-              'text-sm font-medium text-muted-foreground',
-              hour === 0 && 'hidden'
-            )}
-          >
-            {formatTime(hour)}
-          </span>
+          {hours.map((hour) => (
+            <div
+              key={`secondary-trail-hour-${hour}`}
+              className="absolute flex h-20 w-full items-center justify-end pr-2"
+              style={{ top: `${(hour - 0.65) * HOUR_HEIGHT}px` }}
+            >
+              <span
+                className={cn(
+                  'text-sm font-medium text-muted-foreground/60 transition-colors hover:text-muted-foreground/80',
+                  hour === 0 && 'hidden'
+                )}
+              >
+                {formatTime(hour, secondaryTz)}
+              </span>
+            </div>
+          ))}
         </div>
-      ))}
+      )}
+
+      {/* Primary timezone column */}
+      <div
+        className="relative w-16 border-r border-border dark:border-zinc-800"
+        style={{ height: DAY_HEIGHT }}
+      >
+        {hours.map((hour) => (
+          <div
+            key={`primary-trail-hour-${hour}`}
+            className="absolute flex h-20 w-full items-center justify-end pr-2"
+            style={{ top: `${(hour - 0.65) * HOUR_HEIGHT}px` }}
+          >
+            <span
+              className={cn(
+                'text-sm font-medium text-muted-foreground',
+                hour === 0 && 'hidden'
+              )}
+            >
+              {formatTime(hour)}
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/packages/ui/src/components/ui/legacy/calendar/weekday-bar.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/weekday-bar.tsx
@@ -21,6 +21,9 @@ export const WeekdayBar = ({
   const { settings } = useCalendar();
   const showWeekends = settings.appearance.showWeekends;
   const tz = settings?.timezone?.timezone;
+  const secondaryTz = settings?.timezone?.secondaryTimezone;
+  const showSecondary =
+    settings?.timezone?.showSecondaryTimezone && secondaryTz;
 
   // Filter out weekend days if showWeekends is false
   const visibleDates = showWeekends
@@ -31,13 +34,70 @@ export const WeekdayBar = ({
         return day !== 0 && day !== 6; // 0 = Sunday, 6 = Saturday
       });
 
+  // Get timezone abbreviations
+  const getPrimaryTimezoneAbbr = () => {
+    if (tz === 'auto') {
+      return (
+        Intl.DateTimeFormat('en-US', {
+          timeZoneName: 'short',
+          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        })
+          .formatToParts(new Date())
+          .find((part) => part.type === 'timeZoneName')?.value || 'Local'
+      );
+    }
+    return (
+      Intl.DateTimeFormat('en-US', {
+        timeZoneName: 'short',
+        timeZone: tz,
+      })
+        .formatToParts(new Date())
+        .find((part) => part.type === 'timeZoneName')?.value || tz
+    );
+  };
+
+  const getSecondaryTimezoneAbbr = () => {
+    if (!secondaryTz) return '';
+    return (
+      Intl.DateTimeFormat('en-US', {
+        timeZoneName: 'short',
+        timeZone: secondaryTz,
+      })
+        .formatToParts(new Date())
+        .find((part) => part.type === 'timeZoneName')?.value || secondaryTz
+    );
+  };
+
+  const primaryTzAbbr = getPrimaryTimezoneAbbr();
+  const secondaryTzAbbr = getSecondaryTimezoneAbbr();
+
   return (
     <div className="flex flex-col bg-background/50">
       {/* Weekday header bar */}
       <div className="flex">
-        {/* Time column header */}
-        <div className="flex w-16 items-center justify-center rounded-tl-lg border border-r-0 bg-muted/30 p-2 font-medium">
-          <Clock className="h-4 w-4 text-muted-foreground" />
+        {/* Time column headers */}
+        <div className="flex">
+          {/* Secondary timezone header (shows on left when enabled) */}
+          {showSecondary && (
+            <div className="flex w-16 flex-col items-center justify-center rounded-tl-lg border border-r-0 bg-muted/20 p-1 font-medium">
+              <div className="text-[10px] font-medium text-muted-foreground/70">
+                {secondaryTzAbbr}
+              </div>
+            </div>
+          )}
+
+          {/* Primary timezone header with clock icon */}
+          <div
+            className={cn(
+              'flex w-16 flex-col items-center justify-center border border-r-0 bg-muted/30 p-1 font-medium',
+              !showSecondary && 'rounded-tl-lg'
+            )}
+          >
+            <Clock className="mb-0.5 h-3 w-3 text-muted-foreground" />
+            <div className="text-[10px] font-medium text-muted-foreground">
+              {primaryTzAbbr}
+            </div>
+          </div>
         </div>
 
         {/* Weekday columns */}


### PR DESCRIPTION

- Add dual timezone support with side-by-side time columns
- Show secondary timezone column on the left when enabled
- Display timezone abbreviations in column headers with clock icon
- Implement dual real-time current time indicators
  - Primary timezone: red indicator (existing)
  - Secondary timezone: blue indicator for distinction
- Update TimeTrail component for dual timezone hour display
- Enhance WeekdayBar with timezone abbreviation headers
- Modify AllDayEventBar to maintain layout consistency
- Add proper visual hierarchy with muted styling for secondary timezone
- Support automatic timezone detection and abbreviation display
- Maintain backward compatibility when secondary timezone is disabled

Enables users to easily coordinate across different time zones while maintaining a clean, professional Google Calendar-style interface.