### PR TITLE
fix(cms): grant relation tables to service role

### DIFF
--- a/apps/database/supabase/migrations/20260717060430_grant_external_project_relations_service_role.sql
+++ b/apps/database/supabase/migrations/20260717060430_grant_external_project_relations_service_role.sql
@@ -1,0 +1,11 @@
+grant select, insert, update, delete
+on table public.workspace_external_project_relation_definitions
+to service_role;
+
+grant select, insert, update, delete
+on table public.workspace_external_project_relation_definition_targets
+to service_role;
+
+grant select, insert, update, delete
+on table public.workspace_external_project_entry_relations
+to service_role;

--- a/apps/database/supabase/tests/external-project-entry-bundles.sql
+++ b/apps/database/supabase/tests/external-project-entry-bundles.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(26);
+select plan(29);
 
 select has_table(
   'public',
@@ -68,6 +68,30 @@ select ok(
     'execute'
   ),
   'service role can invoke the bundle RPC'
+);
+select ok(
+  has_table_privilege(
+    'service_role',
+    'public.workspace_external_project_relation_definitions',
+    'select, insert, update, delete'
+  ),
+  'service role can manage relation definitions for protected delivery APIs'
+);
+select ok(
+  has_table_privilege(
+    'service_role',
+    'public.workspace_external_project_relation_definition_targets',
+    'select, insert, update, delete'
+  ),
+  'service role can manage relation definition targets for protected delivery APIs'
+);
+select ok(
+  has_table_privilege(
+    'service_role',
+    'public.workspace_external_project_entry_relations',
+    'select, insert, update, delete'
+  ),
+  'service role can manage entry relations for protected delivery APIs'
 );
 select ok(
   (

--- a/apps/database/supabase/tests/external-project-entry-bundles.sql
+++ b/apps/database/supabase/tests/external-project-entry-bundles.sql
@@ -70,27 +70,24 @@ select ok(
   'service role can invoke the bundle RPC'
 );
 select ok(
-  has_table_privilege(
-    'service_role',
-    'public.workspace_external_project_relation_definitions',
-    'select, insert, update, delete'
-  ),
+  has_table_privilege('service_role', 'public.workspace_external_project_relation_definitions', 'select')
+    and has_table_privilege('service_role', 'public.workspace_external_project_relation_definitions', 'insert')
+    and has_table_privilege('service_role', 'public.workspace_external_project_relation_definitions', 'update')
+    and has_table_privilege('service_role', 'public.workspace_external_project_relation_definitions', 'delete'),
   'service role can manage relation definitions for protected delivery APIs'
 );
 select ok(
-  has_table_privilege(
-    'service_role',
-    'public.workspace_external_project_relation_definition_targets',
-    'select, insert, update, delete'
-  ),
+  has_table_privilege('service_role', 'public.workspace_external_project_relation_definition_targets', 'select')
+    and has_table_privilege('service_role', 'public.workspace_external_project_relation_definition_targets', 'insert')
+    and has_table_privilege('service_role', 'public.workspace_external_project_relation_definition_targets', 'update')
+    and has_table_privilege('service_role', 'public.workspace_external_project_relation_definition_targets', 'delete'),
   'service role can manage relation definition targets for protected delivery APIs'
 );
 select ok(
-  has_table_privilege(
-    'service_role',
-    'public.workspace_external_project_entry_relations',
-    'select, insert, update, delete'
-  ),
+  has_table_privilege('service_role', 'public.workspace_external_project_entry_relations', 'select')
+    and has_table_privilege('service_role', 'public.workspace_external_project_entry_relations', 'insert')
+    and has_table_privilege('service_role', 'public.workspace_external_project_entry_relations', 'update')
+    and has_table_privilege('service_role', 'public.workspace_external_project_entry_relations', 'delete'),
   'service role can manage entry relations for protected delivery APIs'
 );
 select ok(


### PR DESCRIPTION
## Summary
- grant the service role CRUD access to external-project relation definitions, targets, and entry relations
- add pgTAP regression coverage for every required table privilege

## Production impact
Restores external-project delivery and protected relation APIs currently failing with `permission denied for table workspace_external_project_relation_definitions`.

## Verification
- isolated local Supabase reset
- external-project-entry-bundles pgTAP: 29/29
- `bun check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant `service_role` CRUD on external-project relation tables to fix “permission denied” errors and restore protected delivery APIs.

- **Bug Fixes**
  - Granted `service_role` select/insert/update/delete on `public.workspace_external_project_relation_definitions`, `public.workspace_external_project_relation_definition_targets`, and `public.workspace_external_project_entry_relations`.
  - Added pgTAP tests to verify each CRUD privilege on these tables (plan increased from 26 to 29).

<sup>Written for commit 3f5cca2e61daa21423f7b98a0d3a36af3a476393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/4991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

