### PR TITLE
fix(cms): canonicalize sync schemas

### DIFF
--- a/apps/backend/src/workspaces_external_projects_sync_snapshot/schema_helpers.rs
+++ b/apps/backend/src/workspaces_external_projects_sync_snapshot/schema_helpers.rs
@@ -37,11 +37,51 @@ fn normalize_collection_schema(value: &Value) -> Value {
         "collection_type": value.get("collection_type").cloned().unwrap_or(Value::Null),
         "config": as_record_value(value.get("config")),
         "description": value.get("description").cloned().unwrap_or(Value::Null),
-        "metadataFields": array_or_empty(value.get("metadataFields")),
-        "profileFields": array_or_empty(value.get("profileFields")),
+        "metadataFields": normalize_sync_fields(value.get("metadataFields")),
+        "profileFields": normalize_sync_fields(value.get("profileFields")),
         "slug": value.get("slug").cloned().unwrap_or(Value::Null),
         "title": value.get("title").cloned().unwrap_or(Value::Null),
     })
+}
+
+fn normalize_sync_fields(value: Option<&Value>) -> Value {
+    Value::Array(
+        value
+            .and_then(Value::as_array)
+            .map(|fields| fields.iter().map(normalize_sync_field).collect())
+            .unwrap_or_default(),
+    )
+}
+
+fn normalize_sync_field(value: &Value) -> Value {
+    let mut field = Map::new();
+    if let Some(default_value) = value.get("defaultValue")
+        && !default_value.is_null()
+    {
+        field.insert("defaultValue".to_owned(), default_value.clone());
+    }
+    field.insert(
+        "description".to_owned(),
+        value.get("description").cloned().unwrap_or(Value::Null),
+    );
+    field.insert(
+        "key".to_owned(),
+        value.get("key").cloned().unwrap_or(Value::Null),
+    );
+    field.insert(
+        "label".to_owned(),
+        value.get("label").cloned().unwrap_or(Value::Null),
+    );
+    field.insert("options".to_owned(), array_or_empty(value.get("options")));
+    field.insert(
+        "required".to_owned(),
+        value.get("required").cloned().unwrap_or(Value::Bool(false)),
+    );
+    field.insert(
+        "type".to_owned(),
+        value.get("type").cloned().unwrap_or(Value::Null),
+    );
+    Value::Object(field)
 }
 
 /// getCollectionSchema:
