### PR TITLE
fix: update content save debounce to 2s, optimize optimistic updates …

### DIFF
--- a/.github/workflows/docker-setup-check.yaml
+++ b/.github/workflows/docker-setup-check.yaml
@@ -140,14 +140,46 @@ jobs:
       - name: Build web dev image
         run: docker build --target dev -f apps/web/Dockerfile .
 
+      - name: Free Docker disk after web dev image
+        if: always()
+        run: |
+          df -h /
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          df -h /
+
       - name: Build web prod image
         run: docker build --target runner --secret id=web_env,src=apps/web/.env.local -f apps/web/Dockerfile .
+
+      - name: Free Docker disk after web prod image
+        if: always()
+        run: |
+          df -h /
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          df -h /
 
       - name: Build TanStack web prod image
         run: docker build --target runner -f apps/tanstack-web/Dockerfile .
 
+      - name: Free Docker disk after TanStack web prod image
+        if: always()
+        run: |
+          df -h /
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          df -h /
+
       - name: Build storage unzip proxy image
         run: docker build -f apps/storage-unzip-proxy/Dockerfile apps/storage-unzip-proxy
+
+      - name: Free Docker disk after storage unzip proxy image
+        if: always()
+        run: |
+          df -h /
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          df -h /
 
       - name: Build backend image
         run: docker build -f apps/backend/Dockerfile .

--- a/apps/tanstack-web/Dockerfile
+++ b/apps/tanstack-web/Dockerfile
@@ -117,6 +117,7 @@ COPY --from=deps /usr/local/bin/bun /usr/local/bin/bun
 
 RUN --mount=type=cache,id=platform-tanstack-web-vite,target=/workspace/apps/tanstack-web/.vite \
   bun run --filter @tuturuuu/types build && \
+  bun run --filter @tuturuuu/supabase build && \
   bun run --filter @tuturuuu/internal-api build && \
   cd apps/tanstack-web && \
   node node_modules/vite/bin/vite.js build && \

