### PR TITLE
feat(mobile/time-tracker): improve missed entry UI

### DIFF
--- a/apps/mobile/lib/features/time_tracker/utils/missed_entry_flow.dart
+++ b/apps/mobile/lib/features/time_tracker/utils/missed_entry_flow.dart
@@ -71,6 +71,13 @@ Future<void> showMissedEntryDialogFlow(
   String? initialTitle,
   String? initialDescription,
   String? initialCategoryId,
+  Future<void> Function({
+    required String name,
+    String? color,
+    String? description,
+  })?
+  onCreateCategory,
+  TimeTrackerCubit? categoryListCubit,
 }) async {
   final canBypassApproval =
       hasBypassPermission ??
@@ -88,6 +95,7 @@ Future<void> showMissedEntryDialogFlow(
       context: context,
       builder: (_) => MissedEntryDialog(
         categories: categories,
+        categoryListCubit: categoryListCubit,
         canBypassRequestApproval: canBypassApproval,
         thresholdDays: thresholdDays,
         initialStartTime: initialStartTime,
@@ -95,6 +103,7 @@ Future<void> showMissedEntryDialogFlow(
         initialTitle: initialTitle,
         initialDescription: initialDescription,
         initialCategoryId: initialCategoryId,
+        onCreateCategory: onCreateCategory,
         onSave:
             ({
               required title,
@@ -146,6 +155,12 @@ Future<void> showMissedEntryDialogForTimeTrackerCubit(
   String? initialTitle,
   String? initialDescription,
   String? initialCategoryId,
+  Future<void> Function({
+    required String name,
+    String? color,
+    String? description,
+  })?
+  onCreateCategory,
 }) {
   return showMissedEntryDialogFlow(
     context,
@@ -153,6 +168,19 @@ Future<void> showMissedEntryDialogForTimeTrackerCubit(
     userId: userId,
     categories: cubit.state.categories,
     thresholdDays: cubit.state.thresholdDays,
+    onCreateCategory:
+        onCreateCategory ??
+        ({
+          required name,
+          color,
+          description,
+        }) => cubit.createCategory(
+          wsId,
+          name,
+          color: color,
+          description: description,
+          throwOnError: true,
+        ),
     onCreateMissedEntry:
         ({
           required title,
@@ -197,5 +225,6 @@ Future<void> showMissedEntryDialogForTimeTrackerCubit(
     initialTitle: initialTitle,
     initialDescription: initialDescription,
     initialCategoryId: initialCategoryId,
+    categoryListCubit: cubit,
   );
 }

--- a/apps/mobile/lib/features/time_tracker/widgets/category_sheet.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/category_sheet.dart
@@ -2,36 +2,36 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:mobile/core/responsive/adaptive_sheet.dart';
-import 'package:mobile/core/responsive/responsive_values.dart';
 import 'package:mobile/data/models/time_tracking/category.dart';
 import 'package:mobile/features/time_tracker/utils/category_color.dart';
 import 'package:mobile/features/time_tracker/widgets/create_category_sheet.dart';
 import 'package:mobile/l10n/l10n.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart' as shad;
 
-/// Opens [CategorySheet] as an adaptive bottom drawer/dialog.
-void showCategorySheet({
+/// Opens [CategorySheet] as an adaptive bottom sheet/dialog.
+Future<void> showCategorySheet({
   required BuildContext context,
   required List<TimeTrackingCategory> categories,
   required String? selectedCategoryId,
   required ValueChanged<String?> onSelected,
-  required Future<void> Function({
+  Future<void> Function({
     required String name,
     String? color,
     String? description,
-  })
+  })?
   onCreateCategory,
+  bool useRootNavigator = true,
 }) {
-  unawaited(
-    showAdaptiveDrawer(
-      context: context,
-      builder: (_) => CategorySheet(
-        hostContext: context,
-        categories: categories,
-        selectedCategoryId: selectedCategoryId,
-        onSelected: onSelected,
-        onCreateCategory: onCreateCategory,
-      ),
+  return showAdaptiveSheet<void>(
+    context: context,
+    useRootNavigator: useRootNavigator,
+    builder: (_) => CategorySheet(
+      hostContext: context,
+      categories: categories,
+      selectedCategoryId: selectedCategoryId,
+      onSelected: onSelected,
+      onCreateCategory: onCreateCategory,
+      useRootNavigator: useRootNavigator,
     ),
   );
 }
@@ -43,7 +43,8 @@ class CategorySheet extends StatelessWidget {
     required this.categories,
     required this.selectedCategoryId,
     required this.onSelected,
-    required this.onCreateCategory,
+    this.onCreateCategory,
+    this.useRootNavigator = true,
     super.key,
   });
 
@@ -55,15 +56,11 @@ class CategorySheet extends StatelessWidget {
     required String name,
     String? color,
     String? description,
-  })
+  })?
   onCreateCategory;
+  final bool useRootNavigator;
 
   Future<void> _closeCurrentSheet(BuildContext context) async {
-    if (context.isCompact) {
-      await shad.closeOverlay<void>(context);
-      return;
-    }
-
     await Navigator.maybePop(context);
   }
 
@@ -73,6 +70,8 @@ class CategorySheet extends StatelessWidget {
   }
 
   Future<void> _showCreateCategorySheet(BuildContext context) async {
+    final create = onCreateCategory;
+    if (create == null) return;
     await _closeCurrentSheet(context);
     if (!hostContext.mounted) {
       return;
@@ -80,7 +79,8 @@ class CategorySheet extends StatelessWidget {
 
     await showAdaptiveSheet<void>(
       context: hostContext,
-      builder: (_) => CreateCategorySheet(onSave: onCreateCategory),
+      useRootNavigator: useRootNavigator,
+      builder: (_) => CreateCategorySheet(onSave: create),
     );
   }
 
@@ -91,12 +91,12 @@ class CategorySheet extends StatelessWidget {
     final colorScheme = theme.colorScheme;
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Phone: shad.openDrawer already paints a drag handle.
-          // Dialog: show one.
-          if (!context.isCompact)
+      child: ColoredBox(
+        color: colorScheme.background,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Drag handle
             Padding(
               padding: const EdgeInsets.only(top: 8, bottom: 4),
               child: Center(
@@ -110,87 +110,90 @@ class CategorySheet extends StatelessWidget {
                 ),
               ),
             ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    l10n.timerSelectCategory,
-                    style: theme.typography.h4,
-                  ),
-                ),
-                shad.IconButton.ghost(
-                  icon: const Icon(shad.LucideIcons.x, size: 18),
-                  onPressed: () => unawaited(_closeCurrentSheet(context)),
-                ),
-              ],
-            ),
-          ),
-
-          const shad.Divider(),
-
-          // Category list
-          ConstrainedBox(
-            constraints: BoxConstraints(
-              maxHeight: MediaQuery.sizeOf(context).height * 0.5,
-            ),
-            child: ListView(
-              shrinkWrap: true,
-              padding: const EdgeInsets.symmetric(vertical: 4),
-              children: [
-                // "No category" option
-                _CategoryTile(
-                  label: l10n.timerNoCategory,
-                  isSelected: selectedCategoryId == null,
-                  onTap: () => unawaited(_selectCategory(context, null)),
-                ),
-                ...categories.map(
-                  (cat) => _CategoryTile(
-                    color: cat.color != null
-                        ? resolveTimeTrackingCategoryColor(
-                            context,
-                            cat.color,
-                            fallback: colorScheme.mutedForeground,
-                          )
-                        : null,
-                    label: cat.name ?? '',
-                    isSelected: cat.id == selectedCategoryId,
-                    onTap: () => unawaited(_selectCategory(context, cat.id)),
-                  ),
-                ),
-              ],
-            ),
-          ),
-
-          const shad.Divider(),
-
-          // "Create new category" button
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-            child: shad.OutlineButton(
-              onPressed: () => unawaited(_showCreateCategorySheet(context)),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(
-                    shad.LucideIcons.plus,
-                    size: 16,
-                    color: colorScheme.primary,
+                  Expanded(
+                    child: Text(
+                      l10n.timerSelectCategory,
+                      style: theme.typography.h4,
+                    ),
                   ),
-                  const shad.Gap(8),
-                  Text(
-                    l10n.timerCreateCategory,
-                    style: theme.typography.small.copyWith(
-                      color: colorScheme.primary,
-                      fontWeight: FontWeight.w600,
+                  shad.IconButton.ghost(
+                    icon: const Icon(shad.LucideIcons.x, size: 18),
+                    onPressed: () => unawaited(_closeCurrentSheet(context)),
+                  ),
+                ],
+              ),
+            ),
+
+            const shad.Divider(),
+
+            // Category list
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.sizeOf(context).height * 0.5,
+              ),
+              child: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                children: [
+                  // "No category" option
+                  _CategoryTile(
+                    label: l10n.timerNoCategory,
+                    isSelected: selectedCategoryId == null,
+                    onTap: () => unawaited(_selectCategory(context, null)),
+                  ),
+                  ...categories.map(
+                    (cat) => _CategoryTile(
+                      color: cat.color != null
+                          ? resolveTimeTrackingCategoryColor(
+                              context,
+                              cat.color,
+                              fallback: colorScheme.mutedForeground,
+                            )
+                          : null,
+                      label: cat.name ?? '',
+                      isSelected: cat.id == selectedCategoryId,
+                      onTap: () => unawaited(_selectCategory(context, cat.id)),
                     ),
                   ),
                 ],
               ),
             ),
-          ),
-        ],
+
+            if (onCreateCategory != null) ...[
+              const shad.Divider(),
+
+              // "Create new category" button
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                child: shad.OutlineButton(
+                  onPressed: () => unawaited(_showCreateCategorySheet(context)),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        shad.LucideIcons.plus,
+                        size: 16,
+                        color: colorScheme.primary,
+                      ),
+                      const shad.Gap(8),
+                      Text(
+                        l10n.timerCreateCategory,
+                        style: theme.typography.small.copyWith(
+                          color: colorScheme.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/time_tracker/widgets/create_category_sheet.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/create_category_sheet.dart
@@ -104,21 +104,43 @@ class _CreateCategorySheetState extends State<CreateCategorySheet> {
             : _descriptionController.text.trim(),
       );
 
-      if (!mounted || !toastContext.mounted) {
+      if (!mounted) {
         return;
       }
 
-      shad.showToast(
-        context: toastContext,
-        builder: (context, overlay) => shad.Alert(
-          title: Text(l10n.timerCreateCategory),
-          content: Text(l10n.timerCategoryCreateSuccess),
-        ),
-      );
+      // Clear before pop: [PopScope] uses `canPop: !_saving`, which only flips
+      // after layout. Defer [maybePop] to a post-frame callback so it runs when
+      // `canPop` is already true.
+      setState(() => _saving = false);
 
-      await Navigator.maybePop(context);
+      if (!mounted) {
+        return;
+      }
+      final sheetContext = context;
+      final toastCtx = toastContext;
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        if (!sheetContext.mounted) {
+          return;
+        }
+        await Navigator.maybePop(sheetContext);
+        if (!toastCtx.mounted) {
+          return;
+        }
+        shad.showToast(
+          context: toastCtx,
+          builder: (context, overlay) => shad.Alert(
+            title: Text(l10n.timerCreateCategory),
+            content: Text(l10n.timerCategoryCreateSuccess),
+          ),
+        );
+      });
     } on ApiException catch (error) {
-      if (!mounted || !toastContext.mounted) {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _saving = false);
+
+      if (!toastContext.mounted) {
         return;
       }
 
@@ -133,10 +155,13 @@ class _CreateCategorySheetState extends State<CreateCategorySheet> {
           content: Text(safeMessage),
         ),
       );
-
-      setState(() => _saving = false);
     } on Exception catch (error) {
-      if (!mounted || !toastContext.mounted) {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _saving = false);
+
+      if (!toastContext.mounted) {
         return;
       }
 
@@ -147,8 +172,6 @@ class _CreateCategorySheetState extends State<CreateCategorySheet> {
           content: Text(error.toString()),
         ),
       );
-
-      setState(() => _saving = false);
     }
   }
 

--- a/apps/mobile/lib/features/time_tracker/widgets/create_category_sheet.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/create_category_sheet.dart
@@ -116,7 +116,7 @@ class _CreateCategorySheetState extends State<CreateCategorySheet> {
         ),
       );
 
-      Navigator.of(context).pop();
+      await Navigator.maybePop(context);
     } on ApiException catch (error) {
       if (!mounted || !toastContext.mounted) {
         return;
@@ -199,7 +199,7 @@ class _CreateCategorySheetState extends State<CreateCategorySheet> {
                       icon: const Icon(shad.LucideIcons.x, size: 18),
                       onPressed: _saving
                           ? null
-                          : () => Navigator.of(context).pop(),
+                          : () => unawaited(Navigator.maybePop(context)),
                     ),
                   ],
                 ),

--- a/apps/mobile/lib/features/time_tracker/widgets/missed_entry_dialog.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/missed_entry_dialog.dart
@@ -270,6 +270,7 @@ class _MissedEntryDialogState extends State<MissedEntryDialog> {
                       ),
                     ),
                     shad.OutlineButton(
+                      leading: Icon(shad.LucideIcons.image),
                       onPressed: _images.length >= _maxImages
                           ? null
                           : () => unawaited(_pickImageSource(nestedContext)),
@@ -588,67 +589,152 @@ class _DateTimePicker extends StatefulWidget {
 }
 
 class _DateTimePickerState extends State<_DateTimePicker> {
+  Future<void> _pickDate() async {
+    final date = await showDatePicker(
+      context: widget.routeContext,
+      useRootNavigator: false,
+      initialDate: widget.value,
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now(),
+    );
+    if (!mounted) {
+      return;
+    }
+    if (date != null) {
+      widget.onChanged(
+        DateTime(
+          date.year,
+          date.month,
+          date.day,
+          widget.value.hour,
+          widget.value.minute,
+        ),
+      );
+    }
+  }
+
+  Future<void> _pickTime() async {
+    final time = await showTimePicker(
+      context: widget.routeContext,
+      useRootNavigator: false,
+      initialTime: TimeOfDay.fromDateTime(widget.value.toLocal()),
+    );
+    if (!mounted) {
+      return;
+    }
+    if (time != null) {
+      widget.onChanged(
+        DateTime(
+          widget.value.year,
+          widget.value.month,
+          widget.value.day,
+          time.hour,
+          time.minute,
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = shad.Theme.of(context);
-    return Row(
+    final colorScheme = theme.colorScheme;
+    final local = widget.value.toLocal();
+    final dateText = widget.dateFmt.format(local);
+    final timeText = widget.timeFmt.format(local);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
           widget.label,
-          style: theme.typography.small,
+          style: theme.typography.small.copyWith(
+            fontWeight: FontWeight.w600,
+            color: colorScheme.foreground,
+          ),
         ),
-        const Spacer(),
-        shad.GhostButton(
-          onPressed: () async {
-            final date = await showDatePicker(
-              context: widget.routeContext,
-              useRootNavigator: false,
-              initialDate: widget.value,
-              firstDate: DateTime(2020),
-              lastDate: DateTime.now(),
-            );
-            if (!mounted) {
-              return;
-            }
-            if (date != null) {
-              widget.onChanged(
-                DateTime(
-                  date.year,
-                  date.month,
-                  date.day,
-                  widget.value.hour,
-                  widget.value.minute,
-                ),
-              );
-            }
-          },
-          child: Text(widget.dateFmt.format(widget.value.toLocal())),
-        ),
-        shad.GhostButton(
-          onPressed: () async {
-            final time = await showTimePicker(
-              context: widget.routeContext,
-              useRootNavigator: false,
-              initialTime: TimeOfDay.fromDateTime(widget.value.toLocal()),
-            );
-            if (!mounted) {
-              return;
-            }
-            if (time != null) {
-              widget.onChanged(
-                DateTime(
-                  widget.value.year,
-                  widget.value.month,
-                  widget.value.day,
-                  time.hour,
-                  time.minute,
-                ),
-              );
-            }
-          },
-          child: Text(widget.timeFmt.format(widget.value.toLocal())),
+        const shad.Gap(8),
+        Row(
+          children: [
+            Expanded(
+              child: _MissedEntryDateTimeSegment(
+                icon: shad.LucideIcons.calendar,
+                text: dateText,
+                onTap: () => unawaited(_pickDate()),
+              ),
+            ),
+            const shad.Gap(10),
+            Expanded(
+              child: _MissedEntryDateTimeSegment(
+                icon: shad.LucideIcons.clock,
+                text: timeText,
+                onTap: () => unawaited(_pickTime()),
+              ),
+            ),
+          ],
         ),
       ],
+    );
+  }
+}
+
+/// Bordered tappable segment aligned with [CategorySelectorButton] styling.
+class _MissedEntryDateTimeSegment extends StatelessWidget {
+  const _MissedEntryDateTimeSegment({
+    required this.icon,
+    required this.text,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String text;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = shad.Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8),
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: colorScheme.border),
+            color: colorScheme.background,
+          ),
+          child: Row(
+            children: [
+              Icon(
+                icon,
+                size: 16,
+                color: colorScheme.primary,
+              ),
+              const shad.Gap(8),
+              Expanded(
+                child: Text(
+                  text,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.typography.small.copyWith(
+                    color: colorScheme.foreground,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              Icon(
+                shad.LucideIcons.chevronDown,
+                size: 14,
+                color: colorScheme.mutedForeground,
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/time_tracker/widgets/missed_entry_dialog.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/missed_entry_dialog.dart
@@ -270,7 +270,7 @@ class _MissedEntryDialogState extends State<MissedEntryDialog> {
                       ),
                     ),
                     shad.OutlineButton(
-                      leading: Icon(shad.LucideIcons.image),
+                      leading: const Icon(shad.LucideIcons.image),
                       onPressed: _images.length >= _maxImages
                           ? null
                           : () => unawaited(_pickImageSource(nestedContext)),

--- a/apps/mobile/lib/features/time_tracker/widgets/missed_entry_dialog.dart
+++ b/apps/mobile/lib/features/time_tracker/widgets/missed_entry_dialog.dart
@@ -3,14 +3,18 @@ import 'dart:io';
 
 import 'package:flutter/material.dart'
     hide AlertDialog, FilledButton, TextButton, TextField;
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
 import 'package:mobile/core/input/platform_text_context_menu.dart';
 import 'package:mobile/core/widgets/dismiss_keyboard_on_pointer_down.dart';
 import 'package:mobile/data/models/time_tracking/category.dart';
 import 'package:mobile/data/sources/api_client.dart';
-import 'package:mobile/features/time_tracker/utils/category_color.dart';
+import 'package:mobile/features/time_tracker/cubit/time_tracker_cubit.dart';
+import 'package:mobile/features/time_tracker/cubit/time_tracker_state.dart';
 import 'package:mobile/features/time_tracker/utils/threshold.dart';
+import 'package:mobile/features/time_tracker/widgets/category_selector_button.dart';
+import 'package:mobile/features/time_tracker/widgets/category_sheet.dart';
 import 'package:mobile/l10n/l10n.dart';
 import 'package:mobile/widgets/image_source_picker_dialog.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart' as shad;
@@ -19,6 +23,8 @@ class MissedEntryDialog extends StatefulWidget {
   const MissedEntryDialog({
     required this.categories,
     required this.onSave,
+    this.categoryListCubit,
+    this.onCreateCategory,
     this.canBypassRequestApproval = false,
     this.thresholdDays,
     this.initialStartTime,
@@ -30,6 +36,10 @@ class MissedEntryDialog extends StatefulWidget {
   });
 
   final List<TimeTrackingCategory> categories;
+
+  /// When set, the category picker reads live [TimeTrackerState.categories]
+  /// so new categories appear after [onCreateCategory] updates the cubit.
+  final TimeTrackerCubit? categoryListCubit;
   final Future<void> Function({
     required String title,
     required DateTime startTime,
@@ -40,6 +50,12 @@ class MissedEntryDialog extends StatefulWidget {
     String? description,
   })
   onSave;
+  final Future<void> Function({
+    required String name,
+    String? color,
+    String? description,
+  })?
+  onCreateCategory;
   final bool canBypassRequestApproval;
   final int? thresholdDays;
   final DateTime? initialStartTime;
@@ -83,11 +99,41 @@ class _MissedEntryDialogState extends State<MissedEntryDialog> {
     super.dispose();
   }
 
+  final GlobalKey<NavigatorState> _nestedNavKey = GlobalKey<NavigatorState>();
+
+  Future<bool> _onNestedNavigatorBack() async {
+    final nested = _nestedNavKey.currentState;
+    if (nested != null && await nested.maybePop()) {
+      return true;
+    }
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
     final theme = shad.Theme.of(context);
-    final materialTheme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.background,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: BackButtonListener(
+        onBackButtonPressed: _onNestedNavigatorBack,
+        child: Navigator(
+          key: _nestedNavKey,
+          onGenerateRoute: (_) => MaterialPageRoute<void>(
+            settings: const RouteSettings(name: 'missed_entry_form'),
+            builder: (nestedContext) => _buildFormPage(nestedContext, context),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFormPage(BuildContext nestedContext, BuildContext hostContext) {
+    final l10n = nestedContext.l10n;
+    final theme = shad.Theme.of(nestedContext);
+    final materialTheme = Theme.of(nestedContext);
     final dateFmt = DateFormat.yMMMd();
     final timeFmt = DateFormat.Hm();
 
@@ -96,9 +142,6 @@ class _MissedEntryDialogState extends State<MissedEntryDialog> {
     final showThresholdWarning =
         _isOlderThanThreshold && !widget.canBypassRequestApproval;
     final requiresProof = showThresholdWarning;
-    final selectedCategory = widget.categories
-        .where((category) => category.id == _categoryId)
-        .firstOrNull;
     final isDarkMode = materialTheme.brightness == Brightness.dark;
     final warningBackgroundColor = isDarkMode
         ? const Color(0xFF3D2F14)
@@ -109,315 +152,311 @@ class _MissedEntryDialogState extends State<MissedEntryDialog> {
     final warningTextColor = isDarkMode
         ? const Color(0xFFFFE0B2)
         : const Color(0xFF5D4037);
-    final keyboardBottomInset = MediaQuery.viewInsetsOf(context).bottom;
+    final keyboardBottomInset = MediaQuery.viewInsetsOf(nestedContext).bottom;
 
-    return Container(
-      decoration: BoxDecoration(
-        color: theme.colorScheme.background,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      child: DismissKeyboardOnPointerDown(
-        child: SafeArea(
-          top: false,
-          child: SingleChildScrollView(
-            padding: EdgeInsets.fromLTRB(24, 24, 24, 24 + keyboardBottomInset),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Text(
-                  l10n.timerAddMissedEntry,
-                  style: theme.typography.h3,
+    return DismissKeyboardOnPointerDown(
+      child: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: EdgeInsets.fromLTRB(24, 24, 24, 24 + keyboardBottomInset),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                l10n.timerAddMissedEntry,
+                style: theme.typography.h3,
+              ),
+              const shad.Gap(24),
+              shad.FormField(
+                key: const shad.FormKey<String>(#missedEntryTitle),
+                label: Text(l10n.timerSessionTitle),
+                child: shad.TextField(
+                  contextMenuBuilder: platformTextContextMenuBuilder(),
+                  controller: _titleCtrl,
                 ),
-                const shad.Gap(24),
-                shad.FormField(
-                  key: const shad.FormKey<String>(#missedEntryTitle),
-                  label: Text(l10n.timerSessionTitle),
-                  child: shad.TextField(
-                    contextMenuBuilder: platformTextContextMenuBuilder(),
-                    controller: _titleCtrl,
-                  ),
+              ),
+              const shad.Gap(16),
+              shad.FormField(
+                key: const shad.FormKey<String>(#missedEntryDesc),
+                label: Text(l10n.timerDescription),
+                child: shad.TextField(
+                  contextMenuBuilder: platformTextContextMenuBuilder(),
+                  controller: _descCtrl,
+                  maxLines: 3,
                 ),
-                const shad.Gap(16),
-                shad.FormField(
-                  key: const shad.FormKey<String>(#missedEntryDesc),
-                  label: Text(l10n.timerDescription),
-                  child: shad.TextField(
-                    contextMenuBuilder: platformTextContextMenuBuilder(),
-                    controller: _descCtrl,
-                    maxLines: 3,
-                  ),
-                ),
-                const shad.Gap(16),
-                if (widget.categories.isNotEmpty)
-                  shad.FormField(
-                    key: const shad.FormKey<String?>(#missedEntryCategory),
-                    label: Text(l10n.timerCategory),
-                    child: shad.OutlineButton(
-                      onPressed: () => unawaited(_pickCategory()),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Row(
-                            children: [
-                              if (selectedCategory?.color != null) ...[
-                                Container(
-                                  width: 10,
-                                  height: 10,
-                                  decoration: BoxDecoration(
-                                    shape: BoxShape.circle,
-                                    color: resolveTimeTrackingCategoryColor(
-                                      context,
-                                      selectedCategory?.color,
-                                      fallback: theme.colorScheme.primary,
-                                    ),
-                                  ),
-                                ),
-                                const shad.Gap(8),
-                              ],
-                              Text(
-                                selectedCategory?.name ?? l10n.timerNoCategory,
-                              ),
-                            ],
-                          ),
-                          const Icon(shad.LucideIcons.chevronDown, size: 16),
-                        ],
+              ),
+              const shad.Gap(16),
+              if (widget.categoryListCubit != null)
+                BlocBuilder<TimeTrackerCubit, TimeTrackerState>(
+                  bloc: widget.categoryListCubit,
+                  buildWhen: (previous, current) =>
+                      previous.categories != current.categories,
+                  builder: (context, state) {
+                    if (state.categories.isEmpty) {
+                      return const SizedBox.shrink();
+                    }
+                    return shad.FormField(
+                      key: const shad.FormKey<String?>(#missedEntryCategory),
+                      label: Text(l10n.timerCategory),
+                      child: CategorySelectorButton(
+                        categories: state.categories,
+                        selectedCategoryId: _categoryId,
+                        onTap: () => unawaited(_pickCategory(nestedContext)),
                       ),
+                    );
+                  },
+                )
+              else if (widget.categories.isNotEmpty)
+                shad.FormField(
+                  key: const shad.FormKey<String?>(#missedEntryCategory),
+                  label: Text(l10n.timerCategory),
+                  child: CategorySelectorButton(
+                    categories: widget.categories,
+                    selectedCategoryId: _categoryId,
+                    onTap: () => unawaited(_pickCategory(nestedContext)),
+                  ),
+                ),
+              const shad.Gap(16),
+              _DateTimePicker(
+                routeContext: nestedContext,
+                label: l10n.timerStartTime,
+                value: _startTime,
+                dateFmt: dateFmt,
+                timeFmt: timeFmt,
+                onChanged: (dt) => setState(() => _startTime = dt),
+              ),
+              const shad.Gap(12),
+              _DateTimePicker(
+                routeContext: nestedContext,
+                label: l10n.timerEndTime,
+                value: _endTime,
+                dateFmt: dateFmt,
+                timeFmt: timeFmt,
+                onChanged: (dt) => setState(() => _endTime = dt),
+              ),
+              if (showThresholdWarning) ...[
+                const shad.Gap(12),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: warningBackgroundColor,
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(
+                      color: warningBorderColor,
                     ),
                   ),
-                const shad.Gap(16),
-                _DateTimePicker(
-                  label: l10n.timerStartTime,
-                  value: _startTime,
-                  dateFmt: dateFmt,
-                  timeFmt: timeFmt,
-                  onChanged: (dt) => setState(() => _startTime = dt),
+                  child: Text(
+                    widget.thresholdDays == 0
+                        ? l10n.timerThresholdWarningAll
+                        : l10n.timerThresholdWarning(
+                            widget.thresholdDays ?? 0,
+                          ),
+                    style: theme.typography.small.copyWith(
+                      color: warningTextColor,
+                    ),
+                  ),
                 ),
                 const shad.Gap(12),
-                _DateTimePicker(
-                  label: l10n.timerEndTime,
-                  value: _endTime,
-                  dateFmt: dateFmt,
-                  timeFmt: timeFmt,
-                  onChanged: (dt) => setState(() => _endTime = dt),
-                ),
-                if (showThresholdWarning) ...[
-                  const shad.Gap(12),
-                  Container(
-                    padding: const EdgeInsets.all(12),
-                    decoration: BoxDecoration(
-                      color: warningBackgroundColor,
-                      borderRadius: BorderRadius.circular(10),
-                      border: Border.all(
-                        color: warningBorderColor,
-                      ),
-                    ),
-                    child: Text(
-                      widget.thresholdDays == 0
-                          ? l10n.timerThresholdWarningAll
-                          : l10n.timerThresholdWarning(
-                              widget.thresholdDays ?? 0,
-                            ),
-                      style: theme.typography.small.copyWith(
-                        color: warningTextColor,
-                      ),
-                    ),
-                  ),
-                  const shad.Gap(12),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          l10n.timerRequestProofImagesCount(
-                            _images.length,
-                            _maxImages,
-                          ),
-                          style: theme.typography.small,
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        l10n.timerRequestProofImagesCount(
+                          _images.length,
+                          _maxImages,
                         ),
-                      ),
-                      shad.OutlineButton(
-                        onPressed: _images.length >= _maxImages
-                            ? null
-                            : () => unawaited(_pickImageSource()),
-                        child: Text(l10n.timerRequestAddImage),
-                      ),
-                    ],
-                  ),
-                  const shad.Gap(8),
-                  if (_images.isNotEmpty)
-                    SizedBox(
-                      height: 76,
-                      child: ListView.separated(
-                        scrollDirection: Axis.horizontal,
-                        itemBuilder: (context, index) {
-                          final image = _images[index];
-                          return Stack(
-                            children: [
-                              ClipRRect(
-                                borderRadius: BorderRadius.circular(8),
-                                child: Image.file(
-                                  File(image.path),
-                                  width: 76,
-                                  height: 76,
-                                  fit: BoxFit.cover,
-                                ),
-                              ),
-                              Positioned(
-                                top: 2,
-                                right: 2,
-                                child: GestureDetector(
-                                  onTap: () {
-                                    setState(() {
-                                      _images.removeAt(index);
-                                    });
-                                  },
-                                  child: Container(
-                                    padding: const EdgeInsets.all(2),
-                                    decoration: const BoxDecoration(
-                                      color: Colors.black54,
-                                      shape: BoxShape.circle,
-                                    ),
-                                    child: const Icon(
-                                      Icons.close,
-                                      color: Colors.white,
-                                      size: 14,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          );
-                        },
-                        separatorBuilder: (_, _) => const shad.Gap(8),
-                        itemCount: _images.length,
+                        style: theme.typography.small,
                       ),
                     ),
-                  if (requiresProof && _images.isEmpty) ...[
-                    const shad.Gap(8),
-                    Text(
-                      l10n.timerProofOfWorkRequired,
-                      style: theme.typography.small.copyWith(
-                        color: theme.colorScheme.destructive,
-                      ),
+                    shad.OutlineButton(
+                      onPressed: _images.length >= _maxImages
+                          ? null
+                          : () => unawaited(_pickImageSource(nestedContext)),
+                      child: Text(l10n.timerRequestAddImage),
                     ),
                   ],
-                ],
-                const shad.Gap(12),
-                Text(
-                  '${l10n.timerDuration}: $durationText',
-                  style: theme.typography.small.copyWith(
-                    color: theme.colorScheme.mutedForeground,
-                  ),
                 ),
-                const shad.Gap(24),
-                shad.PrimaryButton(
-                  onPressed: _isValid && !_isSubmitting
-                      ? () async {
-                          final navigator = Navigator.of(context);
-                          final toastContext = Navigator.of(
-                            context,
-                            rootNavigator: true,
-                          ).context;
-                          setState(() => _isSubmitting = true);
-
-                          final workSessionTitle = _titleCtrl.text.isEmpty
-                              ? l10n.timerWorkSession
-                              : _titleCtrl.text;
-                          final successTitle = showThresholdWarning
-                              ? l10n.timerRequestSubmittedTitle
-                              : l10n.timerMissedEntrySavedTitle;
-                          final successContent = showThresholdWarning
-                              ? l10n.timerRequestSubmittedContent
-                              : l10n.timerMissedEntrySavedContent;
-                          final errorTitle = l10n.commonSomethingWentWrong;
-
-                          try {
-                            await widget.onSave(
-                              title: workSessionTitle,
-                              categoryId: _categoryId,
-                              startTime: _startTime,
-                              endTime: _endTime,
-                              shouldSubmitAsRequest: showThresholdWarning,
-                              imageLocalPaths: _images
-                                  .map((file) => file.path)
-                                  .toList(),
-                              description: _descCtrl.text.isEmpty
-                                  ? null
-                                  : _descCtrl.text,
-                            );
-
-                            if (!context.mounted) {
-                              return;
-                            }
-
-                            shad.showToast(
-                              context: toastContext,
-                              builder: (context, overlay) => shad.Alert(
-                                title: Text(successTitle),
-                                content: Text(successContent),
+                const shad.Gap(8),
+                if (_images.isNotEmpty)
+                  SizedBox(
+                    height: 76,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemBuilder: (context, index) {
+                        final image = _images[index];
+                        return Stack(
+                          children: [
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: Image.file(
+                                File(image.path),
+                                width: 76,
+                                height: 76,
+                                fit: BoxFit.cover,
                               ),
-                            );
-
-                            setState(() => _isSubmitting = false);
-
-                            final dialogContext = context;
-                            await shad.closeOverlay<void>(dialogContext);
-                            if (!dialogContext.mounted) {
-                              return;
-                            }
-
-                            if (navigator.canPop()) {
-                              navigator.pop();
-                            }
-                          } on ApiException catch (error) {
-                            if (!context.mounted) {
-                              return;
-                            }
-
-                            shad.showToast(
-                              context: toastContext,
-                              builder: (context, overlay) =>
-                                  shad.Alert.destructive(
-                                    title: Text(errorTitle),
-                                    content: Text(_toErrorMessage(error)),
+                            ),
+                            Positioned(
+                              top: 2,
+                              right: 2,
+                              child: GestureDetector(
+                                onTap: () {
+                                  setState(() {
+                                    _images.removeAt(index);
+                                  });
+                                },
+                                child: Container(
+                                  padding: const EdgeInsets.all(2),
+                                  decoration: const BoxDecoration(
+                                    color: Colors.black54,
+                                    shape: BoxShape.circle,
                                   ),
-                            );
-
-                            setState(() => _isSubmitting = false);
-                          } on Object {
-                            if (!context.mounted) {
-                              return;
-                            }
-
-                            shad.showToast(
-                              context: toastContext,
-                              builder: (context, overlay) =>
-                                  shad.Alert.destructive(
-                                    title: Text(errorTitle),
-                                    content: Text(
-                                      context.l10n.commonSomethingWentWrong,
-                                    ),
+                                  child: const Icon(
+                                    Icons.close,
+                                    color: Colors.white,
+                                    size: 14,
                                   ),
-                            );
-
-                            setState(() => _isSubmitting = false);
-                          }
-                        }
-                      : null,
-                  child: _isSubmitting
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: shad.CircularProgressIndicator(),
-                        )
-                      : Text(
-                          showThresholdWarning
-                              ? l10n.timerSubmitForApproval
-                              : l10n.timerSave,
-                        ),
-                ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                      separatorBuilder: (_, _) => const shad.Gap(8),
+                      itemCount: _images.length,
+                    ),
+                  ),
+                if (requiresProof && _images.isEmpty) ...[
+                  const shad.Gap(8),
+                  Text(
+                    l10n.timerProofOfWorkRequired,
+                    style: theme.typography.small.copyWith(
+                      color: theme.colorScheme.destructive,
+                    ),
+                  ),
+                ],
               ],
-            ),
+              const shad.Gap(12),
+              Text(
+                '${l10n.timerDuration}: $durationText',
+                style: theme.typography.small.copyWith(
+                  color: theme.colorScheme.mutedForeground,
+                ),
+              ),
+              const shad.Gap(24),
+              shad.PrimaryButton(
+                onPressed: _isValid && !_isSubmitting
+                    ? () async {
+                        final navigator = Navigator.of(hostContext);
+                        final toastContext = Navigator.of(
+                          hostContext,
+                          rootNavigator: true,
+                        ).context;
+                        setState(() => _isSubmitting = true);
+
+                        final workSessionTitle = _titleCtrl.text.isEmpty
+                            ? l10n.timerWorkSession
+                            : _titleCtrl.text;
+                        final successTitle = showThresholdWarning
+                            ? l10n.timerRequestSubmittedTitle
+                            : l10n.timerMissedEntrySavedTitle;
+                        final successContent = showThresholdWarning
+                            ? l10n.timerRequestSubmittedContent
+                            : l10n.timerMissedEntrySavedContent;
+                        final errorTitle = l10n.commonSomethingWentWrong;
+
+                        try {
+                          await widget.onSave(
+                            title: workSessionTitle,
+                            categoryId: _categoryId,
+                            startTime: _startTime,
+                            endTime: _endTime,
+                            shouldSubmitAsRequest: showThresholdWarning,
+                            imageLocalPaths: _images
+                                .map((file) => file.path)
+                                .toList(),
+                            description: _descCtrl.text.isEmpty
+                                ? null
+                                : _descCtrl.text,
+                          );
+
+                          if (!mounted ||
+                              !hostContext.mounted ||
+                              !nestedContext.mounted) {
+                            return;
+                          }
+
+                          shad.showToast(
+                            context: toastContext,
+                            builder: (context, overlay) => shad.Alert(
+                              title: Text(successTitle),
+                              content: Text(successContent),
+                            ),
+                          );
+
+                          setState(() => _isSubmitting = false);
+
+                          if (!nestedContext.mounted) {
+                            return;
+                          }
+                          await shad.closeOverlay<void>(nestedContext);
+                          if (!mounted || !hostContext.mounted) {
+                            return;
+                          }
+
+                          if (navigator.canPop()) {
+                            navigator.pop();
+                          }
+                        } on ApiException catch (error) {
+                          if (!mounted || !hostContext.mounted) {
+                            return;
+                          }
+
+                          shad.showToast(
+                            context: toastContext,
+                            builder: (context, overlay) =>
+                                shad.Alert.destructive(
+                                  title: Text(errorTitle),
+                                  content: Text(_toErrorMessage(error)),
+                                ),
+                          );
+
+                          setState(() => _isSubmitting = false);
+                        } on Object {
+                          if (!mounted ||
+                              !hostContext.mounted ||
+                              !nestedContext.mounted) {
+                            return;
+                          }
+
+                          shad.showToast(
+                            context: toastContext,
+                            builder: (context, overlay) =>
+                                shad.Alert.destructive(
+                                  title: Text(errorTitle),
+                                  content: Text(
+                                    nestedContext.l10n.commonSomethingWentWrong,
+                                  ),
+                                ),
+                          );
+
+                          setState(() => _isSubmitting = false);
+                        }
+                      }
+                    : null,
+                child: _isSubmitting
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: shad.CircularProgressIndicator(),
+                      )
+                    : Text(
+                        showThresholdWarning
+                            ? l10n.timerSubmitForApproval
+                            : l10n.timerSave,
+                      ),
+              ),
+            ],
           ),
         ),
       ),
@@ -444,10 +483,10 @@ class _MissedEntryDialogState extends State<MissedEntryDialog> {
 
   static const int _maxImages = 5;
 
-  Future<void> _pickImageSource() async {
-    final l10n = context.l10n;
+  Future<void> _pickImageSource(BuildContext modalContext) async {
+    final l10n = modalContext.l10n;
     final source = await showImageSourcePickerDialog(
-      context: context,
+      context: modalContext,
       title: l10n.selectImageSource,
       cameraLabel: l10n.camera,
       galleryLabel: l10n.gallery,
@@ -487,78 +526,23 @@ class _MissedEntryDialogState extends State<MissedEntryDialog> {
     });
   }
 
-  Future<void> _pickCategory() async {
-    final l10n = context.l10n;
-    final theme = shad.Theme.of(context);
-    final selectedCategoryId = await shad.showDialog<String?>(
-      context: context,
-      builder: (dialogCtx) {
-        final barrierColor = Theme.of(
-          dialogCtx,
-        ).colorScheme.scrim.withValues(alpha: 0.55);
-
-        return shad.AlertDialog(
-          barrierColor: barrierColor,
-          title: Text(l10n.timerCategory),
-          content: SizedBox(
-            width: double.maxFinite,
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: 320),
-              child: ListView(
-                shrinkWrap: true,
-                children: [
-                  shad.GhostButton(
-                    onPressed: () => Navigator.of(dialogCtx).pop(),
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: Text(l10n.timerNoCategory),
-                    ),
-                  ),
-                  ...widget.categories.map(
-                    (category) => shad.GhostButton(
-                      onPressed: () => Navigator.of(dialogCtx).pop(category.id),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Row(
-                          children: [
-                            if (category.color != null) ...[
-                              Container(
-                                width: 10,
-                                height: 10,
-                                decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  color: resolveTimeTrackingCategoryColor(
-                                    context,
-                                    category.color,
-                                    fallback: theme.colorScheme.primary,
-                                  ),
-                                ),
-                              ),
-                              const shad.Gap(8),
-                            ],
-                            Expanded(
-                              child: Text(category.name ?? ''),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        );
+  Future<void> _pickCategory(BuildContext sheetContext) async {
+    final categories =
+        widget.categoryListCubit?.state.categories ?? widget.categories;
+    await showCategorySheet(
+      context: sheetContext,
+      categories: categories,
+      selectedCategoryId: _categoryId,
+      onSelected: (id) {
+        if (mounted) {
+          setState(() {
+            _categoryId = id;
+          });
+        }
       },
+      onCreateCategory: widget.onCreateCategory,
+      useRootNavigator: false,
     );
-
-    if (!mounted) {
-      return;
-    }
-
-    setState(() {
-      _categoryId = selectedCategoryId;
-    });
   }
 
   String _toErrorMessage(ApiException error) {
@@ -581,6 +565,7 @@ class _MissedEntryDialogState extends State<MissedEntryDialog> {
 
 class _DateTimePicker extends StatefulWidget {
   const _DateTimePicker({
+    required this.routeContext,
     required this.label,
     required this.value,
     required this.dateFmt,
@@ -588,6 +573,10 @@ class _DateTimePicker extends StatefulWidget {
     required this.onChanged,
   });
 
+  /// Host route used for picker routes so they stack on the missed-entry
+  /// nested [Navigator] instead of the root navigator (which sits behind
+  /// the drawer overlay back handler).
+  final BuildContext routeContext;
   final String label;
   final DateTime value;
   final DateFormat dateFmt;
@@ -612,7 +601,8 @@ class _DateTimePickerState extends State<_DateTimePicker> {
         shad.GhostButton(
           onPressed: () async {
             final date = await showDatePicker(
-              context: context,
+              context: widget.routeContext,
+              useRootNavigator: false,
               initialDate: widget.value,
               firstDate: DateTime(2020),
               lastDate: DateTime.now(),
@@ -637,7 +627,8 @@ class _DateTimePickerState extends State<_DateTimePicker> {
         shad.GhostButton(
           onPressed: () async {
             final time = await showTimePicker(
-              context: context,
+              context: widget.routeContext,
+              useRootNavigator: false,
               initialTime: TimeOfDay.fromDateTime(widget.value.toLocal()),
             );
             if (!mounted) {


### PR DESCRIPTION
# Description

- Utilized cleaner category picker
- Enhanced back handling for Android devices 
- Improved UI for Start Time/End Time Picker

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->


## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<img width="414" height="873" alt="image" src="https://github.com/user-attachments/assets/7637d30e-659e-4854-91a6-39c5d8981361" />
<img width="410" height="852" alt="image" src="https://github.com/user-attachments/assets/a9871740-a855-485d-b8f9-61017820d609" />
<img width="415" height="865" alt="image" src="https://github.com/user-attachments/assets/cd32b515-38d8-49a8-8740-f653175370ba" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the missed entry flow on mobile with a cleaner category picker, create-from-flow support, refined date/time inputs, and reliable Android back handling. This makes adding or submitting missed entries faster and more stable.

- **New Features**
  - Live category selection and creation: `showMissedEntryDialogFlow` now accepts `onCreateCategory` and `categoryListCubit`; the dialog listens to `TimeTrackerCubit` for real-time category updates and `showMissedEntryDialogForTimeTrackerCubit` wires `createCategory` by default.
  - New category picker UI: `CategorySelectorButton` + adaptive `showCategorySheet` with “No category”; the sheet returns a `Future`, supports `useRootNavigator`, and only shows “Create category” when a callback is provided.
  - Redesigned date/time inputs with segmented buttons and pickers stacked on a nested `Navigator` for smoother flow.

- **Bug Fixes**
  - Android back works correctly within the dialog, category sheet, date/time pickers, and image source picker using a nested `Navigator` and back listener.
  - Fixed toast and navigation timing when creating categories with post-frame handling and `Navigator.maybePop`; cleaned up mounted checks to prevent stuck overlays.

<sup>Written for commit 7297fd73c61c56ad060b4f84a6e14f3dea46b77f. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4645">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

