### PR TITLE
feat(relationships): improve layout and overflow handling in dependencies, parent, related, and subtasks sections

### DIFF
--- a/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/relationships/dependencies-section.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/relationships/dependencies-section.tsx
@@ -50,9 +50,9 @@ export function DependenciesSection({
     subTab === 'blocks' ? onAddBlockingTaskDialog : onAddBlockedByTaskDialog;
 
   return (
-    <div className="space-y-3">
+    <div className="flex flex-col gap-3">
       {/* Sub-tab navigation */}
-      <div className="flex gap-2">
+      <div className="flex shrink-0 gap-2">
         <Button
           variant={subTab === 'blocks' ? 'default' : 'outline'}
           size="sm"
@@ -73,8 +73,8 @@ export function DependenciesSection({
 
       {/* Task list */}
       {currentList.length > 0 && (
-        <ScrollArea className="max-h-[150px]">
-          <div className="space-y-1">
+        <ScrollArea className="h-[150px]">
+          <div className="space-y-1 pr-2">
             {currentList.map((task) => (
               <ClickableTaskItem
                 key={task.id}

--- a/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/relationships/parent-section.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/relationships/parent-section.tsx
@@ -26,7 +26,7 @@ export function ParentSection({
   }, [taskId, childTaskIds]);
 
   return (
-    <div className="space-y-3">
+    <div className="flex flex-col gap-3">
       {parentTask ? (
         <ClickableTaskItem
           task={parentTask}

--- a/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/relationships/related-section.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/relationships/related-section.tsx
@@ -29,11 +29,11 @@ export function RelatedSection({
   }, [taskId, relatedTasks]);
 
   return (
-    <div className="space-y-3">
+    <div className="flex flex-col gap-3">
       {/* Related tasks list */}
       {relatedTasks.length > 0 && (
-        <ScrollArea className="max-h-[150px]">
-          <div className="space-y-1">
+        <ScrollArea className="h-[150px]">
+          <div className="space-y-1 pr-2">
             {relatedTasks.map((task) => (
               <ClickableTaskItem
                 key={task.id}

--- a/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/relationships/subtasks-section.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/relationships/subtasks-section.tsx
@@ -34,7 +34,7 @@ export function SubtasksSection({
   const hasAddOptions = onAddSubtask || onAddExistingAsSubtask;
 
   return (
-    <div className="space-y-3">
+    <div className="flex flex-col gap-3">
       {/* Empty state */}
       {childTasks.length === 0 && (
         <div className="py-4 text-center">
@@ -48,8 +48,8 @@ export function SubtasksSection({
 
       {/* Task list */}
       {childTasks.length > 0 && (
-        <ScrollArea className="max-h-50">
-          <div className="space-y-1">
+        <ScrollArea className="h-[200px]">
+          <div className="space-y-1 pr-2">
             {childTasks.map((task) => (
               <ClickableTaskItem
                 key={task.id}


### PR DESCRIPTION
# Screenshots for proof (must have)

Before: 
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/53b3bf5e-3d7c-4ea2-8414-2dc26618ebc2" />
<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/73e0fba0-42ff-46bd-b608-51d7234512e7" />
<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/3e3e979d-9fd3-4a20-9586-efd5b7b415ae" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves layout and overflow handling in the task edit dialog’s Relationships sections for smoother scrolling and a stable UI. Prevents button rows from squishing and keeps list content readable.

- **Bug Fixes**
  - Switched to flex column with gap for consistent spacing across sections.
  - Set fixed scroll heights: `h-[150px]` for Dependencies/Related, `h-[200px]` for Subtasks.
  - Added right padding in lists to avoid scrollbar overlap.
  - Made sub-tab nav `shrink-0` so buttons stay visible.
  - Aligned Parent section spacing with the others.

<sup>Written for commit 2915de618c72ed93dc12da5def16106cf6fb864c. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4620">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

