### PR TITLE
fix(posts): show blacklisted email recipients with warning instead of filtering

### DIFF
--- a/apps/database/supabase/migrations/20260506113000_include_blacklisted_recipients_in_post_review_rows.sql
+++ b/apps/database/supabase/migrations/20260506113000_include_blacklisted_recipients_in_post_review_rows.sql
@@ -1,0 +1,233 @@
+create or replace function public.get_workspace_post_review_base_rows(
+  p_ws_id uuid,
+  p_group_id uuid default null,
+  p_post_id uuid default null,
+  p_included_group_ids uuid[] default null,
+  p_excluded_group_ids uuid[] default null,
+  p_user_id uuid default null,
+  p_cutoff timestamptz default null,
+  p_q text default null,
+  p_start_date timestamptz default null,
+  p_end_date timestamptz default null
+)
+returns table (
+  row_key text,
+  ws_id uuid,
+  group_id uuid,
+  group_name text,
+  post_id uuid,
+  post_title text,
+  post_content text,
+  post_created_at timestamptz,
+  user_id uuid,
+  email text,
+  recipient text,
+  user_display_name text,
+  user_full_name text,
+  user_phone text,
+  user_avatar_url text,
+  has_check boolean,
+  check_created_at timestamptz,
+  notes text,
+  is_completed boolean,
+  approval_status public.approval_status,
+  approval_rejection_reason text,
+  email_id uuid,
+  subject text,
+  queue_status text,
+  queue_attempt_count integer,
+  queue_last_error text,
+  queue_sent_at timestamptz,
+  delivery_issue_reason text,
+  can_remove_approval boolean,
+  review_stage text
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with base as (
+    select
+      concat(ugp.id::text, ':', wu.id::text) as row_key,
+      wug.ws_id,
+      wug.id as group_id,
+      wug.name as group_name,
+      ugp.id as post_id,
+      ugp.title as post_title,
+      ugp.content as post_content,
+      ugp.created_at as post_created_at,
+      wu.id as user_id,
+      wu.email,
+      coalesce(wu.full_name, wu.display_name) as recipient,
+      wu.display_name as user_display_name,
+      wu.full_name as user_full_name,
+      wu.phone as user_phone,
+      wu.avatar_url as user_avatar_url,
+      upc.post_id is not null as has_check,
+      upc.created_at as check_created_at,
+      upc.notes,
+      upc.is_completed,
+      upc.approval_status,
+      upc.rejection_reason as approval_rejection_reason,
+      coalesce(
+        upc.email_id,
+        peq.sent_email_id,
+        direct_sent_email.id
+      ) as email_id,
+      coalesce(linked_sent_email.subject, direct_sent_email.subject) as subject,
+      case
+        when peq.status is not null then peq.status
+        when coalesce(
+          upc.email_id,
+          peq.sent_email_id,
+          direct_sent_email.id
+        ) is not null then 'sent'
+        else null
+      end as queue_status,
+      coalesce(peq.attempt_count, 0) as queue_attempt_count,
+      peq.last_error as queue_last_error,
+      peq.sent_at as queue_sent_at,
+      case
+        when public.check_email_blocked(wu.email) then 'blacklisted_email_or_domain'
+        when upc.post_id is null or upc.approval_status <> 'APPROVED' then null
+        when coalesce(
+          upc.email_id,
+          peq.sent_email_id,
+          direct_sent_email.id
+        ) is not null then null
+        when peq.status is not null then null
+        when coalesce(nullif(trim(wu.email), ''), '') = '' then 'missing_email'
+        when sender_link.platform_user_id is null then 'missing_sender_platform_user'
+        else null
+      end as delivery_issue_reason,
+      (
+        upc.post_id is not null
+        and upc.approval_status = 'APPROVED'
+        and coalesce(
+          upc.email_id,
+          peq.sent_email_id,
+          direct_sent_email.id
+        ) is null
+        and coalesce(peq.status, '') not in ('sent', 'processing')
+      ) as can_remove_approval
+    from public.user_group_posts ugp
+    inner join public.workspace_user_groups wug
+      on wug.id = ugp.group_id
+    inner join public.workspace_user_groups_users wugu
+      on wugu.group_id = ugp.group_id
+    inner join public.workspace_users wu
+      on wu.id = wugu.user_id
+    left join public.user_group_post_checks upc
+      on upc.post_id = ugp.id
+     and upc.user_id = wu.id
+    left join lateral (
+      select wulu.platform_user_id
+      from public.workspace_user_linked_users wulu
+      where wulu.ws_id = wug.ws_id
+        and wulu.virtual_user_id = upc.approved_by
+      order by wulu.created_at desc, wulu.platform_user_id asc
+      limit 1
+    ) as sender_link
+      on true
+    left join public.post_email_queue peq
+      on peq.post_id = ugp.id
+     and peq.user_id = wu.id
+    left join public.sent_emails linked_sent_email
+      on linked_sent_email.id = coalesce(upc.email_id, peq.sent_email_id)
+    left join lateral (
+      select
+        se.id,
+        se.subject
+      from public.sent_emails se
+      where se.post_id = ugp.id
+        and se.receiver_id = wu.id
+      order by se.created_at desc, se.id desc
+      limit 1
+    ) as direct_sent_email
+      on true
+    where wug.ws_id = p_ws_id
+      and wu.ws_id = p_ws_id
+      and (
+        p_group_id is null
+        or ugp.group_id = p_group_id
+      )
+      and (
+        p_post_id is null
+        or ugp.id = p_post_id
+      )
+      and (
+        p_cutoff is null
+        or ugp.created_at >= p_cutoff
+      )
+      and (
+        p_start_date is null
+        or ugp.created_at >= p_start_date
+      )
+      and (
+        p_end_date is null
+        or ugp.created_at < p_end_date
+      )
+      and (
+        p_included_group_ids is null
+        or array_length(p_included_group_ids, 1) is null
+        or ugp.group_id = any(p_included_group_ids)
+      )
+      and (
+        p_excluded_group_ids is null
+        or array_length(p_excluded_group_ids, 1) is null
+        or not (ugp.group_id = any(p_excluded_group_ids))
+      )
+      and (
+        p_user_id is null
+        or wu.id = p_user_id
+      )
+      and (
+        p_q is null
+        or p_q = ''
+        or coalesce(wu.full_name, wu.display_name, '') ilike '%' || p_q || '%'
+        or coalesce(wu.email, '') ilike '%' || p_q || '%'
+      )
+  )
+  select
+    base.row_key,
+    base.ws_id,
+    base.group_id,
+    base.group_name,
+    base.post_id,
+    base.post_title,
+    base.post_content,
+    base.post_created_at,
+    base.user_id,
+    base.email,
+    base.recipient,
+    base.user_display_name,
+    base.user_full_name,
+    base.user_phone,
+    base.user_avatar_url,
+    base.has_check,
+    base.check_created_at,
+    base.notes,
+    base.is_completed,
+    base.approval_status,
+    base.approval_rejection_reason,
+    base.email_id,
+    base.subject,
+    base.queue_status,
+    base.queue_attempt_count,
+    base.queue_last_error,
+    base.queue_sent_at,
+    base.delivery_issue_reason,
+    base.can_remove_approval,
+    public.get_post_review_stage(
+      base.has_check,
+      base.approval_status,
+      base.email_id,
+      base.queue_status,
+      base.delivery_issue_reason
+    ) as review_stage
+  from base;
+$$;
+
+comment on function public.get_workspace_post_review_base_rows(uuid, uuid, uuid, uuid[], uuid[], uuid, timestamptz, text, timestamptz, timestamptz) is
+'Returns workspace post review rows. Keeps group members in scope and flags undeliverable recipients when their email or domain is blacklisted.';

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -8597,6 +8597,7 @@
     "completed": "Completed",
     "created_at": "Created At",
     "delivery_failed": "Delivery Failed",
+    "delivery_issue_reason_blacklisted_email_or_domain": "This recipient is marked as blocked because the email address or its domain is blacklisted.",
     "delivery_issue_reason_missing_email": "This recipient does not have a deliverable email address on record yet.",
     "delivery_issue_reason_missing_sender_platform_user": "The approver is not linked to a sender platform user, so delivery cannot be queued yet.",
     "details_description": "Select a recipient to inspect their review and delivery pipeline details.",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -8597,6 +8597,7 @@
     "completed": "Hoàn thành",
     "created_at": "Ngày tạo",
     "delivery_failed": "Gửi thất bại",
+    "delivery_issue_reason_blacklisted_email_or_domain": "Người nhận này bị chặn vì địa chỉ email hoặc tên miền email nằm trong danh sách đen.",
     "delivery_issue_reason_missing_email": "Người nhận này chưa có địa chỉ email hợp lệ để gửi.",
     "delivery_issue_reason_missing_sender_platform_user": "Người phê duyệt chưa được liên kết với tài khoản người gửi trên nền tảng nên chưa thể đưa vào hàng đợi.",
     "details_description": "Chọn một người nhận để xem chi tiết quy trình kiểm tra, phê duyệt và gửi bài viết.",

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/posts/types.ts
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/posts/types.ts
@@ -34,7 +34,8 @@ export type PostApprovalStatus = (typeof POST_APPROVAL_STATUSES)[number];
 export type PostReviewStage = (typeof POST_REVIEW_STAGES)[number];
 export type PostDeliveryIssueReason =
   | 'missing_email'
-  | 'missing_sender_platform_user';
+  | 'missing_sender_platform_user'
+  | 'blacklisted_email_or_domain';
 
 export function isPostApprovalStatus(
   value?: string

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/groups/[groupId]/posts/[postId]/card.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/groups/[groupId]/posts/[postId]/card.tsx
@@ -64,7 +64,11 @@ function UserCard({
       ? tableT('delivery_issue_reason_missing_email')
       : recipient.delivery_issue_reason === 'missing_sender_platform_user'
         ? tableT('delivery_issue_reason_missing_sender_platform_user')
+        : recipient.delivery_issue_reason === 'blacklisted_email_or_domain'
+          ? tableT('delivery_issue_reason_blacklisted_email_or_domain')
         : null;
+  const isEmailBlocked =
+    recipient.delivery_issue_reason === 'blacklisted_email_or_domain';
   const stageIconClassName = cn(
     'mr-1 h-3.5 w-3.5',
     stageAppearance.iconClassName
@@ -193,7 +197,7 @@ function UserCard({
         </div>
       )}
 
-      {recipient.review_stage === 'undeliverable' && deliveryIssueMessage && (
+      {deliveryIssueMessage && (
         <div className="mb-3 rounded border border-dynamic-orange/20 bg-dynamic-orange/5 p-2 text-dynamic-orange text-sm">
           {deliveryIssueMessage}
         </div>
@@ -221,7 +225,11 @@ function UserCard({
         </div>
       )}
 
-      {canApprovePosts && post.id && recipient.user_id && hasExistingCheck && (
+      {canApprovePosts &&
+        !isEmailBlocked &&
+        post.id &&
+        recipient.user_id &&
+        hasExistingCheck && (
         <div className="mt-4">
           <PostApprovalActions
             wsId={wsId}

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/groups/[groupId]/posts/[postId]/card.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/groups/[groupId]/posts/[postId]/card.tsx
@@ -66,7 +66,7 @@ function UserCard({
         ? tableT('delivery_issue_reason_missing_sender_platform_user')
         : recipient.delivery_issue_reason === 'blacklisted_email_or_domain'
           ? tableT('delivery_issue_reason_blacklisted_email_or_domain')
-        : null;
+          : null;
   const isEmailBlocked =
     recipient.delivery_issue_reason === 'blacklisted_email_or_domain';
   const stageIconClassName = cn(
@@ -230,16 +230,16 @@ function UserCard({
         post.id &&
         recipient.user_id &&
         hasExistingCheck && (
-        <div className="mt-4">
-          <PostApprovalActions
-            wsId={wsId}
-            itemId={`${post.id}:${recipient.user_id}`}
-            approvalStatus={approvalStatus ?? 'PENDING'}
-            queueStatus={recipient.queue_status ?? undefined}
-            canRemoveApproval={Boolean(recipient.can_remove_approval)}
-          />
-        </div>
-      )}
+          <div className="mt-4">
+            <PostApprovalActions
+              wsId={wsId}
+              itemId={`${post.id}:${recipient.user_id}`}
+              approvalStatus={approvalStatus ?? 'PENDING'}
+              queueStatus={recipient.queue_status ?? undefined}
+              canRemoveApproval={Boolean(recipient.can_remove_approval)}
+            />
+          </div>
+        )}
 
       {canUpdateUserGroupsPosts && (
         <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
- Redefines get_workspace_post_review_base_rows to keep blacklisted recipients
- Adds delivery_issue_reason field for blacklisted_email_or_domain
- Shows warning banner but allows marking complete/incomplete
- Hides approval actions to prevent sending to blocked emails/domains

# Description

<!-- Provide a brief overview of the changes in this PR -->

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<img width="810" height="295" alt="image" src="https://github.com/user-attachments/assets/00ce2324-7190-4861-9bbf-6f0f52227177" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show blacklisted email recipients in post review instead of hiding them. Display a warning, allow marking complete/incomplete, and block approval to prevent accidental sends.

- **Bug Fixes**
  - Keep blacklisted recipients in `public.get_workspace_post_review_base_rows` and flag them with `delivery_issue_reason = 'blacklisted_email_or_domain'`.
  - Show an orange warning banner on the recipient card; hide approval actions for blocked emails/domains while keeping complete/incomplete toggles.
  - Extend `PostDeliveryIssueReason` to include `blacklisted_email_or_domain`.
  - Add i18n strings for the new warning in `en.json` and `vi.json`.

<sup>Written for commit 69eec8805e8ee3924efb415f117bcf2b0d9f7ed6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

