### PR TITLE
fix(cms): accept compressed sync manifests

### DIFF
--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/setup/route.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/setup/route.test.ts
@@ -1,3 +1,4 @@
+import { gzipSync } from 'node:zlib';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { accessMocks, logDrainMocks } = vi.hoisted(() => ({
@@ -89,8 +90,9 @@ describe('external project setup route', () => {
       new Request(
         'http://localhost/api/v1/workspaces/ws_123/external-projects/setup',
         {
-          body: JSON.stringify({ manifest }),
+          body: gzipSync(JSON.stringify({ manifest })),
           headers: {
+            'Content-Encoding': 'gzip',
             'Content-Type': 'application/json',
           },
           method: 'POST',

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/setup/route.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/setup/route.ts
@@ -6,7 +6,11 @@ import {
   requireWorkspaceExternalProjectSetupAccess,
 } from '@/lib/external-projects/access';
 import { withRequestLogDrain } from '@/lib/infrastructure/log-drain';
-import { syncManifestSchema } from '../sync/shared';
+import {
+  readSyncJsonRequest,
+  SyncManifestRequestBodyError,
+  syncManifestSchema,
+} from '../sync/shared';
 
 interface Params {
   params: Promise<{
@@ -37,7 +41,9 @@ async function setupExternalProjectStudio(
   if (!access.ok) return access.response;
 
   try {
-    const payload = setupRequestSchema.parse(await request.json());
+    const payload = setupRequestSchema.parse(
+      await readSyncJsonRequest(request)
+    );
     const manifest = payload.manifest;
     const adapter = payload.adapter ?? manifest?.adapter;
 
@@ -64,11 +70,15 @@ async function setupExternalProjectStudio(
       autoSetup: true,
     });
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (
+      error instanceof z.ZodError ||
+      error instanceof SyncManifestRequestBodyError
+    ) {
       return NextResponse.json(
         {
           error: 'Invalid external project setup payload',
-          details: error.flatten(),
+          details:
+            error instanceof z.ZodError ? error.flatten() : error.message,
         },
         { status: 400 }
       );

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/apply/route.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/apply/route.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 import { requireWorkspaceExternalProjectAccess } from '@/lib/external-projects/access';
 import { applyWorkspaceExternalProjectSyncManifest } from '@/lib/external-projects/sync';
 import { withRequestLogDrain } from '@/lib/infrastructure/log-drain';
-import { parseSyncManifestRequest } from '../shared';
+import {
+  readSyncManifestRequest,
+  SyncManifestRequestBodyError,
+} from '../shared';
 
 interface Params {
   params: Promise<{
@@ -21,7 +24,7 @@ async function applyManifest(request: NextRequest, { params }: Params) {
   if (!access.ok) return access.response;
 
   try {
-    const { force, manifest } = parseSyncManifestRequest(await request.json());
+    const { force, manifest } = await readSyncManifestRequest(request);
     const result = await applyWorkspaceExternalProjectSyncManifest(
       {
         actorId: access.user.id,
@@ -35,11 +38,15 @@ async function applyManifest(request: NextRequest, { params }: Params) {
 
     return NextResponse.json(result);
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (
+      error instanceof z.ZodError ||
+      error instanceof SyncManifestRequestBodyError
+    ) {
       return NextResponse.json(
         {
           error: 'Invalid external project sync manifest',
-          details: error.flatten(),
+          details:
+            error instanceof z.ZodError ? error.flatten() : error.message,
         },
         { status: 400 }
       );

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/diff/route.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/diff/route.ts
@@ -6,7 +6,10 @@ import {
   getWorkspaceExternalProjectSyncSnapshot,
 } from '@/lib/external-projects/sync';
 import { withRequestLogDrain } from '@/lib/infrastructure/log-drain';
-import { parseSyncManifestRequest } from '../shared';
+import {
+  readSyncManifestRequest,
+  SyncManifestRequestBodyError,
+} from '../shared';
 
 interface Params {
   params: Promise<{
@@ -24,7 +27,7 @@ async function diffManifest(request: NextRequest, { params }: Params) {
   if (!access.ok) return access.response;
 
   try {
-    const { manifest } = parseSyncManifestRequest(await request.json());
+    const { manifest } = await readSyncManifestRequest(request);
     const snapshot = await getWorkspaceExternalProjectSyncSnapshot(
       {
         binding: access.binding,
@@ -35,11 +38,15 @@ async function diffManifest(request: NextRequest, { params }: Params) {
 
     return NextResponse.json(buildExternalProjectSyncDiff(snapshot, manifest));
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (
+      error instanceof z.ZodError ||
+      error instanceof SyncManifestRequestBodyError
+    ) {
       return NextResponse.json(
         {
           error: 'Invalid external project sync manifest',
-          details: error.flatten(),
+          details:
+            error instanceof z.ZodError ? error.flatten() : error.message,
         },
         { status: 400 }
       );

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.test.ts
@@ -13,6 +13,18 @@ const manifest = {
 } as const;
 
 describe('readSyncManifestRequest', () => {
+  it('parses an identity-encoded manifest request', async () => {
+    const request = new Request('https://example.com/sync', {
+      body: JSON.stringify({ manifest }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+
+    await expect(readSyncManifestRequest(request)).resolves.toEqual({
+      manifest,
+    });
+  });
+
   it('parses a gzip-compressed manifest request', async () => {
     const body = gzipSync(JSON.stringify({ force: true, manifest }));
     const request = new Request('https://example.com/sync', {
@@ -34,6 +46,39 @@ describe('readSyncManifestRequest', () => {
     const request = new Request('https://example.com/sync', {
       body: JSON.stringify({ manifest }),
       headers: { 'Content-Encoding': 'br' },
+      method: 'POST',
+    });
+
+    await expect(readSyncManifestRequest(request)).rejects.toBeInstanceOf(
+      SyncManifestRequestBodyError
+    );
+  });
+
+  it.each([
+    {
+      body: Buffer.from('not-gzip'),
+      contentEncoding: 'gzip',
+      name: 'invalid gzip data',
+    },
+    {
+      body: gzipSync('{ invalid json'),
+      contentEncoding: 'gzip',
+      name: 'invalid gzip JSON',
+    },
+    {
+      body: '{ invalid json',
+      contentEncoding: 'identity',
+      name: 'invalid identity JSON',
+    },
+    {
+      body: gzipSync('x'.repeat(16 * 1024 * 1024 + 1)),
+      contentEncoding: 'gzip',
+      name: 'an oversized decompressed body',
+    },
+  ])('rejects $name', async ({ body, contentEncoding }) => {
+    const request = new Request('https://example.com/sync', {
+      body,
+      headers: { 'Content-Encoding': contentEncoding },
       method: 'POST',
     });
 

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.test.ts
@@ -1,0 +1,44 @@
+import { gzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import {
+  readSyncManifestRequest,
+  SyncManifestRequestBodyError,
+} from './shared';
+
+const manifest = {
+  adapter: 'exocorpse',
+  content: { entries: [] },
+  schema: { collections: [] },
+  version: 1,
+} as const;
+
+describe('readSyncManifestRequest', () => {
+  it('parses a gzip-compressed manifest request', async () => {
+    const body = gzipSync(JSON.stringify({ force: true, manifest }));
+    const request = new Request('https://example.com/sync', {
+      body,
+      headers: {
+        'Content-Encoding': 'gzip',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    await expect(readSyncManifestRequest(request)).resolves.toEqual({
+      force: true,
+      manifest,
+    });
+  });
+
+  it('rejects unsupported content encodings', async () => {
+    const request = new Request('https://example.com/sync', {
+      body: JSON.stringify({ manifest }),
+      headers: { 'Content-Encoding': 'br' },
+      method: 'POST',
+    });
+
+    await expect(readSyncManifestRequest(request)).rejects.toBeInstanceOf(
+      SyncManifestRequestBodyError
+    );
+  });
+});

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.test.ts
@@ -54,6 +54,21 @@ describe('readSyncManifestRequest', () => {
     );
   });
 
+  it('rejects an oversized compressed request before buffering it', async () => {
+    const request = new Request('https://example.com/sync', {
+      body: gzipSync(JSON.stringify({ manifest })),
+      headers: {
+        'Content-Encoding': 'gzip',
+        'Content-Length': String(4 * 1024 * 1024 + 1),
+      },
+      method: 'POST',
+    });
+
+    await expect(readSyncManifestRequest(request)).rejects.toBeInstanceOf(
+      SyncManifestRequestBodyError
+    );
+  });
+
   it.each([
     {
       body: Buffer.from('not-gzip'),

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.ts
@@ -139,7 +139,13 @@ export async function readSyncManifestRequest(request: Request): Promise<{
     request.headers.get('content-encoding')?.trim().toLowerCase() ?? 'identity';
 
   if (contentEncoding === 'identity') {
-    return parseSyncManifestRequest(await request.json());
+    let payload: unknown;
+    try {
+      payload = await request.json();
+    } catch {
+      throw new SyncManifestRequestBodyError('Invalid JSON sync manifest');
+    }
+    return parseSyncManifestRequest(payload);
   }
 
   if (contentEncoding !== 'gzip') {

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.ts
@@ -1,3 +1,4 @@
+import { gunzipSync } from 'node:zlib';
 import type { ExternalProjectSyncManifest } from '@tuturuuu/types';
 import { z } from 'zod';
 import { EXTERNAL_PROJECT_ADAPTER_OPTIONS } from '@/lib/external-projects/constants';
@@ -114,6 +115,10 @@ export const syncManifestRequestSchema = z.object({
   manifest: syncManifestSchema,
 });
 
+const MAX_SYNC_MANIFEST_BYTES = 16 * 1024 * 1024;
+
+export class SyncManifestRequestBodyError extends Error {}
+
 export function parseSyncManifestRequest(value: unknown): {
   force?: boolean;
   manifest: ExternalProjectSyncManifest;
@@ -124,4 +129,42 @@ export function parseSyncManifestRequest(value: unknown): {
     force: parsed.force,
     manifest: parsed.manifest as ExternalProjectSyncManifest,
   };
+}
+
+export async function readSyncManifestRequest(request: Request): Promise<{
+  force?: boolean;
+  manifest: ExternalProjectSyncManifest;
+}> {
+  const contentEncoding =
+    request.headers.get('content-encoding')?.trim().toLowerCase() ?? 'identity';
+
+  if (contentEncoding === 'identity') {
+    return parseSyncManifestRequest(await request.json());
+  }
+
+  if (contentEncoding !== 'gzip') {
+    throw new SyncManifestRequestBodyError(
+      `Unsupported Content-Encoding: ${contentEncoding}`
+    );
+  }
+
+  let decompressed: Buffer;
+  try {
+    decompressed = gunzipSync(Buffer.from(await request.arrayBuffer()), {
+      maxOutputLength: MAX_SYNC_MANIFEST_BYTES,
+    });
+  } catch {
+    throw new SyncManifestRequestBodyError(
+      'Invalid or oversized gzip sync manifest'
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(decompressed.toString('utf8'));
+  } catch {
+    throw new SyncManifestRequestBodyError('Invalid JSON sync manifest');
+  }
+
+  return parseSyncManifestRequest(payload);
 }

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/sync/shared.ts
@@ -116,8 +116,34 @@ export const syncManifestRequestSchema = z.object({
 });
 
 const MAX_SYNC_MANIFEST_BYTES = 16 * 1024 * 1024;
+const MAX_COMPRESSED_SYNC_MANIFEST_BYTES = 4 * 1024 * 1024;
 
 export class SyncManifestRequestBodyError extends Error {}
+
+async function readRequestBytes(request: Request, limit: number) {
+  const contentLength = Number(request.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > limit) {
+    throw new SyncManifestRequestBodyError('Oversized sync manifest');
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) return Buffer.alloc(0);
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > limit) {
+      await reader.cancel();
+      throw new SyncManifestRequestBodyError('Oversized sync manifest');
+    }
+    chunks.push(value);
+  }
+
+  return Buffer.concat(chunks, totalBytes);
+}
 
 export function parseSyncManifestRequest(value: unknown): {
   force?: boolean;
@@ -135,42 +161,40 @@ export async function readSyncManifestRequest(request: Request): Promise<{
   force?: boolean;
   manifest: ExternalProjectSyncManifest;
 }> {
+  return parseSyncManifestRequest(await readSyncJsonRequest(request));
+}
+
+export async function readSyncJsonRequest(request: Request): Promise<unknown> {
   const contentEncoding =
     request.headers.get('content-encoding')?.trim().toLowerCase() ?? 'identity';
 
-  if (contentEncoding === 'identity') {
-    let payload: unknown;
-    try {
-      payload = await request.json();
-    } catch {
-      throw new SyncManifestRequestBodyError('Invalid JSON sync manifest');
-    }
-    return parseSyncManifestRequest(payload);
-  }
-
-  if (contentEncoding !== 'gzip') {
+  if (contentEncoding !== 'identity' && contentEncoding !== 'gzip') {
     throw new SyncManifestRequestBodyError(
       `Unsupported Content-Encoding: ${contentEncoding}`
     );
   }
 
-  let decompressed: Buffer;
+  let decoded: Buffer;
   try {
-    decompressed = gunzipSync(Buffer.from(await request.arrayBuffer()), {
-      maxOutputLength: MAX_SYNC_MANIFEST_BYTES,
-    });
+    const encoded = await readRequestBytes(
+      request,
+      contentEncoding === 'gzip'
+        ? MAX_COMPRESSED_SYNC_MANIFEST_BYTES
+        : MAX_SYNC_MANIFEST_BYTES
+    );
+    decoded =
+      contentEncoding === 'gzip'
+        ? gunzipSync(encoded, { maxOutputLength: MAX_SYNC_MANIFEST_BYTES })
+        : encoded;
   } catch {
     throw new SyncManifestRequestBodyError(
-      'Invalid or oversized gzip sync manifest'
+      'Invalid or oversized sync manifest'
     );
   }
 
-  let payload: unknown;
   try {
-    payload = JSON.parse(decompressed.toString('utf8'));
+    return JSON.parse(decoded.toString('utf8'));
   } catch {
     throw new SyncManifestRequestBodyError('Invalid JSON sync manifest');
   }
-
-  return parseSyncManifestRequest(payload);
 }


### PR DESCRIPTION
## Summary
- accept gzip-compressed external-project sync manifests
- cap decompressed payloads at 16 MiB
- return a validation error for invalid or unsupported encodings

## Verification
- focused sync shared/apply tests pass (5 tests)
- bun check passes all checks