### PR TITLE
feat(time-tracking): enhance session tile and history stats UI

### DIFF
--- a/apps/mobile/lib/features/time_tracker/widgets/history_stats_accordion.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/history_stats_accordion.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile/data/models/time_tracking/period_stats.dart';
+import 'package:mobile/features/time_tracker/utils/category_color.dart';
 import 'package:mobile/l10n/l10n.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart' as shad;
 
@@ -135,6 +136,11 @@ class _Body extends StatelessWidget {
             final percent = totalDuration > 0
                 ? entry.duration / totalDuration
                 : 0.0;
+            final fillColor = resolveTimeTrackingCategoryColor(
+              context,
+              entry.color,
+              fallback: theme.colorScheme.primary,
+            );
             return Padding(
               padding: const EdgeInsets.only(bottom: 10),
               child: Column(
@@ -167,7 +173,11 @@ class _Body extends StatelessWidget {
                     ],
                   ),
                   const shad.Gap(6),
-                  shad.LinearProgressIndicator(value: percent.clamp(0, 1)),
+                  _CategoryShareBar(
+                    value: percent.clamp(0, 1),
+                    fillColor: fillColor,
+                    trackColor: theme.colorScheme.muted,
+                  ),
                 ],
               ),
             );
@@ -185,6 +195,42 @@ class _Body extends StatelessWidget {
     final minutes = (totalSeconds % 3600) ~/ 60;
     if (hours > 0) return '${hours}h ${minutes}m';
     return '${minutes}m';
+  }
+}
+
+class _CategoryShareBar extends StatelessWidget {
+  const _CategoryShareBar({
+    required this.value,
+    required this.fillColor,
+    required this.trackColor,
+  });
+
+  final double value;
+  final Color fillColor;
+  final Color trackColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(999),
+      child: SizedBox(
+        height: 6,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            ColoredBox(color: trackColor),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: FractionallySizedBox(
+                widthFactor: value,
+                heightFactor: 1,
+                child: ColoredBox(color: fillColor),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/features/time_tracker/widgets/session_tile.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/session_tile.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart' hide AlertDialog;
 import 'package:intl/intl.dart';
+import 'package:mobile/core/theme/dynamic_colors.dart';
 import 'package:mobile/data/models/time_tracking/session.dart';
-import 'package:mobile/features/time_tracker/utils/category_color.dart';
+import 'package:mobile/features/time_tracker/widgets/time_tracking_category_chip.dart';
 import 'package:mobile/l10n/l10n.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart' as shad;
 
@@ -34,6 +35,12 @@ class SessionTile extends StatelessWidget {
     final durationText = _formatDuration(dur);
 
     final timeRange = _formatTimeRange(session.startTime, session.endTime);
+    final categoryLabel = session.categoryName?.trim().isNotEmpty == true
+        ? session.categoryName!.trim()
+        : l10n.timerNoCategory;
+    final colorKey = session.categoryColor ?? categoryColor;
+
+    final descriptionPreview = _descriptionPreview(session.description);
 
     return Dismissible(
       key: Key(session.id),
@@ -68,45 +75,95 @@ class SessionTile extends StatelessWidget {
           onDelete?.call();
         }
       },
-      child: InkWell(
-        onTap: onTap ?? onEdit,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              _CategoryDot(color: session.categoryColor ?? categoryColor),
-              const shad.Gap(12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      session.title ?? 'Work session',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.typography.base.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    if (timeRange.isNotEmpty)
-                      Text(
-                        timeRange,
-                        style: theme.typography.small.copyWith(
-                          color: theme.colorScheme.mutedForeground,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
+        child: Material(
+          color: theme.colorScheme.card,
+          borderRadius: BorderRadius.circular(12),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(12),
+            onTap: onTap ?? onEdit,
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: theme.colorScheme.border),
+              ),
+              padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          session.title ?? l10n.timerRunningSessionNoTitle,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.typography.base.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
                         ),
                       ),
+                      const shad.Gap(10),
+                      _SessionDurationBadge(
+                        label: durationText,
+                      ),
+                    ],
+                  ),
+                  const shad.Gap(8),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Wrap(
+                          spacing: 8,
+                          runSpacing: 6,
+                          children: [
+                            TimeTrackingCategoryChip(
+                              label: categoryLabel,
+                              rawColor: colorKey,
+                            ),
+                            if (session.pendingApproval)
+                              shad.OutlineBadge(
+                                child: Text(
+                                  l10n.timerRequestPending,
+                                  style: theme.typography.small.copyWith(
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                      if (timeRange.isNotEmpty) ...[
+                        const shad.Gap(8),
+                        Flexible(
+                          child: Align(
+                            alignment: AlignmentDirectional.centerEnd,
+                            child: _SessionTimeRangeChip(label: timeRange),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                  if (descriptionPreview != null) ...[
+                    const shad.Gap(6),
+                    Text(
+                      descriptionPreview,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.typography.small.copyWith(
+                        color: theme.colorScheme.mutedForeground,
+                        height: 1.25,
+                      ),
+                    ),
                   ],
-                ),
+                ],
               ),
-              const shad.Gap(12),
-              Text(
-                durationText,
-                style: theme.typography.base.copyWith(
-                  fontWeight: FontWeight.w600,
-                  fontFeatures: [const FontFeature.tabularFigures()],
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),
@@ -151,25 +208,92 @@ class SessionTile extends StatelessWidget {
     final endStr = fmt.format(end.toLocal());
     return '$startStr – $endStr';
   }
+
+  String? _descriptionPreview(String? raw) {
+    if (raw == null) return null;
+    final collapsed = raw.trim().replaceAll(RegExp(r'\s+'), ' ');
+    if (collapsed.isEmpty) return null;
+    return collapsed;
+  }
 }
 
-class _CategoryDot extends StatelessWidget {
-  const _CategoryDot({this.color});
+/// Matches web session duration: dynamic-orange/10 surface, orange ring, mono text.
+class _SessionDurationBadge extends StatelessWidget {
+  const _SessionDurationBadge({required this.label});
 
-  final String? color;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
+    final theme = shad.Theme.of(context);
+    final orange = DynamicColors.of(context).orange;
+
     return Container(
-      width: 12,
-      height: 12,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: resolveTimeTrackingCategoryColor(
-          context,
-          color,
-          fallback: shad.Theme.of(context).colorScheme.muted,
+        borderRadius: BorderRadius.circular(8),
+        color: orange.withAlpha(26),
+        border: Border.all(color: orange.withAlpha(51)),
+      ),
+      child: Text(
+        label,
+        style: theme.typography.small.copyWith(
+          fontFamily: 'monospace',
+          fontWeight: FontWeight.w700,
+          fontFeatures: const [FontFeature.tabularFigures()],
+          color: orange,
+          fontSize: 14,
+          height: 1.2,
         ),
+      ),
+    );
+  }
+}
+
+/// Clock readout chip: mono digits, dynamic-blue tint (secondary to duration).
+class _SessionTimeRangeChip extends StatelessWidget {
+  const _SessionTimeRangeChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = shad.Theme.of(context);
+    final blue = DynamicColors.of(context).blue;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        color: blue.withAlpha(26),
+        border: Border.all(color: blue.withAlpha(51)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.schedule,
+            size: 13,
+            color: blue.withAlpha(230),
+          ),
+          const shad.Gap(5),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 168),
+            child: Text(
+              label,
+              style: theme.typography.small.copyWith(
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.w600,
+                fontFeatures: const [FontFeature.tabularFigures()],
+                color: blue,
+                fontSize: 11,
+                height: 1.2,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/time_tracker/widgets/time_tracking_category_chip.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/time_tracking_category_chip.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:mobile/features/time_tracker/utils/category_color.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart' as shad;
+
+/// Compact category pill styled like task label chips (tinted fill + border).
+class TimeTrackingCategoryChip extends StatelessWidget {
+  const TimeTrackingCategoryChip({
+    required this.label,
+    this.rawColor,
+    super.key,
+  });
+
+  final String label;
+  final String? rawColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = shad.Theme.of(context);
+    final trimmedColor = rawColor?.trim();
+    final hasColor = trimmedColor != null && trimmedColor.isNotEmpty;
+
+    if (!hasColor) {
+      return shad.OutlineBadge(
+        child: Text(
+          label,
+          style: const TextStyle(fontSize: 10),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      );
+    }
+
+    final color = resolveTimeTrackingCategoryColor(
+      context,
+      trimmedColor,
+      fallback: theme.colorScheme.mutedForeground,
+    );
+
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 200),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withAlpha(30),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withAlpha(180)),
+      ),
+      child: Text(
+        label,
+        style: theme.typography.small.copyWith(
+          fontSize: 10,
+          color: color.withAlpha(240),
+          fontWeight: FontWeight.w600,
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Introduced a new `_CategoryShareBar` widget for improved visual representation of category share in history stats.
- Updated `SessionTile` to include a `TimeTrackingCategoryChip` for displaying session categories with dynamic colors.
- Refactored layout and styling in `SessionTile` for better responsiveness and user experience.
- Added a description preview feature in `SessionTile` to enhance information display.

# Description

<!-- Provide a brief overview of the changes in this PR -->

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<img width="408" height="867" alt="image" src="https://github.com/user-attachments/assets/e287d33a-7d7b-45dc-aa18-90ee524722ac" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances the time tracking UI with a card-style SessionTile and clearer history stats. Adds category-colored chips and a tinted share bar for better scanability.

- New Features
  - SessionTile: card layout with border and larger tap target, plus duration badge and time range chip; shows pending approval when relevant.
  - Category chip (`TimeTrackingCategoryChip`): displays category name with resolved dynamic color and graceful fallback; truncates long labels.
  - Description preview: trims/collapses whitespace and shows up to 2 lines.
  - History stats: `_CategoryShareBar` replaces the linear progress bar with a rounded, category-colored share bar.

<sup>Written for commit 923fe8846e3a09859eff3eff9915b87b7287ebaa. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4626">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

