### PR TITLE
fix(reports): report fields not being editable

### DIFF
--- a/apps/web/src/__tests__/editable-report-preview-reset.test.tsx
+++ b/apps/web/src/__tests__/editable-report-preview-reset.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type LatestApprovedLog = {
+  title?: string;
+  content?: string;
+  feedback?: string;
+} | null;
+
+let latestApprovedLogState: LatestApprovedLog = null;
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+  useFormatter: () => ({
+    dateTime: (value: Date) => value.toISOString(),
+  }),
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+vi.mock('@/hooks/use-config-map', () => ({
+  useConfigMap: () => ({
+    getConfig: () => null,
+  }),
+}));
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/hooks/use-report-history',
+  () => ({
+    useReportHistory: () => ({
+      logsQuery: { data: [] },
+      selectedLog: null,
+      setSelectedLog: vi.fn(),
+      formatRelativeTime: vi.fn(),
+      latestApprovedLog: latestApprovedLogState,
+      isLoadingRejectedBase: false,
+    }),
+  })
+);
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/hooks/use-report-mutations',
+  () => ({
+    useReportMutations: () => ({
+      createMutation: { mutate: vi.fn(), isPending: false },
+      updateMutation: { mutate: vi.fn(), isPending: false },
+      deleteMutation: { mutate: vi.fn(), isPending: false },
+      updateScoresMutation: { mutateAsync: vi.fn(), isPending: false },
+      approveMutation: { mutate: vi.fn(), isPending: false },
+      rejectMutation: { mutate: vi.fn(), isPending: false },
+    }),
+  })
+);
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/hooks/use-report-export',
+  () => ({
+    useReportExport: () => ({
+      handlePdfExport: vi.fn(),
+      handlePrintExport: vi.fn(),
+      handlePngExport: vi.fn(),
+      isExporting: false,
+      defaultExportType: 'pdf',
+      setDefaultExportType: vi.fn(),
+      printAfterExport: false,
+      setPrintAfterExport: vi.fn(),
+    }),
+  })
+);
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/hooks/use-report-dynamic-text',
+  () => ({
+    useReportDynamicText: () => (text: string) => text,
+  })
+);
+
+vi.mock('@tuturuuu/ui/custom/report-preview', () => ({
+  default: () => <div data-testid="report-preview" />,
+}));
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/components/report-history',
+  () => ({
+    ReportHistory: () => null,
+  })
+);
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/components/report-actions',
+  () => ({
+    ReportActions: () => null,
+  })
+);
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/components/delete-report-dialog',
+  () => ({
+    DeleteReportDialog: () => null,
+  })
+);
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/approvals/components/reject-dialog',
+  () => ({
+    RejectDialog: () => null,
+  })
+);
+
+vi.mock(
+  '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/score-display',
+  () => ({
+    default: () => null,
+  })
+);
+
+import EditableReportPreview from '@/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/editable-report-preview';
+
+describe('EditableReportPreview form reset behavior', () => {
+  beforeEach(() => {
+    latestApprovedLogState = {
+      title: 'Approved title',
+      content: 'Approved content',
+      feedback: 'Approved feedback',
+    };
+  });
+
+  it('does not overwrite typed title when approved snapshot object identity changes', () => {
+    const report = {
+      id: 'report-1',
+      user_id: 'user-1',
+      user_name: 'Test User',
+      group_id: 'group-1',
+      group_name: 'Test Group',
+      creator_name: 'Manager',
+      title: 'Current title',
+      content: 'Current content',
+      feedback: 'Current feedback',
+      report_approval_status: 'REJECTED' as const,
+      scores: [],
+    };
+
+    const { rerender } = render(
+      <EditableReportPreview
+        wsId="ws-1"
+        report={report}
+        configs={[]}
+        isNew={false}
+        canUpdateReports
+      />
+    );
+
+    const titleInput = screen.getByLabelText('user-report-data-table.title');
+
+    fireEvent.change(titleInput, { target: { value: 'Typed by user' } });
+    expect(titleInput).toHaveValue('Typed by user');
+
+    latestApprovedLogState = {
+      title: 'Approved title',
+      content: 'Approved content',
+      feedback: 'Approved feedback',
+    };
+
+    rerender(
+      <EditableReportPreview
+        wsId="ws-1"
+        report={{ ...report }}
+        configs={[]}
+        isNew={false}
+        canUpdateReports
+      />
+    );
+
+    expect(screen.getByLabelText('user-report-data-table.title')).toHaveValue(
+      'Typed by user'
+    );
+  });
+});

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/editable-report-preview.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/editable-report-preview.tsx
@@ -28,7 +28,7 @@ import { Tabs, TabsList, TabsTrigger } from '@tuturuuu/ui/tabs';
 import { cn } from '@tuturuuu/utils/format';
 import { useFormatter, useLocale, useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as z from 'zod';
 import {
   MAX_MONTHLY_REPORT_TEXT_LENGTH,
@@ -164,52 +164,55 @@ export default function EditableReportPreview({
 
   const defaultReportTitle = isNew ? getDefaultReportTitle() : '';
 
-  const getFormValues = () => {
+  const latestApprovedTitle = latestApprovedLog?.title || '';
+  const latestApprovedContent = latestApprovedLog?.content || '';
+  const latestApprovedFeedback = latestApprovedLog?.feedback || '';
+  const hasLatestApprovedLog = Boolean(latestApprovedLog);
+
+  const formValues = useMemo(() => {
     const isRejected = report.report_approval_status === 'REJECTED';
-    if (isRejected && latestApprovedLog) {
+    if (isRejected && hasLatestApprovedLog) {
       return {
-        title: latestApprovedLog.title || '',
-        content: latestApprovedLog.content || '',
-        feedback: latestApprovedLog.feedback || '',
+        title: latestApprovedTitle,
+        content: latestApprovedContent,
+        feedback: latestApprovedFeedback,
       };
     }
+
     const reportTitle = report?.title || '';
     return {
       title: reportTitle || defaultReportTitle,
       content: report?.content || '',
       feedback: report?.feedback || '',
     };
-  };
-
-  const form = useForm({
-    resolver: zodResolver(UserReportFormSchema),
-    defaultValues: getFormValues(),
-  });
-
-  useEffect(() => {
-    const isRejected = report.report_approval_status === 'REJECTED';
-    const formValues =
-      isRejected && latestApprovedLog
-        ? {
-            title: latestApprovedLog.title || '',
-            content: latestApprovedLog.content || '',
-            feedback: latestApprovedLog.feedback || '',
-          }
-        : {
-            title: report?.title || defaultReportTitle,
-            content: report?.content || '',
-            feedback: report?.feedback || '',
-          };
-    form.reset(formValues);
   }, [
     report.report_approval_status,
-    latestApprovedLog,
-    defaultReportTitle,
+    hasLatestApprovedLog,
+    latestApprovedTitle,
+    latestApprovedContent,
+    latestApprovedFeedback,
     report?.title,
     report?.content,
     report?.feedback,
-    form,
+    defaultReportTitle,
   ]);
+
+  const form = useForm({
+    resolver: zodResolver(UserReportFormSchema),
+    defaultValues: formValues,
+  });
+
+  const lastResetSignatureRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const nextSignature = JSON.stringify(formValues);
+    if (lastResetSignatureRef.current === nextSignature) {
+      return;
+    }
+
+    lastResetSignatureRef.current = nextSignature;
+    form.reset(formValues);
+  }, [form, formValues]);
 
   const title = useWatch({ control: form.control, name: 'title' });
   const content = useWatch({ control: form.control, name: 'content' });

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/editable-report-preview.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/reports/[reportId]/editable-report-preview.tsx
@@ -205,14 +205,17 @@ export default function EditableReportPreview({
   const lastResetSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const nextSignature = JSON.stringify(formValues);
+    const nextSignature = JSON.stringify({
+      reportId: report.id ?? null,
+      formValues,
+    });
     if (lastResetSignatureRef.current === nextSignature) {
       return;
     }
 
     lastResetSignatureRef.current = nextSignature;
     form.reset(formValues);
-  }, [form, formValues]);
+  }, [form, formValues, report.id]);
 
   const title = useWatch({ control: form.control, name: 'title' });
   const content = useWatch({ control: form.control, name: 'content' });

--- a/apps/web/src/lib/infrastructure/cron-monitoring.test.ts
+++ b/apps/web/src/lib/infrastructure/cron-monitoring.test.ts
@@ -54,6 +54,7 @@ describe('readCronMonitoringSnapshot', () => {
       expect(snapshot.jobs).toHaveLength(1);
       expect(snapshot.jobs[0]?.id).toBe('payment-products');
     } finally {
+      restoreEnv();
       fs.rmSync(tempDir, { force: true, recursive: true });
     }
   });
@@ -74,6 +75,7 @@ describe('readCronMonitoringSnapshot', () => {
       expect(snapshot.jobs).toHaveLength(1);
       expect(snapshot.jobs[0]?.path).toBe('/api/cron/payment/products');
     } finally {
+      restoreEnv();
       fs.rmSync(tempDir, { force: true, recursive: true });
     }
   });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes report fields being reset in the report preview. User-typed title, content, and feedback now persist across rerenders and when the latest approved snapshot or report props change.

- **Bug Fixes**
  - Editable report form: derive default `formValues` with `useMemo` and gate `form.reset` with a stable signature (`reportId` + values in a `useRef`) to avoid overwriting edits on identity-only changes.
  - Add `editable-report-preview-reset.test.tsx` to verify typed values persist across rerenders.
  - Tests: call `restoreEnv()` in `cron-monitoring.test.ts` to fix Windows failures.

<sup>Written for commit aafa458072031ccb9c5782151c577347850f4bc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

