### PR TITLE
feat(posts): auto-select next entry after approving or rejecting a post

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/posts/client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/posts/client.tsx
@@ -219,6 +219,31 @@ export default function PostsClient({
     [setQueryState]
   );
 
+  const handleApprovalCompleted = useCallback(
+    async (processedPost: PostEmail) => {
+      const currentPosts = postsData.data ?? [];
+      const processedKey = createPostEmailKey(processedPost);
+      const processedIndex = currentPosts.findIndex(
+        (post) => createPostEmailKey(post) === processedKey
+      );
+      const nextPost =
+        processedIndex >= 0
+          ? (currentPosts[processedIndex + 1] ??
+              currentPosts[processedIndex - 1] ??
+              null)
+          : (currentPosts[0] ?? null);
+
+      setSelectedPost(nextPost);
+      setPosts({
+        ...posts,
+        selected: nextPost ? createPostEmailKey(nextPost) : null,
+      });
+
+      await refetch();
+    },
+    [posts, postsData.data, refetch, setPosts]
+  );
+
   useEffect(() => {
     if (posts.selected && postsData?.data) {
       const found = postsData.data.find(
@@ -366,6 +391,7 @@ export default function PostsClient({
             postEmail={selectedPost}
             canApprovePosts={canApprovePosts}
             canForceSendPosts={canForceSendPosts}
+            onApprovalCompleted={handleApprovalCompleted}
           />
         </div>
       </div>

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/posts/client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/posts/client.tsx
@@ -229,8 +229,8 @@ export default function PostsClient({
       const nextPost =
         processedIndex >= 0
           ? (currentPosts[processedIndex + 1] ??
-              currentPosts[processedIndex - 1] ??
-              null)
+            currentPosts[processedIndex - 1] ??
+            null)
           : (currentPosts[0] ?? null);
 
       setSelectedPost(nextPost);

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/posts/post-display.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/posts/post-display.tsx
@@ -33,11 +33,13 @@ export function PostDisplay({
   postEmail,
   canApprovePosts = false,
   canForceSendPosts = false,
+  onApprovalCompleted,
 }: {
   wsId: string;
   postEmail: PostEmail | null;
   canApprovePosts?: boolean;
   canForceSendPosts?: boolean;
+  onApprovalCompleted?: (postEmail: PostEmail) => void | Promise<void>;
 }) {
   const locale = useLocale();
   const t = useTranslations('post-email-data-table');
@@ -130,6 +132,7 @@ export function PostDisplay({
                   queueStatus={postEmail.queue_status}
                   canRemoveApproval={postEmail.can_remove_approval}
                   compact
+                  onCompleted={() => onApprovalCompleted?.(postEmail)}
                 />
               )}
               {canShowForceSend && (

--- a/apps/web/src/components/post-approval-actions.tsx
+++ b/apps/web/src/components/post-approval-actions.tsx
@@ -26,7 +26,7 @@ interface Props {
   queueStatus?: string;
   canRemoveApproval?: boolean;
   compact?: boolean;
-  onCompleted?: () => void;
+  onCompleted?: () => void | Promise<void>;
 }
 
 export function PostApprovalActions({
@@ -93,8 +93,12 @@ export function PostApprovalActions({
       await queryClient.invalidateQueries({
         queryKey: ['group-post-checks'],
       });
-      router.refresh();
-      onCompleted?.();
+
+      if (onCompleted) {
+        await onCompleted();
+      } else {
+        router.refresh();
+      }
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : tCommon('error'));


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes in this PR -->

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<!--
REQUIRED: Provide screenshots or recordings that demonstrate:
- The changes have been tested on your local machine
- UI changes (if applicable)
- Before/after comparisons (if applicable)
- Key functionality working as expected

Drag and drop images here or paste them directly
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically selects the next post after you approve or reject one, so reviewers can move through the queue faster. The list refreshes, the next item is highlighted, and minor formatting fixes are included.

- **New Features**
  - Auto-selects the next post after approval/rejection. Falls back to the previous or first item, then refetches the list.
  - Adds optional `onApprovalCompleted` (awaited) from `PostApprovalActions` through `PostDisplay` to `PostsClient`; falls back to `router.refresh` if not provided and keeps `group-post-checks` invalidated.

<sup>Written for commit 51151a04500b2c9a279c3d5806d9cc3533673168. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

