### PR TITLE
feat: enhance image upload handling and error messaging in text editor and task dialog

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,21 +5,100 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.4.3"
+        "@opencode-ai/plugin": "1.4.7"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.3.tgz",
-      "integrity": "sha512-Ob/3tVSIeuMRJBr2O23RtrnC5djRe01Lglx+TwGEmjrH9yDBJ2tftegYLnNEjRoMuzITgq9LD8168p4pzv+U/A==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.7.tgz",
+      "integrity": "sha512-RbzMl7ILvQDHpZNvqzi6RCYaGcB3eBwNIMRZww467drLvMd1eOwr4/qAurrvYDsIIEctE6cKsrLuSGIKCW/Fxg==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.4.3",
+        "@opencode-ai/sdk": "1.4.7",
+        "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.97",
-        "@opentui/solid": ">=0.1.97"
+        "@opentui/core": ">=0.1.99",
+        "@opentui/solid": ">=0.1.99"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -31,13 +110,19 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.3.tgz",
-      "integrity": "sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.7.tgz",
+      "integrity": "sha512-onEtaooQyoDP5gTShQeQSf0Sd8V7949G9pPNyIyRXnVtFqyDIhUDLGtL/a/+EIW9x5s+Y6lDy/3oVoGMvQ0rQQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -53,11 +138,134 @@
         "node": ">= 8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
