### PR TITLE
feat(tudo): enhance task properties with search support

### DIFF
--- a/packages/ui/src/components/ui/tu-do/boards/boardId/kanban/bulk/bulk-actions-menu.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/kanban/bulk/bulk-actions-menu.tsx
@@ -15,7 +15,6 @@ import {
   Move,
   Plus,
   Rabbit,
-  Search,
   Tags,
   Timer,
   Trash2,
@@ -35,10 +34,10 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from '@tuturuuu/ui/dropdown-menu';
-import { Input } from '@tuturuuu/ui/input';
 import { toast } from '@tuturuuu/ui/sonner';
 import { useTranslations } from 'next-intl';
 import { mapEstimationPoints } from '../../../../shared/estimation-mapping';
+import { TaskResourceSearchField } from '../../../../shared/task-resource-search-field';
 
 interface BulkActionsMenuProps {
   workspace: Workspace;
@@ -334,17 +333,11 @@ export function BulkActionsMenu({
           {t('common.labels')}
         </DropdownMenuSubTrigger>
         <DropdownMenuSubContent className="w-80 p-0">
-          <div className="border-b p-2">
-            <div className="relative">
-              <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder={t('common.search_labels')}
-                value={search.labelQuery}
-                onChange={(e) => search.setLabelQuery(e.target.value)}
-                className="h-8 border-0 bg-muted/50 pl-9 text-sm focus-visible:ring-0"
-              />
-            </div>
-          </div>
+          <TaskResourceSearchField
+            value={search.labelQuery}
+            onChange={search.setLabelQuery}
+            placeholder={t('common.search_labels')}
+          />
 
           {filtered.labels.length === 0 ? (
             <div className="px-2 py-6 text-center text-muted-foreground text-xs">
@@ -434,17 +427,11 @@ export function BulkActionsMenu({
           {tc('projects')}
         </DropdownMenuSubTrigger>
         <DropdownMenuSubContent className="w-80 p-0">
-          <div className="border-b p-2">
-            <div className="relative">
-              <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder={tc('search_projects')}
-                value={search.projectQuery}
-                onChange={(e) => search.setProjectQuery(e.target.value)}
-                className="h-8 border-0 bg-muted/50 pl-9 text-sm focus-visible:ring-0"
-              />
-            </div>
-          </div>
+          <TaskResourceSearchField
+            value={search.projectQuery}
+            onChange={search.setProjectQuery}
+            placeholder={tc('search_projects')}
+          />
 
           {filtered.projects.length === 0 ? (
             <div className="px-2 py-6 text-center text-muted-foreground text-xs">
@@ -598,17 +585,11 @@ export function BulkActionsMenu({
             {t('common.assignees')}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-80 p-0">
-            <div className="border-b p-2">
-              <div className="relative">
-                <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  placeholder={tc('search_members')}
-                  value={search.assigneeQuery}
-                  onChange={(e) => search.setAssigneeQuery(e.target.value)}
-                  className="h-8 border-0 bg-muted/50 pl-9 text-sm focus-visible:ring-0"
-                />
-              </div>
-            </div>
+            <TaskResourceSearchField
+              value={search.assigneeQuery}
+              onChange={search.setAssigneeQuery}
+              placeholder={tc('search_members')}
+            />
 
             {filtered.members.length === 0 ? (
               <div className="px-2 py-6 text-center text-muted-foreground text-xs">

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/kanban/bulk/bulk-actions-menu.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/kanban/bulk/bulk-actions-menu.tsx
@@ -25,6 +25,7 @@ import {
 } from '@tuturuuu/icons';
 import type { Workspace } from '@tuturuuu/types';
 import type { TaskList } from '@tuturuuu/types/primitives/TaskList';
+import type { WorkspaceMember } from '@tuturuuu/ui/hooks/use-workspace-members';
 import { Avatar, AvatarFallback, AvatarImage } from '@tuturuuu/ui/avatar';
 import {
   DropdownMenuContent,
@@ -36,12 +37,17 @@ import {
 } from '@tuturuuu/ui/dropdown-menu';
 import { toast } from '@tuturuuu/ui/sonner';
 import { useTranslations } from 'next-intl';
+import type { BoardConfig } from '@tuturuuu/utils/task-helper';
 import { mapEstimationPoints } from '../../../../shared/estimation-mapping';
 import { TaskResourceSearchField } from '../../../../shared/task-resource-search-field';
+import type {
+  KanbanFilteredLabel,
+  KanbanFilteredProject,
+} from '../data/use-filtered-resources';
 
 interface BulkActionsMenuProps {
   workspace: Workspace;
-  boardConfig: any;
+  boardConfig: BoardConfig | null | undefined;
   columns: TaskList[];
   bulkWorking: boolean;
   estimationOptions: number[];
@@ -51,9 +57,9 @@ interface BulkActionsMenuProps {
     assignees: Set<string>;
   };
   filtered: {
-    labels: any[];
-    projects: any[];
-    members: any[];
+    labels: KanbanFilteredLabel[];
+    projects: KanbanFilteredProject[];
+    members: WorkspaceMember[];
   };
   search: {
     labelQuery: string;
@@ -442,7 +448,7 @@ export function BulkActionsMenu({
           ) : (
             <div className="max-h-50 overflow-auto">
               <div className="flex flex-col gap-1 p-1">
-                {filtered.projects.slice(0, 50).map((project: any) => {
+                {filtered.projects.slice(0, 50).map((project) => {
                   const isApplied = appliedSets.projects.has(project.id);
                   return (
                     <DropdownMenuItem
@@ -600,7 +606,7 @@ export function BulkActionsMenu({
             ) : (
               <div className="max-h-37.5 overflow-auto">
                 <div className="flex flex-col gap-1 p-1">
-                  {filtered.members.slice(0, 50).map((member: any) => {
+                  {filtered.members.slice(0, 50).map((member) => {
                     const isApplied = appliedSets.assignees.has(member.id);
                     return (
                       <DropdownMenuItem

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/kanban/data/use-filtered-resources.ts
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/kanban/data/use-filtered-resources.ts
@@ -1,7 +1,11 @@
 'use client';
 
 import { useMemo } from 'react';
-import { normalizeBoardText } from '../../board-text-utils';
+import {
+  labelNameMatchesQuery,
+  memberMatchesSearchQuery,
+  projectNameMatchesQuery,
+} from '../../../../shared/task-resource-search-filters';
 
 export function useFilteredResources({
   workspaceLabels,
@@ -19,33 +23,20 @@ export function useFilteredResources({
   };
 }) {
   const filteredLabels = useMemo(() => {
-    return workspaceLabels.filter(
-      (label) =>
-        !search.labelQuery ||
-        normalizeBoardText(label.name).includes(
-          normalizeBoardText(search.labelQuery)
-        )
+    return workspaceLabels.filter((label) =>
+      labelNameMatchesQuery(label.name, search.labelQuery)
     );
   }, [workspaceLabels, search.labelQuery]);
 
   const filteredProjects = useMemo(() => {
-    return workspaceProjects.filter(
-      (project: any) =>
-        !search.projectQuery ||
-        normalizeBoardText(project.name).includes(
-          normalizeBoardText(search.projectQuery)
-        )
+    return workspaceProjects.filter((project: any) =>
+      projectNameMatchesQuery(project.name, search.projectQuery)
     );
   }, [workspaceProjects, search.projectQuery]);
 
   const filteredMembers = useMemo(() => {
-    return workspaceMembers.filter(
-      (member: any) =>
-        !search.assigneeQuery ||
-        member.display_name
-          ?.toLowerCase()
-          .includes(search.assigneeQuery.toLowerCase()) ||
-        member.email?.toLowerCase().includes(search.assigneeQuery.toLowerCase())
+    return workspaceMembers.filter((member: any) =>
+      memberMatchesSearchQuery(member, search.assigneeQuery)
     );
   }, [workspaceMembers, search.assigneeQuery]);
 

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/kanban/data/use-filtered-resources.ts
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/kanban/data/use-filtered-resources.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import type { WorkspaceMember } from '@tuturuuu/ui/hooks/use-workspace-members';
 import { useMemo } from 'react';
 import {
   labelNameMatchesQuery,
@@ -7,15 +8,24 @@ import {
   projectNameMatchesQuery,
 } from '../../../../shared/task-resource-search-filters';
 
+/** Minimal shape for bulk label lists (matches useBulkResources labels). */
+export type KanbanFilteredLabel = { id: string; name: string; color: string };
+
+/** Minimal shape for bulk project lists (matches useBulkResources projects). */
+export type KanbanFilteredProject = {
+  id: string;
+  name: string | null | undefined;
+};
+
 export function useFilteredResources({
   workspaceLabels,
   workspaceProjects,
   workspaceMembers,
   search,
 }: {
-  workspaceLabels: any[];
-  workspaceProjects: any[];
-  workspaceMembers: any[];
+  workspaceLabels: KanbanFilteredLabel[];
+  workspaceProjects: KanbanFilteredProject[];
+  workspaceMembers: WorkspaceMember[];
   search: {
     labelQuery: string;
     projectQuery: string;
@@ -29,13 +39,13 @@ export function useFilteredResources({
   }, [workspaceLabels, search.labelQuery]);
 
   const filteredProjects = useMemo(() => {
-    return workspaceProjects.filter((project: any) =>
+    return workspaceProjects.filter((project) =>
       projectNameMatchesQuery(project.name, search.projectQuery)
     );
   }, [workspaceProjects, search.projectQuery]);
 
   const filteredMembers = useMemo(() => {
-    return workspaceMembers.filter((member: any) =>
+    return workspaceMembers.filter((member) =>
       memberMatchesSearchQuery(member, search.assigneeQuery)
     );
   }, [workspaceMembers, search.assigneeQuery]);

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/menus/task-assignees-menu.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/menus/task-assignees-menu.tsx
@@ -1,4 +1,4 @@
-import { Check, Loader2, Search, UserStar, UserX } from '@tuturuuu/icons';
+import { Check, Loader2, UserStar, UserX } from '@tuturuuu/icons';
 import { Avatar, AvatarFallback, AvatarImage } from '@tuturuuu/ui/avatar';
 import {
   DropdownMenuItem,
@@ -6,9 +6,10 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from '@tuturuuu/ui/dropdown-menu';
-import { Input } from '@tuturuuu/ui/input';
 import { cn } from '@tuturuuu/utils/format';
 import { useMemo, useState } from 'react';
+import { TaskResourceSearchField } from '../../../shared/task-resource-search-field';
+import { memberMatchesSearchQuery } from '../../../shared/task-resource-search-filters';
 
 interface Member {
   id: string;
@@ -85,12 +86,8 @@ export function TaskAssigneesMenu({
     };
   }, [availableMembers, taskAssignees]);
 
-  // Filter members based on search
-  const filteredMembers = allMembers.filter(
-    (member) =>
-      !searchQuery ||
-      member.display_name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      member.email?.toLowerCase().includes(searchQuery.toLowerCase())
+  const filteredMembers = allMembers.filter((member) =>
+    memberMatchesSearchQuery(member, searchQuery)
   );
 
   return (
@@ -100,20 +97,11 @@ export function TaskAssigneesMenu({
         {t.assignees}
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-80 p-0">
-        {/* Search Input */}
-        <div className="border-b p-2">
-          <div className="relative">
-            <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder={t.searchMembers}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              onPointerDownCapture={(e) => e.stopPropagation()}
-              className="h-8 border-0 bg-muted/50 pl-9 text-sm focus-visible:ring-0"
-            />
-          </div>
-        </div>
+        <TaskResourceSearchField
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={t.searchMembers}
+        />
 
         {/* Members List */}
         {isLoading ? (

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/menus/task-labels-menu.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/menus/task-labels-menu.tsx
@@ -1,15 +1,15 @@
-import { Check, Loader2, Plus, Search, Tag } from '@tuturuuu/icons';
+import { Check, Loader2, Plus, Tag } from '@tuturuuu/icons';
 import {
   DropdownMenuItem,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from '@tuturuuu/ui/dropdown-menu';
-import { Input } from '@tuturuuu/ui/input';
 import { cn } from '@tuturuuu/utils/format';
 import { useState } from 'react';
 import { LabelChip, type TaskLabel } from '../../../shared/label-chip';
-import { normalizeBoardText } from '../board-text-utils';
+import { TaskResourceSearchField } from '../../../shared/task-resource-search-field';
+import { labelNameMatchesQuery } from '../../../shared/task-resource-search-filters';
 
 interface TaskLabelsMenuProps {
   taskLabels: Array<Pick<TaskLabel, 'id' | 'name' | 'color'>>;
@@ -50,10 +50,8 @@ export function TaskLabelsMenu({
 
   const [searchQuery, setSearchQuery] = useState('');
 
-  const filteredLabels = availableLabels.filter(
-    (label) =>
-      !searchQuery ||
-      normalizeBoardText(label.name).includes(normalizeBoardText(searchQuery))
+  const filteredLabels = availableLabels.filter((label) =>
+    labelNameMatchesQuery(label.name, searchQuery)
   );
 
   return (
@@ -63,19 +61,11 @@ export function TaskLabelsMenu({
         {t.labels}
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-80 p-0">
-        <div className="border-b p-2">
-          <div className="relative">
-            <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder={t.searchLabels}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              onPointerDownCapture={(e) => e.stopPropagation()}
-              className="h-8 border-0 bg-muted/50 pl-9 text-sm focus-visible:ring-0"
-            />
-          </div>
-        </div>
+        <TaskResourceSearchField
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={t.searchLabels}
+        />
 
         {isLoading ? (
           <div className="flex items-center justify-center gap-2 px-2 py-6">

--- a/packages/ui/src/components/ui/tu-do/boards/boardId/menus/task-projects-menu.tsx
+++ b/packages/ui/src/components/ui/tu-do/boards/boardId/menus/task-projects-menu.tsx
@@ -1,14 +1,14 @@
-import { Box, Check, Loader2, Plus, Search } from '@tuturuuu/icons';
+import { Box, Check, Loader2, Plus } from '@tuturuuu/icons';
 import {
   DropdownMenuItem,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from '@tuturuuu/ui/dropdown-menu';
-import { Input } from '@tuturuuu/ui/input';
 import { cn } from '@tuturuuu/utils/format';
 import { useState } from 'react';
-import { normalizeBoardText } from '../board-text-utils';
+import { TaskResourceSearchField } from '../../../shared/task-resource-search-field';
+import { projectNameMatchesQuery } from '../../../shared/task-resource-search-filters';
 
 interface TaskProject {
   id: string;
@@ -57,11 +57,8 @@ export function TaskProjectsMenu({
 
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Filter projects based on search
-  const filteredProjects = availableProjects.filter(
-    (project) =>
-      !searchQuery ||
-      normalizeBoardText(project.name).includes(normalizeBoardText(searchQuery))
+  const filteredProjects = availableProjects.filter((project) =>
+    projectNameMatchesQuery(project.name, searchQuery)
   );
 
   return (
@@ -71,20 +68,11 @@ export function TaskProjectsMenu({
         {t.projects}
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-80 p-0">
-        {/* Search Input */}
-        <div className="border-b p-2">
-          <div className="relative">
-            <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder={t.searchProjects}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              onPointerDownCapture={(e) => e.stopPropagation()}
-              className="h-8 border-0 bg-muted/50 pl-9 text-sm focus-visible:ring-0"
-            />
-          </div>
-        </div>
+        <TaskResourceSearchField
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={t.searchProjects}
+        />
 
         {/* Projects List */}
         {isLoading ? (

--- a/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/task-properties-section.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-edit-dialog/task-properties-section.tsx
@@ -52,6 +52,12 @@ import {
 import { LabelChip } from '../label-chip';
 import type { SchedulingSettings } from '../task-edit-dialog/hooks/use-task-mutations';
 import type { WorkspaceTaskLabel } from '../task-edit-dialog/types';
+import { TaskResourceSearchField } from '../task-resource-search-field';
+import {
+  labelNameMatchesQuery,
+  memberMatchesSearchQuery,
+  projectNameMatchesQuery,
+} from '../task-resource-search-filters';
 import { UserAvatar } from '../user-avatar';
 import { translateTaskListNameForDisplay } from '../utils/translate-task-list-display-name';
 import { TaskListSelector } from './components/task-list-selector';
@@ -357,6 +363,60 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
   const [isProjectsPopoverOpen, setIsProjectsPopoverOpen] = useState(false);
   const [isAssigneesPopoverOpen, setIsAssigneesPopoverOpen] = useState(false);
   const [isSchedulingPopoverOpen, setIsSchedulingPopoverOpen] = useState(false);
+  const [labelSearchQuery, setLabelSearchQuery] = useState('');
+  const [projectSearchQuery, setProjectSearchQuery] = useState('');
+  const [assigneeSearchQuery, setAssigneeSearchQuery] = useState('');
+
+  const unselectedAvailableLabels = useMemo(
+    () =>
+      availableLabels.filter(
+        (l) => !selectedLabels.some((sl) => sl.id === l.id)
+      ),
+    [availableLabels, selectedLabels]
+  );
+  const filteredUnselectedLabels = useMemo(
+    () =>
+      unselectedAvailableLabels.filter((l) =>
+        labelNameMatchesQuery(l.name, labelSearchQuery)
+      ),
+    [unselectedAvailableLabels, labelSearchQuery]
+  );
+
+  const unselectedTaskProjects = useMemo(
+    () =>
+      taskProjects.filter(
+        (p) => !selectedProjects.some((sp) => sp.id === p.id)
+      ),
+    [taskProjects, selectedProjects]
+  );
+  const filteredUnselectedProjects = useMemo(
+    () =>
+      unselectedTaskProjects.filter((p) =>
+        projectNameMatchesQuery(p.name, projectSearchQuery)
+      ),
+    [unselectedTaskProjects, projectSearchQuery]
+  );
+
+  const unselectedWorkspaceMembers = useMemo(
+    () =>
+      workspaceMembers.filter(
+        (m) =>
+          !selectedAssignees.some(
+            (a) => (a.id || a.user_id) === (m.user_id || m.id)
+          )
+      ),
+    [workspaceMembers, selectedAssignees]
+  );
+  const filteredUnselectedMembers = useMemo(
+    () =>
+      unselectedWorkspaceMembers.filter((m) =>
+        memberMatchesSearchQuery(
+          { display_name: m.display_name, email: m.email },
+          assigneeSearchQuery
+        )
+      ),
+    [unselectedWorkspaceMembers, assigneeSearchQuery]
+  );
 
   // Track last saved settings locally (updates after successful save)
   const [lastSavedSettings, setLastSavedSettings] = useState<
@@ -1079,7 +1139,10 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
             {/* Labels Badge */}
             <Popover
               open={isLabelsPopoverOpen}
-              onOpenChange={setIsLabelsPopoverOpen}
+              onOpenChange={(open) => {
+                setIsLabelsPopoverOpen(open);
+                if (!open) setLabelSearchQuery('');
+              }}
             >
               <PopoverTrigger asChild>
                 <button
@@ -1157,16 +1220,24 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
                         </div>
                       </div>
                     )}
+                    <TaskResourceSearchField
+                      value={labelSearchQuery}
+                      onChange={setLabelSearchQuery}
+                      placeholder={t('common.search_labels')}
+                    />
                     <div
                       className="max-h-60 overflow-y-auto overscroll-contain"
                       onWheel={(e) => e.stopPropagation()}
                     >
                       <div className="p-1">
-                        {availableLabels
-                          .filter(
-                            (l) => !selectedLabels.some((sl) => sl.id === l.id)
-                          )
-                          .map((label) => (
+                        {labelSearchQuery &&
+                        unselectedAvailableLabels.length > 0 &&
+                        filteredUnselectedLabels.length === 0 ? (
+                          <div className="px-2 py-4 text-center text-muted-foreground text-xs">
+                            {t('common.no_labels_found')}
+                          </div>
+                        ) : (
+                          filteredUnselectedLabels.map((label) => (
                             <button
                               key={label.id}
                               type="button"
@@ -1179,7 +1250,8 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
                                 className="h-6 px-2 text-xs"
                               />
                             </button>
-                          ))}
+                          ))
+                        )}
                       </div>
                     </div>
                     <div className="border-t p-2">
@@ -1205,7 +1277,10 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
             {!isDraftMode && (
               <Popover
                 open={isProjectsPopoverOpen}
-                onOpenChange={setIsProjectsPopoverOpen}
+                onOpenChange={(open) => {
+                  setIsProjectsPopoverOpen(open);
+                  if (!open) setProjectSearchQuery('');
+                }}
               >
                 <PopoverTrigger asChild>
                   <button
@@ -1273,17 +1348,24 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
                           </div>
                         </div>
                       )}
+                      <TaskResourceSearchField
+                        value={projectSearchQuery}
+                        onChange={setProjectSearchQuery}
+                        placeholder={t('common.search_projects')}
+                      />
                       <div
                         className="max-h-60 overflow-y-auto overscroll-contain"
                         onWheel={(e) => e.stopPropagation()}
                       >
                         <div className="p-1">
-                          {taskProjects
-                            .filter(
-                              (p) =>
-                                !selectedProjects.some((sp) => sp.id === p.id)
-                            )
-                            .map((project) => (
+                          {projectSearchQuery &&
+                          unselectedTaskProjects.length > 0 &&
+                          filteredUnselectedProjects.length === 0 ? (
+                            <div className="px-2 py-4 text-center text-muted-foreground text-xs">
+                              {t('common.no_projects_found')}
+                            </div>
+                          ) : (
+                            filteredUnselectedProjects.map((project) => (
                               <button
                                 key={project.id}
                                 type="button"
@@ -1295,7 +1377,8 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
                                   {project.name}
                                 </span>
                               </button>
-                            ))}
+                            ))
+                          )}
                         </div>
                       </div>
                       <div className="border-t p-2">
@@ -1322,7 +1405,10 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
             {!isPersonalWorkspace && (
               <Popover
                 open={isAssigneesPopoverOpen}
-                onOpenChange={setIsAssigneesPopoverOpen}
+                onOpenChange={(open) => {
+                  setIsAssigneesPopoverOpen(open);
+                  if (!open) setAssigneeSearchQuery('');
+                }}
               >
                 <PopoverTrigger asChild>
                   <button
@@ -1384,20 +1470,24 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
                           </div>
                         </div>
                       )}
+                      <TaskResourceSearchField
+                        value={assigneeSearchQuery}
+                        onChange={setAssigneeSearchQuery}
+                        placeholder={t('common.search_members')}
+                      />
                       <div
                         className="max-h-60 overflow-y-auto overscroll-contain"
                         onWheel={(e) => e.stopPropagation()}
                       >
                         <div className="p-1">
-                          {workspaceMembers
-                            .filter(
-                              (m) =>
-                                !selectedAssignees.some(
-                                  (a) =>
-                                    (a.id || a.user_id) === (m.user_id || m.id)
-                                )
-                            )
-                            .map((member, index) => (
+                          {assigneeSearchQuery &&
+                          unselectedWorkspaceMembers.length > 0 &&
+                          filteredUnselectedMembers.length === 0 ? (
+                            <div className="px-2 py-4 text-center text-muted-foreground text-xs">
+                              {t('common.no_members_found')}
+                            </div>
+                          ) : (
+                            filteredUnselectedMembers.map((member, index) => (
                               <button
                                 key={
                                   member.user_id ||
@@ -1419,7 +1509,8 @@ export function TaskPropertiesSection(props: TaskPropertiesSectionProps) {
                                 </span>
                                 <Plus className="h-4 w-4 shrink-0" />
                               </button>
-                            ))}
+                            ))
+                          )}
                         </div>
                       </div>
                     </>

--- a/packages/ui/src/components/ui/tu-do/shared/task-resource-search-field.tsx
+++ b/packages/ui/src/components/ui/tu-do/shared/task-resource-search-field.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Search } from '@tuturuuu/icons';
+import { Input } from '@tuturuuu/ui/input';
+import { cn } from '@tuturuuu/utils/format';
+
+export interface TaskResourceSearchFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  className?: string;
+  inputClassName?: string;
+  /** When true, prevents parent menus/popovers from stealing keyboard or pointer events (dropdown + popover). */
+  stopEventBubbling?: boolean;
+}
+
+/**
+ * Shared search row used by task resource pickers (labels, projects, assignees)
+ * in the kanban card menu and the task edit dialog for consistent UX and styling.
+ */
+export function TaskResourceSearchField({
+  value,
+  onChange,
+  placeholder,
+  className,
+  inputClassName,
+  stopEventBubbling = true,
+}: TaskResourceSearchFieldProps) {
+  return (
+    <div className={cn('border-b p-2', className)}>
+      <div className="relative">
+        <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={stopEventBubbling ? (e) => e.stopPropagation() : undefined}
+          onPointerDownCapture={
+            stopEventBubbling ? (e) => e.stopPropagation() : undefined
+          }
+          className={cn(
+            'h-8 border-0 bg-muted/50 pl-9 text-sm focus-visible:ring-0',
+            inputClassName
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/ui/tu-do/shared/task-resource-search-filters.ts
+++ b/packages/ui/src/components/ui/tu-do/shared/task-resource-search-filters.ts
@@ -1,0 +1,27 @@
+import { normalizeBoardText } from '../boards/boardId/board-text-utils';
+
+export function labelNameMatchesQuery(
+  name: string | null | undefined,
+  query: string
+): boolean {
+  return !query || normalizeBoardText(name).includes(normalizeBoardText(query));
+}
+
+export function projectNameMatchesQuery(
+  name: string | null | undefined,
+  query: string
+): boolean {
+  return labelNameMatchesQuery(name, query);
+}
+
+export function memberMatchesSearchQuery(
+  member: { display_name?: string | null; email?: string | null },
+  query: string
+): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    (member.display_name?.toLowerCase().includes(q) ?? false) ||
+    (member.email?.toLowerCase().includes(q) ?? false)
+  );
+}


### PR DESCRIPTION
- Removed individual search input implementations for labels, projects, and assignees in various menus.
- Introduced a new TaskResourceSearchField component to standardize search input styling and behavior.
- Updated filtering logic to utilize shared search filter functions for improved maintainability and readability.
- Enhanced the task edit dialog to include search functionality for labels, projects, and assignees using the new component.

# Description

<!-- Provide a brief overview of the changes in this PR -->

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)
<img width="1919" height="461" alt="image" src="https://github.com/user-attachments/assets/8ee99cf2-dbd9-4617-a14f-97bd5f934e1f" />
<img width="1906" height="274" alt="image" src="https://github.com/user-attachments/assets/11e1868e-470e-4f42-a4a8-50f85c099ccb" />
<img width="1919" height="847" alt="image" src="https://github.com/user-attachments/assets/ca142a90-22db-464c-9c13-170ba57d2486" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes task resource search across labels, projects, and assignees using a shared `TaskResourceSearchField` and filter helpers. Replaces duplicated inputs in menus and adds consistent search UX to the task edit dialog.

- **New Features**
  - Search added to the task edit dialog for labels, projects, and assignees.
  - Clear empty states when no results match.
  - Search resets when popovers close and prevents event bubbling inside dropdowns/popovers.

- **Refactors**
  - Replaced per-menu inputs with `TaskResourceSearchField` in bulk actions, labels, projects, and assignees menus.
  - Centralized filtering via `task-resource-search-filters` and updated `useFilteredResources` with stronger typing (`WorkspaceMember`, `BoardConfig`, `KanbanFiltered*`).
  - Precomputed unselected items before filtering in the dialog for simpler, faster lists.

<sup>Written for commit 1af2d6ea4d807700133460bbc930a17ee3680dbf. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4639">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



