### PR TITLE
fix: FK constrant

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/[userId]/follow-up/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/users/[userId]/follow-up/page.tsx
@@ -71,10 +71,11 @@ export default async function GuestLeadFollowUpPage({ params }: Props) {
           .eq('id', userId)
           .maybeSingle();
 
-        // Fetch user's groups for report context
         const { data: userGroups } = await supabase
           .from('workspace_user_groups_users')
-          .select('group:workspace_user_groups!inner(id, name, ws_id)')
+          .select(
+            'group:workspace_user_groups!workspace_user_roles_users_role_id_fkey!inner(id, name, ws_id)'
+          )
           .eq('user_id', userId)
           .eq('group.ws_id', wsId);
 

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/courses/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/courses/route.ts
@@ -130,7 +130,7 @@ export const GET = withSessionAuth(
     const queryBuilder = context.supabase
       .from('workspace_user_groups')
       .select(
-        'id, name, description, cert_template, created_at, archived, ending_date, is_course_published, sessions, starting_date, workspace_course_modules(id), workspace_user_groups_users(user_id)',
+        'id, name, description, cert_template, created_at, archived, ending_date, is_course_published, sessions, starting_date, workspace_course_modules(id), workspace_user_groups_users!workspace_user_roles_users_role_id_fkey(user_id)',
         { count: 'exact' }
       )
       .eq('ws_id', access.normalizedWsId)

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/teach/courses/[courseId]/members/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/teach/courses/[courseId]/members/route.ts
@@ -55,7 +55,7 @@ export const GET = withSessionAuth(
     const { data, error } = await access.sbAdmin
       .from('workspace_user_groups_users')
       .select(
-        'role, workspace_users(id, display_name, full_name, email, avatar_url, archived)'
+        'role, workspace_users!workspace_user_roles_users_user_id_fkey(id, display_name, full_name, email, avatar_url, archived)'
       )
       .eq('group_id', parsedParams.data.courseId)
       .order('role', { ascending: true });

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/users/[userId]/user-groups/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/users/[userId]/user-groups/route.ts
@@ -46,7 +46,9 @@ async function getDataWithApiKey({
 
   const mainQuery = sbAdmin
     .from('workspace_user_groups_users')
-    .select('*, workspace_user_groups!inner(*)')
+    .select(
+      '*, workspace_user_groups!workspace_user_roles_users_role_id_fkey!inner(*)'
+    )
     .eq('workspace_user_groups.ws_id', wsId)
     .eq('user_id', userId);
 
@@ -92,7 +94,9 @@ async function getDataFromSession({
 
   const { data, error } = await sbAdmin
     .from('workspace_user_groups_users')
-    .select('*, workspace_user_groups!inner(*)')
+    .select(
+      '*, workspace_user_groups!workspace_user_roles_users_role_id_fkey!inner(*)'
+    )
     .eq('workspace_user_groups.ws_id', normalizedWsId)
     .eq('user_id', userId);
 

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/users/database/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/users/database/route.ts
@@ -282,7 +282,9 @@ async function handleUsersDatabaseRequest(
         await Promise.all([
           sbAdmin
             .from('workspace_user_groups_users')
-            .select('user_id, workspace_user_groups!inner(is_guest, ws_id)')
+            .select(
+              'user_id, workspace_user_groups!workspace_user_roles_users_role_id_fkey!inner(is_guest, ws_id)'
+            )
             .eq('workspace_user_groups.ws_id', wsId)
             .eq('workspace_user_groups.is_guest', true)
             .in('user_id', workspaceUserIds),

--- a/apps/web/src/lib/tulearn/courses.ts
+++ b/apps/web/src/lib/tulearn/courses.ts
@@ -67,7 +67,7 @@ export async function getAssignedCourseIds({
   const { data, error } = await sbAdmin
     .from('workspace_user_groups_users')
     .select(
-      'group_id, workspace_user_groups!inner(id, ws_id, archived, is_guest, is_course_published)'
+      'group_id, workspace_user_groups!workspace_user_roles_users_role_id_fkey!inner(id, ws_id, archived, is_guest, is_course_published)'
     )
     .eq('user_id', studentWorkspaceUserId)
     .eq('workspace_user_groups.ws_id', wsId)


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes in this PR -->

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<!--
REQUIRED: Provide screenshots or recordings that demonstrate:
- The changes have been tested on your local machine
- UI changes (if applicable)
- Before/after comparisons (if applicable)
- Key functionality working as expected

Drag and drop images here or paste them directly
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken joins by switching Supabase selects to explicit foreign key paths. Restores correct data for user groups, course members, and assigned courses after recent FK constraint changes.

- **Bug Fixes**
  - Replaced implicit joins with explicit FKs on `workspace_user_groups_users` → `workspace_user_groups` and `workspace_user_groups_users` → `workspace_users`.
  - Updated queries in courses list, course members, user groups, users database, dashboard follow-up page, and `getAssignedCourseIds`.
  - Removes ambiguous join errors and returns consistent results across these endpoints.

<sup>Written for commit 53fd4529477fa177b05c653123779c5b38153495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/4812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

