### PR TITLE
fix(cms): accept offset concurrency timestamps

### DIFF
--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/entries/[entryId]/bundle/route.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/entries/[entryId]/bundle/route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  requireWorkspaceExternalProjectAccess: vi.fn(),
+  upsertWorkspaceExternalProjectEntryBundle: vi.fn(),
+}));
+
+vi.mock('@/lib/external-projects/access', () => ({
+  requireWorkspaceExternalProjectAccess: (
+    ...args: Parameters<typeof mocks.requireWorkspaceExternalProjectAccess>
+  ) => mocks.requireWorkspaceExternalProjectAccess(...args),
+}));
+
+vi.mock('@/lib/external-projects/store-relations', () => ({
+  upsertWorkspaceExternalProjectEntryBundle: (
+    ...args: Parameters<typeof mocks.upsertWorkspaceExternalProjectEntryBundle>
+  ) => mocks.upsertWorkspaceExternalProjectEntryBundle(...args),
+}));
+
+const entryId = '00000000-0000-4000-8000-000000000001';
+
+function createRequest(expectedUpdatedAt: string) {
+  return new Request(
+    `http://localhost/api/v1/workspaces/personal/external-projects/entries/${entryId}/bundle`,
+    {
+      body: JSON.stringify({
+        blocks: [],
+        entry: {},
+        expectedUpdatedAt,
+        relations: [],
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PUT',
+    }
+  );
+}
+
+describe('external project entry bundle route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mocks.requireWorkspaceExternalProjectAccess.mockResolvedValue({
+      admin: { role: 'admin-client' },
+      normalizedWorkspaceId: 'ws-normalized',
+      ok: true,
+      user: {
+        id: 'user-1',
+      },
+    });
+    mocks.upsertWorkspaceExternalProjectEntryBundle.mockResolvedValue({
+      blocks: [],
+      entry: { id: entryId },
+      relations: [],
+    });
+  });
+
+  it('preserves offset timestamps and database microseconds for concurrency', async () => {
+    const expectedUpdatedAt = '2026-07-12T23:20:06.973736+00:00';
+    const { PUT } = await import(
+      '@/legacy-api-routes/v1/workspaces/[wsId]/external-projects/entries/[entryId]/bundle/route'
+    );
+
+    const response = await PUT(createRequest(expectedUpdatedAt), {
+      params: Promise.resolve({
+        entryId,
+        wsId: 'personal',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      mocks.upsertWorkspaceExternalProjectEntryBundle
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entryId,
+        expectedUpdatedAt,
+        workspaceId: 'ws-normalized',
+      }),
+      { role: 'admin-client' }
+    );
+  });
+
+  it('rejects malformed concurrency timestamps', async () => {
+    const { PUT } = await import(
+      '@/legacy-api-routes/v1/workspaces/[wsId]/external-projects/entries/[entryId]/bundle/route'
+    );
+
+    const response = await PUT(createRequest('not-a-timestamp'), {
+      params: Promise.resolve({
+        entryId,
+        wsId: 'personal',
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(
+      mocks.upsertWorkspaceExternalProjectEntryBundle
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/entries/[entryId]/bundle/route.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/entries/[entryId]/bundle/route.ts
@@ -33,7 +33,7 @@ const updateBundleSchema = z.object({
       title: z.string().trim().min(1).max(160).optional(),
     })
     .default({}),
-  expectedUpdatedAt: z.string().datetime(),
+  expectedUpdatedAt: z.string().datetime({ offset: true }),
   relations: z.array(
     z.object({
       definitionId: z.string().uuid(),


### PR DESCRIPTION
## Summary
- accept ISO datetimes with explicit offsets for external-project bundle optimistic concurrency
- preserve PostgreSQL microseconds without lossy client normalization
- add route coverage for the production timestamp shape and malformed input

## Verification
- focused route tests: 2 passed
- repository check: type-check and Biome passed; 2,385 tests passed; only sandbox loopback listener test failed with EPERM and then passed 4/4 outside the sandbox
- Next.js 16.3 production build compiled successfully; prerender then stopped on the known missing Supabase URL in the isolated worktree

## Migration tracking
- the changed route remains explicitly registered as legacy-next in the TanStack/Rust migration override manifest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept ISO 8601 timestamps with explicit offsets for optimistic concurrency in the external‑project entry bundle route, preserving Postgres microsecond precision. Adds route tests to validate the production timestamp shape and reject malformed input.

- **Bug Fixes**
  - Updated validation to `z.string().datetime({ offset: true })` in the bundle route.
  - Added route tests for valid offset + microseconds and malformed timestamps.

<sup>Written for commit 3060ecb4a253dc0c935b717e65672be04f14d9fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/4992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

