### PR TITLE
fix(monitoring): aggregate network IO from all containers so Network Trend populates

### DIFF
--- a/scripts/watch-blue-green-deploy.js
+++ b/scripts/watch-blue-green-deploy.js
@@ -3421,12 +3421,12 @@ async function collectDockerResources(
           (Number.isFinite(container.memoryBytes) ? container.memoryBytes : 0),
         0
       ),
-      totalRxBytes: resourceContainers.reduce(
+      totalRxBytes: allContainers.reduce(
         (sum, container) =>
           sum + (Number.isFinite(container.rxBytes) ? container.rxBytes : 0),
         0
       ),
-      totalTxBytes: resourceContainers.reduce(
+      totalTxBytes: allContainers.reduce(
         (sum, container) =>
           sum + (Number.isFinite(container.txBytes) ? container.txBytes : 0),
         0


### PR DESCRIPTION
### Motivation
- The Network Trend chart and resource network summary were empty/zero because `totalRxBytes`/`totalTxBytes` were being derived only from the monitored/filtered subset, which can be empty or exclude containers that still report network I/O, so totals must come from all running containers.

### Description
- Update in `scripts/watch-blue-green-deploy.js` to compute `totalRxBytes` and `totalTxBytes` by reducing over `allContainers` instead of `resourceContainers`, so aggregated network metrics and the observability `resources` payload (and resulting chart buckets) are populated.

### Testing
- Attempted formatting with `bun ff -- scripts/watch-blue-green-deploy.js` but it failed in this environment because `biome` is not installed, and attempted verification with `bun check` failed because `turbo` is not available, so no repository-level checks or unit test runs completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8012db15c8333bea83bd3bc703c74)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty Network Trend and network summary by aggregating network I/O across all running containers so charts populate correctly. Updates `scripts/watch-blue-green-deploy.js` to compute `totalRxBytes` and `totalTxBytes` using `allContainers` instead of `resourceContainers`.

<sup>Written for commit 463dd48d91ccbbceb8e9fa293c823662a05f4ad5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

