### PR TITLE
feat(members): refactor members management UI to client-side

### DIFF
--- a/apps/web/src/__tests__/invite-links-section.test.tsx
+++ b/apps/web/src/__tests__/invite-links-section.test.tsx
@@ -11,6 +11,7 @@ vi.mock('next/navigation', () => ({
 vi.mock('next-intl', () => ({
   useTranslations: (namespace?: string) => (key: string) =>
     namespace ? `${namespace}.${key}` : key,
+  useLocale: () => 'en',
 }));
 
 vi.mock('@tuturuuu/ui/sonner', () => ({

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/invite-link-members-dialog.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/invite-link-members-dialog.tsx
@@ -12,7 +12,8 @@ import {
 } from '@tuturuuu/ui/dialog';
 import { ScrollArea } from '@tuturuuu/ui/scroll-area';
 import moment from 'moment';
-import { useTranslations } from 'next-intl';
+import 'moment/locale/vi';
+import { useLocale, useTranslations } from 'next-intl';
 import type { InviteLinkDetails } from '@/lib/workspace-invite-links';
 
 interface Props {
@@ -26,6 +27,7 @@ interface Props {
 
 function JoinedUserRow({ inviteLink }: { inviteLink: InviteLinkDetails }) {
   const t = useTranslations();
+  const locale = useLocale();
 
   if (inviteLink.uses.length === 0) {
     return (
@@ -44,16 +46,11 @@ function JoinedUserRow({ inviteLink }: { inviteLink: InviteLinkDetails }) {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h4 className="font-semibold text-base text-foreground">
-            {t('ws-invite-links.members-joined')}
-          </h4>
-          <p className="text-foreground/60 text-sm">
-            {t('ws-invite-links.users-joined-description')}
-          </p>
-        </div>
+        <h4 className="font-semibold text-base text-foreground">
+          {t('ws-invite-links.members-joined')}
+        </h4>
         <div className="rounded-full bg-dynamic-blue/10 px-3 py-1 font-medium text-dynamic-blue text-xs">
           {inviteLink.uses.length}{' '}
           {inviteLink.uses.length === 1
@@ -99,13 +96,13 @@ function JoinedUserRow({ inviteLink }: { inviteLink: InviteLinkDetails }) {
                   </div>
                 </div>
 
-                <div className="rounded-xl border border-border bg-foreground/[0.03] px-3 py-2 text-left sm:text-right">
+                <div className="min-w-0 shrink-0 space-y-0.5 text-left sm:text-right">
                   <p className="font-medium text-foreground text-sm">
                     {t('ws-invite-links.joined')}{' '}
-                    {moment(inviteUse.joined_at).fromNow()}
+                    {moment(inviteUse.joined_at).locale(locale).fromNow()}
                   </p>
                   <p className="text-foreground/50 text-xs">
-                    {moment(inviteUse.joined_at).format('MMM D, YYYY • h:mm A')}
+                    {moment(inviteUse.joined_at).locale(locale).format('lll')}
                   </p>
                 </div>
               </div>
@@ -126,10 +123,11 @@ export function InviteLinkMembersDialog({
   onRetry,
 }: Props) {
   const t = useTranslations();
+  const locale = useLocale();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl overflow-hidden p-0">
+      <DialogContent className="w-full max-w-5xl overflow-hidden p-0 sm:max-w-5xl">
         <DialogHeader className="border-border border-b bg-linear-to-br from-background via-background to-foreground/[0.03] px-6 py-5">
           <DialogTitle className="flex items-center gap-3 text-xl">
             <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-linear-to-br from-dynamic-blue to-dynamic-purple shadow-md">
@@ -174,63 +172,73 @@ export function InviteLinkMembersDialog({
               </div>
             </div>
           ) : inviteLink ? (
-            <>
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                <div className="rounded-2xl border border-border bg-foreground/[0.02] p-4">
-                  <p className="text-foreground/60 text-xs uppercase tracking-[0.18em]">
+            <div className="space-y-10">
+              <div className="grid auto-rows-fr grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="flex min-h-30 flex-col rounded-2xl border border-border bg-foreground/[0.02] p-4">
+                  <p className="shrink-0 text-foreground/60 text-xs uppercase tracking-[0.18em]">
                     {t('ws-invite-links.link-code')}
                   </p>
-                  <div className="mt-3 flex items-center gap-3">
-                    <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-dynamic-blue/10">
+                  <div className="mt-3 flex min-h-0 flex-1 items-center gap-3">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-dynamic-blue/10">
                       <Link2 className="h-4 w-4 text-dynamic-blue" />
                     </div>
-                    <code className="font-medium font-mono text-foreground text-sm">
-                      {inviteLink.code}
-                    </code>
+                    <div className="min-w-0 flex-1 overflow-x-auto rounded-lg bg-foreground/[0.04] px-2.5 py-2">
+                      <code className="block whitespace-nowrap font-medium font-mono text-foreground text-sm">
+                        {inviteLink.code}
+                      </code>
+                    </div>
                   </div>
                 </div>
 
-                <div className="rounded-2xl border border-border bg-foreground/[0.02] p-4">
+                <div className="flex min-h-30 flex-col rounded-2xl border border-border bg-foreground/[0.02] p-4">
                   <p className="text-foreground/60 text-xs uppercase tracking-[0.18em]">
                     {t('ws-invite-links.total-uses')}
                   </p>
-                  <p className="mt-3 font-semibold text-foreground text-lg">
-                    {inviteLink.current_uses}
-                    {inviteLink.max_uses ? ` / ${inviteLink.max_uses}` : ''}
-                  </p>
+                  <div className="mt-3 flex flex-1 flex-col justify-end">
+                    <p className="font-semibold text-foreground text-lg leading-tight">
+                      {inviteLink.current_uses}
+                      {inviteLink.max_uses ? ` / ${inviteLink.max_uses}` : ''}
+                    </p>
+                  </div>
                 </div>
 
-                <div className="rounded-2xl border border-border bg-foreground/[0.02] p-4">
+                <div className="flex min-h-30 flex-col rounded-2xl border border-border bg-foreground/[0.02] p-4">
                   <p className="text-foreground/60 text-xs uppercase tracking-[0.18em]">
                     {t('ws-invite-links.created-at')}
                   </p>
-                  <p className="mt-3 font-semibold text-foreground text-sm">
-                    {moment(inviteLink.created_at).format('MMM D, YYYY')}
-                  </p>
-                  <p className="text-foreground/50 text-xs">
-                    {moment(inviteLink.created_at).fromNow()}
-                  </p>
+                  <div className="mt-3 flex flex-1 flex-col justify-end gap-0.5">
+                    <p className="font-semibold text-foreground text-sm leading-snug">
+                      {moment(inviteLink.created_at)
+                        .locale(locale)
+                        .format('ll')}
+                    </p>
+                    <p className="text-foreground/50 text-xs">
+                      {moment(inviteLink.created_at).locale(locale).fromNow()}
+                    </p>
+                  </div>
                 </div>
 
-                <div className="rounded-2xl border border-border bg-foreground/[0.02] p-4">
+                <div className="flex min-h-30 flex-col rounded-2xl border border-border bg-foreground/[0.02] p-4">
                   <p className="text-foreground/60 text-xs uppercase tracking-[0.18em]">
                     {t('ws-members.invite_membership_label')}
                   </p>
-                  <p className="mt-3 font-semibold text-foreground text-sm">
-                    {inviteLink.memberType === 'GUEST'
-                      ? t('ws-invite-links.membership-short-guest')
-                      : t('ws-invite-links.membership-short-member')}
-                  </p>
-                  <p className="text-foreground/50 text-xs">
-                    {inviteLink.memberType === 'GUEST'
-                      ? t('ws-members.invite_membership_guest')
-                      : t('ws-members.invite_membership_member')}
-                  </p>
+                  <div className="mt-3 flex flex-1 flex-col justify-end gap-0.5">
+                    <p className="font-semibold text-foreground text-sm leading-snug">
+                      {inviteLink.memberType === 'GUEST'
+                        ? t('ws-invite-links.membership-short-guest')
+                        : t('ws-invite-links.membership-short-member')}
+                    </p>
+                    <p className="text-pretty text-foreground/50 text-xs leading-snug">
+                      {inviteLink.memberType === 'GUEST'
+                        ? t('ws-members.invite_membership_guest')
+                        : t('ws-members.invite_membership_member')}
+                    </p>
+                  </div>
                 </div>
               </div>
 
               <JoinedUserRow inviteLink={inviteLink} />
-            </>
+            </div>
           ) : null}
         </div>
       </DialogContent>

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/invite-member-button.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/invite-member-button.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { UserPlus } from '@tuturuuu/icons';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UserPlus } from '@tuturuuu/icons';
 import { inviteWorkspaceMember } from '@tuturuuu/internal-api/workspaces';
 import type { User } from '@tuturuuu/types/primitives/User';
 import { Button } from '@tuturuuu/ui/button';
@@ -189,7 +189,9 @@ export default function InviteMemberButton({
               />
 
               <Button type="submit" className="w-full">
-                {inviteMutation.isPending ? t('common.loading') : t('invite_submit')}
+                {inviteMutation.isPending
+                  ? t('common.loading')
+                  : t('invite_submit')}
               </Button>
             </form>
           </Form>

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/invite-member-button.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/invite-member-button.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { UserPlus } from '@tuturuuu/icons';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { inviteWorkspaceMember } from '@tuturuuu/internal-api/workspaces';
 import type { User } from '@tuturuuu/types/primitives/User';
 import { Button } from '@tuturuuu/ui/button';
 import {
@@ -34,6 +36,7 @@ import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import * as z from 'zod';
+import { workspaceMembersKeys } from './members-queries';
 
 interface Props {
   wsId: string;
@@ -59,6 +62,7 @@ export default function InviteMemberButton({
   disabled,
 }: Props) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const t = useTranslations('ws-members');
 
   const [open, setOpen] = useState(false);
@@ -72,27 +76,25 @@ export default function InviteMemberButton({
     },
   });
 
-  const inviteMember = async (values: z.infer<typeof FormSchema>) => {
-    const res = await fetch(`/api/workspaces/${wsId}/members/invite`, {
-      method: 'POST',
-      body: JSON.stringify({
+  const inviteMutation = useMutation({
+    mutationFn: async (values: z.infer<typeof FormSchema>) =>
+      inviteWorkspaceMember(wsId, {
         email: values.email,
         memberType: values.memberType,
       }),
-    });
-
-    if (res.ok) {
+    onSuccess: (_data, values) => {
       toast.success(t('invitation-sent'), {
         description: t('invitation-sent-description', {
           email: values.email,
         }),
       });
       setOpen(false);
-      router.refresh();
-    } else {
-      const data = await res.json();
-
-      if (data.errorCode === 'SEAT_LIMIT_REACHED') {
+      queryClient.invalidateQueries({
+        queryKey: workspaceMembersKeys.lists(),
+      });
+    },
+    onError: (error: Error & { errorCode?: string }) => {
+      if (error.errorCode === 'SEAT_LIMIT_REACHED') {
         toast.error(t('seat-limit-reached'), {
           description: t('seat-limit-reached-description'),
           action: {
@@ -101,12 +103,17 @@ export default function InviteMemberButton({
           },
           duration: 10000,
         });
-      } else {
-        toast.error(t('invitation-failed'), {
-          description: data.message || t('invitation-failed-description'),
-        });
+        return;
       }
-    }
+
+      toast.error(t('invitation-failed'), {
+        description: error.message || t('invitation-failed-description'),
+      });
+    },
+  });
+
+  const inviteMember = async (values: z.infer<typeof FormSchema>) => {
+    await inviteMutation.mutateAsync(values);
   };
 
   return (
@@ -182,7 +189,7 @@ export default function InviteMemberButton({
               />
 
               <Button type="submit" className="w-full">
-                {t('invite_submit')}
+                {inviteMutation.isPending ? t('common.loading') : t('invite_submit')}
               </Button>
             </form>
           </Form>

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/invite-member-button.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/invite-member-button.tsx
@@ -64,6 +64,7 @@ export default function InviteMemberButton({
   const router = useRouter();
   const queryClient = useQueryClient();
   const t = useTranslations('ws-members');
+  const tCommon = useTranslations('common');
 
   const [open, setOpen] = useState(false);
 
@@ -190,7 +191,7 @@ export default function InviteMemberButton({
 
               <Button type="submit" className="w-full">
                 {inviteMutation.isPending
-                  ? t('common.loading')
+                  ? tCommon('loading')
                   : t('invite_submit')}
               </Button>
             </form>

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/member-list.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/member-list.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Crown, User as UserIcon } from '@tuturuuu/icons';
 import { Masonry } from '@tuturuuu/masonry';
 import type { Workspace } from '@tuturuuu/types';
@@ -5,9 +7,8 @@ import type { User } from '@tuturuuu/types/primitives/User';
 import { Avatar, AvatarFallback, AvatarImage } from '@tuturuuu/ui/avatar';
 import { Badge } from '@tuturuuu/ui/badge';
 import { getInitials } from '@tuturuuu/utils/name-helper';
-import { getCurrentUser } from '@tuturuuu/utils/user-helper';
 import moment from 'moment';
-import { getLocale, getTranslations } from 'next-intl/server';
+import { useLocale, useTranslations } from 'next-intl';
 import InviteMemberButton from './invite-member-button';
 import { MemberPermissionBreakdown } from './member-permission-breakdown';
 import { MemberSettingsButton } from './member-settings-button';
@@ -27,18 +28,31 @@ interface Props {
   invited?: boolean;
   loading?: boolean;
   canManageMembers?: boolean;
+  currentUser?: User | null;
 }
 
-export default async function MemberList({
+export default function MemberList({
   workspace,
   members,
   invited,
   loading,
   canManageMembers,
+  currentUser,
 }: Props) {
-  const locale = await getLocale();
-  const t = await getTranslations('ws-members');
-  const user = await getCurrentUser();
+  const locale = useLocale();
+  const t = useTranslations('ws-members');
+  const tCommon = useTranslations('common');
+
+  if (loading && (!members || members.length === 0)) {
+    return (
+      <div className="flex items-center justify-center rounded-lg border border-border bg-background/50 p-12">
+        <div className="flex flex-col items-center gap-3">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-foreground/20 border-t-foreground" />
+          <p className="text-foreground/60 text-sm">{tCommon('loading')}</p>
+        </div>
+      </div>
+    );
+  }
 
   if (!members || members.length === 0) {
     return (
@@ -50,7 +64,7 @@ export default async function MemberList({
         {!!workspace?.id && (
           <InviteMemberButton
             wsId={workspace?.id}
-            currentUser={user!}
+            currentUser={currentUser ?? undefined}
             canManageMembers={canManageMembers}
             label={t('invite_member')}
             variant="outline"
@@ -128,7 +142,7 @@ export default async function MemberList({
           <MemberSettingsButton
             workspace={workspace}
             user={member}
-            currentUser={user!}
+            currentUser={currentUser}
             canManageMembers={canManageMembers}
           />
         </div>
@@ -152,7 +166,7 @@ export default async function MemberList({
         ) : null}
 
         <div className="flex gap-2">
-          {user?.id === member.id && (
+          {currentUser?.id === member.id && (
             <div
               className={`rounded border px-2 py-0.5 text-center font-semibold ${
                 loading

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/member-settings-button.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/member-settings-button.tsx
@@ -15,14 +15,17 @@ import {
 } from '@tuturuuu/ui/dialog';
 import { toast } from '@tuturuuu/ui/hooks/use-toast';
 import { getInitials } from '@tuturuuu/utils/name-helper';
+import { removeWorkspaceMember } from '@tuturuuu/internal-api/workspaces';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
+import { workspaceMembersKeys } from './members-queries';
 
 interface Props {
   workspace: Workspace;
   user: User;
-  currentUser: User;
+  currentUser?: User | null;
   canManageMembers?: boolean;
 }
 
@@ -33,21 +36,20 @@ export function MemberSettingsButton({
   canManageMembers,
 }: Props) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const t = useTranslations('ws-members');
 
   const [open, setOpen] = useState(false);
 
-  const deleteMember = async () => {
-    const invited = user?.pending;
-
-    const response = await fetch(
-      `/api/workspaces/${ws.id}/members${user.id ? `?id=${user.id}` : `?email=${user.email}`}`,
-      {
-        method: 'DELETE',
-      }
-    );
-
-    if (response.ok) {
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      await removeWorkspaceMember(ws.id, {
+        email: user.id ? null : user.email,
+        userId: user.id ?? null,
+      });
+    },
+    onSuccess: () => {
+      const invited = user?.pending;
       toast({
         title: invited ? t('invitation_revoked') : t('member_removed'),
         description: invited
@@ -59,18 +61,27 @@ export function MemberSettingsButton({
           : `"${user?.display_name || 'Unknown'}" ${t('has_been_removed')}`,
         color: 'teal',
       });
-      if (user.id === currentUser?.id) router.push('/onboarding');
-    } else {
+
+      queryClient.invalidateQueries({
+        queryKey: workspaceMembersKeys.lists(),
+      });
+      if (currentUser?.id === user.id) router.push('/onboarding');
+      setOpen(false);
+    },
+    onError: () => {
+      const invited = user?.pending;
       toast({
         title: t('error'),
         description: invited
           ? t('revoke_error')
           : `${t('remove_error')} "${user?.display_name || 'Unknown'}"`,
       });
-    }
+    },
+  });
 
-    router.refresh();
-    setOpen(false);
+  const deleteMember = async () => {
+    if (!canManageMembers && currentUser?.id !== user.id) return;
+    await deleteMutation.mutateAsync();
   };
 
   return (
@@ -121,14 +132,15 @@ export function MemberSettingsButton({
           </div>
         </div>
 
-        {(canManageMembers || currentUser.id === user.id) && (
+        {(canManageMembers || currentUser?.id === user.id) && (
           <div className="mt-4">
             <Button
               variant="destructive"
               className="w-full"
               onClick={deleteMember}
+              disabled={deleteMutation.isPending}
             >
-              {currentUser.id === user.id
+              {currentUser?.id === user.id
                 ? 'Leave Workspace'
                 : user.pending
                   ? 'Revoke Invitation'

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/member-settings-button.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/member-settings-button.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Settings, User as UserIcon } from '@tuturuuu/icons';
+import { removeWorkspaceMember } from '@tuturuuu/internal-api/workspaces';
 import type { Workspace } from '@tuturuuu/types';
 import type { User } from '@tuturuuu/types/primitives/User';
 import { Avatar, AvatarFallback, AvatarImage } from '@tuturuuu/ui/avatar';
@@ -15,8 +17,6 @@ import {
 } from '@tuturuuu/ui/dialog';
 import { toast } from '@tuturuuu/ui/hooks/use-toast';
 import { getInitials } from '@tuturuuu/utils/name-helper';
-import { removeWorkspaceMember } from '@tuturuuu/internal-api/workspaces';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/member-tabs.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/member-tabs.tsx
@@ -1,13 +1,16 @@
+'use client';
+
 import { Tabs, TabsList } from '@tuturuuu/ui/tabs';
-import { getTranslations } from 'next-intl/server';
+import { useTranslations } from 'next-intl';
+import type { MemberStatus } from './members-queries';
 import TabNavigation from './tab-navigation';
 
 interface Props {
-  value?: string;
+  value?: MemberStatus;
 }
 
-export default async function MemberTabs({ value }: Props) {
-  const t = await getTranslations();
+export default function MemberTabs({ value }: Props) {
+  const t = useTranslations();
 
   return (
     <Tabs value={value} defaultValue="all" className="w-full">

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/members-client-shell.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/members-client-shell.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import type { Workspace } from '@tuturuuu/types';
+import type { User } from '@tuturuuu/types/primitives/User';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
+import { useTranslations } from 'next-intl';
+import InviteLinksSection from './invite-links-section';
+import InviteMemberButton from './invite-member-button';
+import MemberList from './member-list';
+import MemberTabs from './member-tabs';
+import { memberStatusValues, useWorkspaceMembers } from './members-queries';
+
+interface Props {
+  workspace: Workspace;
+  wsId: string;
+  currentUser?: User | null;
+  canManageMembers: boolean;
+  disableInvite: boolean;
+}
+
+export default function MembersClientShell({
+  workspace,
+  wsId,
+  currentUser,
+  canManageMembers,
+  disableInvite,
+}: Props) {
+  const t = useTranslations();
+  const [status] = useQueryState(
+    'status',
+    parseAsStringLiteral(memberStatusValues)
+      .withDefault('all')
+      .withOptions({ shallow: true })
+  );
+
+  const { data, isPending, isError } = useWorkspaceMembers(wsId, status);
+
+  return (
+    <div className="space-y-8">
+      <div className="relative overflow-hidden rounded-xl border border-border bg-linear-to-br from-background via-background to-foreground/2 p-6 shadow-sm">
+        <div className="pointer-events-none absolute -top-4 -right-4 h-32 w-32 rounded-full bg-dynamic-blue/5 blur-2xl" />
+        <div className="pointer-events-none absolute -bottom-4 -left-4 h-32 w-32 rounded-full bg-dynamic-purple/5 blur-2xl" />
+
+        <div className="relative flex flex-col justify-between gap-6 md:flex-row md:items-start">
+          <div className="space-y-2">
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-linear-to-br from-dynamic-blue to-dynamic-purple shadow-lg">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-6 w-6 text-background"
+                >
+                  <title>{t('workspace-settings-layout.members')}</title>
+                  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                  <circle cx="9" cy="7" r="4" />
+                  <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+                </svg>
+              </div>
+              <h1 className="bg-linear-to-br from-foreground to-foreground/70 bg-clip-text font-bold text-3xl text-transparent">
+                {t('workspace-settings-layout.members')}
+              </h1>
+            </div>
+            <p className="ml-15 max-w-2xl text-foreground/70 text-lg leading-relaxed">
+              {t('ws-members.description')}
+            </p>
+          </div>
+
+          <div className="flex shrink-0 flex-col items-stretch gap-3 md:flex-row md:items-center">
+            <MemberTabs value={status} />
+            <InviteMemberButton
+              wsId={wsId}
+              currentUser={currentUser ?? undefined}
+              canManageMembers={canManageMembers}
+              label={
+                disableInvite
+                  ? t('ws-members.invite_member_disabled')
+                  : t('ws-members.invite_member')
+              }
+              disabled={disableInvite}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border bg-background p-6 shadow-sm">
+        {isError ? (
+          <div className="rounded-lg border border-dynamic-red/20 bg-dynamic-red/5 p-6 text-dynamic-red text-sm">
+            {t('common.error')}
+          </div>
+        ) : (
+          <MemberList
+            workspace={workspace}
+            members={data ?? []}
+            invited={status === 'invited'}
+            loading={isPending}
+            canManageMembers={canManageMembers}
+            currentUser={currentUser}
+          />
+        )}
+      </div>
+
+      <InviteLinksSection wsId={wsId} canManageMembers={canManageMembers} />
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/members-client-shell.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/members-client-shell.tsx
@@ -2,8 +2,8 @@
 
 import type { Workspace } from '@tuturuuu/types';
 import type { User } from '@tuturuuu/types/primitives/User';
-import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { useTranslations } from 'next-intl';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import InviteLinksSection from './invite-links-section';
 import InviteMemberButton from './invite-member-button';
 import MemberList from './member-list';

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/members-queries.ts
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/members-queries.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { listEnhancedWorkspaceMembers } from '@tuturuuu/internal-api/workspaces';
+
+export const memberStatusValues = ['all', 'joined', 'invited'] as const;
+export type MemberStatus = (typeof memberStatusValues)[number];
+
+export const workspaceMembersKeys = {
+  all: ['workspace-members'] as const,
+  lists: () => [...workspaceMembersKeys.all, 'list'] as const,
+  list: (workspaceId: string, status: MemberStatus) =>
+    [...workspaceMembersKeys.lists(), workspaceId, status] as const,
+};
+
+export function useWorkspaceMembers(workspaceId: string, status: MemberStatus) {
+  return useQuery({
+    queryKey: workspaceMembersKeys.list(workspaceId, status),
+    queryFn: () => listEnhancedWorkspaceMembers(workspaceId, status),
+    enabled: !!workspaceId,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/tab-navigation.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/tab-navigation.tsx
@@ -1,21 +1,27 @@
 'use client';
 
-import useSearchParams from '@tuturuuu/ui/hooks/useSearchParams';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { TabsTrigger } from '@tuturuuu/ui/tabs';
+import {
+  memberStatusValues,
+  type MemberStatus,
+} from './members-queries';
 
 interface Props {
-  value: string;
+  value: MemberStatus;
   label: string;
 }
 
 export default function TabNavigation({ value, label }: Props) {
-  const searchParams = useSearchParams();
+  const [, setStatus] = useQueryState(
+    'status',
+    parseAsStringLiteral(memberStatusValues)
+      .withDefault('all')
+      .withOptions({ shallow: true })
+  );
 
   return (
-    <TabsTrigger
-      value={value}
-      onClick={() => searchParams.set({ status: value === 'all' ? '' : value })}
-    >
+    <TabsTrigger value={value} onClick={() => setStatus(value)}>
       {label}
     </TabsTrigger>
   );

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/tab-navigation.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/_components/tab-navigation.tsx
@@ -1,11 +1,8 @@
 'use client';
 
-import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { TabsTrigger } from '@tuturuuu/ui/tabs';
-import {
-  memberStatusValues,
-  type MemberStatus,
-} from './members-queries';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
+import { type MemberStatus, memberStatusValues } from './members-queries';
 
 interface Props {
   value: MemberStatus;

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(workspace-settings)/members/page.tsx
@@ -1,7 +1,3 @@
-import {
-  createAdminClient,
-  createClient,
-} from '@tuturuuu/supabase/next/server';
 import { getCurrentUser } from '@tuturuuu/utils/user-helper';
 import {
   getPermissions,
@@ -9,13 +5,8 @@ import {
 } from '@tuturuuu/utils/workspace-helper';
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getTranslations } from 'next-intl/server';
 import WorkspaceWrapper from '@/components/workspace-wrapper';
-import { getWorkspaceMembers } from '@/lib/workspace-members';
-import InviteLinksSection from './_components/invite-links-section';
-import InviteMemberButton from './_components/invite-member-button';
-import MemberList from './_components/member-list';
-import MemberTabs from './_components/member-tabs';
+import MembersClientShell from './_components/members-client-shell';
 
 export const metadata: Metadata = {
   title: 'Members',
@@ -27,18 +18,9 @@ interface Props {
   params: Promise<{
     wsId: string;
   }>;
-  searchParams: Promise<{
-    status: string;
-    roles: string;
-  }>;
 }
 
-export default async function WorkspaceMembersPage({
-  params,
-  searchParams,
-}: Props) {
-  const { status } = await searchParams;
-
+export default async function WorkspaceMembersPage({ params }: Props) {
   return (
     <WorkspaceWrapper params={params}>
       {async ({ workspace, wsId }) => {
@@ -54,97 +36,20 @@ export default async function WorkspaceMembersPage({
           redirect(`/${wsId}/settings`);
 
         const user = await getCurrentUser();
-        const members = await getMembers(wsId, await searchParams);
-
-        const t = await getTranslations();
         const disableInvite = await verifyHasSecrets(wsId, ['DISABLE_INVITE']);
 
         const canManageMembers = !withoutPermission('manage_workspace_members');
 
         return (
-          <div className="space-y-8">
-            {/* Header Section with gradient background */}
-            <div className="relative overflow-hidden rounded-xl border border-border bg-linear-to-br from-background via-background to-foreground/2 p-6 shadow-sm">
-              {/* Decorative elements */}
-              <div className="pointer-events-none absolute -top-4 -right-4 h-32 w-32 rounded-full bg-dynamic-blue/5 blur-2xl" />
-              <div className="pointer-events-none absolute -bottom-4 -left-4 h-32 w-32 rounded-full bg-dynamic-purple/5 blur-2xl" />
-
-              <div className="relative flex flex-col justify-between gap-6 md:flex-row md:items-start">
-                <div className="space-y-2">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-linear-to-br from-dynamic-blue to-dynamic-purple shadow-lg">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="h-6 w-6 text-background"
-                      >
-                        <title>{t('workspace-settings-layout.members')}</title>
-                        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                        <circle cx="9" cy="7" r="4" />
-                        <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-                        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-                      </svg>
-                    </div>
-                    <h1 className="bg-linear-to-br from-foreground to-foreground/70 bg-clip-text font-bold text-3xl text-transparent">
-                      {t('workspace-settings-layout.members')}
-                    </h1>
-                  </div>
-                  <p className="ml-15 max-w-2xl text-foreground/70 text-lg leading-relaxed">
-                    {t('ws-members.description')}
-                  </p>
-                </div>
-
-                <div className="flex shrink-0 flex-col items-stretch gap-3 md:flex-row md:items-center">
-                  <MemberTabs value={status || 'all'} />
-                  <InviteMemberButton
-                    wsId={wsId}
-                    currentUser={user!}
-                    canManageMembers={canManageMembers}
-                    label={
-                      disableInvite
-                        ? t('ws-members.invite_member_disabled')
-                        : t('ws-members.invite_member')
-                    }
-                    disabled={disableInvite}
-                  />
-                </div>
-              </div>
-            </div>
-
-            {/* Members List Section */}
-            <div className="rounded-xl border border-border bg-background p-6 shadow-sm">
-              <MemberList
-                workspace={workspace}
-                members={members}
-                invited={status === 'invited'}
-                canManageMembers={canManageMembers}
-              />
-            </div>
-
-            {/* Invite Links Section */}
-            <InviteLinksSection
-              wsId={wsId}
-              canManageMembers={canManageMembers}
-            />
-          </div>
+          <MembersClientShell
+            workspace={workspace}
+            wsId={wsId}
+            currentUser={user}
+            canManageMembers={canManageMembers}
+            disableInvite={disableInvite}
+          />
         );
       }}
     </WorkspaceWrapper>
   );
 }
-
-const getMembers = async (wsId: string, { status }: { status: string }) => {
-  const supabase = await createClient();
-  const sbAdmin = await createAdminClient();
-  return getWorkspaceMembers({
-    supabase,
-    sbAdmin,
-    wsId,
-    status,
-  });
-};

--- a/apps/web/src/app/api/workspaces/[wsId]/members/enhanced/route.ts
+++ b/apps/web/src/app/api/workspaces/[wsId]/members/enhanced/route.ts
@@ -6,10 +6,7 @@ import {
   PERSONAL_WORKSPACE_SLUG,
   resolveWorkspaceId,
 } from '@tuturuuu/utils/constants';
-import {
-  getPermissions,
-  getWorkspace,
-} from '@tuturuuu/utils/workspace-helper';
+import { getPermissions, getWorkspace } from '@tuturuuu/utils/workspace-helper';
 import { type NextRequest, NextResponse } from 'next/server';
 import { getWorkspaceMembers } from '@/lib/workspace-members';
 
@@ -40,7 +37,10 @@ export async function GET(request: NextRequest, { params }: Params) {
   }
 
   const permissions = await getPermissions({ wsId });
-  if (!permissions || permissions.withoutPermission('manage_workspace_members')) {
+  if (
+    !permissions ||
+    permissions.withoutPermission('manage_workspace_members')
+  ) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/apps/web/src/app/api/workspaces/[wsId]/members/enhanced/route.ts
+++ b/apps/web/src/app/api/workspaces/[wsId]/members/enhanced/route.ts
@@ -6,7 +6,10 @@ import {
   PERSONAL_WORKSPACE_SLUG,
   resolveWorkspaceId,
 } from '@tuturuuu/utils/constants';
-import { getWorkspace } from '@tuturuuu/utils/workspace-helper';
+import {
+  getPermissions,
+  getWorkspace,
+} from '@tuturuuu/utils/workspace-helper';
 import { type NextRequest, NextResponse } from 'next/server';
 import { getWorkspaceMembers } from '@/lib/workspace-members';
 
@@ -34,6 +37,11 @@ export async function GET(request: NextRequest, { params }: Params) {
   const wsId = await normalizeWorkspaceId(id);
   if (!wsId) {
     return NextResponse.json({ error: 'Workspace not found' }, { status: 404 });
+  }
+
+  const permissions = await getPermissions({ wsId });
+  if (!permissions || permissions.withoutPermission('manage_workspace_members')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
   // Get status filter from query params

--- a/packages/internal-api/src/index.ts
+++ b/packages/internal-api/src/index.ts
@@ -340,6 +340,7 @@ export {
 } from './workspace-user-audit';
 export {
   getWorkspace,
+  inviteWorkspaceMember,
   inviteWorkspaceMembers,
   listCmsWorkspaces,
   listEnhancedWorkspaceMembers,

--- a/packages/internal-api/src/workspaces.ts
+++ b/packages/internal-api/src/workspaces.ts
@@ -54,11 +54,19 @@ export async function listWorkspaceMembers(
 
 export async function listEnhancedWorkspaceMembers(
   workspaceId: string,
+  status?: 'all' | 'joined' | 'invited',
   options?: InternalApiClientOptions
 ) {
   const client = getInternalApiClient(options);
+  const searchParams = new URLSearchParams();
+
+  if (status && status !== 'all') {
+    searchParams.set('status', status);
+  }
+
+  const suffix = searchParams.toString();
   return client.json<InternalApiEnhancedWorkspaceMember[]>(
-    `/api/workspaces/${encodePathSegment(workspaceId)}/members/enhanced`,
+    `/api/workspaces/${encodePathSegment(workspaceId)}/members/enhanced${suffix ? `?${suffix}` : ''}`,
     {
       cache: 'no-store',
     }
@@ -87,6 +95,50 @@ export async function inviteWorkspaceMembers(
       method: 'POST',
     }
   );
+}
+
+export async function inviteWorkspaceMember(
+  workspaceId: string,
+  payload: { email: string; memberType: 'MEMBER' | 'GUEST' },
+  options?: InternalApiClientOptions
+) {
+  const client = getInternalApiClient(options);
+  const response = await client.fetch(
+    `/api/workspaces/${encodePathSegment(workspaceId)}/members/invite`,
+    {
+      body: JSON.stringify(payload),
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    }
+  );
+
+  if (!response.ok) {
+    const fallbackMessage = `Internal API request failed: ${response.status}`;
+    let data: { errorCode?: string; message?: string } | null = null;
+
+    try {
+      data = (await response.json()) as {
+        errorCode?: string;
+        message?: string;
+      };
+    } catch {
+      data = null;
+    }
+
+    const error = new Error(data?.message || fallbackMessage) as Error & {
+      errorCode?: string;
+    };
+    error.errorCode = data?.errorCode;
+    throw error;
+  }
+
+  return (await response.json()) as {
+    message?: string;
+    errorCode?: string;
+  };
 }
 
 export async function removeWorkspaceMember(


### PR DESCRIPTION
# Description

- Migrated workspace members page to be client side rendered
- Fixed UI for invite links view



## Why?

- Improves Responsiveness of page

# Screenshots for proof (must have)
<img width="1082" height="913" alt="image" src="https://github.com/user-attachments/assets/741acbe0-a031-4b38-ab8d-bcd6504b1701" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the workspace Members page to client-side rendering with `@tanstack/react-query` for faster, more responsive management. Also improves the Invite Links dialog and localizes timestamps.

- **New Features**
  - Client-side members page using `@tanstack/react-query` and `nuqs`; new `MembersClientShell` with URL-backed status tabs plus loading and error states.
  - Member actions now use `@tuturuuu/internal-api` (`inviteWorkspaceMember`, `removeWorkspaceMember`, `listEnhancedWorkspaceMembers(status)`); buttons show pending states, queries are invalidated for instant refresh, and self-removal redirects.

- **Bug Fixes**
  - Invite Links dialog layout refined (scrollable long codes) and dates localized via `useLocale` + `moment` (`fromNow`, `ll/lll`).
  - Enhanced members API enforces permissions and returns 403 for users without `manage_workspace_members`.

<sup>Written for commit 689dff2eec86ab067741988ac867b11e26d72414. Summary will update on new commits. <a href="https://cubic.dev/pr/tutur3u/platform/pull/4646">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

