### PR TITLE
Prevent filters from closing after one click

### DIFF
--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -62,6 +62,7 @@ function DropdownMenuItem({
   className,
   inset,
   variant = 'default',
+  onSelect,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
   inset?: boolean;
@@ -76,6 +77,12 @@ function DropdownMenuItem({
         "data-[variant=destructive]:*:[svg]:!text-destructive relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
+      onSelect={(e) => {
+        // Prevent default close behavior for menu items
+        e.preventDefault();
+        // Call the original onSelect if provided
+        onSelect?.(e);
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
The filter now can select multiple filters without closing after choosing one