### PR TITLE
fix(time-tracking): resolve actor_id from override auth context in activity triggers

### DIFF
--- a/apps/database/supabase/migrations/20260416031500_fix_time_tracking_activity_actor_override.sql
+++ b/apps/database/supabase/migrations/20260416031500_fix_time_tracking_activity_actor_override.sql
@@ -1,0 +1,108 @@
+-- Ensure activity logging records actor_id when request updates are performed
+-- through SECURITY DEFINER RPCs that proxy the authenticated user via
+-- time_tracking.override_auth_uid.
+
+CREATE OR REPLACE FUNCTION public.log_time_tracking_request_update()
+RETURNS TRIGGER AS $$
+DECLARE
+    v_changed_fields JSONB := '{}'::JSONB;
+    v_status_changed BOOLEAN := FALSE;
+    v_content_changed BOOLEAN := FALSE;
+    v_actor_override text := NULLIF(current_setting('time_tracking.override_auth_uid', true), '');
+    v_actor_id uuid := COALESCE(v_actor_override::uuid, auth.uid());
+BEGIN
+    -- Track status changes
+    IF OLD.approval_status IS DISTINCT FROM NEW.approval_status THEN
+        v_status_changed := TRUE;
+    END IF;
+
+    -- Track content field changes
+    IF OLD.title IS DISTINCT FROM NEW.title THEN
+        v_changed_fields := jsonb_set(v_changed_fields, '{title}', jsonb_build_object('old', OLD.title, 'new', NEW.title));
+        v_content_changed := TRUE;
+    END IF;
+
+    IF OLD.description IS DISTINCT FROM NEW.description THEN
+        v_changed_fields := jsonb_set(v_changed_fields, '{description}', jsonb_build_object('old', OLD.description, 'new', NEW.description));
+        v_content_changed := TRUE;
+    END IF;
+
+    IF OLD.start_time IS DISTINCT FROM NEW.start_time THEN
+        v_changed_fields := jsonb_set(v_changed_fields, '{start_time}', jsonb_build_object('old', OLD.start_time, 'new', NEW.start_time));
+        v_content_changed := TRUE;
+    END IF;
+
+    IF OLD.end_time IS DISTINCT FROM NEW.end_time THEN
+        v_changed_fields := jsonb_set(v_changed_fields, '{end_time}', jsonb_build_object('old', OLD.end_time, 'new', NEW.end_time));
+        v_content_changed := TRUE;
+    END IF;
+
+    IF OLD.task_id IS DISTINCT FROM NEW.task_id THEN
+        v_changed_fields := jsonb_set(v_changed_fields, '{task_id}', jsonb_build_object('old', OLD.task_id, 'new', NEW.task_id));
+        v_content_changed := TRUE;
+    END IF;
+
+    IF OLD.category_id IS DISTINCT FROM NEW.category_id THEN
+        v_changed_fields := jsonb_set(v_changed_fields, '{category_id}', jsonb_build_object('old', OLD.category_id, 'new', NEW.category_id));
+        v_content_changed := TRUE;
+    END IF;
+
+    IF OLD.images IS DISTINCT FROM NEW.images THEN
+        v_changed_fields := jsonb_set(v_changed_fields, '{images}', jsonb_build_object('old', OLD.images, 'new', NEW.images));
+        v_content_changed := TRUE;
+    END IF;
+
+    -- Status/content updates should always have an actor.
+    IF (v_status_changed OR v_content_changed) AND v_actor_id IS NULL THEN
+        RAISE EXCEPTION 'User authentication required for time tracking request activity updates';
+    END IF;
+
+    -- Log status change separately with feedback preservation
+    IF v_status_changed THEN
+        INSERT INTO time_tracking_request_activity (
+            request_id,
+            action_type,
+            actor_id,
+            previous_status,
+            new_status,
+            feedback_reason,
+            metadata
+        ) VALUES (
+            NEW.id,
+            'STATUS_CHANGED',
+            v_actor_id,
+            OLD.approval_status::TEXT,
+            NEW.approval_status::TEXT,
+            CASE
+                WHEN NEW.approval_status::TEXT = 'NEEDS_INFO' AND NEW.needs_info_reason IS NOT NULL
+                THEN NEW.needs_info_reason
+                WHEN NEW.approval_status::TEXT = 'REJECTED' AND NEW.rejection_reason IS NOT NULL
+                THEN NEW.rejection_reason
+                ELSE NULL
+            END,
+            jsonb_build_object(
+                'approved_by', NEW.approved_by,
+                'rejected_by', NEW.rejected_by,
+                'needs_info_requested_by', NEW.needs_info_requested_by
+            )
+        );
+    END IF;
+
+    -- Log content changes
+    IF v_content_changed THEN
+        INSERT INTO time_tracking_request_activity (
+            request_id,
+            action_type,
+            actor_id,
+            changed_fields
+        ) VALUES (
+            NEW.id,
+            'CONTENT_UPDATED',
+            v_actor_id,
+            v_changed_fields
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;

--- a/apps/web/src/__tests__/time-tracking-request-update-route.test.ts
+++ b/apps/web/src/__tests__/time-tracking-request-update-route.test.ts
@@ -167,6 +167,43 @@ describe('time tracking request update route', () => {
     );
   });
 
+  it('passes actor auth uid to RPC for CONTENT_UPDATED trigger actor attribution', async () => {
+    const { PUT } = await import(
+      '@/app/api/v1/workspaces/[wsId]/time-tracking/requests/[id]/route'
+    );
+
+    const response = await PUT(
+      new NextRequest(
+        'http://localhost/api/v1/workspaces/ws-1/time-tracking/requests/request-1',
+        {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            title: 'Mobile App Authentication + UI/UX changes',
+            description: 'Updated content',
+            startTime: '2026-04-16T02:00:00.000Z',
+            endTime: '2026-04-16T03:00:00.000Z',
+            removedImages: [],
+            newImagePaths: [],
+          }),
+        }
+      ),
+      {
+        params: Promise.resolve({ wsId: 'ws-1', id: 'request-1' }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.adminUpdateRpc).toHaveBeenCalledWith(
+      'update_time_tracking_request_content',
+      expect.objectContaining({
+        p_actor_auth_uid: 'user-1',
+      })
+    );
+  });
+
   it('falls back to admin storage cleanup when request-scoped cleanup hits RLS', async () => {
     mocks.adminUpdateRpc.mockResolvedValue({
       data: null,


### PR DESCRIPTION
When update_time_tracking_request_content runs as SECURITY DEFINER RPC, auth.uid() is NULL in the log_time_tracking_request_update trigger. This caused CONTENT_UPDATED inserts to fail with null value in actor_id NOT NULL column.

Fix by reading actor from time_tracking.override_auth_uid config that the RPC sets via set_config(), with auth.uid() as fallback. Also add explicit check that fails with clear error when actor cannot be resolved.

Add regression test for route passing p_actor_auth_uid to the RPC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes actor attribution in time-tracking activity when updates run via SECURITY DEFINER RPCs. The trigger now resolves the `actor_id` from an override auth UID and blocks NULL inserts with a clear error.

- **Bug Fixes**
  - Read `time_tracking.override_auth_uid` via `current_setting()` in `log_time_tracking_request_update()`, with `auth.uid()` as fallback.
  - Raise a clear exception if status/content changes happen without a resolved actor.
  - Add regression test to ensure the route passes `p_actor_auth_uid` to `update_time_tracking_request_content`.

<sup>Written for commit 9c9ae95b96d828ad40fe977adcab587ebf1c7044. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4622">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

