### PR TITLE
fix(editor): avoid duplicate link extension

### DIFF
--- a/packages/editor/src/react.tsx
+++ b/packages/editor/src/react.tsx
@@ -52,7 +52,7 @@ export function RichTextEditor({
     content: content ?? { type: 'doc', content: [] },
     editable: !readOnly,
     extensions: [
-      StarterKit,
+      StarterKit.configure({ link: false }),
       Link.configure({ openOnClick: readOnly }),
       Image,
       Placeholder.configure({


### PR DESCRIPTION
## Summary

- disable StarterKit's bundled Link extension in the lightweight editor
- retain the separately configured Link extension for read-only behavior
- remove the production Tiptap duplicate-extension warning

## Verification

- `bun --cwd packages/editor test` (20 passed)
- `bun --cwd packages/editor type-check`
- `bun --cwd packages/editor build`
- `TURBO_CONCURRENCY=4 bun check` (editor/type-check/biome pass; unrelated existing `@tuturuuu/realtime` Zod test failures in five suites)

## Production evidence

Richfield's deployed admin editor emitted `Duplicate extension names found: ['link']`. The package currently registered both StarterKit and a configured Link extension.
