### PR TITLE
fix(cli): use posix path methods for cross-platform compatibility

### DIFF
--- a/packages/sdk/src/cli/config.ts
+++ b/packages/sdk/src/cli/config.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir, platform } from 'node:os';
-import { dirname, join, win32 } from 'node:path';
+import { dirname, posix, win32 } from 'node:path';
 
 export interface CliSession {
   accessToken: string;
@@ -67,7 +67,7 @@ export function getDefaultConfigPath(
   }
 
   if (options.platform === 'darwin') {
-    return join(
+    return posix.join(
       options.homeDir,
       'Library',
       'Application Support',
@@ -77,8 +77,8 @@ export function getDefaultConfigPath(
   }
 
   const configHome =
-    options.env.XDG_CONFIG_HOME || join(options.homeDir, '.config');
-  return join(configHome, 'tuturuuu', 'config.json');
+    options.env.XDG_CONFIG_HOME || posix.join(options.homeDir, '.config');
+  return posix.join(configHome, 'tuturuuu', 'config.json');
 }
 
 export async function readCliConfig(

--- a/scripts/check-server-console.js
+++ b/scripts/check-server-console.js
@@ -36,9 +36,12 @@ if (result.error) {
   throw result.error;
 }
 
+const normalizePathSeparators = (line) => line.replace(/\\/g, '/');
+
 const violations = result.stdout
   .split(/\r?\n/)
   .filter(Boolean)
+  .map(normalizePathSeparators)
   .filter(
     (line) => !allowedFragments.some((fragment) => line.includes(fragment))
   );


### PR DESCRIPTION
# Description

Fix Failing Tests on Windows

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<!--
REQUIRED: Provide screenshots or recordings that demonstrate:
- The changes have been tested on your local machine
- UI changes (if applicable)
- Before/after comparisons (if applicable)
- Key functionality working as expected

Drag and drop images here or paste them directly
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `posix.join` for CLI config paths on macOS/Linux and normalize path separators in the console check script to fix cross-platform path issues and flaky checks on Windows.

- **Bug Fixes**
  - Switched to `posix.join` for `darwin` and XDG paths in `getDefaultConfigPath` (kept `win32` for Windows) to ensure consistent path building from `node:path`.
  - Normalized `\` to `/` in `scripts/check-server-console.js` output before filtering, preventing false violations on Windows.

<sup>Written for commit 5a29e6db6d052cf9e503960bccea68857b91d397. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

