### PR TITLE
fix(cms): paginate external project snapshots

### DIFF
--- a/apps/web/src/lib/external-projects/store.test.ts
+++ b/apps/web/src/lib/external-projects/store.test.ts
@@ -63,6 +63,7 @@ function createOrderedSelectResult<T>(result: T) {
     eq: vi.fn(() => query),
     in: vi.fn(() => query),
     order: vi.fn(() => query),
+    range: vi.fn(() => query),
   };
 
   Object.defineProperty(query, 'then', {
@@ -128,6 +129,7 @@ describe('external project store cleanup', () => {
             }),
             limit: vi.fn(() => query),
             order: vi.fn(() => query),
+            range: vi.fn(() => query),
           };
 
           Object.defineProperty(query, 'then', {
@@ -183,6 +185,56 @@ describe('external project store cleanup', () => {
       entryIds.slice(0, 100),
       entryIds.slice(100, 200),
       entryIds.slice(200),
+    ]);
+  });
+
+  it('loads every entry page when a workspace exceeds the row limit', async () => {
+    const entries = Array.from({ length: 1185 }, (_, index) => ({
+      id: `entry-${index}`,
+      slug: `entry-${index}`,
+    }));
+    const ranges: Array<[number, number]> = [];
+    const db = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => {
+          let selectedRange: [number, number] = [0, 999];
+          const query = {
+            eq: vi.fn(() => query),
+            order: vi.fn(() => query),
+            range: vi.fn((from: number, to: number) => {
+              selectedRange = [from, to];
+              ranges.push(selectedRange);
+              return query;
+            }),
+          };
+
+          Object.defineProperty(query, 'then', {
+            value: (
+              resolve: (value: { data: unknown[]; error: null }) => unknown,
+              reject?: (reason: unknown) => unknown
+            ) =>
+              Promise.resolve({
+                data: entries.slice(selectedRange[0], selectedRange[1] + 1),
+                error: null,
+              }).then(resolve, reject),
+          });
+
+          return query;
+        }),
+      })),
+    };
+
+    const { listWorkspaceExternalProjectEntries } = await import('./store');
+    const result = await listWorkspaceExternalProjectEntries(
+      'workspace-1',
+      { includeDrafts: true },
+      db as never
+    );
+
+    expect(result).toHaveLength(1185);
+    expect(ranges).toEqual([
+      [0, 999],
+      [1000, 1999],
     ]);
   });
 

