### PR TITLE
fix(tudo): Edit List Functionality in Web App

### DIFF
--- a/apps/calendar/messages/en.json
+++ b/apps/calendar/messages/en.json
@@ -2212,6 +2212,7 @@
     "starts": "Starts",
     "starts_at": "Starts {date}",
     "status": "Status",
+    "status_category": "Status Category",
     "stay-updated": "Stay in the Loop",
     "stress": "stress",
     "styles": "Styles",

--- a/apps/calendar/messages/vi.json
+++ b/apps/calendar/messages/vi.json
@@ -2212,6 +2212,7 @@
     "starts": "Bắt đầu",
     "starts_at": "Bắt đầu {date}",
     "status": "Trạng thái",
+    "status_category": "Nhóm trạng thái",
     "stay-updated": "Cập nhật thường xuyên",
     "stress": "căng thẳng",
     "styles": "Kiểu dáng",

--- a/apps/finance/messages/en.json
+++ b/apps/finance/messages/en.json
@@ -2195,6 +2195,7 @@
     "starts": "Starts",
     "starts_at": "Starts {date}",
     "status": "Status",
+    "status_category": "Status Category",
     "stay-updated": "Stay in the Loop",
     "stress": "stress",
     "styles": "Styles",

--- a/apps/finance/messages/vi.json
+++ b/apps/finance/messages/vi.json
@@ -2195,6 +2195,7 @@
     "starts": "Bắt đầu",
     "starts_at": "Bắt đầu {date}",
     "status": "Trạng thái",
+    "status_category": "Nhóm trạng thái",
     "stay-updated": "Cập nhật thường xuyên",
     "stress": "căng thẳng",
     "styles": "Kiểu dáng",

--- a/apps/rewise/messages/en.json
+++ b/apps/rewise/messages/en.json
@@ -2200,6 +2200,7 @@
     "starts": "Starts",
     "starts_at": "Starts {date}",
     "status": "Status",
+    "status_category": "Status Category",
     "stay-updated": "Stay in the Loop",
     "stress": "stress",
     "styles": "Styles",

--- a/apps/rewise/messages/vi.json
+++ b/apps/rewise/messages/vi.json
@@ -2200,6 +2200,7 @@
     "starts": "Bắt đầu",
     "starts_at": "Bắt đầu {date}",
     "status": "Trạng thái",
+    "status_category": "Nhóm trạng thái",
     "stay-updated": "Cập nhật thường xuyên",
     "stress": "căng thẳng",
     "styles": "Kiểu dáng",

--- a/apps/tasks/messages/en.json
+++ b/apps/tasks/messages/en.json
@@ -2295,6 +2295,7 @@
     "starts": "Starts",
     "starts_at": "Starts {date}",
     "status": "Status",
+    "status_category": "Status Category",
     "stay-updated": "Stay in the Loop",
     "stress": "stress",
     "styles": "Styles",

--- a/apps/tasks/messages/vi.json
+++ b/apps/tasks/messages/vi.json
@@ -2295,6 +2295,7 @@
     "starts": "Bắt đầu",
     "starts_at": "Bắt đầu {date}",
     "status": "Trạng thái",
+    "status_category": "Nhóm trạng thái",
     "stay-updated": "Cập nhật thường xuyên",
     "stress": "căng thẳng",
     "styles": "Kiểu dáng",

--- a/apps/track/messages/en.json
+++ b/apps/track/messages/en.json
@@ -2195,6 +2195,7 @@
     "starts": "Starts",
     "starts_at": "Starts {date}",
     "status": "Status",
+    "status_category": "Status Category",
     "stay-updated": "Stay in the Loop",
     "stress": "stress",
     "styles": "Styles",

--- a/apps/track/messages/vi.json
+++ b/apps/track/messages/vi.json
@@ -2195,6 +2195,7 @@
     "starts": "Bắt đầu",
     "starts_at": "Bắt đầu {date}",
     "status": "Trạng thái",
+    "status_category": "Nhóm trạng thái",
     "stay-updated": "Cập nhật thường xuyên",
     "stress": "căng thẳng",
     "styles": "Kiểu dáng",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2516,6 +2516,7 @@
     "starts": "Starts",
     "starts_at": "Starts {date}",
     "status": "Status",
+    "status_category": "Status Category",
     "stay-updated": "Stay in the Loop",
     "stress": "stress",
     "styles": "Styles",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -2516,6 +2516,7 @@
     "starts": "Bắt đầu",
     "starts_at": "Bắt đầu {date}",
     "status": "Trạng thái",
