### PR TITLE
Feedback dialog auto-close in edge case

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/structure.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/structure.tsx
@@ -280,8 +280,32 @@ export function Structure({
   };
 
   const isHoverMode = behavior === 'hover';
-  const onMouseEnter = isHoverMode ? () => setIsCollapsed(false) : undefined;
-  const onMouseLeave = isHoverMode ? () => setIsCollapsed(true) : undefined;
+
+  // Helper function to check if any dialogs are currently open
+  const hasOpenDialogs = useCallback(() => {
+    const hasDialogs =
+      document.querySelector('[data-state="open"][role="dialog"]') !== null;
+    const hasAlertDialogs =
+      document.querySelector('[data-state="open"][role="alertdialog"]') !==
+      null;
+    return hasDialogs || hasAlertDialogs;
+  }, []);
+
+  const onMouseEnter = isHoverMode
+    ? () => {
+        if (!hasOpenDialogs()) {
+          setIsCollapsed(false);
+        }
+      }
+    : undefined;
+
+  const onMouseLeave = isHoverMode
+    ? () => {
+        if (!hasOpenDialogs()) {
+          setIsCollapsed(true);
+        }
+      }
+    : undefined;
 
   const isRootWorkspace = wsId === ROOT_WORKSPACE_ID;
 


### PR DESCRIPTION
Fixes this behaviour: "When you try to submit a feedback while using the "expand-on-hover" and try to attach files, the sidebar auto-closes, and exit the feedback dialog as well."