### PR TITLE
fix(navigation): task opening functionality in notifications and sidebar

### DIFF
--- a/apps/web/src/__tests__/notifications/notification-card.test.tsx
+++ b/apps/web/src/__tests__/notifications/notification-card.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock next-intl
@@ -15,6 +15,7 @@ vi.mock('next/navigation', () => ({
     push: vi.fn(),
     refresh: vi.fn(),
   }),
+  usePathname: () => '/workspace-1',
 }));
 
 // Mock @tanstack/react-query
@@ -34,6 +35,18 @@ vi.mock('motion/react', () => ({
       children: React.ReactNode;
       className?: string;
     }) => <div className={className}>{children}</div>,
+  },
+}));
+
+const mockDispatchRequestOpenTask = vi.fn();
+
+vi.mock('@tuturuuu/ui/tu-do/shared/task-open-events', () => ({
+  dispatchRequestOpenTask: (payload: { taskId: string; wsId?: string }) => {
+    mockDispatchRequestOpenTask(payload);
+    return {
+      handled: true,
+      requestId: 'test-request-id',
+    };
   },
 }));
 
@@ -221,6 +234,33 @@ describe('NotificationCard', () => {
       expect(screen.getByText('Title:')).toBeInTheDocument();
       expect(screen.getByText('Old Title')).toBeInTheDocument();
       expect(screen.getByText('New Title')).toBeInTheDocument();
+    });
+  });
+
+  describe('task detail action', () => {
+    it('should open task dialog event for task notifications', () => {
+      const notification = createMockNotification({
+        entity_type: 'task',
+        entity_id: 'task-open-123',
+      });
+
+      render(
+        <NotificationCard
+          notification={notification}
+          onMarkAsRead={mockOnMarkAsRead}
+          t={mockT}
+          wsId="workspace-1"
+          isUpdating={false}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'view_details →' }));
+
+      expect(mockDispatchRequestOpenTask).toHaveBeenCalledTimes(1);
+      expect(mockDispatchRequestOpenTask).toHaveBeenCalledWith({
+        taskId: 'task-open-123',
+        wsId: 'workspace-1',
+      });
     });
   });
 });

--- a/apps/web/src/__tests__/notifications/notification-card.test.tsx
+++ b/apps/web/src/__tests__/notifications/notification-card.test.tsx
@@ -39,6 +39,7 @@ vi.mock('motion/react', () => ({
 }));
 
 const mockDispatchRequestOpenTask = vi.fn();
