### PR TITLE
fix(infrastructure): proxy workspace list

### DIFF
--- a/apps/infrastructure/next.config.test.ts
+++ b/apps/infrastructure/next.config.test.ts
@@ -13,7 +13,12 @@ describe('Infrastructure next config rewrites', () => {
 
     expect(rewrites).toEqual({
       afterFiles: [],
-      beforeFiles: [],
+      beforeFiles: [
+        {
+          destination: 'https://web.example.com/api/v1/workspaces',
+          source: '/api/v1/workspaces',
+        },
+      ],
       fallback: [
         {
           destination: 'https://web.example.com/api/:path*',

--- a/apps/infrastructure/next.config.ts
+++ b/apps/infrastructure/next.config.ts
@@ -15,7 +15,12 @@ const nextConfig = createTuturuuuNextConfig({
   async rewrites() {
     return {
       afterFiles: [],
-      beforeFiles: [],
+      beforeFiles: [
+        {
+          destination: `${WEB_APP_URL}/api/v1/workspaces`,
+          source: '/api/v1/workspaces',
+        },
+      ],
       fallback: [
         {
           destination: `${WEB_APP_URL}/api/:path*`,


### PR DESCRIPTION
## Summary
- proxy the shared workspace collection endpoint before local dynamic workspace routes
- preserve Infrastructure-owned workspace detail routes
- add a rewrite contract test

## Production evidence
- the Infrastructure workspace picker requests `/api/v1/workspaces`
- production currently returns a satellite HTML 404 for that endpoint
- the authenticated canary workspace exists and is available from the platform API

## Verification
- `bunx vitest run apps/infrastructure/next.config.test.ts`
- `bun type-check:infra`
- `bun check`
- `git diff --check`
- Turbopack local build reached compilation but is blocked by the sandbox port-binding restriction; webpack cannot be substituted because this app enables a Turbopack-only compiler option

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxy `/api/v1/workspaces` in the Infrastructure app to the Web app API to fix 404s in the workspace picker. The rewrite runs before dynamic workspace routes and keeps local workspace detail routes intact.

- **Bug Fixes**
  - Added Next.js `beforeFiles` rewrite: `/api/v1/workspaces` -> `${WEB_APP_URL}/api/v1/workspaces`.
  - Kept `/api/:path*` fallback rewrite to `${WEB_APP_URL}`.
  - Added a rewrite contract test to validate the config.

<sup>Written for commit a444f9d3ae68ec4be3b8844e7749d78863770bb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

