### PR TITLE
test(inventory): target visible storefront product

### DIFF
--- a/apps/inventory/e2e/storefront-cache-invalidation.spec.ts
+++ b/apps/inventory/e2e/storefront-cache-invalidation.spec.ts
@@ -78,7 +78,9 @@ test('invalidates cached availability and preserves the shared storefront shell'
       await expect(page.locator('main[aria-busy="true"]')).toBeVisible();
     });
     await expect(page).toHaveURL(new RegExp(`/${fixture.slug}/?$`, 'u'));
-    await expect(page.getByText('Cache Test Product').first()).toBeVisible();
+    await expect(
+      page.getByText('Cache Test Product').filter({ visible: true })
+    ).toBeVisible();
     expect(documentRequests).toBe(1);
     await page.screenshot({
       fullPage: true,


### PR DESCRIPTION
## Summary
- target the visible product heading after instant navigation
- ignore the retained hidden product heading from the outgoing route
- keep the cache invalidation and shared-shell assertions unchanged

## Validation
- Biome check on the changed E2E spec
- Inventory TypeScript type-check
- failing main job: https://github.com/tutur3u/platform/actions/runs/30288265307/job/90051358962