+      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
+      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -67,6 +275,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -89,6 +313,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -102,6 +348,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/packages/ui/src/components/ui/text-editor/editor.tsx
+++ b/packages/ui/src/components/ui/text-editor/editor.tsx
@@ -152,6 +152,16 @@ export function RichTextEditor({
     []
   );
 
+  const delegatedImageUpload = useCallback(async (file: File) => {
+    const handler = onImageUploadRef.current;
+    if (!handler) {
+      throw new Error(
+        'You do not have permission to upload images in this editor.'
+      );
+    }
+    return handler(file);
+  }, []);
+
   // Store debounced function ref for flushing
   useEffect(() => {
     debouncedOnChangeRef.current = debouncedOnChange;
@@ -280,8 +290,8 @@ export function RichTextEditor({
       doc: allowCollaboration ? yjsDoc : undefined,
       provider: allowCollaboration ? yjsProvider : undefined,
       collaborationUser: allowCollaboration ? collaborationUser : undefined,
-      onImageUpload: onImageUploadRef.current,
-      onVideoUpload: onImageUploadRef.current,
+      onImageUpload: delegatedImageUpload,
+      onVideoUpload: delegatedImageUpload,
       mentionTranslations,
       readOnly,
     }),
@@ -507,8 +517,8 @@ export function RichTextEditor({
           doc: yjsDoc,
           provider: yjsProvider,
           collaborationUser: collaborationUser,
-          onImageUpload: onImageUploadRef.current,
-          onVideoUpload: onImageUploadRef.current,
+          onImageUpload: delegatedImageUpload,
+          onVideoUpload: delegatedImageUpload,
           mentionTranslations,
           readOnly,
         }),
@@ -520,6 +530,7 @@ export function RichTextEditor({
     yjsDoc,
     allowCollaboration,
     collaborationUser,
+    delegatedImageUpload,
     titlePlaceholder,
     writePlaceholder,
     mentionTranslations,

--- a/packages/ui/src/components/ui/text-editor/editor.tsx
+++ b/packages/ui/src/components/ui/text-editor/editor.tsx
@@ -152,15 +152,21 @@ export function RichTextEditor({
     []
   );
 
-  const delegatedImageUpload = useCallback(async (file: File) => {
-    const handler = onImageUploadRef.current;
-    if (!handler) {
-      throw new Error(
-        'You do not have permission to upload images in this editor.'
-      );
+  const delegatedImageUpload = useMemo(() => {
+    if (!onImageUpload) {
+      return undefined;
     }
-    return handler(file);
-  }, []);
+
+    return async (file: File) => {
+      const handler = onImageUploadRef.current;
+      if (!handler) {
+        throw new Error(
+          'You do not have permission to upload images in this editor.'
+        );
+      }
+      return handler(file);
+    };
+  }, [onImageUpload]);
 
   // Store debounced function ref for flushing
   useEffect(() => {
@@ -497,6 +503,43 @@ export function RichTextEditor({
       }
     },
   });
+
+  const hadDelegatedImageUploadRef = useRef(Boolean(delegatedImageUpload));
+  useEffect(() => {
+    if (!editor) return;
+
+    const hasDelegatedImageUpload = Boolean(delegatedImageUpload);
+    if (hadDelegatedImageUploadRef.current === hasDelegatedImageUpload) {
+      return;
+    }
+
+    hadDelegatedImageUploadRef.current = hasDelegatedImageUpload;
+
+    editor.setOptions({
+      extensions: getEditorExtensions({
+        titlePlaceholder,
+        writePlaceholder,
+        doc: allowCollaboration ? yjsDoc : undefined,
+        provider: allowCollaboration ? yjsProvider : undefined,
+        collaborationUser: allowCollaboration ? collaborationUser : undefined,
+        onImageUpload: delegatedImageUpload,
+        onVideoUpload: delegatedImageUpload,
+        mentionTranslations,
+        readOnly,
+      }),
+    });
+  }, [
+    editor,
+    delegatedImageUpload,
+    titlePlaceholder,
+    writePlaceholder,
+    allowCollaboration,
+    yjsDoc,
+    yjsProvider,
+    collaborationUser,
+    mentionTranslations,
+    readOnly,
+  ]);
 
   // Recreate editor when collaboration provider becomes available so the
   // CollaborationCaret extension is included. The provider is null on first

--- a/packages/ui/src/components/ui/text-editor/editor.tsx
+++ b/packages/ui/src/components/ui/text-editor/editor.tsx
@@ -127,6 +127,10 @@ export function RichTextEditor({
   const debouncedOnChangeRef = useRef<ReturnType<typeof debounce> | null>(null);
   // Track when we're in a programmatic update to skip content sync
   const isProgrammaticUpdateRef = useRef(false);
+  const getDelegatedImageUpload = useCallback(
+    () => onImageUploadRef.current,
+    []
+  );
 
   useEffect(() => {
     onImageUploadRef.current = onImageUpload;
@@ -151,22 +155,6 @@ export function RichTextEditor({
       }, 500),
     []
   );
-
-  const delegatedImageUpload = useMemo(() => {
-    if (!onImageUpload) {
-      return undefined;
-    }
-
-    return async (file: File) => {
-      const handler = onImageUploadRef.current;
-      if (!handler) {
-        throw new Error(
-          'You do not have permission to upload images in this editor.'
-        );
-      }
-      return handler(file);
-    };
-  }, [onImageUpload]);
 
   // Store debounced function ref for flushing
   useEffect(() => {
@@ -296,8 +284,10 @@ export function RichTextEditor({
       doc: allowCollaboration ? yjsDoc : undefined,
       provider: allowCollaboration ? yjsProvider : undefined,
       collaborationUser: allowCollaboration ? collaborationUser : undefined,
-      onImageUpload: delegatedImageUpload,
-      onVideoUpload: delegatedImageUpload,
+      onImageUpload,
+      onVideoUpload: onImageUpload,
+      getOnImageUpload: getDelegatedImageUpload,
+      getOnVideoUpload: getDelegatedImageUpload,
       mentionTranslations,
       readOnly,
     }),
@@ -504,43 +494,6 @@ export function RichTextEditor({
     },
   });
 
-  const hadDelegatedImageUploadRef = useRef(Boolean(delegatedImageUpload));
-  useEffect(() => {
-    if (!editor) return;
-
-    const hasDelegatedImageUpload = Boolean(delegatedImageUpload);
-    if (hadDelegatedImageUploadRef.current === hasDelegatedImageUpload) {
-      return;
-    }
-
-    hadDelegatedImageUploadRef.current = hasDelegatedImageUpload;
-
-    editor.setOptions({
-      extensions: getEditorExtensions({
-        titlePlaceholder,
-        writePlaceholder,
-        doc: allowCollaboration ? yjsDoc : undefined,
-        provider: allowCollaboration ? yjsProvider : undefined,
-        collaborationUser: allowCollaboration ? collaborationUser : undefined,
-        onImageUpload: delegatedImageUpload,
-        onVideoUpload: delegatedImageUpload,
-        mentionTranslations,
-        readOnly,
-      }),
-    });
-  }, [
-    editor,
-    delegatedImageUpload,
-    titlePlaceholder,
-    writePlaceholder,
-    allowCollaboration,
-    yjsDoc,
-    yjsProvider,
-    collaborationUser,
-    mentionTranslations,
-    readOnly,
-  ]);
-
   // Recreate editor when collaboration provider becomes available so the
   // CollaborationCaret extension is included. The provider is null on first
   // render because it's created asynchronously in useEffect; this dep
@@ -560,8 +513,10 @@ export function RichTextEditor({
           doc: yjsDoc,
           provider: yjsProvider,
           collaborationUser: collaborationUser,
-          onImageUpload: delegatedImageUpload,
-          onVideoUpload: delegatedImageUpload,
+          onImageUpload,
+          onVideoUpload: onImageUpload,
+          getOnImageUpload: getDelegatedImageUpload,
+          getOnVideoUpload: getDelegatedImageUpload,
           mentionTranslations,
           readOnly,
         }),
@@ -573,11 +528,12 @@ export function RichTextEditor({
     yjsDoc,
     allowCollaboration,
     collaborationUser,
-    delegatedImageUpload,
+    onImageUpload,
     titlePlaceholder,
     writePlaceholder,
     mentionTranslations,
     readOnly,
+    getDelegatedImageUpload,
   ]);
 
   // Update editor's editable state when props change

--- a/packages/ui/src/components/ui/text-editor/extensions.ts
+++ b/packages/ui/src/components/ui/text-editor/extensions.ts
@@ -37,6 +37,8 @@ interface EditorExtensionsOptions {
   collaborationUser?: { name: string; color: string };
   onImageUpload?: (file: File) => Promise<string>;
   onVideoUpload?: (file: File) => Promise<string>;
+  getOnImageUpload?: () => ((file: File) => Promise<string>) | undefined;
+  getOnVideoUpload?: () => ((file: File) => Promise<string>) | undefined;
   /** Translations for mention chip dialogs */
   mentionTranslations?: {
     delete_task?: string;
@@ -69,6 +71,8 @@ export function getEditorExtensions({
   collaborationUser,
   onImageUpload,
   onVideoUpload,
+  getOnImageUpload,
+  getOnVideoUpload,
   mentionTranslations,
   readOnly = false,
 }: EditorExtensionsOptions = {}): Extensions {
@@ -201,7 +205,12 @@ export function getEditorExtensions({
           'relative border-r border-dynamic-border px-4 py-3 last:border-r-0 [&>p]:my-0 hover:bg-dynamic-surface/50 focus:bg-dynamic-surface/70 focus:outline-none focus:ring-2 focus:ring-dynamic-blue/50 focus:ring-inset',
       },
     }),
-    CustomImage({ onImageUpload }),
+    CustomImage({
+      onImageUpload,
+      onVideoUpload,
+      getOnImageUpload,
+      getOnVideoUpload,
+    }),
     Video({ onVideoUpload }).configure({
       HTMLAttributes: {
         class: 'rounded-md my-4',

--- a/packages/ui/src/components/ui/text-editor/image-extension.ts
+++ b/packages/ui/src/components/ui/text-editor/image-extension.ts
@@ -8,6 +8,7 @@ import {
 } from 'prosemirror-state';
 import ImageResize from 'tiptap-extension-resize-image';
 import {
+  formatBytes,
   getImageDimensions,
   getVideoDimensions,
   MAX_IMAGE_SIZE,
@@ -137,6 +138,13 @@ function calculatePresetWidth(
 interface ImageOptions {
   onImageUpload?: (file: File) => Promise<string>;
   onVideoUpload?: (file: File) => Promise<string>;
+}
+
+function getUploadErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return fallback;
 }
 
 /**
@@ -457,6 +465,9 @@ export const CustomImage = (options: ImageOptions = {}) => {
                           'Image size must be less than 5MB:',
                           image.name
                         );
+                        toast.error('Image too large', {
+                          description: `"${image.name}" exceeds the ${formatBytes(MAX_IMAGE_SIZE)} upload limit.`,
+                        });
                         continue;
                       }
 
@@ -536,6 +547,12 @@ export const CustomImage = (options: ImageOptions = {}) => {
                         image.name,
                         error
                       );
+                      toast.error('Failed to upload image', {
+                        description: getUploadErrorMessage(
+                          error,
+                          'Please try again.'
+                        ),
+                      });
                       // Remove placeholder on error
                       const removeTr = view.state.tr;
                       removeTr.setMeta(imageUploadPlaceholderPluginKey, {
@@ -617,6 +634,9 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       // Validate file size (max 5MB)
                       if (image.size > MAX_IMAGE_SIZE) {
                         console.error('Image too large:', image.name);
+                        toast.error('Image too large', {
+                          description: `"${image.name}" exceeds the ${formatBytes(MAX_IMAGE_SIZE)} upload limit.`,
+                        });
                         continue;
                       }
 
@@ -688,6 +708,12 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       currentPos = insertPos + node.nodeSize;
                     } catch (error) {
                       console.error('Failed to upload image:', error);
+                      toast.error('Failed to upload image', {
+                        description: getUploadErrorMessage(
+                          error,
+                          'Please try again.'
+                        ),
+                      });
                       // Remove placeholder on error
                       const removeTr = view.state.tr;
                       removeTr.setMeta(imageUploadPlaceholderPluginKey, {
@@ -706,6 +732,9 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       // Validate file size (max 50MB for videos)
                       if (video.size > MAX_VIDEO_SIZE) {
                         console.error('Video too large:', video.name);
+                        toast.error('Video too large', {
+                          description: `"${video.name}" exceeds the ${formatBytes(MAX_VIDEO_SIZE)} upload limit.`,
+                        });
                         continue;
                       }
 
@@ -780,6 +809,12 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       currentPos = insertPos + node.nodeSize;
                     } catch (error) {
                       console.error('Failed to upload video:', error);
+                      toast.error('Failed to upload video', {
+                        description: getUploadErrorMessage(
+                          error,
+                          'Please try again.'
+                        ),
+                      });
                       // Remove placeholder on error
                       const removeTr = view.state.tr;
                       removeTr.setMeta(imageUploadPlaceholderPluginKey, {

--- a/packages/ui/src/components/ui/text-editor/image-extension.ts
+++ b/packages/ui/src/components/ui/text-editor/image-extension.ts
@@ -139,6 +139,8 @@ function calculatePresetWidth(
 interface ImageOptions {
   onImageUpload?: (file: File) => Promise<string>;
   onVideoUpload?: (file: File) => Promise<string>;
+  getOnImageUpload?: () => ((file: File) => Promise<string>) | undefined;
+  getOnVideoUpload?: () => ((file: File) => Promise<string>) | undefined;
 }
 
 /**
@@ -164,6 +166,10 @@ interface ExtendedImageResizeOptions {
   HTMLAttributes: Record<string, any>;
   minWidth?: number;
   maxWidth?: number;
+  onImageUpload?: (file: File) => Promise<string>;
+  onVideoUpload?: (file: File) => Promise<string>;
+  getOnImageUpload?: () => ((file: File) => Promise<string>) | undefined;
+  getOnVideoUpload?: () => ((file: File) => Promise<string>) | undefined;
 }
 
 export const CustomImage = (options: ImageOptions = {}) => {
@@ -223,9 +229,15 @@ export const CustomImage = (options: ImageOptions = {}) => {
     addProseMirrorPlugins() {
       const parentPlugins = this.parent?.() || [];
       const getOnImageUpload = () =>
-        this?.options?.onImageUpload ?? options.onImageUpload;
+        this?.options?.getOnImageUpload?.() ??
+        this?.options?.onImageUpload ??
+        options.getOnImageUpload?.() ??
+        options.onImageUpload;
       const getOnVideoUpload = () =>
-        this?.options?.onVideoUpload ?? options.onVideoUpload;
+        this?.options?.getOnVideoUpload?.() ??
+        this?.options?.onVideoUpload ??
+        options.getOnVideoUpload?.() ??
+        options.onVideoUpload;
 
       return [
         ...parentPlugins,
@@ -610,6 +622,15 @@ export const CustomImage = (options: ImageOptions = {}) => {
                   });
                 }
 
+                if (videos.length > 0 && !onVideoUpload) {
+                  const blockedVideosDescription =
+                    'You do not have permission to upload media in this editor.';
+
+                  toast.error('Videos cannot be uploaded', {
+                    description: blockedVideosDescription,
+                  });
+                }
+
                 if (!onImageUpload && !onVideoUpload) {
                   event.preventDefault();
                   return true;
@@ -875,6 +896,10 @@ export const CustomImage = (options: ImageOptions = {}) => {
   return baseExtension.configure({
     inline: false,
     allowBase64: false,
+    onImageUpload: options.onImageUpload,
+    onVideoUpload: options.onVideoUpload,
+    getOnImageUpload: options.getOnImageUpload,
+    getOnVideoUpload: options.getOnVideoUpload,
     HTMLAttributes: {
       class: 'rounded-md mt-4 mb-2 block w-full',
     },

--- a/packages/ui/src/components/ui/text-editor/image-extension.ts
+++ b/packages/ui/src/components/ui/text-editor/image-extension.ts
@@ -14,6 +14,7 @@ import {
   MAX_IMAGE_SIZE,
   MAX_VIDEO_SIZE,
 } from './media-utils';
+import { getKnownUploadErrorKey, getUploadErrorMessage } from './upload-errors';
 import {
   createLoadingPlaceholder,
   findUploadPlaceholder,
@@ -140,13 +141,6 @@ interface ImageOptions {
   onVideoUpload?: (file: File) => Promise<string>;
 }
 
-function getUploadErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message;
-  }
-  return fallback;
-}
-
 /**
  * Adjusts a drop position to the nearest valid block-level insertion point.
  * If dropping inside a textblock (paragraph, heading, etc.), moves to after that block.
@@ -228,7 +222,10 @@ export const CustomImage = (options: ImageOptions = {}) => {
 
     addProseMirrorPlugins() {
       const parentPlugins = this.parent?.() || [];
-      const { onImageUpload, onVideoUpload } = options;
+      const getOnImageUpload = () =>
+        this?.options?.onImageUpload ?? options.onImageUpload;
+      const getOnVideoUpload = () =>
+        this?.options?.onVideoUpload ?? options.onVideoUpload;
 
       return [
         ...parentPlugins,
@@ -423,6 +420,7 @@ export const CustomImage = (options: ImageOptions = {}) => {
                   return false;
                 }
 
+                const onImageUpload = getOnImageUpload();
                 if (!onImageUpload) {
                   event.preventDefault();
                   toast.error('Insufficient permissions', {
@@ -496,7 +494,16 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       view.dispatch(placeholderTr);
 
                       // Upload the image
-                      const url = await onImageUpload(image);
+                      const currentOnImageUpload = getOnImageUpload();
+                      if (!currentOnImageUpload) {
+                        throw Object.assign(
+                          new Error('Upload handler unavailable'),
+                          {
+                            code: 'INSUFFICIENT_PERMISSIONS',
+                          }
+                        );
+                      }
+                      const url = await currentOnImageUpload(image);
 
                       // Get fresh state after upload
                       const currentState = view.state;
@@ -547,12 +554,18 @@ export const CustomImage = (options: ImageOptions = {}) => {
                         image.name,
                         error
                       );
-                      toast.error('Failed to upload image', {
-                        description: getUploadErrorMessage(
-                          error,
-                          'Please try again.'
-                        ),
-                      });
+                      const errorKey = getKnownUploadErrorKey(error);
+                      toast.error(
+                        errorKey === 'insufficient_permissions'
+                          ? 'Insufficient permissions'
+                          : 'Failed to upload image',
+                        {
+                          description: getUploadErrorMessage(
+                            error,
+                            'Please try again.'
+                          ),
+                        }
+                      );
                       // Remove placeholder on error
                       const removeTr = view.state.tr;
                       removeTr.setMeta(imageUploadPlaceholderPluginKey, {
@@ -585,10 +598,15 @@ export const CustomImage = (options: ImageOptions = {}) => {
 
                 if (images.length === 0 && videos.length === 0) return false;
 
+                const onImageUpload = getOnImageUpload();
+                const onVideoUpload = getOnVideoUpload();
+
                 if (images.length > 0 && !onImageUpload) {
-                  toast.error('Insufficient permissions', {
-                    description:
-                      'You do not have permission to upload images in this editor.',
+                  const blockedImagesDescription =
+                    'You do not have permission to upload media in this editor.';
+
+                  toast.error('Images cannot be uploaded', {
+                    description: blockedImagesDescription,
                   });
                 }
 
@@ -627,7 +645,8 @@ export const CustomImage = (options: ImageOptions = {}) => {
 
                   // Process images
                   for (const image of images) {
-                    if (!onImageUpload) continue;
+                    const currentOnImageUpload = getOnImageUpload();
+                    if (!currentOnImageUpload) continue;
                     const uploadId = generateUploadId();
 
                     try {
@@ -665,7 +684,7 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       view.dispatch(placeholderTr);
 
                       // Upload the image
-                      const url = await onImageUpload(image);
+                      const url = await currentOnImageUpload(image);
 
                       // Try imageResize first (custom), fallback to image (base)
                       const { schema } = view.state;
@@ -708,12 +727,18 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       currentPos = insertPos + node.nodeSize;
                     } catch (error) {
                       console.error('Failed to upload image:', error);
-                      toast.error('Failed to upload image', {
-                        description: getUploadErrorMessage(
-                          error,
-                          'Please try again.'
-                        ),
-                      });
+                      const errorKey = getKnownUploadErrorKey(error);
+                      toast.error(
+                        errorKey === 'insufficient_permissions'
+                          ? 'Insufficient permissions'
+                          : 'Failed to upload image',
+                        {
+                          description: getUploadErrorMessage(
+                            error,
+                            'Please try again.'
+                          ),
+                        }
+                      );
                       // Remove placeholder on error
                       const removeTr = view.state.tr;
                       removeTr.setMeta(imageUploadPlaceholderPluginKey, {
@@ -725,7 +750,8 @@ export const CustomImage = (options: ImageOptions = {}) => {
 
                   // Process videos
                   for (const video of videos) {
-                    if (!onVideoUpload) continue;
+                    const currentOnVideoUpload = getOnVideoUpload();
+                    if (!currentOnVideoUpload) continue;
                     const uploadId = generateUploadId();
 
                     try {
@@ -768,7 +794,7 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       view.dispatch(placeholderTr);
 
                       // Upload the video
-                      const url = await onVideoUpload(video);
+                      const url = await currentOnVideoUpload(video);
 
                       // Check for video node type
                       const { schema } = view.state;
@@ -809,12 +835,18 @@ export const CustomImage = (options: ImageOptions = {}) => {
                       currentPos = insertPos + node.nodeSize;
                     } catch (error) {
                       console.error('Failed to upload video:', error);
-                      toast.error('Failed to upload video', {
-                        description: getUploadErrorMessage(
-                          error,
-                          'Please try again.'
-                        ),
-                      });
+                      const errorKey = getKnownUploadErrorKey(error);
+                      toast.error(
+                        errorKey === 'insufficient_permissions'
+                          ? 'Insufficient permissions'
+                          : 'Failed to upload video',
+                        {
+                          description: getUploadErrorMessage(
+                            error,
+                            'Please try again.'
+                          ),
+                        }
+                      );
                       // Remove placeholder on error
                       const removeTr = view.state.tr;
                       removeTr.setMeta(imageUploadPlaceholderPluginKey, {

--- a/packages/ui/src/components/ui/text-editor/upload-errors.ts
+++ b/packages/ui/src/components/ui/text-editor/upload-errors.ts
@@ -30,6 +30,10 @@ export function getKnownUploadErrorKey(
   const name = errorLike.name ?? error.name;
   const message = (errorLike.message ?? error.message ?? '').toLowerCase();
 
+  if (code === 'PENDING_PERMISSION_CHECK') {
+    return 'pending_permission_check';
+  }
+
   if (
     code === 'INSUFFICIENT_PERMISSIONS' ||
     code === 'FORBIDDEN' ||
@@ -45,10 +49,6 @@ export function getKnownUploadErrorKey(
     name === 'PermissionError'
   ) {
     return 'insufficient_permissions';
-  }
-
-  if (code === 'PENDING_PERMISSION_CHECK') {
-    return 'pending_permission_check';
   }
 
   if (
@@ -83,6 +83,10 @@ export function getUploadErrorMessage(
   const knownErrorKey = getKnownUploadErrorKey(error);
   if (knownErrorKey) {
     return UPLOAD_ERROR_MESSAGES[knownErrorKey];
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
   }
 
   return fallback;

--- a/packages/ui/src/components/ui/text-editor/upload-errors.ts
+++ b/packages/ui/src/components/ui/text-editor/upload-errors.ts
@@ -1,0 +1,89 @@
+type UploadErrorLike = {
+  name?: string;
+  code?: string;
+  status?: number;
+  statusCode?: number;
+  message?: string;
+};
+
+const UPLOAD_ERROR_MESSAGES = {
+  insufficient_permissions:
+    'You do not have permission to upload media in this editor.',
+  pending_permission_check:
+    'Checking upload permissions. Please try again in a moment.',
+  file_too_large: 'This file is too large to upload.',
+  storage_quota_exceeded:
+    'Storage quota exceeded. Please free up space and try again.',
+  network_error:
+    'Network error while uploading. Please check your connection and try again.',
+} as const;
+
+export function getKnownUploadErrorKey(
+  error: unknown
+): keyof typeof UPLOAD_ERROR_MESSAGES | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  const errorLike = error as UploadErrorLike;
+  const code = errorLike.code?.toUpperCase();
+  const name = errorLike.name ?? error.name;
+  const message = (errorLike.message ?? error.message ?? '').toLowerCase();
+
+  if (
+    code === 'INSUFFICIENT_PERMISSIONS' ||
+    code === 'FORBIDDEN' ||
+    code === 'PERMISSION_DENIED' ||
+    code === '42501' ||
+    errorLike.status === 401 ||
+    errorLike.status === 403 ||
+    errorLike.statusCode === 401 ||
+    errorLike.statusCode === 403 ||
+    message.includes('permission') ||
+    message.includes('forbidden') ||
+    message.includes('not authorized') ||
+    name === 'PermissionError'
+  ) {
+    return 'insufficient_permissions';
+  }
+
+  if (code === 'PENDING_PERMISSION_CHECK') {
+    return 'pending_permission_check';
+  }
+
+  if (
+    code === 'FILE_TOO_LARGE' ||
+    code === 'PAYLOAD_TOO_LARGE' ||
+    errorLike.status === 413 ||
+    name === 'SizeLimitError'
+  ) {
+    return 'file_too_large';
+  }
+
+  if (name === 'StorageQuotaError') {
+    return 'storage_quota_exceeded';
+  }
+
+  if (
+    error.name === 'AbortError' ||
+    code === 'NETWORK_ERROR' ||
+    (error instanceof TypeError &&
+      (message.includes('network') || message.includes('fetch')))
+  ) {
+    return 'network_error';
+  }
+
+  return null;
+}
+
+export function getUploadErrorMessage(
+  error: unknown,
+  fallback: string
+): string {
+  const knownErrorKey = getKnownUploadErrorKey(error);
+  if (knownErrorKey) {
+    return UPLOAD_ERROR_MESSAGES[knownErrorKey];
+  }
+
+  return fallback;
+}

--- a/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog.tsx
@@ -182,6 +182,12 @@ export function TaskEditDialog({
   // User requested: always disable editing for shared tasks, regardless of permission
   const disabled = !!shareCode;
 
+  // Keep this permission query disabled when `disabled` shared-link mode is active
+  // (`enabled` becomes false) so `canManageTaskMedia` stays undefined while
+  // `isCheckingTaskMediaPermission` remains false for read-only visitors. That
+  // allows `imageUploadHandler` to stay unset for shared-link views without
+  // forcing a permission request that could re-enable upload affordances. The
+  // query only runs when `effectiveTaskWsId` exists and `disabled` is false.
   const { data: canManageTaskMedia, isPending: isCheckingTaskMediaPermission } =
     useQuery({
       queryKey: [
@@ -934,35 +940,64 @@ export function TaskEditDialog({
       if (!effectiveTaskWsId) {
         throw new Error(t('error'));
       }
-      if (canManageTaskMedia === false) {
-        throw new Error(t('insufficient_permissions'));
-      }
-      try {
-        const uploadResult = await uploadWorkspaceTaskFile(
-          effectiveTaskWsId,
-          file,
-          { taskId: task?.id }
-        );
 
-        const query = new URLSearchParams({ path: uploadResult.path });
-        if (task?.id) {
-          query.set('taskId', task.id);
-        }
-
-        return `/api/v1/workspaces/${encodeURIComponent(effectiveTaskWsId)}/storage/share?${query.toString()}`;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : t('error');
-        toast.error(t('error'), { description: message });
-        throw error;
+      if (disabled) {
+        throw Object.assign(new Error(t('insufficient_permissions')), {
+          code: 'INSUFFICIENT_PERMISSIONS',
+        });
       }
+
+      let hasPermission = canManageTaskMedia;
+      if (hasPermission === undefined || isCheckingTaskMediaPermission) {
+        hasPermission = await queryClient.fetchQuery({
+          queryKey: [
+            'workspace-permission',
+            effectiveTaskWsId,
+            'manage_drive_tasks_directory',
+          ],
+          queryFn: async () => {
+            const result = await checkWorkspacePermission(
+              effectiveTaskWsId,
+              'manage_drive_tasks_directory'
+            );
+            return result.hasPermission;
+          },
+          staleTime: 5 * 60 * 1000,
+        });
+      }
+
+      if (!hasPermission) {
+        throw Object.assign(new Error(t('insufficient_permissions')), {
+          code: 'INSUFFICIENT_PERMISSIONS',
+        });
+      }
+
+      const uploadResult = await uploadWorkspaceTaskFile(
+        effectiveTaskWsId,
+        file,
+        { taskId: task?.id }
+      );
+
+      const query = new URLSearchParams({ path: uploadResult.path });
+      if (task?.id) {
+        query.set('taskId', task.id);
+      }
+
+      return `/api/v1/workspaces/${encodeURIComponent(effectiveTaskWsId)}/storage/share?${query.toString()}`;
     },
-    [canManageTaskMedia, effectiveTaskWsId, task?.id, t]
+    [
+      canManageTaskMedia,
+      disabled,
+      effectiveTaskWsId,
+      isCheckingTaskMediaPermission,
+      queryClient,
+      task?.id,
+      t,
+    ]
   );
 
   const imageUploadHandler =
-    !effectiveTaskWsId ||
-    isCheckingTaskMediaPermission ||
-    canManageTaskMedia === false
+    !effectiveTaskWsId || disabled || canManageTaskMedia === false
       ? undefined
       : handleImageUpload;
 

--- a/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog.tsx
@@ -182,22 +182,23 @@ export function TaskEditDialog({
   // User requested: always disable editing for shared tasks, regardless of permission
   const disabled = !!shareCode;
 
-  const { data: canManageTaskMedia = false } = useQuery({
-    queryKey: [
-      'workspace-permission',
-      effectiveTaskWsId,
-      'manage_drive_tasks_directory',
-    ],
-    queryFn: async () => {
-      const result = await checkWorkspacePermission(
+  const { data: canManageTaskMedia, isPending: isCheckingTaskMediaPermission } =
+    useQuery({
+      queryKey: [
+        'workspace-permission',
         effectiveTaskWsId,
-        'manage_drive_tasks_directory'
-      );
-      return result.hasPermission;
-    },
-    enabled: Boolean(effectiveTaskWsId) && !disabled,
-    staleTime: 5 * 60 * 1000,
-  });
+        'manage_drive_tasks_directory',
+      ],
+      queryFn: async () => {
+        const result = await checkWorkspacePermission(
+          effectiveTaskWsId,
+          'manage_drive_tasks_directory'
+        );
+        return result.hasPermission;
+      },
+      enabled: Boolean(effectiveTaskWsId) && !disabled,
+      staleTime: 5 * 60 * 1000,
+    });
 
   // Core loading state
   const [isLoading, setIsLoading] = useState(false);
@@ -933,7 +934,7 @@ export function TaskEditDialog({
       if (!effectiveTaskWsId) {
         throw new Error(t('error'));
       }
-      if (!canManageTaskMedia) {
+      if (canManageTaskMedia === false) {
         throw new Error(t('insufficient_permissions'));
       }
       try {
@@ -958,7 +959,12 @@ export function TaskEditDialog({
     [canManageTaskMedia, effectiveTaskWsId, task?.id, t]
   );
 
-  const imageUploadHandler = canManageTaskMedia ? handleImageUpload : undefined;
+  const imageUploadHandler =
+    !effectiveTaskWsId ||
+    isCheckingTaskMediaPermission ||
+    canManageTaskMedia === false
+      ? undefined
+      : handleImageUpload;
 
   const handleEstimationConfigSuccess = useCallback(async () => {
     await queryClient.invalidateQueries({

--- a/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/hooks/use-task-dialog-keyboard-shortcuts.ts
+++ b/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/hooks/use-task-dialog-keyboard-shortcuts.ts
@@ -226,7 +226,13 @@ export function useTaskDialogKeyboardShortcuts({
   useEffect(() => {
     if (!editorInstance || !isOpen) return;
 
-    const editorDom = editorInstance.view.dom as HTMLElement | null;
+    let editorDom: HTMLElement | null = null;
+    try {
+      editorDom = editorInstance.view.dom as HTMLElement | null;
+    } catch {
+      return;
+    }
+
     if (!editorDom) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes in this PR -->

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<!--
REQUIRED: Provide screenshots or recordings that demonstrate:
- The changes have been tested on your local machine
- UI changes (if applicable)
- Before/after comparisons (if applicable)
- Key functionality working as expected

Drag and drop images here or paste them directly
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances image/video uploads in the rich text editor and task dialog with delegated handlers and clearer errors. Uploads are disabled for shared links or missing permissions, with precise toasts for size limits and common failures.

- **Bug Fixes**
  - Use delegated `getOnImageUpload`/`getOnVideoUpload` so the editor checks the latest handler at runtime; keep handlers unset to hide upload affordances in shared-link mode or when permission is unknown/denied.
  - In the task dialog, don’t run the permission query in shared-link mode; re-check permission on upload if pending, and throw `INSUFFICIENT_PERMISSIONS` when blocked; compute `imageUploadHandler` as undefined when no workspace, shared link, or denied permission.
  - Improve toasts: specific “Image too large”/“Video too large” with formatted limits; classify permission, pending check, quota, and network errors across drag, paste, and drop.
  - Harden keyboard shortcuts by guarding editor DOM access to prevent runtime errors.

- **Dependencies**
  - Updated `@opencode-ai/plugin` to `1.4.7` and `@opencode-ai/sdk` to `1.4.7`.
  - Plugin peer requirements updated to `@opentui/core` and `@opentui/solid` >= `0.1.99`.

<sup>Written for commit d9ab669a0a9f89d274a920bcbee6c011b4e197e8. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4632">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