@@ -252,4 +292,37 @@ pub(super) fn with_field_definitions_from_database(
     schema_map.insert("profileFields".to_owned(), profile_value);
 
     Value::Object(schema_map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_omitted_collection_field_defaults() {
+        let schema = normalize_collection_schema(&json!({
+            "collection_type": "characters",
+            "metadataFields": [],
+            "profileFields": [{
+                "defaultValue": null,
+                "key": "brand",
+                "label": "Brand",
+                "type": "string"
+            }],
+            "slug": "characters",
+            "title": "Characters"
+        }));
+
+        assert_eq!(
+            schema.get("profileFields"),
+            Some(&json!([{
+                "description": null,
+                "key": "brand",
+                "label": "Brand",
+                "options": [],
+                "required": false,
+                "type": "string"
+            }]))
+        );
+    }
 }

--- a/apps/web/src/lib/external-projects/sync.test.ts
+++ b/apps/web/src/lib/external-projects/sync.test.ts
@@ -12,6 +12,64 @@ import {
 } from './sync';
 
 describe('external project sync diff', () => {
+  it('treats stored schema ordering and expanded field defaults as equivalent', () => {
+    const snapshot: ExternalProjectSyncSnapshot = {
+      adapter: 'exocorpse',
+      canonicalProjectId: 'exocorpse-main',
+      content: { entries: [] },
+      generatedAt: '2026-07-13T00:00:00.000Z',
+      schema: {
+        collections: [
+          {
+            collection_type: 'worlds',
+            slug: 'worlds',
+            title: 'Worlds',
+          },
+          {
+            collection_type: 'characters',
+            slug: 'characters',
+            title: 'Characters',
+          },
+        ],
+        profileFields: [
+          {
+            description: null,
+            key: 'brand',
+            label: 'Brand',
+            options: [],
+            required: false,
+            type: 'string',
+          },
+        ],
+      },
+      version: 1,
+      workspaceId: 'ws-1',
+    };
+    const manifest = normalizeExternalProjectSyncManifest({
+      adapter: 'exocorpse',
+      content: { entries: [] },
+      schema: {
+        collections: [...snapshot.schema.collections].reverse(),
+        profileFields: [
+          {
+            key: 'brand',
+            label: 'Brand',
+            type: 'string',
+          },
+        ],
+      },
+      version: 1,
+    });
+
+    expect(buildExternalProjectSyncDiff(snapshot, manifest).summary).toEqual({
+      archive: 0,
+      create: 0,
+      delete: 0,
+      noop: 0,
+      update: 0,
+    });
+  });
+
   it('creates, updates, and archives content without hard deletes by default', () => {
     const snapshot: ExternalProjectSyncSnapshot = {
       adapter: 'yoola',

--- a/apps/web/src/lib/external-projects/sync.test.ts
+++ b/apps/web/src/lib/external-projects/sync.test.ts
@@ -52,6 +52,7 @@ describe('external project sync diff', () => {
         collections: [...snapshot.schema.collections].reverse(),
         profileFields: [
           {
+            defaultValue: null,
             key: 'brand',
             label: 'Brand',
             type: 'string',

--- a/apps/web/src/lib/external-projects/sync.ts
+++ b/apps/web/src/lib/external-projects/sync.ts
@@ -143,10 +143,38 @@ function normalizeCollectionSchema(
     collection_type: value.collection_type,
     config: asRecord(value.config),
     description: value.description ?? null,
-    metadataFields: value.metadataFields ?? [],
-    profileFields: value.profileFields ?? [],
+    metadataFields: (value.metadataFields ?? []).map(normalizeSyncField),
+    profileFields: (value.profileFields ?? []).map(normalizeSyncField),
     slug: value.slug,
     title: value.title,
+  };
+}
+
+function normalizeSyncField(
+  value: ExternalProjectSyncField
+): ExternalProjectSyncField {
+  return {
+    ...(value.defaultValue === undefined
+      ? {}
+      : { defaultValue: value.defaultValue }),
+    description: value.description ?? null,
+    key: value.key,
+    label: value.label ?? null,
+    options: value.options ?? [],
+    required: value.required ?? false,
+    type: value.type,
+  };
+}
+
+function normalizeSyncSchema(
+  value: ExternalProjectSyncSchema | undefined
+): ExternalProjectSyncSchema {
+  return {
+    collections: (value?.collections ?? [])
+      .map(normalizeCollectionSchema)
+      .sort((left, right) => left.slug.localeCompare(right.slug)),
+    metadataFields: (value?.metadataFields ?? []).map(normalizeSyncField),
+    profileFields: (value?.profileFields ?? []).map(normalizeSyncField),
   };
 }
 
@@ -188,13 +216,7 @@ export function normalizeExternalProjectSyncManifest(
         title: entry.title,
       })),
     },
-    schema: {
-      collections: (value.schema?.collections ?? []).map(
-        normalizeCollectionSchema
-      ),
-      metadataFields: value.schema?.metadataFields ?? [],
-      profileFields: value.schema?.profileFields ?? [],
-    },
+    schema: normalizeSyncSchema(value.schema),
     version: 1,
   };
 }
@@ -311,14 +333,7 @@ export function buildExternalProjectSyncDiff(
 ): ExternalProjectSyncDiff {
   const manifest = normalizeExternalProjectSyncManifest(manifestInput);
   const operations: ExternalProjectSyncOperation[] = [];
-  const snapshotSchema = {
-    ...snapshot.schema,
-    collections: (snapshot.schema?.collections ?? []).map(
-      normalizeCollectionSchema
-    ),
-    metadataFields: snapshot.schema?.metadataFields ?? [],
-    profileFields: snapshot.schema?.profileFields ?? [],
-  } satisfies ExternalProjectSyncSchema;
+  const snapshotSchema = normalizeSyncSchema(snapshot.schema);
 
   if (valuesDiffer(snapshotSchema, manifest.schema)) {
     const removedFieldKeys = getRemovedSchemaFieldKeys(

--- a/apps/web/src/lib/external-projects/sync.ts
+++ b/apps/web/src/lib/external-projects/sync.ts
@@ -154,9 +154,7 @@ function normalizeSyncField(
   value: ExternalProjectSyncField
 ): ExternalProjectSyncField {
   return {
-    ...(value.defaultValue === undefined
-      ? {}
-      : { defaultValue: value.defaultValue }),
+    ...(value.defaultValue == null ? {} : { defaultValue: value.defaultValue }),
     description: value.description ?? null,
     key: value.key,
     label: value.label ?? null,


### PR DESCRIPTION
## Summary
- canonicalize stored and manifest field defaults before diffing
- compare collection schemas in stable slug order because collection order is not persisted
- preserve meaningful profile and metadata field ordering
- add a regression test for the exact production non-converging schema shape

## Production evidence
- Exocorpse is at 0 create / 1 update / 0 archive / 0 delete
- the sole operation is a schema update where collection order and expanded field defaults differ semantically but not functionally

## Verification
- `bunx vitest run src/lib/external-projects/sync.test.ts src/lib/external-projects/sync-apply.test.ts` (13 passed)
- `bun check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalize external project sync schemas and align snapshot/manifest normalization paths so diffs treat reordered collections and expanded or null field defaults as equivalent. Prevents unnecessary schema updates.

- **Bug Fixes**
  - Normalize schemas for snapshot and manifest with shared helpers: omit null `defaultValue`, set `description` to null, ensure `options` is `[]`, `required` is `false`.
  - Sort collections by slug for stable comparison; preserve profile/metadata field order.
  - Use normalized schema in diffing; add tests in web and backend for ordering/defaults and the prior non-converging case.

<sup>Written for commit 4abff20ae1900150e0b6539f2ae19edcbdd9bc53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/4963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

