### PR TITLE
feat(text-editor): add markdown paste support

### DIFF
--- a/packages/ui/src/components/ui/text-editor/__tests__/extensions-integration.test.ts
+++ b/packages/ui/src/components/ui/text-editor/__tests__/extensions-integration.test.ts
@@ -34,6 +34,14 @@ describe('Editor Extensions Integration', () => {
       expect(hasTextShortcuts).toBe(true);
     });
 
+    it('should include markdown paste extension', () => {
+      const extensions = getEditorExtensions();
+      const hasMarkdownPaste = extensions.some(
+        (ext) => ext.name === 'markdownPaste'
+      );
+      expect(hasMarkdownPaste).toBe(true);
+    });
+
     it('should include task list extensions', () => {
       const extensions = getEditorExtensions();
       const hasTaskList = extensions.some((ext) => ext.name === 'taskList');

--- a/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
+++ b/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { __markdownPastePrivate } from '../markdown-paste-extension';
+
+const { markdownToHtml } = __markdownPastePrivate;
+
+describe('markdownToHtml', () => {
+  it('should convert headings', () => {
+    const md = '# H1\n## H2\n### H3';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<h1>');
+    expect(html).toContain('<h2>');
+    expect(html).toContain('<h3>');
+  });
+
+  it('should convert bold and italic', () => {
+    const md = '**bold** and *italic*';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<em>italic</em>');
+  });
+
+  it('should convert strikethrough and highlight', () => {
+    const md = '~~deleted~~ and ==highlighted==';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<s>deleted</s>');
+    expect(html).toContain('<mark>highlighted</mark>');
+  });
+
+  it('should convert inline code', () => {
+    const md = 'some `code` here';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<code>code</code>');
+  });
+
+  it('should convert code blocks', () => {
+    const md = '```ts\nconst x = 1;\n```';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<pre><code class="language-ts">');
+    expect(html).toContain('const x = 1;');
+  });
+
+  it('should convert bullet lists', () => {
+    const md = '- item 1\n- item 2';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li><p>item 1</p></li>');
+    expect(html).toContain('<li><p>item 2</p></li>');
+  });
+
+  it('should convert ordered lists', () => {
+    const md = '1. first\n2. second';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li><p>first</p></li>');
+  });
+
+  it('should convert task lists', () => {
+    const md = '- [ ] unchecked\n- [x] checked';
+    const html = markdownToHtml(md);
+    expect(html).toContain('data-type="taskList"');
+    expect(html).toContain('data-type="taskItem"');
+    expect(html).toContain('data-checked="false"');
+    expect(html).toContain('data-checked="true"');
+  });
+
+  it('should convert nested unordered lists', () => {
+    const md = '- Item A\n  - Nested A1\n  - Nested A2\n- Item B';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<ul>');
+    // Parent item
+    expect(html).toContain('<li><p>Item A</p>');
+    // Nested list inside parent li
+    expect(html).toContain(
+      '<ul><li><p>Nested A1</p></li><li><p>Nested A2</p></li></ul>'
+    );
+    // Next sibling
+    expect(html).toContain('<li><p>Item B</p></li>');
+  });
+
+  it('should convert nested ordered lists inside bullet lists', () => {
+    const md = '- Step Two\n  1. Sub-step\n  2. Sub-step';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<li><p>Step Two</p>');
+    expect(html).toContain(
+      '<ol><li><p>Sub-step</p></li><li><p>Sub-step</p></li></ol>'
+    );
+  });
+
+  it('should convert deeply nested lists', () => {
+    const md = '- A\n  - B\n    - C\n      - D';
+    const html = markdownToHtml(md);
+    // Four levels of nesting
+    expect(html.match(/<ul>/g)?.length).toBe(4);
+    expect(html).toContain('<li><p>D</p></li>');
+  });
+
+  it('should convert task lists with nested regular lists', () => {
+    const md = '- [ ] Parent task\n  - Sub item 1\n  - Sub item 2';
+    const html = markdownToHtml(md);
+    expect(html).toContain('data-type="taskItem"');
+    expect(html).toContain('<div><p>Parent task</p>');
+    expect(html).toContain(
+      '<ul><li><p>Sub item 1</p></li><li><p>Sub item 2</p></li></ul>'
+    );
+    expect(html).toContain('</div></li>');
+  });
+
+  it('should convert links', () => {
+    const md = '[link](https://example.com)';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<a href="https://example.com">link</a>');
+  });
+
+  it('should convert images', () => {
+    const md = '![alt text](https://example.com/img.png)';
+    const html = markdownToHtml(md);
+    expect(html).toContain(
+      '<img src="https://example.com/img.png" alt="alt text" />'
+    );
+  });
+
+  it('should convert blockquotes', () => {
+    const md = '> quote here';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<blockquote>');
+    expect(html).toContain('quote here');
+  });
+
+  it('should convert horizontal rules', () => {
+    const md = '---';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<hr>');
+  });
+
+  it('should convert tables', () => {
+    const md = '| A | B |\n|---|---|\n| 1 | 2 |';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<table>');
+    expect(html).toContain('<th><p>A</p></th>');
+    expect(html).toContain('<td><p>1</p></td>');
+  });
+
+  it('should convert paragraphs', () => {
+    const md = 'Hello world';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<p>Hello world</p>');
+  });
+
+  it('should escape HTML in plain text', () => {
+    const md = '<script>alert(1)</script>';
+    const html = markdownToHtml(md);
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('should sanitize dangerous link URLs', () => {
+    const md = '[click](javascript:alert(1))';
+    const html = markdownToHtml(md);
+    expect(html).not.toContain('<a href="javascript:');
+    expect(html).toContain('[click](javascript:alert(1))');
+  });
+
+  it('should allow safe link URLs', () => {
+    const md = '[click](https://example.com)';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<a href="https://example.com">click</a>');
+  });
+
+  it('should sanitize dangerous image URLs', () => {
+    const md = '![x](javascript:alert(1))';
+    const html = markdownToHtml(md);
+    expect(html).not.toContain('<img src="javascript:');
+  });
+
+  it('should not mutate inline code with markdown-like syntax', () => {
+    const md = '`const x = **1**`';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<code>const x = **1**</code>');
+    expect(html).not.toContain('<strong>');
+  });
+});

--- a/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
+++ b/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
@@ -111,6 +111,27 @@ describe('markdownToHtml', () => {
     expect(html).toContain('<a href="https://example.com">link</a>');
   });
 
+  it('should strip double-quoted link titles', () => {
+    const md = '[OpenAI](https://openai.com "Title here")';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<a href="https://openai.com">OpenAI</a>');
+    expect(html).not.toContain('Title here');
+  });
+
+  it('should strip single-quoted link titles', () => {
+    const md = "[OpenAI](https://openai.com 'Title here')";
+    const html = markdownToHtml(md);
+    expect(html).toContain('<a href="https://openai.com">OpenAI</a>');
+    expect(html).not.toContain('Title here');
+  });
+
+  it('should strip parenthesized link titles', () => {
+    const md = '[OpenAI](https://openai.com (Title here))';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<a href="https://openai.com">OpenAI</a>');
+    expect(html).not.toContain('Title here');
+  });
+
   it('should convert autolink URLs', () => {
     const md = '<https://example.com>';
     const html = markdownToHtml(md);

--- a/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
+++ b/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
@@ -111,6 +111,37 @@ describe('markdownToHtml', () => {
     expect(html).toContain('<a href="https://example.com">link</a>');
   });
 
+  it('should convert autolink URLs', () => {
+    const md = '<https://example.com>';
+    const html = markdownToHtml(md);
+    expect(html).toContain(
+      '<a href="https://example.com">https://example.com</a>'
+    );
+  });
+
+  it('should convert autolink email addresses', () => {
+    const md = '<user@example.com>';
+    const html = markdownToHtml(md);
+    expect(html).toContain(
+      '<a href="mailto:user@example.com">user@example.com</a>'
+    );
+  });
+
+  it('should convert mailto autolinks', () => {
+    const md = '<mailto:user@example.com>';
+    const html = markdownToHtml(md);
+    expect(html).toContain(
+      '<a href="mailto:user@example.com">mailto:user@example.com</a>'
+    );
+  });
+
+  it('should sanitize dangerous autolink URLs', () => {
+    const md = '<javascript:alert(1)>';
+    const html = markdownToHtml(md);
+    expect(html).not.toContain('<a href="javascript:');
+    expect(html).toContain('&lt;javascript:alert(1)&gt;');
+  });
+
   it('should convert images', () => {
     const md = '![alt text](https://example.com/img.png)';
     const html = markdownToHtml(md);

--- a/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
+++ b/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
@@ -126,6 +126,18 @@ describe('markdownToHtml', () => {
     expect(html).toContain('quote here');
   });
 
+  it('should convert nested blockquotes', () => {
+    const md = '> This is a blockquote\n>> Nested quote\n>>> Deep nesting';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<blockquote>');
+    expect(html).toContain('<p>This is a blockquote</p>');
+    expect(html).toContain('<p>Nested quote</p>');
+    expect(html).toContain('<p>Deep nesting</p>');
+    // Three levels of nesting = three opening blockquote tags
+    expect(html.match(/<blockquote>/g)?.length).toBe(3);
+    expect(html.match(/<\/blockquote>/g)?.length).toBe(3);
+  });
+
   it('should convert horizontal rules', () => {
     const md = '---';
     const html = markdownToHtml(md);

--- a/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
+++ b/packages/ui/src/components/ui/text-editor/__tests__/markdown-paste-extension.test.ts
@@ -178,4 +178,25 @@ describe('markdownToHtml', () => {
     expect(html).toContain('<code>const x = **1**</code>');
     expect(html).not.toContain('<strong>');
   });
+
+  it('should preserve subscript HTML tags', () => {
+    const md = 'H<sub>2</sub>O';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<sub>2</sub>');
+    expect(html).toContain('<p>H<sub>2</sub>O</p>');
+  });
+
+  it('should preserve superscript HTML tags', () => {
+    const md = 'x<sup>2</sup>';
+    const html = markdownToHtml(md);
+    expect(html).toContain('<sup>2</sup>');
+    expect(html).toContain('<p>x<sup>2</sup></p>');
+  });
+
+  it('should escape non-sub/sup HTML tags', () => {
+    const md = '<div>text</div>';
+    const html = markdownToHtml(md);
+    expect(html).toContain('&lt;div&gt;');
+    expect(html).not.toContain('<div>');
+  });
 });

--- a/packages/ui/src/components/ui/text-editor/editor.tsx
+++ b/packages/ui/src/components/ui/text-editor/editor.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { QueryClient } from '@tanstack/react-query';
-import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model';
 import {
   type Editor,
   EditorContent,
@@ -17,7 +16,6 @@ import { flushSync } from 'react-dom';
 import type * as Y from 'yjs';
 import { migrateInlineImagesToBlock } from './content-migration';
 import { getEditorExtensions } from './extensions';
-import { __markdownPastePrivate } from './markdown-paste-extension';
 import { FixedToolbar, ToolBar } from './tool-bar';
 
 const hasContent = (node: JSONContent): boolean => {
@@ -473,38 +471,6 @@ export function RichTextEditor({
         }
 
         return false;
-      },
-      handlePaste: (view, event) => {
-        const clipboardData = event.clipboardData;
-        if (!clipboardData) return false;
-
-        const text = clipboardData.getData('text/plain');
-        if (!text || !__markdownPastePrivate.looksLikeMarkdown(text)) {
-          return false;
-        }
-
-        event.preventDefault();
-
-        const html = __markdownPastePrivate.markdownToHtml(text);
-        const { state } = view;
-        const { from, to } = state.selection;
-
-        const browserParser = new DOMParser();
-        const dom = browserParser.parseFromString(
-          `<div>${html}</div>`,
-          'text/html'
-        );
-        const firstChild = dom.body.firstChild;
-        if (!firstChild) return false;
-
-        const slice = ProseMirrorDOMParser.fromSchema(state.schema).parseSlice(
-          firstChild as Element
-        );
-
-        const tr = state.tr.replaceRange(from, to, slice);
-        view.dispatch(tr);
-
-        return true;
       },
     },
     onCreate: ({ editor }) => {

--- a/packages/ui/src/components/ui/text-editor/editor.tsx
+++ b/packages/ui/src/components/ui/text-editor/editor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { QueryClient } from '@tanstack/react-query';
+import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model';
 import {
   type Editor,
   EditorContent,
@@ -16,6 +17,7 @@ import { flushSync } from 'react-dom';
 import type * as Y from 'yjs';
 import { migrateInlineImagesToBlock } from './content-migration';
 import { getEditorExtensions } from './extensions';
+import { __markdownPastePrivate } from './markdown-paste-extension';
 import { FixedToolbar, ToolBar } from './tool-bar';
 
 const hasContent = (node: JSONContent): boolean => {
@@ -471,6 +473,38 @@ export function RichTextEditor({
         }
 
         return false;
+      },
+      handlePaste: (view, event) => {
+        const clipboardData = event.clipboardData;
+        if (!clipboardData) return false;
+
+        const text = clipboardData.getData('text/plain');
+        if (!text || !__markdownPastePrivate.looksLikeMarkdown(text)) {
+          return false;
+        }
+
+        event.preventDefault();
+
+        const html = __markdownPastePrivate.markdownToHtml(text);
+        const { state } = view;
+        const { from, to } = state.selection;
+
+        const browserParser = new DOMParser();
+        const dom = browserParser.parseFromString(
+          `<div>${html}</div>`,
+          'text/html'
+        );
+        const firstChild = dom.body.firstChild;
+        if (!firstChild) return false;
+
+        const slice = ProseMirrorDOMParser.fromSchema(state.schema).parseSlice(
+          firstChild as Element
+        );
+
+        const tr = state.tr.replaceRange(from, to, slice);
+        view.dispatch(tr);
+
+        return true;
       },
     },
     onCreate: ({ editor }) => {

--- a/packages/ui/src/components/ui/text-editor/extensions.ts
+++ b/packages/ui/src/components/ui/text-editor/extensions.ts
@@ -22,6 +22,7 @@ import type * as Y from 'yjs';
 import { CustomImage } from './image-extension';
 import { ListConverter } from './list-converter-extension';
 import { ListItemBase } from './list-item-extension';
+import { MarkdownPaste } from './markdown-paste-extension';
 import { Mention } from './mention-extension';
 import { NodeDrag } from './node-drag-extension';
 import { TaskItemCheckbox } from './task-item-checkbox-extension';
@@ -146,6 +147,7 @@ export function getEditorExtensions({
       emptyNodeClass: 'is-empty',
     }),
     TextShortcuts,
+    MarkdownPaste,
     Highlight,
     Link.configure({
       openOnClick: true,

--- a/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
+++ b/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
@@ -62,6 +62,29 @@ function parseInline(text: string): string {
     return `\0SUBSUP${subSupTokens.length - 1}\0`;
   });
 
+  // Step 1c: Tokenize angle-bracket autolinks so they survive escaping
+  const autolinkTokens: string[] = [];
+  html = html.replace(
+    /<([A-Za-z][A-Za-z0-9+.-]*:[^\s<>]+|[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+)>/g,
+    (_match, raw: string) => {
+      const link = raw.trim();
+      const isEmail = /^[^\s<>@:]+@[^\s<>@]+\.[^\s<>@]+$/.test(link);
+      if (isEmail) {
+        autolinkTokens.push(
+          `<a href="mailto:${escapeHtml(link)}">${escapeHtml(link)}</a>`
+        );
+        return `\0AUTOLINK${autolinkTokens.length - 1}\0`;
+      }
+      if (sanitizeLinkUrl(link)) {
+        autolinkTokens.push(
+          `<a href="${escapeHtml(link)}">${escapeHtml(link)}</a>`
+        );
+        return `\0AUTOLINK${autolinkTokens.length - 1}\0`;
+      }
+      return _match;
+    }
+  );
+
   // Step 2: Escape remaining text
   html = escapeHtml(html);
 
@@ -111,6 +134,12 @@ function parseInline(text: string): string {
   html = html.replace(
     /\0SUBSUP(\d+)\0/g,
     (_match, index) => subSupTokens[Number(index)] ?? ''
+  );
+
+  // Step 4c: Restore autolink tokens
+  html = html.replace(
+    /\0AUTOLINK(\d+)\0/g,
+    (_match, index) => autolinkTokens[Number(index)] ?? ''
   );
 
   return html;
@@ -463,6 +492,8 @@ const MARKDOWN_SIGNATURES = [
   /^\s*[-*+]\s+\[[ xX]\]/m, // task list
   /!\[[^\]]*\]\([^)]+\)/m, // image
   /\[[^\]]+\]\([^)]+\)/m, // link
+  /<[A-Za-z][A-Za-z0-9+.-]*:[^\s<>]+>/m, // autolink (url)
+  /<[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+>/m, // autolink (email)
   /^\s*---\s*$/m, // horizontal rule
   /^\s*\|.*\|/m, // table
   /<sub>[^<]*<\/sub>/m, // subscript

--- a/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
+++ b/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
@@ -387,7 +387,7 @@ function markdownToHtml(markdown: string): string {
       continue;
     }
 
-    // Blockquote
+    // Blockquote (supports nesting via recursive markdownToHtml)
     if (line.startsWith('>')) {
       const quoteLines: string[] = [];
       while (
@@ -395,12 +395,14 @@ function markdownToHtml(markdown: string): string {
         lines[i] !== undefined &&
         lines[i]!.startsWith('>')
       ) {
-        quoteLines.push(lines[i]!.slice(1).trimStart());
+        const stripped = lines[i]!.slice(1);
+        quoteLines.push(
+          stripped.startsWith(' ') ? stripped.slice(1) : stripped
+        );
         i++;
       }
-      result.push(
-        `<blockquote><p>${parseInline(quoteLines.join(' '))}</p></blockquote>`
-      );
+      const innerHtml = markdownToHtml(quoteLines.join('\n'));
+      result.push(`<blockquote>${innerHtml}</blockquote>`);
       continue;
     }
 

--- a/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
+++ b/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
@@ -47,6 +47,28 @@ function sanitizeImageUrl(url: string): string {
   return '';
 }
 
+function applyInlineFormatting(html: string): string {
+  // Highlight: ==text==
+  html = html.replace(/==([^=\n]+)==/g, '<mark>$1</mark>');
+
+  // Strikethrough: ~~text~~
+  html = html.replace(/~~([^~\n]+)~~/g, '<s>$1</s>');
+
+  // Bold + Italic: ***text***
+  html = html.replace(/\*\*\*([^*\n]+)\*\*\*/g, '<strong><em>$1</em></strong>');
+
+  // Bold: **text**
+  html = html.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
+
+  // Italic: *text* (but not inside words)
+  html = html.replace(
+    /(?<![A-Za-z0-9])\*([^*\n]+)\*(?![A-Za-z0-9])/g,
+    '<em>$1</em>'
+  );
+
+  return html;
+}
+
 function parseInline(text: string): string {
   // Step 1: Tokenize code spans so later replacements don't touch them
   const codeTokens: string[] = [];
@@ -85,44 +107,43 @@ function parseInline(text: string): string {
     }
   );
 
+  // Step 1d: Tokenize markdown images/links before escaping text. This avoids
+  // converting emphasized link text into escaped tag literals.
+  const mediaTokens: string[] = [];
+
+  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, url) => {
+    const safeUrl = sanitizeImageUrl(url);
+    if (!safeUrl) {
+      return _match;
+    }
+
+    mediaTokens.push(
+      `<img src="${escapeHtml(safeUrl)}" alt="${escapeHtml(alt)}" />`
+    );
+    return `\0MEDIA${mediaTokens.length - 1}\0`;
+  });
+
+  html = html.replace(
+    /\[([^\]]+)\]\(([^)\s]+)(?:\s+(?:"([^"]*)"|'([^']*)'|\(([^)]*)\)))?\)/g,
+    (_match, linkText, url) => {
+      const safeUrl = sanitizeLinkUrl(url);
+      if (!safeUrl) {
+        return _match;
+      }
+
+      const formattedLinkText = applyInlineFormatting(escapeHtml(linkText));
+      mediaTokens.push(
+        `<a href="${escapeHtml(safeUrl)}">${formattedLinkText}</a>`
+      );
+      return `\0MEDIA${mediaTokens.length - 1}\0`;
+    }
+  );
+
   // Step 2: Escape remaining text
   html = escapeHtml(html);
 
   // Step 3: Apply inline formatting (order matters)
-
-  // Highlight: ==text==
-  html = html.replace(/==([^=\n]+)==/g, '<mark>$1</mark>');
-
-  // Strikethrough: ~~text~~
-  html = html.replace(/~~([^~\n]+)~~/g, '<s>$1</s>');
-
-  // Bold + Italic: ***text***
-  html = html.replace(/\*\*\*([^*\n]+)\*\*\*/g, '<strong><em>$1</em></strong>');
-
-  // Bold: **text**
-  html = html.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
-
-  // Italic: *text* (but not inside words)
-  html = html.replace(
-    /(?<![A-Za-z0-9])\*([^*\n]+)\*(?![A-Za-z0-9])/g,
-    '<em>$1</em>'
-  );
-
-  // Images: ![alt](url) — sanitize src
-  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, url) => {
-    const safeUrl = sanitizeImageUrl(url);
-    return safeUrl
-      ? `<img src="${safeUrl}" alt="${escapeHtml(alt)}" />`
-      : escapeHtml(`![${alt}](${url})`);
-  });
-
-  // Links: [text](url) — sanitize href
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, linkText, url) => {
-    const safeUrl = sanitizeLinkUrl(url);
-    return safeUrl
-      ? `<a href="${safeUrl}">${escapeHtml(linkText)}</a>`
-      : escapeHtml(`[${linkText}](${url})`);
-  });
+  html = applyInlineFormatting(html);
 
   // Step 4: Restore code tokens
   html = html.replace(
@@ -140,6 +161,12 @@ function parseInline(text: string): string {
   html = html.replace(
     /\0AUTOLINK(\d+)\0/g,
     (_match, index) => autolinkTokens[Number(index)] ?? ''
+  );
+
+  // Step 4d: Restore image/link tokens
+  html = html.replace(
+    /\0MEDIA(\d+)\0/g,
+    (_match, index) => mediaTokens[Number(index)] ?? ''
   );
 
   return html;
@@ -179,6 +206,7 @@ function parseListTree(
     if (indent < minIndent) break;
 
     const marker = match[2] || '';
+    const markerPrefixLen = match[0].length;
     let content = match[3] || '';
 
     // Check for task list: - [ ] or - [x]
@@ -233,7 +261,7 @@ function parseListTree(
 
       if (nextIndent > indent) {
         // Indented continuation text
-        contentLines.push(nextLine.slice(indent + 2));
+        contentLines.push(nextLine.slice(markerPrefixLen));
         i++;
       } else {
         // Not indented, not a list line → end of this item

--- a/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
+++ b/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
@@ -55,6 +55,13 @@ function parseInline(text: string): string {
     return `\0CODE${codeTokens.length - 1}\0`;
   });
 
+  // Step 1b: Tokenize raw <sub>/<sup> HTML tags so they survive escaping
+  const subSupTokens: string[] = [];
+  html = html.replace(/<(sub|sup)>([^<]*)<\/\1>/g, (_match, tag, content) => {
+    subSupTokens.push(`<${tag}>${escapeHtml(content)}</${tag}>`);
+    return `\0SUBSUP${subSupTokens.length - 1}\0`;
+  });
+
   // Step 2: Escape remaining text
   html = escapeHtml(html);
 
@@ -98,6 +105,12 @@ function parseInline(text: string): string {
   html = html.replace(
     /\0CODE(\d+)\0/g,
     (_match, index) => codeTokens[Number(index)] ?? ''
+  );
+
+  // Step 4b: Restore <sub>/<sup> tokens
+  html = html.replace(
+    /\0SUBSUP(\d+)\0/g,
+    (_match, index) => subSupTokens[Number(index)] ?? ''
   );
 
   return html;
@@ -450,6 +463,8 @@ const MARKDOWN_SIGNATURES = [
   /\[[^\]]+\]\([^)]+\)/m, // link
   /^\s*---\s*$/m, // horizontal rule
   /^\s*\|.*\|/m, // table
+  /<sub>[^<]*<\/sub>/m, // subscript
+  /<sup>[^<]*<\/sup>/m, // superscript
 ];
 
 function looksLikeMarkdown(text: string): boolean {

--- a/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
+++ b/packages/ui/src/components/ui/text-editor/markdown-paste-extension.ts
@@ -1,0 +1,534 @@
+import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model';
+import { Extension } from '@tiptap/react';
+import { Plugin, PluginKey } from 'prosemirror-state';
+
+// ---------------------------------------------------------------------------
+// Markdown -> HTML converter (toolbar-supported features only)
+// ---------------------------------------------------------------------------
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+const BLOCK_START_PATTERNS = [
+  /^#{1,6}\s/,
+  /^\s*[-*+]\s/,
+  /^\s*\d+\.\s/,
+  /^\s*```/,
+  /^\s*>/,
+  /^\s*---\s*$/,
+  /^\s*\*\*\*\s*$/,
+  /^\s*___\s*$/,
+  /^\s*\|/,
+];
+
+function isBlockStart(line: string): boolean {
+  return BLOCK_START_PATTERNS.some((p) => p.test(line));
+}
+
+function sanitizeLinkUrl(url: string): string {
+  const trimmed = url.trim();
+  if (/^https?:\/\//i.test(trimmed) || /^mailto:/i.test(trimmed)) {
+    return trimmed;
+  }
+  return '';
+}
+
+function sanitizeImageUrl(url: string): string {
+  const trimmed = url.trim();
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return '';
+}
+
+function parseInline(text: string): string {
+  // Step 1: Tokenize code spans so later replacements don't touch them
+  const codeTokens: string[] = [];
+  let html = text.replace(/`([^`\n]+)`/g, (_match, code) => {
+    codeTokens.push(`<code>${escapeHtml(code)}</code>`);
+    return `\0CODE${codeTokens.length - 1}\0`;
+  });
+
+  // Step 2: Escape remaining text
+  html = escapeHtml(html);
+
+  // Step 3: Apply inline formatting (order matters)
+
+  // Highlight: ==text==
+  html = html.replace(/==([^=\n]+)==/g, '<mark>$1</mark>');
+
+  // Strikethrough: ~~text~~
+  html = html.replace(/~~([^~\n]+)~~/g, '<s>$1</s>');
+
+  // Bold + Italic: ***text***
+  html = html.replace(/\*\*\*([^*\n]+)\*\*\*/g, '<strong><em>$1</em></strong>');
+
+  // Bold: **text**
+  html = html.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
+
+  // Italic: *text* (but not inside words)
+  html = html.replace(
+    /(?<![A-Za-z0-9])\*([^*\n]+)\*(?![A-Za-z0-9])/g,
+    '<em>$1</em>'
+  );
+
+  // Images: ![alt](url) — sanitize src
+  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, url) => {
+    const safeUrl = sanitizeImageUrl(url);
+    return safeUrl
+      ? `<img src="${safeUrl}" alt="${escapeHtml(alt)}" />`
+      : escapeHtml(`![${alt}](${url})`);
+  });
+
+  // Links: [text](url) — sanitize href
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, linkText, url) => {
+    const safeUrl = sanitizeLinkUrl(url);
+    return safeUrl
+      ? `<a href="${safeUrl}">${escapeHtml(linkText)}</a>`
+      : escapeHtml(`[${linkText}](${url})`);
+  });
+
+  // Step 4: Restore code tokens
+  html = html.replace(
+    /\0CODE(\d+)\0/g,
+    (_match, index) => codeTokens[Number(index)] ?? ''
+  );
+
+  return html;
+}
+
+// ---------------------------------------------------------------------------
+// Tree-based list parser (supports nested lists and task lists)
+// ---------------------------------------------------------------------------
+
+interface ListNode {
+  content: string;
+  checked: boolean | null;
+  marker: string;
+  indent: number;
+  children: ListNode[];
+}
+
+function parseListTree(
+  lines: string[],
+  startIndex: number,
+  minIndent: number
+): { nodes: ListNode[]; endIndex: number } {
+  const nodes: ListNode[] = [];
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line === undefined || line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    const match = line.match(/^(\s*)([-*+]|\d+\.)\s+(.*)$/);
+    if (!match) break;
+
+    const indent = match[1] ? match[1].length : 0;
+    if (indent < minIndent) break;
+
+    const marker = match[2] || '';
+    let content = match[3] || '';
+
+    // Check for task list: - [ ] or - [x]
+    let checked: boolean | null = null;
+    const taskMatch = content.match(/^\[([ xX])\]\s+(.*)$/);
+    if (taskMatch) {
+      checked = taskMatch[1] ? taskMatch[1].toLowerCase() === 'x' : false;
+      content = taskMatch[2] || '';
+    }
+
+    i++;
+
+    // Collect non-list continuation lines for this item
+    const contentLines: string[] = [content];
+    while (i < lines.length) {
+      const nextLine = lines[i];
+      if (nextLine === undefined) break;
+
+      if (nextLine.trim() === '') {
+        // Blank line — keep scanning to see if indented content follows
+        let j = i + 1;
+        while (
+          j < lines.length &&
+          lines[j] !== undefined &&
+          lines[j]!.trim() === ''
+        )
+          j++;
+        const afterBlank = lines[j];
+        if (afterBlank !== undefined) {
+          const afterIndent = afterBlank.match(/^(\s*)/)?.[1]?.length ?? 0;
+          if (afterIndent > indent) {
+            // Indented content after blank line → part of this item
+            i++;
+            continue;
+          }
+        }
+        break;
+      }
+
+      const nextMatch = nextLine.match(/^(\s*)/);
+      const nextIndent = nextMatch?.[1]?.length ?? 0;
+      const isListLine = nextLine.match(/^(\s*)([-*+]|\d+\.)\s+/);
+
+      if (isListLine) {
+        if (nextIndent > indent) {
+          // Nested list starts here — stop collecting content
+          break;
+        }
+        // Same level or back to parent → new item, stop
+        break;
+      }
+
+      if (nextIndent > indent) {
+        // Indented continuation text
+        contentLines.push(nextLine.slice(indent + 2));
+        i++;
+      } else {
+        // Not indented, not a list line → end of this item
+        break;
+      }
+    }
+
+    const node: ListNode = {
+      indent,
+      marker,
+      content: contentLines.join('\n'),
+      checked,
+      children: [],
+    };
+
+    // Check for nested list at current position
+    if (i < lines.length) {
+      const nextLine = lines[i];
+      if (nextLine !== undefined) {
+        const nextMatch = nextLine.match(/^(\s*)([-*+]|\d+\.)\s+/);
+        if (nextMatch) {
+          const nextIndent = nextMatch[1] ? nextMatch[1].length : 0;
+          if (nextIndent > indent) {
+            const { nodes: childNodes, endIndex } = parseListTree(
+              lines,
+              i,
+              nextIndent
+            );
+            node.children = childNodes;
+            i = endIndex;
+          }
+        }
+      }
+    }
+
+    nodes.push(node);
+  }
+
+  return { nodes, endIndex: i };
+}
+
+function renderListTree(nodes: ListNode[], ordered: boolean): string {
+  if (nodes.length === 0) return '';
+
+  const tag = ordered ? 'ol' : 'ul';
+  const isTaskList = nodes.some((n) => n.checked !== null);
+  const dataType = isTaskList ? ' data-type="taskList"' : '';
+
+  let html = `<${tag}${dataType}>`;
+
+  for (const node of nodes) {
+    if (isTaskList) {
+      html += `<li data-type="taskItem" data-checked="${node.checked}"><div>`;
+      html += `<p>${parseInline(node.content)}</p>`;
+      if (node.children.length > 0) {
+        const childOrdered = /^\d+\.$/.test(node.children[0]?.marker || '');
+        html += renderListTree(node.children, childOrdered);
+      }
+      html += '</div></li>';
+    } else {
+      html += `<li><p>${parseInline(node.content)}</p>`;
+      if (node.children.length > 0) {
+        const childOrdered = /^\d+\.$/.test(node.children[0]?.marker || '');
+        html += renderListTree(node.children, childOrdered);
+      }
+      html += '</li>';
+    }
+  }
+
+  html += `</${tag}>`;
+  return html;
+}
+
+function parseTable(
+  lines: string[],
+  startIndex: number
+): { html: string; endIndex: number } {
+  let i = startIndex;
+  const rows: string[][] = [];
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line === undefined || !line.trim().startsWith('|')) break;
+
+    const cells = line
+      .split('|')
+      .map((c) => c.trim())
+      .filter((_, idx, arr) => idx !== 0 || arr[0] !== '');
+    // Remove leading/trailing empty cells caused by outer pipes
+    const cleaned = cells.filter(
+      (c, idx) =>
+        !(idx === 0 && c === '') && !(idx === cells.length - 1 && c === '')
+    );
+    rows.push(cleaned.length > 0 ? cleaned : cells);
+    i++;
+  }
+
+  // Remove separator row (second row if it looks like ---|---|---)
+  const hasSeparator =
+    rows.length > 1 && rows[1]!.every((c) => /^:?-+:?$/.test(c));
+  const dataRows = hasSeparator ? [rows[0]!, ...rows.slice(2)] : rows;
+
+  if (dataRows.length === 0) {
+    return { html: '', endIndex: startIndex };
+  }
+
+  let html = '<table>';
+
+  // Header row
+  html += '<thead><tr>';
+  for (const cell of dataRows[0]!) {
+    html += `<th><p>${parseInline(cell)}</p></th>`;
+  }
+  html += '</tr></thead>';
+
+  // Body rows
+  if (dataRows.length > 1) {
+    html += '<tbody>';
+    for (let r = 1; r < dataRows.length; r++) {
+      html += '<tr>';
+      for (const cell of dataRows[r]!) {
+        html += `<td><p>${parseInline(cell)}</p></td>`;
+      }
+      html += '</tr>';
+    }
+    html += '</tbody>';
+  }
+
+  html += '</table>';
+  return { html, endIndex: i };
+}
+
+function markdownToHtml(markdown: string): string {
+  const lines = markdown.split('\n');
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line === undefined || line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // Code block
+    const codeBlockMatch = line.match(/^\s*```\s*(\w*)\s*$/);
+    if (codeBlockMatch) {
+      const lang = codeBlockMatch[1] || '';
+      const start = i + 1;
+      i++;
+      while (
+        i < lines.length &&
+        lines[i] !== undefined &&
+        !lines[i]!.match(/^\s*```\s*$/)
+      ) {
+        i++;
+      }
+      const code = lines.slice(start, i).join('\n');
+      result.push(
+        `<pre><code${lang ? ` class="language-${escapeHtml(lang)}"` : ''}>${escapeHtml(code)}</code></pre>`
+      );
+      i++;
+      continue;
+    }
+
+    // Heading
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      const level = headingMatch[1]!.length;
+      const content = headingMatch[2] || '';
+      result.push(`<h${level}>${parseInline(content)}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^(\s*---\s*|\s*\*\*\*\s*|\s*___\s*)$/.test(line)) {
+      result.push('<hr>');
+      i++;
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith('>')) {
+      const quoteLines: string[] = [];
+      while (
+        i < lines.length &&
+        lines[i] !== undefined &&
+        lines[i]!.startsWith('>')
+      ) {
+        quoteLines.push(lines[i]!.slice(1).trimStart());
+        i++;
+      }
+      result.push(
+        `<blockquote><p>${parseInline(quoteLines.join(' '))}</p></blockquote>`
+      );
+      continue;
+    }
+
+    // List
+    const listMatch = line.match(/^(\s*)([-*+]|\d+\.)\s+/);
+    if (listMatch) {
+      const indent = listMatch[1] ? listMatch[1].length : 0;
+      const { nodes, endIndex } = parseListTree(lines, i, indent);
+      const ordered = /^\d+\.$/.test(nodes[0]?.marker || '');
+      result.push(renderListTree(nodes, ordered));
+      i = endIndex;
+      continue;
+    }
+
+    // Table
+    if (line.trim().startsWith('|')) {
+      const { html, endIndex } = parseTable(lines, i);
+      if (html) {
+        result.push(html);
+        i = endIndex;
+        continue;
+      }
+    }
+
+    // Paragraph
+    const paraLines: string[] = [line];
+    i++;
+    while (
+      i < lines.length &&
+      lines[i] !== undefined &&
+      lines[i]!.trim() !== '' &&
+      !isBlockStart(lines[i]!)
+    ) {
+      paraLines.push(lines[i]!);
+      i++;
+    }
+    result.push(`<p>${parseInline(paraLines.join(' '))}</p>`);
+  }
+
+  return result.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic: does this text look like Markdown?
+// ---------------------------------------------------------------------------
+
+const MARKDOWN_SIGNATURES = [
+  /^#{1,6}\s/m, // heading
+  /\*\*[^*]+\*\*/m, // bold
+  /\*[^*\n]+\*/m, // italic
+  /~~[^~]+~~/m, // strikethrough
+  /==[^=]+==/m, // highlight
+  /`[^`]+`/m, // inline code
+  /^\s*```/m, // code block
+  /^\s*>\s/m, // blockquote
+  /^\s*[-*+]\s/m, // bullet list
+  /^\s*\d+\.\s/m, // ordered list
+  /^\s*[-*+]\s+\[[ xX]\]/m, // task list
+  /!\[[^\]]*\]\([^)]+\)/m, // image
+  /\[[^\]]+\]\([^)]+\)/m, // link
+  /^\s*---\s*$/m, // horizontal rule
+  /^\s*\|.*\|/m, // table
+];
+
+function looksLikeMarkdown(text: string): boolean {
+  return MARKDOWN_SIGNATURES.some((pattern) => pattern.test(text));
+}
+
+// ---------------------------------------------------------------------------
+// Test-only exports (not part of the public API contract)
+// ---------------------------------------------------------------------------
+
+export const __markdownPastePrivate = {
+  markdownToHtml,
+  looksLikeMarkdown,
+};
+
+const markdownPastePluginKey = new PluginKey('markdownPastePlugin');
+
+// ---------------------------------------------------------------------------
+// Tiptap extension
+// ---------------------------------------------------------------------------
+
+export const MarkdownPaste = Extension.create({
+  name: 'markdownPaste',
+  priority: 200,
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: markdownPastePluginKey,
+        props: {
+          handleDOMEvents: {
+            paste: (
+              view: import('@tiptap/pm/view').EditorView,
+              event: ClipboardEvent
+            ) => {
+              const clipboardData = event.clipboardData;
+              if (!clipboardData) return false;
+
+              // If files are present, let image/video paste plugins handle it
+              if (clipboardData.files.length > 0) {
+                return false;
+              }
+
+              const text = clipboardData.getData('text/plain');
+              if (!text || !looksLikeMarkdown(text)) {
+                return false;
+              }
+
+              // When plain text looks like markdown, convert it to editor nodes
+              // even if HTML is also present on the clipboard. Many apps wrap
+              // markdown in simple HTML tags that Tiptap would insert as plain
+              // text paragraphs; we prefer structured conversion instead.
+              event.preventDefault();
+
+              const html = markdownToHtml(text);
+              const { state } = view;
+              const { from, to } = state.selection;
+
+              // Parse the generated HTML into a ProseMirror slice
+              const browserParser = new DOMParser();
+              const dom = browserParser.parseFromString(
+                `<div>${html}</div>`,
+                'text/html'
+              );
+              const firstChild = dom.body.firstChild;
+              if (!firstChild) return false;
+
+              const slice = ProseMirrorDOMParser.fromSchema(
+                state.schema
+              ).parseSlice(firstChild as Element);
+
+              const tr = state.tr.replaceRange(from, to, slice);
+              view.dispatch(tr);
+
+              return true;
+            },
+          },
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
# Description

Add Markdown paste support to the rich text editor. Pasted Markdown is converted into structured, safe content with nested lists, nested blockquotes, tables, code blocks, inline formatting, and subscript/superscript.

- **New Features**
  - Detects Markdown in the clipboard and converts to editor nodes on paste.
  - Supports headings, inline formatting, fenced code blocks, links/images (sanitized), nested blockquotes, horizontal rules, subscript/superscript, and paragraphs.
  - Handles bullet, ordered, and task lists with deep nesting; parses simple tables with header and body.
  - Adds unit tests for the converter and an integration test to ensure the `MarkdownPaste` extension is loaded.

# Screenshots for proof (must have)
<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/74f4e52c-9a7f-4ee8-9717-0ca0142aac22" />
<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/815cb4f0-c4db-4870-8591-3ffce6fc8a3e" />
<img width="1919" height="1026" alt="image" src="https://github.com/user-attachments/assets/ee35ee28-e73b-4635-b621-a60cf25a9a1f" />
<img width="1919" height="1028" alt="image" src="https://github.com/user-attachments/assets/2690b9fa-53da-49ba-8201-ea1874fd8e43" />
<img width="1919" height="1038" alt="image" src="https://github.com/user-attachments/assets/6fd77d2c-68a3-4079-9cc4-261160ade5df" />



