### PR TITLE
fix(cms): batch large project queries

### DIFF
--- a/apps/web/src/lib/external-projects/store.test.ts
+++ b/apps/web/src/lib/external-projects/store.test.ts
@@ -81,6 +81,111 @@ describe('external project store cleanup', () => {
     mocks.deleteWorkspaceStorageObjectByPath.mockResolvedValue(undefined);
   });
 
+  it('loads entry relationships in bounded batches for large projects', async () => {
+    const entryIds = Array.from(
+      { length: 205 },
+      (_, index) => `entry-${index}`
+    );
+    const relationshipBatches: Record<string, string[][]> = {
+      workspace_external_project_assets: [],
+      workspace_external_project_blocks: [],
+    };
+    const collections = [
+      {
+        collection_type: 'characters',
+        config: {},
+        id: 'collection-1',
+        slug: 'characters',
+        title: 'Characters',
+      },
+    ];
+    const entries = entryIds.map((id, index) => ({
+      collection_id: 'collection-1',
+      created_at: '2026-01-01T00:00:00Z',
+      id,
+      metadata: {},
+      profile_data: {},
+      slug: `character-${index}`,
+      sort_order: index,
+      source_adapter: 'exocorpse',
+      stable_source_id: id,
+      status: 'published',
+      subtitle: null,
+      summary: null,
+      title: `Character ${index}`,
+    }));
+
+    const db = {
+      from: vi.fn((table: string) => ({
+        select: vi.fn(() => {
+          let selectedIds: string[] | null = null;
+          const query = {
+            eq: vi.fn(() => query),
+            in: vi.fn((_column: string, ids: string[]) => {
+              selectedIds = ids;
+              relationshipBatches[table]?.push(ids);
+              return query;
+            }),
+            limit: vi.fn(() => query),
+            order: vi.fn(() => query),
+          };
+
+          Object.defineProperty(query, 'then', {
+            value: (
+              resolve: (value: { data: unknown[]; error: null }) => unknown,
+              reject?: (reason: unknown) => unknown
+            ) => {
+              let data: unknown[] = [];
+
+              if (table === 'workspace_external_project_collections') {
+                data = collections;
+              } else if (table === 'workspace_external_project_entries') {
+                data = entries;
+              } else if (
+                table === 'workspace_external_project_blocks' &&
+                selectedIds
+              ) {
+                data = selectedIds.map((entryId, index) => ({
+                  block_type: 'markdown',
+                  content: {},
+                  entry_id: entryId,
+                  id: `block-${entryId}`,
+                  sort_order: index,
+                }));
+              }
+
+              return Promise.resolve({ data, error: null }).then(
+                resolve,
+                reject
+              );
+            },
+          });
+
+          return query;
+        }),
+      })),
+    };
+
+    const { getWorkspaceExternalProjectStudioData } = await import('./store');
+    const studio = await getWorkspaceExternalProjectStudioData(
+      'workspace-1',
+      db as never
+    );
+
+    expect(studio.entries).toHaveLength(205);
+    expect(studio.blocks).toHaveLength(205);
+    expect(relationshipBatches.workspace_external_project_blocks).toEqual([
+      entryIds.slice(0, 100),
+      entryIds.slice(100, 200),
+      entryIds.slice(200),
+    ]);
+    expect(relationshipBatches.workspace_external_project_assets).toEqual([
+      entryIds.slice(0, 100),
+      entryIds.slice(100, 200),
+      entryIds.slice(200),
+    ]);
+  });
+
   it('excludes private delivery collections and entries from public delivery payloads', async () => {
     const collections = [
       {

--- a/apps/web/src/lib/external-projects/store.ts
+++ b/apps/web/src/lib/external-projects/store.ts
@@ -274,6 +274,24 @@ const EPM_IMAGE_PREVIEW_TRANSFORM = {
   resize: 'cover',
 } satisfies ImageTransformOptions;
 
+const EXTERNAL_PROJECT_ID_QUERY_BATCH_SIZE = 100;
+
+function chunkExternalProjectIds(ids: string[]) {
+  const batches: string[][] = [];
+
+  for (
+    let index = 0;
+    index < ids.length;
+    index += EXTERNAL_PROJECT_ID_QUERY_BATCH_SIZE
+  ) {
+    batches.push(
+      ids.slice(index, index + EXTERNAL_PROJECT_ID_QUERY_BATCH_SIZE)
+    );
+  }
+
+  return batches;
+}
+
 function buildYoolaLoadingData(
   collections: ExternalProjectDeliveryCollection[]
 ): ExternalProjectLoadingData {
@@ -522,18 +540,24 @@ async function listWorkspaceExternalProjectBlocksByEntryIds(
     return [];
   }
 
-  const { data, error } = await db
-    .from('workspace_external_project_blocks')
-    .select('*')
-    .eq('ws_id', workspaceId)
-    .in('entry_id', entryIds)
-    .order('sort_order', { ascending: true });
+  const blocks = [];
 
-  if (error) {
-    throw new Error(error.message);
+  for (const entryIdBatch of chunkExternalProjectIds(entryIds)) {
+    const { data, error } = await db
+      .from('workspace_external_project_blocks')
+      .select('*')
+      .eq('ws_id', workspaceId)
+      .in('entry_id', entryIdBatch)
+      .order('sort_order', { ascending: true });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    blocks.push(...(data ?? []));
   }
 
-  return data ?? [];
+  return blocks;
 }
 
 async function listWorkspaceExternalProjectAssetsByEntryIds(
@@ -545,18 +569,24 @@ async function listWorkspaceExternalProjectAssetsByEntryIds(
     return [];
   }
 
-  const { data, error } = await db
-    .from('workspace_external_project_assets')
-    .select('*')
-    .eq('ws_id', workspaceId)
-    .in('entry_id', entryIds)
-    .order('sort_order', { ascending: true });
+  const assets = [];
 
-  if (error) {
-    throw new Error(error.message);
+  for (const entryIdBatch of chunkExternalProjectIds(entryIds)) {
+    const { data, error } = await db
+      .from('workspace_external_project_assets')
+      .select('*')
+      .eq('ws_id', workspaceId)
+      .in('entry_id', entryIdBatch)
+      .order('sort_order', { ascending: true });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    assets.push(...(data ?? []));
   }
 
-  return data ?? [];
+  return assets;
 }
 
 export async function listCanonicalExternalProjects(db?: AdminDb) {

--- a/apps/web/src/lib/external-projects/store.ts
+++ b/apps/web/src/lib/external-projects/store.ts
@@ -275,6 +275,7 @@ const EPM_IMAGE_PREVIEW_TRANSFORM = {
 } satisfies ImageTransformOptions;
 
 const EXTERNAL_PROJECT_ID_QUERY_BATCH_SIZE = 100;
+const EXTERNAL_PROJECT_QUERY_CONCURRENCY = 4;
 
 function chunkExternalProjectIds(ids: string[]) {
   const batches: string[][] = [];
@@ -541,20 +542,33 @@ async function listWorkspaceExternalProjectBlocksByEntryIds(
   }
 
   const blocks = [];
+  const entryIdBatches = chunkExternalProjectIds(entryIds);
 
-  for (const entryIdBatch of chunkExternalProjectIds(entryIds)) {
-    const { data, error } = await db
-      .from('workspace_external_project_blocks')
-      .select('*')
-      .eq('ws_id', workspaceId)
-      .in('entry_id', entryIdBatch)
-      .order('sort_order', { ascending: true });
+  for (
+    let index = 0;
+    index < entryIdBatches.length;
+    index += EXTERNAL_PROJECT_QUERY_CONCURRENCY
+  ) {
+    const results = await Promise.all(
+      entryIdBatches
+        .slice(index, index + EXTERNAL_PROJECT_QUERY_CONCURRENCY)
+        .map(async (entryIdBatch) => {
+          const { data, error } = await db
+            .from('workspace_external_project_blocks')
+            .select('*')
+            .eq('ws_id', workspaceId)
+            .in('entry_id', entryIdBatch)
+            .order('sort_order', { ascending: true });
 
-    if (error) {
-      throw new Error(error.message);
-    }
+          if (error) {
+            throw new Error(error.message);
+          }
 
-    blocks.push(...(data ?? []));
+          return data ?? [];
+        })
+    );
+
+    blocks.push(...results.flat());
   }
 
   return blocks;
@@ -570,20 +584,33 @@ async function listWorkspaceExternalProjectAssetsByEntryIds(
   }
 
   const assets = [];
+  const entryIdBatches = chunkExternalProjectIds(entryIds);
 
-  for (const entryIdBatch of chunkExternalProjectIds(entryIds)) {
-    const { data, error } = await db
-      .from('workspace_external_project_assets')
-      .select('*')
-      .eq('ws_id', workspaceId)
-      .in('entry_id', entryIdBatch)
-      .order('sort_order', { ascending: true });
+  for (
+    let index = 0;
+    index < entryIdBatches.length;
+    index += EXTERNAL_PROJECT_QUERY_CONCURRENCY
+  ) {
+    const results = await Promise.all(
+      entryIdBatches
+        .slice(index, index + EXTERNAL_PROJECT_QUERY_CONCURRENCY)
+        .map(async (entryIdBatch) => {
+          const { data, error } = await db
+            .from('workspace_external_project_assets')
+            .select('*')
+            .eq('ws_id', workspaceId)
+            .in('entry_id', entryIdBatch)
+            .order('sort_order', { ascending: true });
 
-    if (error) {
-      throw new Error(error.message);
-    }
+          if (error) {
+            throw new Error(error.message);
+          }
 
-    assets.push(...(data ?? []));
+          return data ?? [];
+        })
+    );
+
+    assets.push(...results.flat());
   }
 
   return assets;


### PR DESCRIPTION
## Summary
- batch external-project block and asset lookups to avoid oversized PostgREST filter URLs
- preserve the complete relationship result across batches
- add a 205-entry regression test covering the three-query split

## Verification
- bunx vitest run src/lib/external-projects/store.test.ts (10 passed)
- bun check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch large external-project block and asset queries to avoid oversized PostgREST filter URLs. Limit parallel batch requests to keep big-project syncs reliable.

- **Bug Fixes**
  - Split `entry_id` lookups into batches of 100 and merge results while keeping `sort_order`.
  - Applied batching to `workspace_external_project_blocks` and `workspace_external_project_assets`.
  - Added a 205-entry regression test verifying three batches (100/100/5) and full result integrity.

- **Performance**
  - Capped batch execution to 4 concurrent queries per table to reduce DB load during syncs.

<sup>Written for commit c56e6073c016e39f54d3c257178e025d7611eab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/4960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