--- a/apps/web/src/lib/external-projects/store.ts
+++ b/apps/web/src/lib/external-projects/store.ts
@@ -6,7 +6,9 @@ import type {
   Database,
   ExocorpseExternalProjectLoadingCollection,
   ExocorpseExternalProjectLoadingEntry,
+  ExternalProjectAsset,
   ExternalProjectAttentionItem,
+  ExternalProjectBlock,
   ExternalProjectBulkUpdatePayload,
   ExternalProjectCollection,
   ExternalProjectDeliveryCollection,
@@ -276,6 +278,39 @@ const EPM_IMAGE_PREVIEW_TRANSFORM = {
 
 const EXTERNAL_PROJECT_ID_QUERY_BATCH_SIZE = 100;
 const EXTERNAL_PROJECT_QUERY_CONCURRENCY = 4;
+const EXTERNAL_PROJECT_QUERY_PAGE_SIZE = 1000;
+
+type ExternalProjectPageResult<T> = {
+  data: T[] | null;
+  error: { message: string } | null;
+};
+
+async function fetchAllExternalProjectRows<T>(
+  loadPage: (
+    from: number,
+    to: number
+  ) => PromiseLike<ExternalProjectPageResult<T>>
+) {
+  const rows: T[] = [];
+
+  for (let from = 0; ; from += EXTERNAL_PROJECT_QUERY_PAGE_SIZE) {
+    const { data, error } = await loadPage(
+      from,
+      from + EXTERNAL_PROJECT_QUERY_PAGE_SIZE - 1
+    );
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const page = data ?? [];
+    rows.push(...page);
+
+    if (page.length < EXTERNAL_PROJECT_QUERY_PAGE_SIZE) {
+      return rows;
+    }
+  }
+}
 
 function chunkExternalProjectIds(ids: string[]) {
   const batches: string[][] = [];
@@ -552,20 +587,17 @@ async function listWorkspaceExternalProjectBlocksByEntryIds(
     const results = await Promise.all(
       entryIdBatches
         .slice(index, index + EXTERNAL_PROJECT_QUERY_CONCURRENCY)
-        .map(async (entryIdBatch) => {
-          const { data, error } = await db
-            .from('workspace_external_project_blocks')
-            .select('*')
-            .eq('ws_id', workspaceId)
-            .in('entry_id', entryIdBatch)
-            .order('sort_order', { ascending: true });
-
-          if (error) {
-            throw new Error(error.message);
-          }
-
-          return data ?? [];
-        })
+        .map((entryIdBatch) =>
+          fetchAllExternalProjectRows<ExternalProjectBlock>((from, to) =>
+            db
+              .from('workspace_external_project_blocks')
+              .select('*')
+              .eq('ws_id', workspaceId)
+              .in('entry_id', entryIdBatch)
+              .order('sort_order', { ascending: true })
+              .range(from, to)
+          )
+        )
     );
 
     blocks.push(...results.flat());
@@ -594,20 +626,17 @@ async function listWorkspaceExternalProjectAssetsByEntryIds(
     const results = await Promise.all(
       entryIdBatches
         .slice(index, index + EXTERNAL_PROJECT_QUERY_CONCURRENCY)
-        .map(async (entryIdBatch) => {
-          const { data, error } = await db
-            .from('workspace_external_project_assets')
-            .select('*')
-            .eq('ws_id', workspaceId)
-            .in('entry_id', entryIdBatch)
-            .order('sort_order', { ascending: true });
-
-          if (error) {
-            throw new Error(error.message);
-          }
-
-          return data ?? [];
-        })
+        .map((entryIdBatch) =>
+          fetchAllExternalProjectRows<ExternalProjectAsset>((from, to) =>
+            db
+              .from('workspace_external_project_assets')
+              .select('*')
+              .eq('ws_id', workspaceId)
+              .in('entry_id', entryIdBatch)
+              .order('sort_order', { ascending: true })
+              .range(from, to)
+          )
+        )
     );
 
     assets.push(...results.flat());
@@ -750,17 +779,14 @@ export async function listWorkspaceExternalProjectCollections(
   db?: AdminDb
 ) {
   const admin = db ?? ((await createAdminClient()) as TypedSupabaseClient);
-  const { data, error } = await admin
-    .from('workspace_external_project_collections')
-    .select('*')
-    .eq('ws_id', workspaceId)
-    .order('title', { ascending: true });
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  return data;
+  return fetchAllExternalProjectRows<ExternalProjectCollection>((from, to) =>
+    admin
+      .from('workspace_external_project_collections')
+      .select('*')
+      .eq('ws_id', workspaceId)
+      .order('title', { ascending: true })
+      .range(from, to)
+  );
 }
 
 export async function listWorkspaceExternalProjectFieldDefinitions(
@@ -772,31 +798,29 @@ export async function listWorkspaceExternalProjectFieldDefinitions(
   db?: AdminDb
 ) {
   const admin = db ?? ((await createAdminClient()) as TypedSupabaseClient);
-  let query = admin
-    .from('workspace_external_project_field_definitions')
-    .select('*')
-    .eq('ws_id', workspaceId)
-    .order('sort_order', { ascending: true })
-    .order('created_at', { ascending: true });
+  return fetchAllExternalProjectRows<ExternalProjectFieldDefinition>(
+    (from, to) => {
+      let query = admin
+        .from('workspace_external_project_field_definitions')
+        .select('*')
+        .eq('ws_id', workspaceId)
+        .order('sort_order', { ascending: true })
+        .order('created_at', { ascending: true });
 
-  if (Object.hasOwn(options, 'collectionId')) {
-    query =
-      options.collectionId === null
-        ? query.is('collection_id', null)
-        : query.eq('collection_id', options.collectionId as string);
-  }
+      if (Object.hasOwn(options, 'collectionId')) {
+        query =
+          options.collectionId === null
+            ? query.is('collection_id', null)
+            : query.eq('collection_id', options.collectionId as string);
+      }
 
-  if (!options.includeDisabled) {
-    query = query.eq('is_enabled', true);
-  }
+      if (!options.includeDisabled) {
+        query = query.eq('is_enabled', true);
+      }
 
-  const { data, error } = await query;
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  return data ?? [];
+      return query.range(from, to);
+    }
+  );
 }
 
 export async function listWorkspaceExternalProjectEntries(
@@ -808,28 +832,24 @@ export async function listWorkspaceExternalProjectEntries(
   db?: AdminDb
 ) {
   const admin = db ?? ((await createAdminClient()) as TypedSupabaseClient);
-  let query = admin
-    .from('workspace_external_project_entries')
-    .select('*')
-    .eq('ws_id', workspaceId)
-    .order('sort_order', { ascending: true })
-    .order('created_at', { ascending: true });
+  return fetchAllExternalProjectRows<ExternalProjectEntry>((from, to) => {
+    let query = admin
+      .from('workspace_external_project_entries')
+      .select('*')
+      .eq('ws_id', workspaceId)
+      .order('sort_order', { ascending: true })
+      .order('created_at', { ascending: true });
 
-  if (options.collectionId) {
-    query = query.eq('collection_id', options.collectionId);
-  }
+    if (options.collectionId) {
+      query = query.eq('collection_id', options.collectionId);
+    }
 
-  if (!options.includeDrafts) {
-    query = query.eq('status', 'published');
-  }
+    if (!options.includeDrafts) {
+      query = query.eq('status', 'published');
+    }
 
-  const { data, error } = await query;
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  return data;
+    return query.range(from, to);
+  });
 }
 
 export async function getWorkspaceExternalProjectStudioData(

--- a/apps/web/src/lib/external-projects/store.ts
+++ b/apps/web/src/lib/external-projects/store.ts
@@ -595,6 +595,7 @@ async function listWorkspaceExternalProjectBlocksByEntryIds(
               .eq('ws_id', workspaceId)
               .in('entry_id', entryIdBatch)
               .order('sort_order', { ascending: true })
+              .order('id', { ascending: true })
               .range(from, to)
           )
         )
@@ -634,6 +635,7 @@ async function listWorkspaceExternalProjectAssetsByEntryIds(
               .eq('ws_id', workspaceId)
               .in('entry_id', entryIdBatch)
               .order('sort_order', { ascending: true })
+              .order('id', { ascending: true })
               .range(from, to)
           )
         )
@@ -785,6 +787,7 @@ export async function listWorkspaceExternalProjectCollections(
       .select('*')
       .eq('ws_id', workspaceId)
       .order('title', { ascending: true })
+      .order('id', { ascending: true })
       .range(from, to)
   );
 }
@@ -805,7 +808,8 @@ export async function listWorkspaceExternalProjectFieldDefinitions(
         .select('*')
         .eq('ws_id', workspaceId)
         .order('sort_order', { ascending: true })
-        .order('created_at', { ascending: true });
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true });
 
       if (Object.hasOwn(options, 'collectionId')) {
         query =
@@ -838,7 +842,8 @@ export async function listWorkspaceExternalProjectEntries(
       .select('*')
       .eq('ws_id', workspaceId)
       .order('sort_order', { ascending: true })
-      .order('created_at', { ascending: true });
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true });
 
     if (options.collectionId) {
       query = query.eq('collection_id', options.collectionId);


### PR DESCRIPTION
## Summary
- paginate external project collections, entries, and field definitions past PostgREST's 1,000-row cap
- paginate block and asset results inside bounded entry-ID batches
- add a regression test proving an 1,185-entry workspace loads both pages

## Production evidence
- Exocorpse CMS contains 1,185 entries
- the live diff only loaded 1,000 and falsely reported 185 creates
- independent stable-ID and collection/slug comparison found zero actual collisions

## Verification
- `bunx vitest run src/lib/external-projects/store.test.ts` (11 passed)
- `bun check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginated and stabilized external project snapshots to bypass PostgREST’s 1,000-row cap so large workspaces load completely and consistently. Prevents false “create” diffs by fetching all collections, entries, blocks, and assets with deterministic ordering.

- **Bug Fixes**
  - Added a `fetchAllExternalProjectRows` helper (1,000/page via `.range()`) and applied it to collections, field definitions, entries, blocks, and assets.
  - Stabilized page ordering by appending `.order('id', { ascending: true })` after existing sorts to prevent shuffling across pages.
  - Added a regression test that loads 1,185 entries across two pages and verifies the exact ranges returned.

<sup>Written for commit b839bf67bc1be0cf8378055254ddf42923257402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/4962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