+    "status_category": "Nhóm trạng thái",
     "stay-updated": "Cập nhật thường xuyên",
     "stress": "căng thẳng",
     "styles": "Kiểu dáng",

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/board-column.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/board-column.tsx
@@ -291,6 +291,7 @@ export function BoardColumn({
             listId={column.id}
             listName={column.name}
             listStatus={column.status}
+            listColor={column.color as SupportedColor}
             tasks={tasks}
             boardId={boardId}
             wsId={wsId}

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/list-actions.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/list-actions.tsx
@@ -35,7 +35,7 @@ import {
 import { toast } from '@tuturuuu/ui/sonner';
 import { useMoveAllTasksFromList } from '@tuturuuu/utils/task-helper';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useBoardBroadcast } from '../../shared/board-broadcast-context';
 import { EditListDialog } from '../../shared/edit-list-dialog';
 import { BoardSelector } from '../board-selector';
@@ -75,6 +75,23 @@ export function ListActions({
 
   const queryClient = useQueryClient();
   const broadcast = useBoardBroadcast();
+
+  const cachedLists = queryClient.getQueryData<TaskList[]>([
+    'task_lists',
+    boardId,
+  ]);
+  const hasAnotherClosedList =
+    cachedLists?.some(
+      (list) => list.id !== listId && list.status === 'closed' && !list.deleted
+    ) ?? false;
+  const allowedStatuses = useMemo<TaskBoardStatus[]>(() => {
+    if (listStatus === 'closed' || !hasAnotherClosedList) {
+      return ['documents', 'not_started', 'active', 'done', 'closed'];
+    }
+
+    return ['documents', 'not_started', 'active', 'done'];
+  }, [hasAnotherClosedList, listStatus]);
+
   const moveAllTasksFromListMutation = useMoveAllTasksFromList(
     boardId,
     wsId,
@@ -442,12 +459,17 @@ export function ListActions({
         }}
         isSaving={editListMutation.isPending}
         onSave={({ updates }) => {
+          if (!allowedStatuses.includes(updates.status)) {
+            toast.error(t('save_failed'));
+            return;
+          }
           editListMutation.mutate({
             trimmedName: updates.name,
             status: updates.status,
             color: updates.color,
           });
         }}
+        allowedStatuses={allowedStatuses}
       />
 
       <Dialog

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/list-actions.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/list-actions.tsx
@@ -12,6 +12,8 @@ import {
   listWorkspaceTaskLists,
   updateWorkspaceTaskList,
 } from '@tuturuuu/internal-api/tasks';
+import type { SupportedColor } from '@tuturuuu/types/primitives/SupportedColors';
+import type { TaskBoardStatus } from '@tuturuuu/types/primitives/TaskBoard';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import type { TaskList } from '@tuturuuu/types/primitives/TaskList';
 import { Button } from '@tuturuuu/ui/button';
@@ -30,18 +32,19 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@tuturuuu/ui/dropdown-menu';
-import { Input } from '@tuturuuu/ui/input';
 import { toast } from '@tuturuuu/ui/sonner';
 import { useMoveAllTasksFromList } from '@tuturuuu/utils/task-helper';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { useBoardBroadcast } from '../../shared/board-broadcast-context';
+import { EditListDialog } from '../../shared/edit-list-dialog';
 import { BoardSelector } from '../board-selector';
 
 interface Props {
   listId: string;
   listName: string;
-  listStatus?: string;
+  listStatus?: TaskBoardStatus;
+  listColor?: SupportedColor;
   tasks?: Task[];
   boardId?: string;
   wsId?: string;
@@ -55,6 +58,7 @@ export function ListActions({
   listId,
   listName,
   listStatus,
+  listColor,
   tasks = [],
   boardId = '',
   wsId,
@@ -68,7 +72,6 @@ export function ListActions({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
   const [isMoveAllDialogOpen, setIsMoveAllDialogOpen] = useState(false);
-  const [newName, setNewName] = useState(listName);
 
   const queryClient = useQueryClient();
   const broadcast = useBoardBroadcast();
@@ -146,8 +149,16 @@ export function ListActions({
     },
   });
 
-  const renameListMutation = useMutation({
-    mutationFn: async (trimmedName: string) => {
+  const editListMutation = useMutation({
+    mutationFn: async ({
+      trimmedName,
+      status,
+      color,
+    }: {
+      trimmedName: string;
+      status: TaskBoardStatus;
+      color: SupportedColor;
+    }) => {
       if (!wsId || !boardId) {
         throw new Error(t('save_failed'));
       }
@@ -156,14 +167,14 @@ export function ListActions({
         wsId,
         boardId,
         listId,
-        { name: trimmedName },
+        { name: trimmedName, status, color },
         {
           baseUrl:
             typeof window !== 'undefined' ? window.location.origin : undefined,
         }
       );
     },
-    onMutate: async (trimmedName) => {
+    onMutate: async ({ trimmedName, status, color }) => {
       await queryClient.cancelQueries({ queryKey: ['task_lists', boardId] });
       const previousLists = queryClient.getQueryData<TaskList[]>([
         'task_lists',
@@ -175,15 +186,17 @@ export function ListActions({
         (old: TaskList[] | undefined) => {
           if (!old) return old;
           return old.map((l) =>
-            l.id === listId ? { ...l, name: trimmedName } : l
+            l.id === listId ? { ...l, name: trimmedName, status, color } : l
           );
         }
       );
 
       return { previousLists };
     },
-    onSuccess: (_, trimmedName) => {
-      broadcast?.('list:upsert', { list: { id: listId, name: trimmedName } });
+    onSuccess: (_, { trimmedName, status, color }) => {
+      broadcast?.('list:upsert', {
+        list: { id: listId, name: trimmedName, status, color },
+      });
       toast.success(t('name_updated'));
       onEditOpenChange(false);
       onUpdate();
@@ -267,16 +280,6 @@ export function ListActions({
 
   function handleDelete() {
     deleteListMutation.mutate();
-  }
-
-  function handleUpdate() {
-    if (!newName.trim() || newName === listName) {
-      onEditOpenChange(false);
-      return;
-    }
-
-    const trimmedName = newName.trim();
-    renameListMutation.mutate(trimmedName);
   }
 
   function handleArchiveAllTasks() {
@@ -428,34 +431,24 @@ export function ListActions({
         </DialogContent>
       </Dialog>
 
-      <Dialog
+      <EditListDialog
         open={canManageList && isEditOpen}
         onOpenChange={onEditOpenChange}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('edit_list')}</DialogTitle>
-            <DialogDescription>{t('change_list_name')}</DialogDescription>
-          </DialogHeader>
-          <Input
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleUpdate();
-              }
-            }}
-            placeholder={t('list_name')}
-          />
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => onEditOpenChange(false)}>
-              {t('cancel')}
-            </Button>
-            <Button onClick={handleUpdate}>{t('save_changes')}</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        list={{
+          id: listId,
+          name: listName,
+          status: listStatus,
+          color: listColor ?? 'GRAY',
+        }}
+        isSaving={editListMutation.isPending}
+        onSave={({ updates }) => {
+          editListMutation.mutate({
+            trimmedName: updates.name,
+            status: updates.status,
+            color: updates.color,
+          });
+        }}
+      />
 
       <Dialog
         open={canManageList && isArchiveDialogOpen}

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/list-actions.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/list-actions.tsx
@@ -13,8 +13,8 @@ import {
   updateWorkspaceTaskList,
 } from '@tuturuuu/internal-api/tasks';
 import type { SupportedColor } from '@tuturuuu/types/primitives/SupportedColors';
-import type { TaskBoardStatus } from '@tuturuuu/types/primitives/TaskBoard';
 import type { Task } from '@tuturuuu/types/primitives/Task';
+import type { TaskBoardStatus } from '@tuturuuu/types/primitives/TaskBoard';
 import type { TaskList } from '@tuturuuu/types/primitives/TaskList';
 import { Button } from '@tuturuuu/ui/button';
 import {

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/task.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/task.tsx
@@ -2130,6 +2130,8 @@ export const TaskCard = React.memo(TaskCardInner, (prev, next) => {
   if (prev.isMultiSelectMode !== next.isMultiSelectMode) return false;
   if (prev.boardId !== next.boardId) return false;
   if (prev.workspaceId !== next.workspaceId) return false;
+  // Check taskList color changes so cards re-render when list color changes
+  if (prev.taskList?.color !== next.taskList?.color) return false;
   // Shallow compare task critical fields
   const a = prev.task;
   const b = next.task;

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/task.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/task.tsx
@@ -2131,7 +2131,11 @@ export const TaskCard = React.memo(TaskCardInner, (prev, next) => {
   if (prev.boardId !== next.boardId) return false;
   if (prev.workspaceId !== next.workspaceId) return false;
   // Check taskList color changes so cards re-render when list color changes
-  if (prev.taskList?.color !== next.taskList?.color) return false;
+  if (
+    prev.taskList?.color !== next.taskList?.color ||
+    prev.taskList?.status !== next.taskList?.status
+  )
+    return false;
   // Shallow compare task critical fields
   const a = prev.task;
   const b = next.task;

--- a/packages/ui/src/components/ui/tu-do/shared/board-layout-settings.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/board-layout-settings.tsx
@@ -859,11 +859,20 @@ export function BoardLayoutSettings({
     'closed',
   ];
 
+  const hasClosedList = (groupedLists.closed?.length ?? 0) > 0;
+
+  const editListAllowedStatuses = useMemo(() => {
+    if (hasClosedList && editingList?.status !== 'closed') {
+      return statuses.filter((status) => status !== 'closed');
+    }
+
+    return statuses;
+  }, [editingList?.status, hasClosedList, statuses]);
+
   const openCreateListDialog = useCallback((status: TaskBoardStatus) => {
     setCreateListStatus(status);
     setCreatingList(true);
   }, []);
-  const hasClosedList = (groupedLists.closed?.length ?? 0) > 0;
 
   return (
     <>
@@ -1022,6 +1031,7 @@ export function BoardLayoutSettings({
             setEditingList(null);
           }
         }}
+        allowedStatuses={editListAllowedStatuses}
         list={
           editingList
             ? {

--- a/packages/ui/src/components/ui/tu-do/shared/board-layout-settings.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/board-layout-settings.tsx
@@ -62,16 +62,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@tuturuuu/ui/dropdown-menu';
-import { Input } from '@tuturuuu/ui/input';
-import { Label } from '@tuturuuu/ui/label';
 import { ScrollArea } from '@tuturuuu/ui/scroll-area';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@tuturuuu/ui/select';
 import { toast } from '@tuturuuu/ui/sonner';
 import { cn } from '@tuturuuu/utils/format';
 import { useCallback, useMemo, useState } from 'react';
@@ -80,6 +71,7 @@ import {
   useBoardBroadcast,
 } from './board-broadcast-context';
 import { CreateListDialog } from './create-list-dialog';
+import { EditListDialog } from './edit-list-dialog';
 
 interface BoardLayoutSettingsProps {
   open: boolean;
@@ -530,61 +522,6 @@ export function BoardLayoutSettings({
     [t]
   );
   const queryClient = useQueryClient();
-  const colorOptions = useMemo(
-    () => [
-      {
-        value: 'GRAY' as SupportedColor,
-        label: t.gray,
-        class: 'bg-dynamic-gray/30',
-      },
-      {
-        value: 'RED' as SupportedColor,
-        label: t.red,
-        class: 'bg-dynamic-red/30',
-      },
-      {
-        value: 'BLUE' as SupportedColor,
-        label: t.blue,
-        class: 'bg-dynamic-blue/30',
-      },
-      {
-        value: 'GREEN' as SupportedColor,
-        label: t.green,
-        class: 'bg-dynamic-green/30',
-      },
-      {
-        value: 'YELLOW' as SupportedColor,
-        label: t.yellow,
-        class: 'bg-dynamic-yellow/30',
-      },
-      {
-        value: 'ORANGE' as SupportedColor,
-        label: t.orange,
-        class: 'bg-dynamic-orange/30',
-      },
-      {
-        value: 'PURPLE' as SupportedColor,
-        label: t.purple,
-        class: 'bg-dynamic-purple/30',
-      },
-      {
-        value: 'PINK' as SupportedColor,
-        label: t.pink,
-        class: 'bg-dynamic-pink/30',
-      },
-      {
-        value: 'INDIGO' as SupportedColor,
-        label: t.indigo,
-        class: 'bg-dynamic-indigo/30',
-      },
-      {
-        value: 'CYAN' as SupportedColor,
-        label: t.cyan,
-        class: 'bg-dynamic-cyan/30',
-      },
-    ],
-    [t]
-  );
   const [editingList, setEditingList] = useState<WorkspaceTaskList | null>(
     null
   );
@@ -1078,119 +1015,28 @@ export function BoardLayoutSettings({
         }}
       />
 
-      {/* Edit List Dialog */}
-      {editingList && (
-        <Dialog open={!!editingList} onOpenChange={() => setEditingList(null)}>
-          <DialogContent className="sm:max-w-106.25">
-            <DialogHeader>
-              <DialogTitle>{t.editList}</DialogTitle>
-              <DialogDescription>{t.updateListDescription}</DialogDescription>
-            </DialogHeader>
-            <div className="grid gap-4 py-4">
-              <div className="space-y-2">
-                <Label htmlFor="edit-name">{t.listName}</Label>
-                <Input
-                  defaultValue={editingList?.name || ''}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      updateListMutation.mutate({
-                        listId: editingList.id,
-                        updates: {
-                          name: (e.target as HTMLInputElement).value.trim(),
-                        },
-                      });
-                    }
-                  }}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="edit-status">{t.statusCategory}</Label>
-                <Select
-                  defaultValue={editingList?.status || ''}
-                  onValueChange={(value) => {
-                    updateListMutation.mutate({
-                      listId: editingList.id,
-                      updates: { status: value as TaskBoardStatus },
-                    });
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {statuses.map((status) => {
-                      const Icon = statusConfig[status].icon;
-                      return (
-                        <SelectItem key={status} value={status}>
-                          <div className="flex items-center gap-2">
-                            <Icon
-                              className={cn(
-                                'h-4 w-4',
-                                statusConfig[status].color
-                              )}
-                            />
-                            {statusLabels[status]}
-                          </div>
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-2">
-                <Label>{t.color}</Label>
-                <div className="grid grid-cols-5 gap-2">
-                  {colorOptions.map((color) => (
-                    <button
-                      type="button"
-                      key={color.value}
-                      onClick={() =>
-                        updateColorMutation.mutate({
-                          listId: editingList.id,
-                          color: color.value,
-                        })
-                      }
-                      className={cn(
-                        'h-8 w-8 rounded border-2 transition-all',
-                        color.class,
-                        editingList.color === color.value &&
-                          'scale-110 ring-2 ring-primary'
-                      )}
-                      title={color.label}
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setEditingList(null)}
-                disabled={updateListMutation.isPending}
-              >
-                {t.cancel}
-              </Button>
-              <Button
-                onClick={() => {
-                  const nameInput = document.getElementById(
-                    'edit-name'
-                  ) as HTMLInputElement;
-                  if (nameInput?.value.trim()) {
-                    updateListMutation.mutate({
-                      listId: editingList.id,
-                      updates: { name: nameInput.value.trim() },
-                    });
-                  }
-                }}
-                disabled={updateListMutation.isPending}
-              >
-                {updateListMutation.isPending ? t.saving : t.saveChanges}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      )}
+      <EditListDialog
+        open={!!editingList}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            setEditingList(null);
+          }
+        }}
+        list={
+          editingList
+            ? {
+                id: editingList.id,
+                name: editingList.name ?? '',
+                status: editingList.status,
+                color: (editingList.color as SupportedColor | null) ?? null,
+              }
+            : null
+        }
+        isSaving={updateListMutation.isPending}
+        onSave={({ listId, updates }) => {
+          updateListMutation.mutate({ listId, updates });
+        }}
+      />
 
       {/* Delete Confirmation Dialog */}
       <AlertDialog

--- a/packages/ui/src/components/ui/tu-do/shared/board-layout-settings.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/board-layout-settings.tsx
@@ -851,13 +851,10 @@ export function BoardLayoutSettings({
     updateColorMutation.mutate({ listId, color });
   };
 
-  const statuses: TaskBoardStatus[] = [
-    'documents',
-    'not_started',
-    'active',
-    'done',
-    'closed',
-  ];
+  const statuses = useMemo<TaskBoardStatus[]>(
+    () => ['documents', 'not_started', 'active', 'done', 'closed'],
+    []
+  );
 
   const hasClosedList = (groupedLists.closed?.length ?? 0) > 0;
 

--- a/packages/ui/src/components/ui/tu-do/shared/edit-list-dialog.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/edit-list-dialog.tsx
@@ -29,7 +29,7 @@ import {
 } from '@tuturuuu/ui/select';
 import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 type EditableList = {
   id: string;
@@ -42,6 +42,7 @@ interface EditListDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   list: EditableList | null;
+  allowedStatuses?: TaskBoardStatus[];
   isSaving?: boolean;
   onSave: (payload: {
     listId: string;
@@ -88,6 +89,7 @@ export function EditListDialog({
   open,
   onOpenChange,
   list,
+  allowedStatuses,
   isSaving = false,
   onSave,
 }: EditListDialogProps) {
@@ -101,6 +103,7 @@ export function EditListDialog({
     <EditListDialogForm
       key={list.id}
       list={list}
+      allowedStatuses={allowedStatuses}
       isSaving={isSaving}
       onOpenChange={onOpenChange}
       onSave={onSave}
@@ -135,12 +138,14 @@ export function EditListDialog({
 
 function EditListDialogForm({
   list,
+  allowedStatuses,
   onOpenChange,
   isSaving,
   onSave,
   labels,
 }: {
   list: EditableList;
+  allowedStatuses?: TaskBoardStatus[];
   onOpenChange: (open: boolean) => void;
   isSaving: boolean;
   onSave: EditListDialogProps['onSave'];
@@ -170,11 +175,32 @@ function EditListDialogForm({
     yellow: string;
   };
 }) {
+  const resolvedAllowedStatuses = useMemo(() => {
+    if (allowedStatuses && allowedStatuses.length > 0) {
+      return allowedStatuses;
+    }
+
+    if (list.status === 'closed') {
+      return statuses;
+    }
+
+    return statuses.filter((itemStatus) => itemStatus !== 'closed');
+  }, [allowedStatuses, list.status]);
+
+  const defaultStatus = useMemo<TaskBoardStatus>(() => {
+    if (list.status && resolvedAllowedStatuses.includes(list.status)) {
+      return list.status;
+    }
+
+    return resolvedAllowedStatuses.find(() => true) ?? 'active';
+  }, [list.status, resolvedAllowedStatuses]);
+
   const [name, setName] = useState(list.name ?? '');
-  const [status, setStatus] = useState<TaskBoardStatus>(
-    list.status ?? 'active'
-  );
+  const [status, setStatus] = useState<TaskBoardStatus>(defaultStatus);
   const [color, setColor] = useState<SupportedColor>(list.color ?? 'GRAY');
+  const selectedStatus = resolvedAllowedStatuses.includes(status)
+    ? status
+    : defaultStatus;
 
   const statusLabels: Record<TaskBoardStatus, string> = {
     not_started: labels.backlog,
@@ -253,11 +279,14 @@ function EditListDialogForm({
             if (!trimmedName) {
               return;
             }
+            if (!resolvedAllowedStatuses.includes(selectedStatus)) {
+              return;
+            }
             onSave({
               listId: list.id,
               updates: {
                 name: trimmedName,
-                status,
+                status: selectedStatus,
                 color,
               },
             });
@@ -276,14 +305,20 @@ function EditListDialogForm({
           <div className="space-y-2">
             <Label htmlFor="edit-list-status">{labels.statusCategory}</Label>
             <Select
-              value={status}
-              onValueChange={(value) => setStatus(value as TaskBoardStatus)}
+              value={selectedStatus}
+              onValueChange={(value) => {
+                const nextStatus = value as TaskBoardStatus;
+                if (!resolvedAllowedStatuses.includes(nextStatus)) {
+                  return;
+                }
+                setStatus(nextStatus);
+              }}
             >
               <SelectTrigger id="edit-list-status">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {statuses.map((itemStatus) => {
+                {resolvedAllowedStatuses.map((itemStatus) => {
                   const Icon = statusConfig[itemStatus].icon;
                   return (
                     <SelectItem key={itemStatus} value={itemStatus}>

--- a/packages/ui/src/components/ui/tu-do/shared/edit-list-dialog.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/edit-list-dialog.tsx
@@ -29,7 +29,7 @@ import {
 } from '@tuturuuu/ui/select';
 import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 type EditableList = {
   id: string;
@@ -92,91 +92,157 @@ export function EditListDialog({
   onSave,
 }: EditListDialogProps) {
   const t = useTranslations('common');
-  const [name, setName] = useState('');
-  const [status, setStatus] = useState<TaskBoardStatus>('active');
-  const [color, setColor] = useState<SupportedColor>('GRAY');
 
-  useEffect(() => {
-    if (!list || !open) {
-      return;
-    }
+  if (!open || !list) {
+    return null;
+  }
 
-    setName(list.name ?? '');
-    setStatus(list.status ?? 'active');
-    setColor(list.color ?? 'GRAY');
-  }, [list, open]);
+  return (
+    <EditListDialogForm
+      key={list.id}
+      list={list}
+      isSaving={isSaving}
+      onOpenChange={onOpenChange}
+      onSave={onSave}
+      labels={{
+        active: t('active'),
+        backlog: t('backlog'),
+        blue: t('blue'),
+        cancel: t('cancel'),
+        closed: t('closed'),
+        color: t('color'),
+        cyan: t('cyan'),
+        documents: t('documents'),
+        done: t('done'),
+        editList: t('edit_list'),
+        gray: t('gray'),
+        green: t('green'),
+        indigo: t('indigo'),
+        listName: t('list_name'),
+        orange: t('orange'),
+        pink: t('pink'),
+        purple: t('purple'),
+        red: t('red'),
+        saveChanges: t('save_changes'),
+        saving: t('saving'),
+        statusCategory: t('status_category'),
+        updateListDescription: t('change_list_name'),
+        yellow: t('yellow'),
+      }}
+    />
+  );
+}
+
+function EditListDialogForm({
+  list,
+  onOpenChange,
+  isSaving,
+  onSave,
+  labels,
+}: {
+  list: EditableList;
+  onOpenChange: (open: boolean) => void;
+  isSaving: boolean;
+  onSave: EditListDialogProps['onSave'];
+  labels: {
+    active: string;
+    backlog: string;
+    blue: string;
+    cancel: string;
+    closed: string;
+    color: string;
+    cyan: string;
+    documents: string;
+    done: string;
+    editList: string;
+    gray: string;
+    green: string;
+    indigo: string;
+    listName: string;
+    orange: string;
+    pink: string;
+    purple: string;
+    red: string;
+    saveChanges: string;
+    saving: string;
+    statusCategory: string;
+    updateListDescription: string;
+    yellow: string;
+  };
+}) {
+  const [name, setName] = useState(list.name ?? '');
+  const [status, setStatus] = useState<TaskBoardStatus>(
+    list.status ?? 'active'
+  );
+  const [color, setColor] = useState<SupportedColor>(list.color ?? 'GRAY');
 
   const statusLabels: Record<TaskBoardStatus, string> = {
-    not_started: t('backlog'),
-    active: t('active'),
-    done: t('done'),
-    closed: t('closed'),
-    documents: t('documents'),
+    not_started: labels.backlog,
+    active: labels.active,
+    done: labels.done,
+    closed: labels.closed,
+    documents: labels.documents,
   };
 
   const colorOptions = [
     {
       value: 'GRAY' as SupportedColor,
-      label: t('gray'),
+      label: labels.gray,
       class: 'bg-dynamic-gray/30',
     },
     {
       value: 'RED' as SupportedColor,
-      label: t('red'),
+      label: labels.red,
       class: 'bg-dynamic-red/30',
     },
     {
       value: 'BLUE' as SupportedColor,
-      label: t('blue'),
+      label: labels.blue,
       class: 'bg-dynamic-blue/30',
     },
     {
       value: 'GREEN' as SupportedColor,
-      label: t('green'),
+      label: labels.green,
       class: 'bg-dynamic-green/30',
     },
     {
       value: 'YELLOW' as SupportedColor,
-      label: t('yellow'),
+      label: labels.yellow,
       class: 'bg-dynamic-yellow/30',
     },
     {
       value: 'ORANGE' as SupportedColor,
-      label: t('orange'),
+      label: labels.orange,
       class: 'bg-dynamic-orange/30',
     },
     {
       value: 'PURPLE' as SupportedColor,
-      label: t('purple'),
+      label: labels.purple,
       class: 'bg-dynamic-purple/30',
     },
     {
       value: 'PINK' as SupportedColor,
-      label: t('pink'),
+      label: labels.pink,
       class: 'bg-dynamic-pink/30',
     },
     {
       value: 'INDIGO' as SupportedColor,
-      label: t('indigo'),
+      label: labels.indigo,
       class: 'bg-dynamic-indigo/30',
     },
     {
       value: 'CYAN' as SupportedColor,
-      label: t('cyan'),
+      label: labels.cyan,
       class: 'bg-dynamic-cyan/30',
     },
   ];
 
-  if (!list) {
-    return null;
-  }
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-106.25">
         <DialogHeader>
-          <DialogTitle>{t('edit_list')}</DialogTitle>
-          <DialogDescription>{t('change_list_name')}</DialogDescription>
+          <DialogTitle>{labels.editList}</DialogTitle>
+          <DialogDescription>{labels.updateListDescription}</DialogDescription>
         </DialogHeader>
 
         <form
@@ -198,17 +264,17 @@ export function EditListDialog({
           }}
         >
           <div className="space-y-2">
-            <Label htmlFor="edit-list-name">{t('list_name')}</Label>
+            <Label htmlFor="edit-list-name">{labels.listName}</Label>
             <Input
               id="edit-list-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder={t('list_name')}
+              placeholder={labels.listName}
             />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="edit-list-status">{t('status_category')}</Label>
+            <Label htmlFor="edit-list-status">{labels.statusCategory}</Label>
             <Select
               value={status}
               onValueChange={(value) => setStatus(value as TaskBoardStatus)}
@@ -238,7 +304,7 @@ export function EditListDialog({
           </div>
 
           <div className="space-y-2">
-            <Label>{t('color')}</Label>
+            <Label>{labels.color}</Label>
             <div className="grid grid-cols-5 gap-3">
               {colorOptions.map((colorOption) => (
                 <button
@@ -264,10 +330,10 @@ export function EditListDialog({
               onClick={() => onOpenChange(false)}
               disabled={isSaving}
             >
-              {t('cancel')}
+              {labels.cancel}
             </Button>
             <Button type="submit" disabled={isSaving || !name.trim()}>
-              {isSaving ? t('saving') : t('save_changes')}
+              {isSaving ? labels.saving : labels.saveChanges}
             </Button>
           </DialogFooter>
         </form>

--- a/packages/ui/src/components/ui/tu-do/shared/edit-list-dialog.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/edit-list-dialog.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import {
+  Circle,
+  CircleCheck,
+  CircleDashed,
+  CircleX,
+  FileText,
+} from '@tuturuuu/icons';
+import type { SupportedColor } from '@tuturuuu/types/primitives/SupportedColors';
+import type { TaskBoardStatus } from '@tuturuuu/types/primitives/TaskBoard';
+import { Button } from '@tuturuuu/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@tuturuuu/ui/dialog';
+import { Input } from '@tuturuuu/ui/input';
+import { Label } from '@tuturuuu/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@tuturuuu/ui/select';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+
+type EditableList = {
+  id: string;
+  name: string;
+  status?: TaskBoardStatus | null;
+  color?: SupportedColor | null;
+};
+
+interface EditListDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  list: EditableList | null;
+  isSaving?: boolean;
+  onSave: (payload: {
+    listId: string;
+    updates: {
+      name: string;
+      status: TaskBoardStatus;
+      color: SupportedColor;
+    };
+  }) => void;
+}
+
+const statusConfig = {
+  not_started: {
+    icon: CircleDashed,
+    color: 'text-dynamic-gray',
+  },
+  active: {
+    icon: Circle,
+    color: 'text-dynamic-blue',
+  },
+  done: {
+    icon: CircleCheck,
+    color: 'text-dynamic-green',
+  },
+  closed: {
+    icon: CircleX,
+    color: 'text-dynamic-purple',
+  },
+  documents: {
+    icon: FileText,
+    color: 'text-dynamic-cyan',
+  },
+};
+
+const statuses: TaskBoardStatus[] = [
+  'documents',
+  'not_started',
+  'active',
+  'done',
+  'closed',
+];
+
+export function EditListDialog({
+  open,
+  onOpenChange,
+  list,
+  isSaving = false,
+  onSave,
+}: EditListDialogProps) {
+  const t = useTranslations('common');
+  const [name, setName] = useState('');
+  const [status, setStatus] = useState<TaskBoardStatus>('active');
+  const [color, setColor] = useState<SupportedColor>('GRAY');
+
+  useEffect(() => {
+    if (!list || !open) {
+      return;
+    }
+
+    setName(list.name ?? '');
+    setStatus(list.status ?? 'active');
+    setColor(list.color ?? 'GRAY');
+  }, [list, open]);
+
+  const statusLabels: Record<TaskBoardStatus, string> = {
+    not_started: t('backlog'),
+    active: t('active'),
+    done: t('done'),
+    closed: t('closed'),
+    documents: t('documents'),
+  };
+
+  const colorOptions = [
+    {
+      value: 'GRAY' as SupportedColor,
+      label: t('gray'),
+      class: 'bg-dynamic-gray/30',
+    },
+    {
+      value: 'RED' as SupportedColor,
+      label: t('red'),
+      class: 'bg-dynamic-red/30',
+    },
+    {
+      value: 'BLUE' as SupportedColor,
+      label: t('blue'),
+      class: 'bg-dynamic-blue/30',
+    },
+    {
+      value: 'GREEN' as SupportedColor,
+      label: t('green'),
+      class: 'bg-dynamic-green/30',
+    },
+    {
+      value: 'YELLOW' as SupportedColor,
+      label: t('yellow'),
+      class: 'bg-dynamic-yellow/30',
+    },
+    {
+      value: 'ORANGE' as SupportedColor,
+      label: t('orange'),
+      class: 'bg-dynamic-orange/30',
+    },
+    {
+      value: 'PURPLE' as SupportedColor,
+      label: t('purple'),
+      class: 'bg-dynamic-purple/30',
+    },
+    {
+      value: 'PINK' as SupportedColor,
+      label: t('pink'),
+      class: 'bg-dynamic-pink/30',
+    },
+    {
+      value: 'INDIGO' as SupportedColor,
+      label: t('indigo'),
+      class: 'bg-dynamic-indigo/30',
+    },
+    {
+      value: 'CYAN' as SupportedColor,
+      label: t('cyan'),
+      class: 'bg-dynamic-cyan/30',
+    },
+  ];
+
+  if (!list) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-106.25">
+        <DialogHeader>
+          <DialogTitle>{t('edit_list')}</DialogTitle>
+          <DialogDescription>{t('change_list_name')}</DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const trimmedName = name.trim();
+            if (!trimmedName) {
+              return;
+            }
+            onSave({
+              listId: list.id,
+              updates: {
+                name: trimmedName,
+                status,
+                color,
+              },
+            });
+          }}
+        >
+          <div className="space-y-2">
+            <Label htmlFor="edit-list-name">{t('list_name')}</Label>
+            <Input
+              id="edit-list-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t('list_name')}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-list-status">{t('status_category')}</Label>
+            <Select
+              value={status}
+              onValueChange={(value) => setStatus(value as TaskBoardStatus)}
+            >
+              <SelectTrigger id="edit-list-status">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {statuses.map((itemStatus) => {
+                  const Icon = statusConfig[itemStatus].icon;
+                  return (
+                    <SelectItem key={itemStatus} value={itemStatus}>
+                      <div className="flex items-center gap-2">
+                        <Icon
+                          className={cn(
+                            'h-4 w-4',
+                            statusConfig[itemStatus].color
+                          )}
+                        />
+                        {statusLabels[itemStatus]}
+                      </div>
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('color')}</Label>
+            <div className="grid grid-cols-5 gap-3">
+              {colorOptions.map((colorOption) => (
+                <button
+                  type="button"
+                  key={colorOption.value}
+                  onClick={() => setColor(colorOption.value)}
+                  className={cn(
+                    'h-10 w-10 rounded-lg border-2 transition-all hover:scale-105',
+                    colorOption.class,
+                    color === colorOption.value &&
+                      'scale-110 ring-1 ring-primary ring-offset-2 ring-offset-background'
+                  )}
+                  title={colorOption.label}
+                />
+              ))}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              {t('cancel')}
+            </Button>
+            <Button type="submit" disabled={isSaving || !name.trim()}>
+              {isSaving ? t('saving') : t('save_changes')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# Description



## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?
- Resolves problem in DIscord Public Forum

<img width="459" height="469" alt="image" src="https://github.com/user-attachments/assets/c8eb689c-a633-4c79-bc78-3b2139feaf7a" />


## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/ded48270-06f9-4dbf-a0bb-899449b4b302" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/f672913e-2128-4063-9be6-63fb6f53e33f" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the rename-only modal with a shared `EditListDialog` so users can edit list name, status, and color across the app. Enforces a single “closed” list per board and applies list color/status changes to cards instantly.

- **New Features**
  - Shared `EditListDialog` integrated into Board settings and per-list actions; pre-fills values, validates on save, and blocks invalid status selections.

- **Refactors**
  - Optimized status handling: derive allowed statuses from cached lists and the current list in `ListActions` and Board settings.
  - Centralized optimistic updates and broadcasts (`list:upsert` with status/color); added `status_category` i18n (EN, VI); task cards re-render when list color or status changes.

<sup>Written for commit 61a754a7f172ee0cfb62beffb47f8d7c25c6766f. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4608">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