--- a/apps/tanstack-web/src/lib/platform/auth-gate.ts
+++ b/apps/tanstack-web/src/lib/platform/auth-gate.ts
@@ -76,6 +76,25 @@ export function isAuthenticatedProfile(profile: unknown): boolean {
 }
 
 /**
+ * Returns a workspace-local redirect target from TanStack's locale-prefixed
+ * pathname. Parent loaders may run for nested child routes, so auth redirects
+ * must preserve the full requested path instead of the parent route's base path.
+ */
+export function getWorkspaceNextPath(
+  params: { locale: string; wsId: string },
+  pathname: string,
+  fallbackPath: string
+): string {
+  const localePrefix = `/${params.locale}`;
+
+  if (pathname.startsWith(`${localePrefix}/`)) {
+    return pathname.slice(localePrefix.length);
+  }
+
+  return `/${params.wsId}/${fallbackPath.replace(/^\/+/u, '')}`;
+}
+
+/**
  * Resolves the current user from the forwarded request auth.
  *
  * Fail-closed: this server function never throws. Any error or empty/

--- a/apps/tanstack-web/src/routes/$locale/$wsId/crawlers.tsx
+++ b/apps/tanstack-web/src/routes/$locale/$wsId/crawlers.tsx
@@ -5,24 +5,14 @@ import {
   loadCrawlerListData,
   validateCrawlerListSearch,
 } from '@/lib/crawlers/crawler-list-route-data';
-import { requireCurrentUser } from '@/lib/platform/auth-gate';
+import {
+  getWorkspaceNextPath,
+  requireCurrentUser,
+} from '@/lib/platform/auth-gate';
 import { createPageHead } from '@/lib/platform/head';
 import { resolveMessagesLocale } from '@/lib/platform/messages';
 import { resolveWorkspace } from '@/lib/platform/workspace';
 import { requireWorkspacePermission } from '@/lib/platform/workspace-permission';
-
-function getWorkspaceNextPath(
-  params: { locale: string; wsId: string },
-  pathname: string
-) {
-  const localePrefix = `/${params.locale}`;
-
-  if (pathname.startsWith(`${localePrefix}/`)) {
-    return pathname.slice(localePrefix.length);
-  }
-
-  return `/${params.wsId}/crawlers`;
-}
 
 export const Route = createFileRoute('/$locale/$wsId/crawlers')({
   component: CrawlerListRoutePage,
@@ -45,7 +35,7 @@ export const Route = createFileRoute('/$locale/$wsId/crawlers')({
   loader: async ({ location, params, deps }): Promise<CrawlerListData> => {
     await requireCurrentUser({
       locale: params.locale,
-      nextPath: getWorkspaceNextPath(params, location.pathname),
+      nextPath: getWorkspaceNextPath(params, location.pathname, 'crawlers'),
     });
 
     const workspace = await resolveWorkspace({ data: { wsId: params.wsId } });

--- a/apps/tanstack-web/src/routes/$locale/$wsId/crawlers.tsx
+++ b/apps/tanstack-web/src/routes/$locale/$wsId/crawlers.tsx
@@ -11,6 +11,19 @@ import { resolveMessagesLocale } from '@/lib/platform/messages';
 import { resolveWorkspace } from '@/lib/platform/workspace';
 import { requireWorkspacePermission } from '@/lib/platform/workspace-permission';
 
+function getWorkspaceNextPath(
+  params: { locale: string; wsId: string },
+  pathname: string
+) {
+  const localePrefix = `/${params.locale}`;
+
+  if (pathname.startsWith(`${localePrefix}/`)) {
+    return pathname.slice(localePrefix.length);
+  }
+
+  return `/${params.wsId}/crawlers`;
+}
+
 export const Route = createFileRoute('/$locale/$wsId/crawlers')({
   component: CrawlerListRoutePage,
   validateSearch: validateCrawlerListSearch,
@@ -29,10 +42,10 @@ export const Route = createFileRoute('/$locale/$wsId/crawlers')({
       title: 'Crawlers',
     });
   },
-  loader: async ({ params, deps }): Promise<CrawlerListData> => {
+  loader: async ({ location, params, deps }): Promise<CrawlerListData> => {
     await requireCurrentUser({
       locale: params.locale,
-      nextPath: `/${params.wsId}/crawlers`,
+      nextPath: getWorkspaceNextPath(params, location.pathname),
     });
 
     const workspace = await resolveWorkspace({ data: { wsId: params.wsId } });

--- a/apps/teach/messages/en.json
+++ b/apps/teach/messages/en.json
@@ -304,6 +304,7 @@
       "loadFilesError": "Failed to load files.",
       "loadingFiles": "Loading files…",
       "noFilesFound": "No files found.",
+      "saveFailed": "Failed to save lesson. Please try again.",
       "selectAtLeastOneFile": "Select at least one file"
     },
     "loadError": "Failed to load courses. Please try again.",

--- a/apps/teach/messages/vi.json
+++ b/apps/teach/messages/vi.json
@@ -304,6 +304,7 @@
       "loadFilesError": "Không thể tải danh sách tệp.",
       "loadingFiles": "Đang tải tệp…",
       "noFilesFound": "Không tìm thấy tệp.",
+      "saveFailed": "Không thể lưu bài học. Vui lòng thử lại.",
       "selectAtLeastOneFile": "Vui lòng chọn ít nhất một tệp"
     },
     "loadError": "Không tải được khóa học. Vui lòng thử lại.",

--- a/apps/teach/src/app/[locale]/(dashboard)/[wsId]/modules/[moduleId]/[lessonId]/use-lesson-detail.ts
+++ b/apps/teach/src/app/[locale]/(dashboard)/[wsId]/modules/[moduleId]/[lessonId]/use-lesson-detail.ts
@@ -5,12 +5,20 @@ import {
   listWorkspaceCourseModules,
   updateWorkspaceCourseModule,
 } from '@tuturuuu/internal-api/education';
+import type { WorkspaceCourseModule } from '@tuturuuu/types/db';
 import type { JSONContent } from '@tuturuuu/types/tiptap';
 import { toast } from '@tuturuuu/ui/sonner';
 import { useCallback, useEffect, useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
 const SAVE_DEBOUNCE_MS = 800;
+
+type LessonUpdatePayload = Partial<
+  Pick<
+    WorkspaceCourseModule,
+    'content' | 'is_published' | 'name' | 'youtube_links'
+  >
+>;
 
 // ─── Query key ────────────────────────────────────────────────────────────────
 
@@ -124,13 +132,13 @@ export function useLessonDetail(
   // ─── Save mutation ──────────────────────────────────────────────────────────
 
   const saveMutation = useMutation({
-    mutationFn: async (payload: Record<string, unknown>) =>
+    mutationFn: async (payload: LessonUpdatePayload) =>
       updateWorkspaceCourseModule(wsId, lessonId, payload),
     onError: () => {
       toast.error('Failed to save lesson. Please try again.');
     },
     onSuccess: (_, variables) => {
-      qc.setQueryData<any[] | undefined>(
+      qc.setQueryData<WorkspaceCourseModule[] | undefined>(
         lessonQueryKey(wsId, courseId),
         (old) => {
           if (!old) return old;
@@ -139,6 +147,7 @@ export function useLessonDetail(
           );
         }
       );
+      void qc.invalidateQueries({ queryKey: lessonQueryKey(wsId, courseId) });
     },
   });
 

--- a/apps/teach/src/app/[locale]/(dashboard)/[wsId]/modules/[moduleId]/[lessonId]/use-lesson-detail.ts
+++ b/apps/teach/src/app/[locale]/(dashboard)/[wsId]/modules/[moduleId]/[lessonId]/use-lesson-detail.ts
@@ -8,6 +8,7 @@ import {
 import type { WorkspaceCourseModule } from '@tuturuuu/types/db';
 import type { JSONContent } from '@tuturuuu/types/tiptap';
 import { toast } from '@tuturuuu/ui/sonner';
+import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -35,6 +36,7 @@ export function useLessonDetail(
   courseId: string,
   lessonId: string
 ) {
+  const t = useTranslations('teachModules.lesson');
   const qc = useQueryClient();
 
   // Fetch all modules for the course and find this one
@@ -135,7 +137,7 @@ export function useLessonDetail(
     mutationFn: async (payload: LessonUpdatePayload) =>
       updateWorkspaceCourseModule(wsId, lessonId, payload),
     onError: () => {
-      toast.error('Failed to save lesson. Please try again.');
+      toast.error(t('saveFailed'));
     },
     onSuccess: (_, variables) => {
       qc.setQueryData<WorkspaceCourseModule[] | undefined>(

--- a/apps/teach/src/app/[locale]/(dashboard)/[wsId]/modules/[moduleId]/[lessonId]/use-lesson-detail.ts
+++ b/apps/teach/src/app/[locale]/(dashboard)/[wsId]/modules/[moduleId]/[lessonId]/use-lesson-detail.ts
@@ -129,8 +129,16 @@ export function useLessonDetail(
     onError: () => {
       toast.error('Failed to save lesson. Please try again.');
     },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: lessonQueryKey(wsId, courseId) });
+    onSuccess: (_, variables) => {
+      qc.setQueryData<any[] | undefined>(
+        lessonQueryKey(wsId, courseId),
+        (old) => {
+          if (!old) return old;
+          return old.map((m) =>
+            m.id === lessonId ? { ...m, ...variables } : m
+          );
+        }
+      );
     },
   });
 

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/education/courses/[courseId]/modules/[moduleId]/content/content-editor.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/education/courses/[courseId]/modules/[moduleId]/content/content-editor.tsx
@@ -9,7 +9,7 @@ import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
-const CONTENT_SAVE_DEBOUNCE_MS = 500;
+const CONTENT_SAVE_DEBOUNCE_MS = 2000;
 
 interface Props {
   wsId: string;

--- a/apps/web/src/app/[locale]/(marketing)/share/[type]/[resourceId]/content-editor.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/share/[type]/[resourceId]/content-editor.tsx
@@ -9,7 +9,7 @@ import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
-const CONTENT_SAVE_DEBOUNCE_MS = 500;
+const CONTENT_SAVE_DEBOUNCE_MS = 2000;
 
 interface Props {
   wsId: string;

--- a/packages/ui/src/components/ui/text-editor/editor.tsx
+++ b/packages/ui/src/components/ui/text-editor/editor.tsx
@@ -562,6 +562,11 @@ export function RichTextEditor({
   useEffect(() => {
     if (!editor || allowCollaboration) return;
 
+    // Skip sync if the editor is focused to prevent cursor jumping/content flickering while typing
+    if (editor.isFocused) {
+      return;
+    }
+
     // Skip sync if we're in a programmatic update (e.g., after converting text to task)
     // This prevents the effect from reverting editor content before state update propagates
     if (isProgrammaticUpdateRef.current) {

--- a/packages/ui/src/components/ui/text-editor/editor.tsx
+++ b/packages/ui/src/components/ui/text-editor/editor.tsx
@@ -58,6 +58,10 @@ function syncEditorContent(editor: Editor, nextContent: JSONContent | null) {
   }
 }
 
+function serializeEditorContent(content: JSONContent | null) {
+  return JSON.stringify(content ?? { type: 'doc', content: [] });
+}
+
 interface RichTextEditorProps {
   content: JSONContent | null;
   onChange?: (content: JSONContent | null) => void;
@@ -145,6 +149,7 @@ export function RichTextEditor({
   const isProgrammaticUpdateRef = useRef(false);
   const hasDeferredExternalContentRef = useRef(false);
   const deferredExternalContentRef = useRef<JSONContent | null>(null);
+  const deferredEditorSnapshotRef = useRef<string | null>(null);
   const getDelegatedImageUpload = useCallback(
     () => onImageUploadRef.current,
     []
@@ -586,10 +591,16 @@ export function RichTextEditor({
       isProgrammaticUpdateRef.current = false;
       hasDeferredExternalContentRef.current = false;
       deferredExternalContentRef.current = null;
+      deferredEditorSnapshotRef.current = null;
       return;
     }
 
     if (editor.isFocused) {
+      if (!hasDeferredExternalContentRef.current) {
+        deferredEditorSnapshotRef.current = serializeEditorContent(
+          editor.getJSON()
+        );
+      }
       hasDeferredExternalContentRef.current = true;
       deferredExternalContentRef.current = content;
       return;
@@ -597,6 +608,7 @@ export function RichTextEditor({
 
     hasDeferredExternalContentRef.current = false;
     deferredExternalContentRef.current = null;
+    deferredEditorSnapshotRef.current = null;
     syncEditorContent(editor, content);
   }, [editor, content, allowCollaboration]);
 
@@ -608,7 +620,17 @@ export function RichTextEditor({
 
       hasDeferredExternalContentRef.current = false;
       const deferredContent = deferredExternalContentRef.current;
+      const deferredEditorSnapshot = deferredEditorSnapshotRef.current;
       deferredExternalContentRef.current = null;
+      deferredEditorSnapshotRef.current = null;
+
+      if (
+        deferredEditorSnapshot !== null &&
+        serializeEditorContent(editor.getJSON()) !== deferredEditorSnapshot
+      ) {
+        return;
+      }
+
       syncEditorContent(editor, deferredContent);
     };
 

--- a/packages/ui/src/components/ui/text-editor/editor.tsx
+++ b/packages/ui/src/components/ui/text-editor/editor.tsx
@@ -42,6 +42,22 @@ const hasContent = (node: JSONContent): boolean => {
   return false;
 };
 
+function syncEditorContent(editor: Editor, nextContent: JSONContent | null) {
+  const migratedContent = migrateInlineImagesToBlock(nextContent);
+  const currentContent = editor.getJSON();
+  const contentChanged =
+    JSON.stringify(currentContent) !== JSON.stringify(migratedContent);
+
+  if (contentChanged) {
+    editor.commands.setContent(
+      migratedContent || { type: 'doc', content: [] },
+      {
+        emitUpdate: false,
+      }
+    );
+  }
+}
+
 interface RichTextEditorProps {
   content: JSONContent | null;
   onChange?: (content: JSONContent | null) => void;
@@ -127,6 +143,8 @@ export function RichTextEditor({
   const debouncedOnChangeRef = useRef<ReturnType<typeof debounce> | null>(null);
   // Track when we're in a programmatic update to skip content sync
   const isProgrammaticUpdateRef = useRef(false);
+  const hasDeferredExternalContentRef = useRef(false);
+  const deferredExternalContentRef = useRef<JSONContent | null>(null);
   const getDelegatedImageUpload = useCallback(
     () => onImageUploadRef.current,
     []
@@ -562,34 +580,44 @@ export function RichTextEditor({
   useEffect(() => {
     if (!editor || allowCollaboration) return;
 
-    // Skip sync if the editor is focused to prevent cursor jumping/content flickering while typing
-    if (editor.isFocused) {
-      return;
-    }
-
     // Skip sync if we're in a programmatic update (e.g., after converting text to task)
     // This prevents the effect from reverting editor content before state update propagates
     if (isProgrammaticUpdateRef.current) {
       isProgrammaticUpdateRef.current = false;
+      hasDeferredExternalContentRef.current = false;
+      deferredExternalContentRef.current = null;
       return;
     }
 
-    // Migrate inline images to block-level for backward compatibility
-    const migratedContent = migrateInlineImagesToBlock(content);
-    const currentContent = editor.getJSON();
-    const contentChanged =
-      JSON.stringify(currentContent) !== JSON.stringify(migratedContent);
-
-    if (contentChanged) {
-      // Update editor content without triggering onChange
-      editor.commands.setContent(
-        migratedContent || { type: 'doc', content: [] },
-        {
-          emitUpdate: false,
-        }
-      );
+    if (editor.isFocused) {
+      hasDeferredExternalContentRef.current = true;
+      deferredExternalContentRef.current = content;
+      return;
     }
+
+    hasDeferredExternalContentRef.current = false;
+    deferredExternalContentRef.current = null;
+    syncEditorContent(editor, content);
   }, [editor, content, allowCollaboration]);
+
+  useEffect(() => {
+    if (!editor || allowCollaboration) return;
+
+    const syncDeferredContent = () => {
+      if (!hasDeferredExternalContentRef.current) return;
+
+      hasDeferredExternalContentRef.current = false;
+      const deferredContent = deferredExternalContentRef.current;
+      deferredExternalContentRef.current = null;
+      syncEditorContent(editor, deferredContent);
+    };
+
+    editor.on('blur', syncDeferredContent);
+
+    return () => {
+      editor.off('blur', syncDeferredContent);
+    };
+  }, [editor, allowCollaboration]);
 
   // Handle initial cursor positioning when focusing from title
   useEffect(() => {


### PR DESCRIPTION
…in lesson hooks, and prevent editor focus conflicts during sync

# Description

<!-- Provide a brief overview of the changes in this PR -->

## What?

<!-- What changes are being made? List the key modifications, new features, or bug fixes -->

## Why?

<!-- Why are these changes necessary? What problem does this solve or what value does it add? -->

## How?

<!-- How were these changes implemented? Explain the approach, technical decisions, or important implementation details -->

## Screenshots for proof (must have)

<!--
REQUIRED: Provide screenshots or recordings that demonstrate:
- The changes have been tested on your local machine
- UI changes (if applicable)
- Before/after comparisons (if applicable)
- Key functionality working as expected

Drag and drop images here or paste them directly
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set content save debounce to 2s and stabilized editor sync to prevent cursor jumps and UI flicker. Improved lesson save flow and routing reliability for nested workspace pages; CI builds are more reliable.

- **Bug Fixes**
  - Increase save debounce to 2000ms in dashboard and share editors.
  - Optimistically update lesson in modules cache; background invalidate. Localized error toast on save failure.
  - Defer external content while focused; sync on blur only if unchanged to prevent cursor jumps/overwrites.
  - Infra/routing: build `@tuturuuu/supabase` before `@tuturuuu/internal-api`, prune Docker caches between images, and preserve full workspace return path after auth via a shared helper.

<sup>Written for commit c3fede9d12fb0bda114540d2c510ee8be2aa43f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/4882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

