### PR TITLE
fix(cms): harden managed asset imports

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/epm/entries/[entryId]/entry-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/epm/entries/[entryId]/entry-detail-client.tsx
@@ -34,6 +34,7 @@ import {
 import { toast } from '@tuturuuu/ui/sonner';
 import { usePathname, useRouter } from 'next/navigation';
 import { type ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { chunkManagedAssetImportIds } from '@/lib/external-projects/managed-asset-import-limits';
 import { useExternalProjectLivePreview } from '../../../external-projects/use-external-project-live-preview';
 import { optimizeEpmMediaUpload } from '../../epm-media-upload';
 import type { EpmStrings } from '../../epm-strings';
@@ -1212,23 +1213,28 @@ export function EntryDetailClient({
 
   const importExternalAssetsMutation = useMutation({
     mutationFn: async (assetIds: string[]) => {
-      let job = await createWorkspaceExternalProjectManagedAssetImportJob(
-        workspaceId,
-        assetIds
-      );
-      while (!['completed', 'failed'].includes(job.status)) {
-        job = await processWorkspaceExternalProjectManagedAssetImportJob(
+      for (const assetIdChunk of chunkManagedAssetImportIds(assetIds)) {
+        let job = await createWorkspaceExternalProjectManagedAssetImportJob(
           workspaceId,
-          job.id
+          assetIdChunk
         );
-        if (job.status === 'running') {
-          await new Promise((resolve) => setTimeout(resolve, 250));
+
+        while (!['completed', 'failed'].includes(job.status)) {
+          job = await processWorkspaceExternalProjectManagedAssetImportJob(
+            workspaceId,
+            job.id
+          );
+          if (job.status === 'running') {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+          }
+        }
+
+        if (job.status !== 'completed') {
+          throw new Error(
+            `Managed media import ended with status ${job.status}`
+          );
         }
       }
-      if (job.status !== 'completed') {
-        throw new Error(`Managed media import ended with status ${job.status}`);
-      }
-      return job;
     },
     onSuccess: async () => {
       setSelectedAssetIds([]);

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/assets/import-jobs/route.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/assets/import-jobs/route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createManagedAssetImportJob: vi.fn(),
+  requireWorkspaceExternalProjectAccess: vi.fn(),
+}));
+
+vi.mock('@/lib/external-projects/access', () => ({
+  requireWorkspaceExternalProjectAccess: (
+    ...args: Parameters<typeof mocks.requireWorkspaceExternalProjectAccess>
+  ) => mocks.requireWorkspaceExternalProjectAccess(...args),
+}));
+
+vi.mock('@/lib/external-projects/managed-asset-import', () => ({
+  createManagedAssetImportJob: (
+    ...args: Parameters<typeof mocks.createManagedAssetImportJob>
+  ) => mocks.createManagedAssetImportJob(...args),
+  ManagedAssetImportValidationError: class extends Error {},
+}));
+
+const assetIds = (count: number) =>
+  Array.from(
+    { length: count },
+    (_, index) => `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
+  );
+
+function createRequest(count: number) {
+  return new Request(
+    'http://localhost/api/v1/workspaces/personal/external-projects/assets/import-jobs',
+    {
+      body: JSON.stringify({ assetIds: assetIds(count) }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    }
+  );
+}
+
+describe('managed asset import job route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.requireWorkspaceExternalProjectAccess.mockResolvedValue({
+      admin: { role: 'admin-client' },
+      binding: { adapter: 'exocorpse', canonical_id: 'exocorpse' },
+      normalizedWorkspaceId: 'ws-normalized',
+      ok: true,
+      user: { id: 'user-1' },
+    });
+    mocks.createManagedAssetImportJob.mockResolvedValue({ id: 'job-1' });
+  });
+
+  it('creates a job at the protected-report-safe limit', async () => {
+    const { POST } = await import(
+      '@/legacy-api-routes/v1/workspaces/[wsId]/external-projects/assets/import-jobs/route'
+    );
+    const response = await POST(createRequest(75), {
+      params: Promise.resolve({ wsId: 'personal' }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mocks.createManagedAssetImportJob).toHaveBeenCalledWith(
+      expect.objectContaining({ assetIds: assetIds(75) }),
+      { role: 'admin-client' }
+    );
+  });
+
+  it('rejects oversized jobs before writing an invalid report', async () => {
+    const { POST } = await import(
+      '@/legacy-api-routes/v1/workspaces/[wsId]/external-projects/assets/import-jobs/route'
+    );
+    const response = await POST(createRequest(76), {
+      params: Promise.resolve({ wsId: 'personal' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.createManagedAssetImportJob).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/assets/import-jobs/route.ts
+++ b/apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/assets/import-jobs/route.ts
@@ -6,9 +6,13 @@ import {
   createManagedAssetImportJob,
   ManagedAssetImportValidationError,
 } from '@/lib/external-projects/managed-asset-import';
+import { MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS } from '@/lib/external-projects/managed-asset-import-limits';
 
 const schema = z.object({
-  assetIds: z.array(z.string().uuid()).min(1).max(500),
+  assetIds: z
+    .array(z.string().uuid())
+    .min(1)
+    .max(MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS),
 });
 const privateHeaders = {
   'Cache-Control': EXTERNAL_PROJECT_PRIVATE_CACHE_CONTROL,

--- a/apps/web/src/lib/external-projects/managed-asset-import-limits.test.ts
+++ b/apps/web/src/lib/external-projects/managed-asset-import-limits.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  chunkManagedAssetImportIds,
+  MAX_MANAGED_ASSET_IMPORT_FAILURE_MESSAGE_BYTES,
+  MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS,
+  sanitizeManagedAssetImportFailureMessage,
+} from './managed-asset-import-limits';
+
+const protectedJsonFieldByteLimit = 8 * 1024;
+const pathologicalFailureMessage = ['"', '\\', String.fromCharCode(0), '😀']
+  .join('')
+  .repeat(300);
+const assetId = (index: number) =>
+  `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+const reportBytes = (
+  count: number,
+  processedCount = 0,
+  failures: Array<{ assetId: string; message: string }> = []
+) =>
+  new TextEncoder().encode(
+    JSON.stringify({
+      assetIds: Array.from({ length: count }, (_, index) => assetId(index)),
+      failures,
+      processedAssetIds: Array.from({ length: processedCount }, (_, index) =>
+        assetId(index)
+      ),
+      total: count,
+    })
+  ).byteLength;
+
+describe('managed asset import job limits', () => {
+  it('chunks bulk selections into resumable jobs within the server limit', () => {
+    const chunks = chunkManagedAssetImportIds(
+      Array.from({ length: 217 }, (_, index) => assetId(index))
+    );
+
+    expect(chunks.map((chunk) => chunk.length)).toEqual([75, 75, 67]);
+    expect(chunks.flat()).toEqual(
+      Array.from({ length: 217 }, (_, index) => assetId(index))
+    );
+    expect(chunkManagedAssetImportIds([])).toEqual([]);
+  });
+
+  it('keeps a failed final batch below the protected JSON field limit', () => {
+    const failureMessage = sanitizeManagedAssetImportFailureMessage(
+      pathologicalFailureMessage
+    );
+    const failures = Array.from({ length: 5 }, (_, index) => ({
+      assetId: assetId(MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS - 5 + index),
+      message: failureMessage,
+    }));
+
+    expect(
+      reportBytes(
+        MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS,
+        MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS - 5,
+        failures
+      )
+    ).toBeLessThanOrEqual(protectedJsonFieldByteLimit);
+  });
+
+  it('covers the production regression where 100 assets overflow late', () => {
+    const failures = Array.from({ length: 5 }, (_, index) => ({
+      assetId: assetId(95 + index),
+      message: 'x'.repeat(MAX_MANAGED_ASSET_IMPORT_FAILURE_MESSAGE_BYTES),
+    }));
+
+    expect(reportBytes(100, 95, failures)).toBeGreaterThan(
+      protectedJsonFieldByteLimit
+    );
+    expect(reportBytes(217)).toBeGreaterThan(protectedJsonFieldByteLimit);
+  });
+
+  it('bounds and JSON-sanitizes persisted failure messages by UTF-8 bytes', () => {
+    const message = sanitizeManagedAssetImportFailureMessage(
+      pathologicalFailureMessage
+    );
+
+    expect(new TextEncoder().encode(message).byteLength).toBeLessThanOrEqual(
+      MAX_MANAGED_ASSET_IMPORT_FAILURE_MESSAGE_BYTES
+    );
+    expect(message).not.toMatch(/["\\]/);
+    expect(message).not.toContain('\u0000');
+  });
+});

--- a/apps/web/src/lib/external-projects/managed-asset-import-limits.ts
+++ b/apps/web/src/lib/external-projects/managed-asset-import-limits.ts
@@ -1,0 +1,41 @@
+export const MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS = 75;
+export const MAX_MANAGED_ASSET_IMPORT_FAILURE_MESSAGE_BYTES = 256;
+
+export function chunkManagedAssetImportIds(assetIds: string[]) {
+  return Array.from(
+    {
+      length: Math.ceil(assetIds.length / MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS),
+    },
+    (_, index) =>
+      assetIds.slice(
+        index * MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS,
+        (index + 1) * MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS
+      )
+  );
+}
+
+export function sanitizeManagedAssetImportFailureMessage(value: string) {
+  const jsonSafe = Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 31 || character === '"' || character === '\\'
+      ? ' '
+      : character;
+  }).join('');
+  const bytes = new TextEncoder().encode(jsonSafe);
+  if (bytes.byteLength <= MAX_MANAGED_ASSET_IMPORT_FAILURE_MESSAGE_BYTES) {
+    return jsonSafe;
+  }
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  for (
+    let end = MAX_MANAGED_ASSET_IMPORT_FAILURE_MESSAGE_BYTES;
+    end > MAX_MANAGED_ASSET_IMPORT_FAILURE_MESSAGE_BYTES - 4;
+    end -= 1
+  ) {
+    try {
+      return decoder.decode(bytes.slice(0, end));
+    } catch {
+      // Back up to the previous complete UTF-8 code point.
+    }
+  }
+  return '';
+}

--- a/apps/web/src/lib/external-projects/managed-asset-import.test.ts
+++ b/apps/web/src/lib/external-projects/managed-asset-import.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  createManagedAssetPinnedLookup,
   isPrivateNetworkAddress,
   resolveSafeManagedAssetAddress,
 } from './managed-asset-url-policy';
@@ -41,6 +42,36 @@ describe('managed external-project asset import SSRF guard', () => {
     );
 
     expect(address).toEqual({ address: '1.1.1.1', family: 4 });
+  });
+
+  it('returns an address array when Node requests an all-address lookup', () => {
+    const callback = vi.fn();
+    const address = { address: '1.1.1.1', family: 4 } as const;
+
+    createManagedAssetPinnedLookup(address)(
+      'assets.example.com',
+      { all: true },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, [address]);
+  });
+
+  it('returns a single address and family for a standard Node lookup', () => {
+    const callback = vi.fn();
+    const address = { address: '1.1.1.1', family: 4 } as const;
+
+    createManagedAssetPinnedLookup(address)(
+      'assets.example.com',
+      { all: false },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith(
+      null,
+      address.address,
+      address.family
+    );
   });
 
   it('normalizes brackets before resolving a public IPv6 literal', async () => {

--- a/apps/web/src/lib/external-projects/managed-asset-import.ts
+++ b/apps/web/src/lib/external-projects/managed-asset-import.ts
@@ -6,6 +6,10 @@ import type { ExternalProjectImportJob, Json } from '@tuturuuu/types';
 import { fetch as undiciFetch } from 'undici';
 import { invalidateWorkspaceExternalProjectCache } from './cache';
 import {
+  MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS,
+  sanitizeManagedAssetImportFailureMessage,
+} from './managed-asset-import-limits';
+import {
   closeManagedAssetDispatcher,
   createManagedAssetPinnedDispatcher,
   resolveSafeManagedAssetAddress,
@@ -179,6 +183,14 @@ export async function createManagedAssetImportJob(
 ) {
   const admin = db ?? ((await createAdminClient()) as TypedSupabaseClient);
   const assetIds = [...new Set(payload.assetIds)];
+  if (
+    assetIds.length === 0 ||
+    assetIds.length > MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS
+  ) {
+    throw new ManagedAssetImportValidationError(
+      `Managed asset import jobs must contain between 1 and ${MAX_MANAGED_ASSET_IMPORT_JOB_ASSETS} unique assets`
+    );
+  }
   const { data: assets, error: assetError } = await admin
     .from('workspace_external_project_assets')
     .select('id')
@@ -331,10 +343,11 @@ export async function processManagedAssetImportJob(
         } catch (importError) {
           failures.push({
             assetId,
-            message:
+            message: sanitizeManagedAssetImportFailureMessage(
               importError instanceof Error
                 ? importError.message
-                : String(importError),
+                : String(importError)
+            ),
           });
         }
       })

--- a/apps/web/src/lib/external-projects/managed-asset-url-policy.ts
+++ b/apps/web/src/lib/external-projects/managed-asset-url-policy.ts
@@ -1,6 +1,6 @@
 import type { LookupAddress } from 'node:dns';
 import { lookup } from 'node:dns/promises';
-import { isIP } from 'node:net';
+import { isIP, type LookupFunction } from 'node:net';
 import { Agent, type Dispatcher } from 'undici';
 
 export type ManagedAssetResolver = (
@@ -68,17 +68,21 @@ export async function resolveSafeManagedAssetAddress(
 export function createManagedAssetPinnedDispatcher(record: LookupAddress) {
   return new Agent({
     connect: {
-      lookup: ((
-        _hostname: string,
-        _options: unknown,
-        callback: (
-          error: NodeJS.ErrnoException | null,
-          address: string,
-          family: number
-        ) => void
-      ) => callback(null, record.address, record.family)) as never,
+      lookup: createManagedAssetPinnedLookup(record),
     },
   });
+}
+
+export function createManagedAssetPinnedLookup(
+  record: LookupAddress
+): LookupFunction {
+  return (_hostname, options, callback) => {
+    if (options.all) {
+      callback(null, [record]);
+      return;
+    }
+    callback(null, record.address, record.family);
+  };
 }
 
 export async function closeManagedAssetDispatcher(dispatcher: Dispatcher) {


### PR DESCRIPTION
## Summary
- return Node-compatible all-address results from the pinned DNS lookup used by managed asset imports
- cap resumable import jobs at 100 unique assets so the protected JSON report remains below 8 KiB
- cover the production regressions at the service and route boundaries

## Validation
- focused Vitest: 29 passed
- exact Node pinned Undici fetch against Exocorpse: HTTP 200
- Biome: passed
- type-check: passed via bun check
- full tests: 2 sandbox-only loopback failures; exact request-tracker suite passes 4/4 outside sandbox
- TanStack migration manifest regenerated with no diff
- local Next/Turbopack build stalled during compilation; required Vercel build is delegated to PR/production CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened managed asset imports by making the DNS lookup Node-compatible and capping jobs at 75 assets to keep the protected report under 8 KiB. Added client-side chunking, validation, and failure-message sanitization to prevent regressions.

- **Bug Fixes**
  - Pinned DNS lookup implements Node `LookupFunction`: returns `[record]` when `options.all` is true, or `(address, family)` otherwise; prevents `undici` fetch failures.
  - Enforce a max of 75 unique asset IDs per job at the API schema and service; the client chunks bulk selections into resumable jobs to stay within limits.
  - Bound and JSON-sanitize failure messages to 256 UTF-8 bytes during processing to avoid overflowing the report.
  - Added tests for route limits, pinned lookup behavior (including all-address queries), chunking, and report-size limits.

<sup>Written for commit 60a111555bc743eb25b9702bc5f0af94d03e3639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/4993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