+const mockWaitForTaskOpenResult = vi.fn();
 
 vi.mock('@tuturuuu/ui/tu-do/shared/task-open-events', () => ({
   dispatchRequestOpenTask: (payload: { taskId: string; wsId?: string }) => {
@@ -48,6 +49,8 @@ vi.mock('@tuturuuu/ui/tu-do/shared/task-open-events', () => ({
       requestId: 'test-request-id',
     };
   },
+  waitForTaskOpenResult: (requestId: string, timeoutMs?: number) =>
+    mockWaitForTaskOpenResult(requestId, timeoutMs),
 }));
 
 // Import after mocks
@@ -60,6 +63,7 @@ describe('NotificationCard', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWaitForTaskOpenResult.mockResolvedValue(true);
   });
 
   const createMockNotification = (

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/__tests__/recent-sidebar-items.test.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/__tests__/recent-sidebar-items.test.tsx
@@ -113,6 +113,7 @@ function readStoredEntries() {
 
 describe('RecentSidebarItems', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockPathname = '/personal/dashboard';
     window.localStorage.clear();
     mockPush.mockReset();
@@ -123,7 +124,6 @@ describe('RecentSidebarItems', () => {
       requestId: 'request-1',
     });
     mockWaitForTaskOpenResult.mockResolvedValue(true);
-    vi.clearAllMocks();
   });
 
   it('does not rebroadcast on mount when stored entries are already normalized', async () => {

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/__tests__/recent-sidebar-items.test.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/__tests__/recent-sidebar-items.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { NavLink } from '@tuturuuu/ui/custom/navigation';
 import { dispatchRecentSidebarVisit } from '@tuturuuu/ui/tu-do/shared/recent-sidebar-events';
 import type {
@@ -11,9 +11,15 @@ import { RecentSidebarItems } from '../recent-sidebar-items';
 import type { RecentSidebarEntry } from '../recent-sidebar-items.utils';
 
 let mockPathname = '/personal/dashboard';
+const mockPush = vi.fn();
+const mockDispatchRequestOpenTask = vi.fn();
+const mockWaitForTaskOpenResult = vi.fn();
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
+  useRouter: () => ({
+    push: mockPush,
+  }),
 }));
 
 vi.mock('next-intl', () => ({
@@ -43,6 +49,13 @@ vi.mock('@tuturuuu/ui/button', () => ({
   ),
 }));
 
+vi.mock('@tuturuuu/ui/tu-do/shared/task-open-events', () => ({
+  dispatchRequestOpenTask: (payload: { taskId: string; wsId?: string }) =>
+    mockDispatchRequestOpenTask(payload),
+  waitForTaskOpenResult: (requestId: string, timeoutMs?: number) =>
+    mockWaitForTaskOpenResult(requestId, timeoutMs),
+}));
+
 vi.mock('@tuturuuu/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -59,6 +72,7 @@ vi.mock('@tuturuuu/icons', () => {
     FolderKanban: Icon,
     History: Icon,
     LayoutDashboard: Icon,
+    Loader2: Icon,
     PencilRuler: Icon,
     ReceiptText: Icon,
     Trash2: Icon,
@@ -81,12 +95,12 @@ const links: (NavLink | null)[] = [
 const wsId = 'personal';
 const storageKey = `tuturuuu:sidebar-recent-items:${wsId}`;
 
-function renderSidebar() {
+function renderSidebar(onNavigate = vi.fn()) {
   return render(
     <RecentSidebarItems
       isCollapsed={false}
       links={links}
-      onNavigate={vi.fn()}
+      onNavigate={onNavigate}
       wsId={wsId}
     />
   );
@@ -101,6 +115,14 @@ describe('RecentSidebarItems', () => {
   beforeEach(() => {
     mockPathname = '/personal/dashboard';
     window.localStorage.clear();
+    mockPush.mockReset();
+    mockDispatchRequestOpenTask.mockReset();
+    mockWaitForTaskOpenResult.mockReset();
+    mockDispatchRequestOpenTask.mockReturnValue({
+      handled: true,
+      requestId: 'request-1',
+    });
+    mockWaitForTaskOpenResult.mockResolvedValue(true);
     vi.clearAllMocks();
   });
 
@@ -169,5 +191,35 @@ describe('RecentSidebarItems', () => {
         visitedAt: expect.any(String),
       },
     ]);
+  });
+
+  it('opens task dialog for task recent item before navigation fallback', async () => {
+    const onNavigate = vi.fn();
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify([
+        {
+          href: '/personal/tasks/task-123',
+          visitedAt: '2026-03-03T02:00:00.000Z',
+        },
+      ])
+    );
+
+    renderSidebar(onNavigate);
+
+    const taskLink = await screen.findByRole('link', {
+      name: /sidebar_recent_items\.task_item/i,
+    });
+    fireEvent.click(taskLink);
+
+    await waitFor(() => {
+      expect(mockDispatchRequestOpenTask).toHaveBeenCalledWith({
+        taskId: 'task-123',
+        wsId: 'personal',
+      });
+      expect(mockWaitForTaskOpenResult).toHaveBeenCalledWith('request-1', 6000);
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+    });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/recent-sidebar-items.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/recent-sidebar-items.tsx
@@ -7,6 +7,7 @@ import {
   FolderKanban,
   History,
   LayoutDashboard,
+  Loader2,
   PencilRuler,
   ReceiptText,
   Wallet,
@@ -16,13 +17,17 @@ import { Button } from '@tuturuuu/ui/button';
 import type { NavLink } from '@tuturuuu/ui/custom/navigation';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import {
+  dispatchRequestOpenTask,
+  waitForTaskOpenResult,
+} from '@tuturuuu/ui/tu-do/shared/task-open-events';
+import {
   RECENT_SIDEBAR_VISIT_EVENT,
   type RecentSidebarIconKey,
   type RecentSidebarVisitPayload,
 } from '@tuturuuu/ui/tu-do/shared/recent-sidebar-events';
 import { cn } from '@tuturuuu/utils/format';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import {
   type MouseEvent,
@@ -36,6 +41,7 @@ import {
   normalizeRecentSidebarEntries,
   normalizeRecentSidebarHref,
   type RecentSidebarEntry,
+  type ResolvedRecentSidebarItem,
   removeRecentSidebarEntry,
   resolveRecentSidebarEntry,
   resolveRecentSidebarItem,
@@ -44,6 +50,19 @@ import {
 
 const RECENT_SIDEBAR_ITEMS_EVENT = 'tuturuuu:sidebar-recent-items-updated';
 const DEFAULT_VISIBLE_RECENT_SIDEBAR_ITEMS = 1;
+const TASK_LIST_SEGMENT_BLOCKLIST = new Set([
+  'boards',
+  'projects',
+  'templates',
+  'drafts',
+  'habits',
+  'labels',
+  'initiatives',
+  'logs',
+  'notes',
+  'estimates',
+  'cycles',
+]);
 
 interface RecentSidebarItemsProps {
   isCollapsed: boolean;
@@ -133,6 +152,18 @@ function getIcon(iconKey: RecentSidebarIconKey): ReactNode {
   }
 }
 
+function getTaskIdFromRecentHref(href: string): string | null {
+  const [path] = href.split('?');
+  if (!path) return null;
+
+  const segments = path.split('/').filter(Boolean);
+  const tasksIndex = segments.indexOf('tasks');
+  const taskId = tasksIndex >= 0 ? segments[tasksIndex + 1] : null;
+  if (!taskId || TASK_LIST_SEGMENT_BLOCKLIST.has(taskId)) return null;
+
+  return decodeURIComponent(taskId);
+}
+
 export function RecentSidebarItems({
   wsId,
   links,
@@ -140,9 +171,11 @@ export function RecentSidebarItems({
   onNavigate,
 }: RecentSidebarItemsProps) {
   const pathname = usePathname();
+  const router = useRouter();
   const t = useTranslations();
   const [entries, setEntries] = useState<RecentSidebarEntry[]>([]);
   const [showAll, setShowAll] = useState(false);
+  const [openingHref, setOpeningHref] = useState<string | null>(null);
   const eventSourceId = useId();
   const storageKey = getStorageKey(wsId);
 
@@ -365,6 +398,42 @@ export function RecentSidebarItems({
     });
   };
 
+  const handleRecentItemClick = async (
+    event: MouseEvent<HTMLAnchorElement>,
+    item: ResolvedRecentSidebarItem
+  ) => {
+    const taskId =
+      item.iconKey === 'task' ? getTaskIdFromRecentHref(item.href) : null;
+    if (!taskId) {
+      onNavigate();
+      return;
+    }
+
+    event.preventDefault();
+    if (openingHref) return;
+
+    setOpeningHref(item.href);
+    try {
+      const { handled, requestId } = dispatchRequestOpenTask({
+        taskId,
+        wsId,
+      });
+
+      const opened = handled
+        ? await waitForTaskOpenResult(requestId, 6000)
+        : false;
+      if (opened) {
+        onNavigate();
+        return;
+      }
+
+      router.push(item.href);
+      onNavigate();
+    } finally {
+      setOpeningHref(null);
+    }
+  };
+
   if (isCollapsed) {
     if (!resolvedItems.length) return null;
     return (
@@ -375,12 +444,16 @@ export function RecentSidebarItems({
               <TooltipTrigger asChild>
                 <Link
                   href={item.href}
-                  onClick={onNavigate}
+                  onClick={(event) => void handleRecentItemClick(event, item)}
                   className={cn(
                     'flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-accent hover:text-accent-foreground'
                   )}
                 >
-                  {getIcon(item.iconKey)}
+                  {openingHref === item.href ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    getIcon(item.iconKey)
+                  )}
                 </Link>
               </TooltipTrigger>
               <TooltipContent side="right">
@@ -442,11 +515,15 @@ export function RecentSidebarItems({
             <div key={item.href} className="group/item relative">
               <Link
                 href={item.href}
-                onClick={onNavigate}
+                onClick={(event) => void handleRecentItemClick(event, item)}
                 className="flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 pr-2 transition hover:bg-accent/70"
               >
                 <div className="flex h-6 w-6 flex-none items-center justify-center rounded-md bg-foreground/5 text-muted-foreground">
-                  {getIcon(item.iconKey)}
+                  {openingHref === item.href ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    getIcon(item.iconKey)
+                  )}
                 </div>
                 <div className="min-w-0 flex-1 space-y-1">
                   <p className="line-clamp-1 font-medium text-[13px] leading-4">

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/recent-sidebar-items.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/recent-sidebar-items.tsx
@@ -50,6 +50,9 @@ import {
 
 const RECENT_SIDEBAR_ITEMS_EVENT = 'tuturuuu:sidebar-recent-items-updated';
 const DEFAULT_VISIBLE_RECENT_SIDEBAR_ITEMS = 1;
+// Reserved task-route segments that should never be treated as task IDs when
+// parsing recent hrefs. This prevents false-positive task dialog lookups for
+// list/filter routes (e.g. /tasks/boards, /tasks/projects) in click handling.
 const TASK_LIST_SEGMENT_BLOCKLIST = new Set([
   'boards',
   'projects',

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/recent-sidebar-items.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/recent-sidebar-items.tsx
@@ -17,14 +17,14 @@ import { Button } from '@tuturuuu/ui/button';
 import type { NavLink } from '@tuturuuu/ui/custom/navigation';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import {
-  dispatchRequestOpenTask,
-  waitForTaskOpenResult,
-} from '@tuturuuu/ui/tu-do/shared/task-open-events';
-import {
   RECENT_SIDEBAR_VISIT_EVENT,
   type RecentSidebarIconKey,
   type RecentSidebarVisitPayload,
 } from '@tuturuuu/ui/tu-do/shared/recent-sidebar-events';
+import {
+  dispatchRequestOpenTask,
+  waitForTaskOpenResult,
+} from '@tuturuuu/ui/tu-do/shared/task-open-events';
 import { cn } from '@tuturuuu/utils/format';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';

--- a/apps/web/src/components/notifications/notification-card.tsx
+++ b/apps/web/src/components/notifications/notification-card.tsx
@@ -21,7 +21,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { motion } from 'motion/react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { type ComponentProps, type ReactNode, useState } from 'react';
 import { DescriptionDiffViewer } from '@/components/tasks/description-diff-viewer';
 import type { Notification } from '@/hooks/useNotifications';
 import {
@@ -41,6 +41,19 @@ interface NotificationCardProps {
   isUpdating: boolean;
   onActionComplete?: () => void;
   index?: number;
+}
+
+type WorkspaceInviteActionType =
+  | 'WORKSPACE_INVITE_ACCEPT'
+  | 'WORKSPACE_INVITE_DECLINE';
+
+interface WorkspaceInviteAction {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  variant?: ComponentProps<typeof Button>['variant'];
+  type: WorkspaceInviteActionType;
+  payload: { wsId: string };
 }
 
 export function NotificationCard({
@@ -63,15 +76,15 @@ export function NotificationCard({
   const isTaskEntityNotification =
     notification.entity_type === 'task' && !!notification.entity_id;
 
-  const handleAction = async (actionType: string, payload: any) => {
+  const handleAction = async (action: WorkspaceInviteAction) => {
     setIsProcessing(true);
 
     try {
-      switch (actionType) {
+      switch (action.type) {
         case 'WORKSPACE_INVITE_ACCEPT':
         case 'WORKSPACE_INVITE_DECLINE': {
-          const accept = actionType === 'WORKSPACE_INVITE_ACCEPT';
-          const targetWsId = payload.wsId;
+          const accept = action.type === 'WORKSPACE_INVITE_ACCEPT';
+          const targetWsId = action.payload.wsId;
           const url = `/api/workspaces/${targetWsId}/${
             accept ? 'accept-invite' : 'decline-invite'
           }`;
@@ -280,9 +293,9 @@ export function NotificationCard({
               {actions.map((action) => (
                 <Button
                   key={action.id}
-                  variant={action.variant as any}
+                  variant={action.variant}
                   size="sm"
-                  onClick={() => handleAction(action.type, action.payload)}
+                  onClick={() => handleAction(action)}
                   disabled={isProcessing}
                   className="h-8 gap-1.5 text-xs"
                 >
@@ -495,25 +508,10 @@ function SingleChangeDetail({
 // Action Helpers
 // ============================================================================
 
-interface NotificationAction {
-  id: string;
-  label: string;
-  icon?: React.ReactNode;
-  variant?:
-    | 'default'
-    | 'destructive'
-    | 'outline'
-    | 'secondary'
-    | 'ghost'
-    | 'link';
-  type: string;
-  payload: any;
-}
-
 function getNotificationActions(
   notification: Notification,
   t: (key: string) => string
-): NotificationAction[] {
+): WorkspaceInviteAction[] {
   const { type, data } = notification;
 
   switch (type) {
@@ -521,7 +519,9 @@ function getNotificationActions(
       if (data?.action_taken) return [];
 
       const workspaceId = data?.workspace_id;
-      if (!workspaceId) return [];
+      if (typeof workspaceId !== 'string' || workspaceId.length === 0) {
+        return [];
+      }
 
       return [
         {

--- a/apps/web/src/components/notifications/notification-card.tsx
+++ b/apps/web/src/components/notifications/notification-card.tsx
@@ -14,12 +14,13 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from '@tuturuuu/ui/avatar';
 import { Button } from '@tuturuuu/ui/button';
 import { toast } from '@tuturuuu/ui/sonner';
+import { dispatchRequestOpenTask } from '@tuturuuu/ui/tu-do/shared/task-open-events';
 import { cn } from '@tuturuuu/utils/format';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { motion } from 'motion/react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { DescriptionDiffViewer } from '@/components/tasks/description-diff-viewer';
 import type { Notification } from '@/hooks/useNotifications';
@@ -53,11 +54,14 @@ export function NotificationCard({
 }: NotificationCardProps) {
   const isUnread = !notification.read_at;
   const router = useRouter();
+  const pathname = usePathname();
   const queryClient = useQueryClient();
   const [isProcessing, setIsProcessing] = useState(false);
 
   const entityLink = getEntityLink(notification, wsId);
   const actions = getNotificationActions(notification, t);
+  const isTaskEntityNotification =
+    notification.entity_type === 'task' && !!notification.entity_id;
 
   const handleAction = async (actionType: string, payload: any) => {
     setIsProcessing(true);
@@ -291,6 +295,33 @@ export function NotificationCard({
                 </Button>
               ))}
             </div>
+          ) : isTaskEntityNotification ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mt-2 h-7 px-2 text-foreground/50 text-xs hover:text-dynamic-blue"
+              onClick={() => {
+                if (!notification.entity_id) return;
+                const { handled } = dispatchRequestOpenTask({
+                  taskId: notification.entity_id,
+                  wsId: notification.ws_id || wsId,
+                });
+
+                if (!handled) {
+                  const pathParts = pathname.split('/').filter(Boolean);
+                  const firstSegment = pathParts[0] ?? '';
+                  const localePrefix =
+                    pathParts.length > 1 && firstSegment.length <= 5
+                      ? `/${firstSegment}`
+                      : '';
+                  router.push(
+                    `${localePrefix}/${notification.ws_id || wsId}?openTaskId=${encodeURIComponent(notification.entity_id)}`
+                  );
+                }
+              }}
+            >
+              {t('view_details')} →
+            </Button>
           ) : entityLink ? (
             <Link href={entityLink} className="mt-2 inline-block">
               <Button

--- a/apps/web/src/components/notifications/notification-card.tsx
+++ b/apps/web/src/components/notifications/notification-card.tsx
@@ -14,7 +14,10 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from '@tuturuuu/ui/avatar';
 import { Button } from '@tuturuuu/ui/button';
 import { toast } from '@tuturuuu/ui/sonner';
-import { dispatchRequestOpenTask } from '@tuturuuu/ui/tu-do/shared/task-open-events';
+import {
+  dispatchRequestOpenTask,
+  waitForTaskOpenResult,
+} from '@tuturuuu/ui/tu-do/shared/task-open-events';
 import { cn } from '@tuturuuu/utils/format';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -313,14 +316,18 @@ export function NotificationCard({
               variant="ghost"
               size="sm"
               className="mt-2 h-7 px-2 text-foreground/50 text-xs hover:text-dynamic-blue"
-              onClick={() => {
+              onClick={async () => {
                 if (!notification.entity_id) return;
-                const { handled } = dispatchRequestOpenTask({
+                const { handled, requestId } = dispatchRequestOpenTask({
                   taskId: notification.entity_id,
                   wsId: notification.ws_id || wsId,
                 });
 
-                if (!handled) {
+                const opened = handled
+                  ? await waitForTaskOpenResult(requestId, 6000)
+                  : false;
+
+                if (!opened) {
                   const pathParts = pathname.split('/').filter(Boolean);
                   const firstSegment = pathParts[0] ?? '';
                   const localePrefix =

--- a/packages/ui/src/components/ui/custom/notification-popover-client.tsx
+++ b/packages/ui/src/components/ui/custom/notification-popover-client.tsx
@@ -34,11 +34,15 @@ import {
 } from '@tuturuuu/ui/hooks/use-notifications';
 import { Popover, PopoverContent, PopoverTrigger } from '@tuturuuu/ui/popover';
 import { toast } from '@tuturuuu/ui/sonner';
+import {
+  dispatchRequestOpenTask,
+  waitForTaskOpenResult,
+} from '@tuturuuu/ui/tu-do/shared/task-open-events';
 import { cn } from '@tuturuuu/utils/format';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import Link from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 dayjs.extend(relativeTime);
@@ -61,11 +65,19 @@ interface NotificationPopoverClientProps {
   webAppUrl?: string;
 }
 
-// UUID validation regex
+// Workspace identifier validation regex
 const UUID_REGEX =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+const SPECIAL_WORKSPACE_SLUGS = new Set(['personal', 'internal']);
 
-function isValidUUID(value: unknown): value is string {
+function isValidWorkspaceIdentifier(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    (UUID_REGEX.test(value) || SPECIAL_WORKSPACE_SLUGS.has(value))
+  );
+}
+
+function isValidWorkspaceFilterId(value: unknown): value is string {
   return typeof value === 'string' && UUID_REGEX.test(value);
 }
 
@@ -88,20 +100,27 @@ export default function NotificationPopoverClient({
   const params = useParams();
   const queryClient = useQueryClient();
 
-  const wsId = isValidUUID(params.wsId) ? params.wsId : undefined;
+  const workspaceIdParam =
+    typeof params.wsId === 'string' ? params.wsId : undefined;
+  const wsIdForFiltering = isValidWorkspaceFilterId(workspaceIdParam)
+    ? workspaceIdParam
+    : undefined;
+  const wsIdForTaskContext = isValidWorkspaceIdentifier(workspaceIdParam)
+    ? workspaceIdParam
+    : undefined;
 
   // Accurate unread count from dedicated endpoint
-  const { data: unreadCount = 0 } = useUnreadCount(wsId);
+  const { data: unreadCount = 0 } = useUnreadCount(wsIdForFiltering);
 
   // Infinite scroll for inbox (unread) and archive (read)
   const inboxQuery = useInfiniteNotifications({
-    wsId,
+    wsId: wsIdForFiltering,
     unreadOnly: true,
     pageSize: 15,
   });
 
   const archiveQuery = useInfiniteNotifications({
-    wsId,
+    wsId: wsIdForFiltering,
     readOnly: true,
     pageSize: 15,
   });
@@ -110,7 +129,7 @@ export default function NotificationPopoverClient({
   const updateNotification = useUpdateNotification();
 
   // Subscribe to realtime updates
-  useNotificationSubscription(wsId || '', userId || '');
+  useNotificationSubscription(wsIdForFiltering || '', userId || '');
 
   const activeQuery = activeTab === 'inbox' ? inboxQuery : archiveQuery;
   const allNotifications = dedupeNotifications(
@@ -135,7 +154,7 @@ export default function NotificationPopoverClient({
 
   const handleArchiveAll = async () => {
     try {
-      await markAllAsRead.mutateAsync(wsId);
+      await markAllAsRead.mutateAsync(wsIdForFiltering);
       toast.success('All notifications archived');
     } catch (error) {
       console.error('Failed to archive all:', error);
@@ -234,7 +253,7 @@ export default function NotificationPopoverClient({
           notifications={allNotifications}
           hasNotifications={hasNotifications}
           activeTab={activeTab}
-          wsId={wsId}
+          wsId={wsIdForTaskContext}
           noNotificationsText={noNotificationsText}
           emptyArchiveText={emptyArchiveText}
           loadingMoreText={loadingMoreText}
@@ -422,6 +441,8 @@ function NotificationCard({
   const isUnread = !notification.read_at;
   const [processingAction, setProcessingAction] = useState<string | null>(null);
   const router = useRouter();
+  const params = useParams();
+  const pathname = usePathname();
 
   const handleAction = async (actionType: string, payload: any) => {
     setProcessingAction(actionType);
@@ -498,16 +519,14 @@ function NotificationCard({
   };
 
   const notificationWsId = notification.ws_id || wsId;
+  const isTaskEntityNotification =
+    notification.entity_type === 'task' && !!notification.entity_id;
   const entityLink =
-    notification.entity_type === 'task' &&
+    notification.entity_type === 'time_tracking_request' &&
     notification.entity_id &&
     notificationWsId
-      ? `/${notificationWsId}/tasks/${notification.entity_id}`
-      : notification.entity_type === 'time_tracking_request' &&
-          notification.entity_id &&
-          notificationWsId
-        ? `/${notificationWsId}/time-tracker/requests`
-        : null;
+      ? `/${notificationWsId}/time-tracker/requests`
+      : null;
 
   return (
     <div
@@ -604,6 +623,57 @@ function NotificationCard({
                 Accept
               </Button>
             </div>
+          ) : isTaskEntityNotification ? (
+            <Button
+              variant="link"
+              size="sm"
+              className="h-auto p-0 text-xs hover:text-dynamic-blue"
+              disabled={!!processingAction}
+              onClick={async () => {
+                if (!notification.entity_id) return;
+                setProcessingAction('OPEN_TASK');
+                try {
+                  const { handled, requestId } = dispatchRequestOpenTask({
+                    taskId: notification.entity_id,
+                    wsId: notificationWsId,
+                  });
+
+                  const opened = handled
+                    ? await waitForTaskOpenResult(requestId, 6000)
+                    : false;
+
+                  if (!opened && notificationWsId) {
+                    const locale =
+                      typeof params?.locale === 'string' ? params.locale : null;
+                    const targetWorkspacePath = locale
+                      ? `/${locale}/${notificationWsId}`
+                      : `/${notificationWsId}`;
+                    const isAlreadyInTargetWorkspace =
+                      pathname === targetWorkspacePath ||
+                      pathname.startsWith(`${targetWorkspacePath}/`);
+
+                    const openTaskParam = `openTaskId=${encodeURIComponent(notification.entity_id)}`;
+                    const fallbackUrl = isAlreadyInTargetWorkspace
+                      ? `${pathname}?${openTaskParam}`
+                      : `${targetWorkspacePath}?${openTaskParam}`;
+
+                    router.push(fallbackUrl);
+                  }
+                  onActionComplete?.();
+                } finally {
+                  setProcessingAction(null);
+                }
+              }}
+            >
+              {processingAction === 'OPEN_TASK' ? (
+                <>
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Opening...
+                </>
+              ) : (
+                'View details →'
+              )}
+            </Button>
           ) : entityLink ? (
             <Link href={entityLink} onClick={onActionComplete}>
               <Button

--- a/packages/ui/src/components/ui/tu-do/hooks/useTaskDialog.ts
+++ b/packages/ui/src/components/ui/tu-do/hooks/useTaskDialog.ts
@@ -50,7 +50,7 @@ export function useTaskDialog(): {
       taskWorkspacePersonal?: boolean;
     }
   ) => void;
-  openTaskById: (taskId: string) => Promise<void>;
+  openTaskById: (taskId: string) => Promise<boolean>;
   createTask: (
     boardId: string,
     listId: string,

--- a/packages/ui/src/components/ui/tu-do/providers/task-dialog-provider.tsx
+++ b/packages/ui/src/components/ui/tu-do/providers/task-dialog-provider.tsx
@@ -80,7 +80,7 @@ interface TaskDialogContextValue {
   ) => void;
 
   // Open task by ID (fetches task data first)
-  openTaskById: (taskId: string) => Promise<void>;
+  openTaskById: (taskId: string) => Promise<boolean>;
 
   // Open dialog for creating new task
   createTask: (
@@ -355,11 +355,11 @@ export function TaskDialogProvider({
               }),
           });
         } catch {
-          return;
+          return false;
         }
 
         if (!response) {
-          return;
+          return false;
         }
 
         const transformedTask = response.task;
@@ -389,8 +389,10 @@ export function TaskDialogProvider({
           taskWorkspacePersonal: isTaskWorkspacePersonal,
           taskWorkspaceTier,
         });
+        return true;
       } catch (error) {
         console.error('Failed to open task:', error);
+        return false;
       }
     },
     [canUseTaskCursors, isPersonalWorkspace, queueDialogState]

--- a/packages/ui/src/components/ui/tu-do/shared/__tests__/task-dialog-manager.test.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/__tests__/task-dialog-manager.test.tsx
@@ -28,6 +28,13 @@ vi.mock('next/navigation', () => ({
   useParams: () => ({ wsId: 'workspace-1' }),
 }));
 
+vi.mock('nuqs', () => ({
+  parseAsString: {
+    withOptions: () => ({}),
+  },
+  useQueryState: () => [null, vi.fn()],
+}));
+
 const {
   mockGetCurrentUserProfile,
   mockGetCurrentUserTask,

--- a/packages/ui/src/components/ui/tu-do/shared/board-user-presence-avatars.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/board-user-presence-avatars.tsx
@@ -34,7 +34,7 @@ interface BoardUserPresenceAvatarsProps {
   currentMetadata?: BoardFiltersMetadata;
   maxDisplay?: number;
   applyUserBoardView: (metadata: BoardFiltersMetadata) => void;
-  onOpenTask?: (taskId: string) => Promise<void>;
+  onOpenTask?: (taskId: string) => Promise<boolean>;
 }
 
 function arraysEqual<T extends string | number>(arr1: T[], arr2: T[]): boolean {
@@ -233,7 +233,7 @@ function PresenceAvatar({
   userMetadata?: BoardFiltersMetadata;
   viewingTaskId?: string;
   applyUserBoardView: (metadata: BoardFiltersMetadata) => void;
-  onOpenTask?: (taskId: string) => Promise<void>;
+  onOpenTask?: (taskId: string) => Promise<boolean>;
 }) {
   const t = useTranslations('ws-presence');
   const [popoverOpen, setPopoverOpen] = useState(false);

--- a/packages/ui/src/components/ui/tu-do/shared/task-dialog-manager.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-dialog-manager.tsx
@@ -5,6 +5,7 @@ import { getCurrentUserProfile } from '@tuturuuu/internal-api';
 import { getWorkspaceTask } from '@tuturuuu/internal-api/tasks';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import { toWorkspaceSlug } from '@tuturuuu/utils/constants';
+import { parseAsString, useQueryState } from 'nuqs';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTaskDialogContext } from '../providers/task-dialog-provider';
 import {
@@ -15,6 +16,7 @@ import { dispatchRecentSidebarVisit } from './recent-sidebar-events';
 import { TaskEditDialog } from './task-edit-dialog';
 import {
   REQUEST_OPEN_TASK_EVENT,
+  dispatchTaskOpenResult,
   type RequestOpenTaskPayload,
 } from './task-open-events';
 
@@ -27,6 +29,10 @@ import {
  * that benefits from immediate availability over bundle size optimization.
  */
 export function TaskDialogManager({ wsId }: { wsId: string }) {
+  const [openTaskId, setOpenTaskId] = useQueryState(
+    'openTaskId',
+    parseAsString.withOptions({ shallow: true })
+  );
   const {
     state,
     isPersonalWorkspace,
@@ -232,10 +238,56 @@ export function TaskDialogManager({ wsId }: { wsId: string }) {
   useEffect(() => {
     const handleTaskOpenRequest = (event: Event) => {
       const customEvent = event as CustomEvent<RequestOpenTaskPayload>;
+      if (customEvent.detail) {
+        customEvent.detail.handled = true;
+      }
       const taskId = customEvent.detail?.taskId;
       if (!taskId) return;
+      const requestedWsId = customEvent.detail?.wsId;
+      const requestId = customEvent.detail?.requestId;
 
-      void openTaskById(taskId);
+      const emitOpenResult = (opened: boolean) => {
+        if (!requestId) return;
+        dispatchTaskOpenResult({ requestId, opened });
+      };
+
+      void (async () => {
+        if (requestedWsId) {
+          try {
+            const { task } = await getWorkspaceTask(requestedWsId, taskId, {
+              fetch: (input, init) =>
+                fetch(
+                  new URL(String(input), window.location.origin).toString(),
+                  {
+                    ...init,
+                    cache: 'no-store',
+                  }
+                ),
+            });
+
+            const taskWithList = task as {
+              board_id?: string | null;
+              list?: {
+                board_id?: string | null;
+              } | null;
+            };
+            const boardId =
+              taskWithList.board_id || taskWithList.list?.board_id;
+            if (boardId) {
+              openTask(task as Task, boardId, undefined, false, {
+                taskWsId: requestedWsId,
+              });
+              emitOpenResult(true);
+              return;
+            }
+          } catch {
+            // Fall through to the generic current-user lookup below.
+          }
+        }
+
+        const opened = await openTaskById(taskId);
+        emitOpenResult(opened);
+      })();
     };
 
     window.addEventListener(
@@ -249,7 +301,14 @@ export function TaskDialogManager({ wsId }: { wsId: string }) {
         handleTaskOpenRequest as EventListener
       );
     };
-  }, [openTaskById]);
+  }, [openTaskById, openTask]);
+
+  useEffect(() => {
+    if (!openTaskId) return;
+
+    void openTaskById(openTaskId);
+    void setOpenTaskId(null);
+  }, [openTaskId, openTaskById, setOpenTaskId]);
 
   // Open subtask creation dialog for the current task
   const handleAddSubtask = useCallback(() => {

--- a/packages/ui/src/components/ui/tu-do/shared/task-dialog-manager.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-dialog-manager.tsx
@@ -140,10 +140,6 @@ export function TaskDialogManager({ wsId }: { wsId: string }) {
       if (profile?.id) {
         setCurrentUser({
           id: profile.id,
-          email: profile.email ?? undefined,
-        });
-        setCurrentUser({
-          id: profile.id,
           display_name: profile.display_name || undefined,
           email: profile.email ?? undefined,
           avatar_url: profile.avatar_url || undefined,

--- a/packages/ui/src/components/ui/tu-do/shared/task-dialog-manager.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-dialog-manager.tsx
@@ -15,8 +15,8 @@ import {
 import { dispatchRecentSidebarVisit } from './recent-sidebar-events';
 import { TaskEditDialog } from './task-edit-dialog';
 import {
-  REQUEST_OPEN_TASK_EVENT,
   dispatchTaskOpenResult,
+  REQUEST_OPEN_TASK_EVENT,
   type RequestOpenTaskPayload,
 } from './task-open-events';
 

--- a/packages/ui/src/components/ui/tu-do/shared/task-open-events.ts
+++ b/packages/ui/src/components/ui/tu-do/shared/task-open-events.ts
@@ -86,6 +86,9 @@ export function waitForTaskOpenResult(
       resolve(false);
     }, timeoutMs);
 
-    window.addEventListener(TASK_OPEN_RESULT_EVENT, handleResult as EventListener);
+    window.addEventListener(
+      TASK_OPEN_RESULT_EVENT,
+      handleResult as EventListener
+    );
   });
 }

--- a/packages/ui/src/components/ui/tu-do/shared/task-open-events.ts
+++ b/packages/ui/src/components/ui/tu-do/shared/task-open-events.ts
@@ -2,16 +2,90 @@
 
 export interface RequestOpenTaskPayload {
   taskId: string;
+  wsId?: string;
+  handled?: boolean;
+  requestId?: string;
 }
 
 export const REQUEST_OPEN_TASK_EVENT = 'tuturuuu:request-open-task';
+export const TASK_OPEN_RESULT_EVENT = 'tuturuuu:task-open-result';
 
-export function dispatchRequestOpenTask(payload: RequestOpenTaskPayload): void {
-  if (typeof window === 'undefined') return;
+export interface TaskOpenResultPayload {
+  requestId: string;
+  opened: boolean;
+}
+
+export interface RequestOpenTaskDispatchResult {
+  handled: boolean;
+  requestId: string;
+}
+
+export function dispatchRequestOpenTask(
+  payload: RequestOpenTaskPayload
+): RequestOpenTaskDispatchResult {
+  if (typeof window === 'undefined') {
+    return { handled: false, requestId: '' };
+  }
+
+  const requestId =
+    payload.requestId ||
+    (typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random()}`);
+
+  const eventDetail: RequestOpenTaskPayload = {
+    ...payload,
+    requestId,
+    handled: false,
+  };
 
   window.dispatchEvent(
     new CustomEvent<RequestOpenTaskPayload>(REQUEST_OPEN_TASK_EVENT, {
+      detail: eventDetail,
+    })
+  );
+
+  return {
+    handled: !!eventDetail.handled,
+    requestId,
+  };
+}
+
+export function dispatchTaskOpenResult(payload: TaskOpenResultPayload): void {
+  if (typeof window === 'undefined') return;
+
+  window.dispatchEvent(
+    new CustomEvent<TaskOpenResultPayload>(TASK_OPEN_RESULT_EVENT, {
       detail: payload,
     })
   );
+}
+
+export function waitForTaskOpenResult(
+  requestId: string,
+  timeoutMs = 5000
+): Promise<boolean> {
+  if (typeof window === 'undefined' || !requestId) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    const handleResult = (event: Event) => {
+      const customEvent = event as CustomEvent<TaskOpenResultPayload>;
+      if (customEvent.detail?.requestId !== requestId) {
+        return;
+      }
+
+      window.clearTimeout(timeoutId);
+      window.removeEventListener(TASK_OPEN_RESULT_EVENT, handleResult);
+      resolve(!!customEvent.detail?.opened);
+    };
+
+    const timeoutId = window.setTimeout(() => {
+      window.removeEventListener(TASK_OPEN_RESULT_EVENT, handleResult);
+      resolve(false);
+    }, timeoutMs);
+
+    window.addEventListener(TASK_OPEN_RESULT_EVENT, handleResult as EventListener);
+  });
 }


### PR DESCRIPTION
- Integrated task opening logic in the NotificationCard component to handle task notifications.
- Updated RecentSidebarItems to open task dialogs directly from recent items.
- Added tests to verify task dialog opening behavior for notifications and sidebar items.
- Refactored task dialog management to support asynchronous task opening with fallback navigation.

# Description

<!-- Provide a brief overview of the changes in this PR -->

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<img width="423" height="551" alt="image" src="https://github.com/user-attachments/assets/0da9615f-1a22-47c9-bebc-7fe2884487af" />
<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/3e1e9347-ed55-493b-bcef-e8421d99d19e" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task opening from notifications and the Recent sidebar by using a shared “open task” event with a result/timeout and locale-aware fallback. Adds small loading spinners and tighter tests to ensure consistent behavior.

- **Bug Fixes**
  - Notifications: “View details →” now dispatches the task-open event; the popover waits up to 6s and shows an “Opening…” state, while the web card falls back immediately if no handler, using locale/workspace-aware `?openTaskId=` routing.
  - Sidebar: Clicking a task recent item dispatches the event, shows a spinner while opening, waits up to 6s, then falls back to route navigation; still calls `onNavigate`. Adds a blocklist for non-task segments (e.g. boards/projects) to avoid false positives.
  - Task dialog manager listens for open requests (optionally scoped by `wsId`), sets `handled`, emits result events, and supports `openTaskId` via `nuqs` for fallback openings.

- **Refactors**
  - `openTaskById` now returns a boolean and provider logic handles failures cleanly.
  - Introduced request/result events with `waitForTaskOpenResult` and structured `dispatchRequestOpenTask` return values in `@tuturuuu/ui/tu-do/shared/task-open-events`.
  - Notification workspace invite actions are strongly typed and simplified; task-related imports reorganized for clarity.
  - Tests updated for notifications (card and popover) and recent sidebar items; added mocks for `waitForTaskOpenResult` to simulate async openings.

<sup>Written for commit 12ba440c64ea843eaf254bef7508be0581aa400d. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4623">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

