### PR TITLE
fix(external-chat): complete connected-site setup

### DIFF
--- a/apps/cms/src/app/api/v1/admin/external-projects/route.test.ts
+++ b/apps/cms/src/app/api/v1/admin/external-projects/route.test.ts
@@ -31,7 +31,7 @@ vi.mock('@/lib/external-projects/admin-store', () => ({
 }));
 
 vi.mock('@/lib/external-projects/constants', () => ({
-  EXTERNAL_PROJECT_ADAPTER_OPTIONS: ['junly', 'yoola'],
+  EXTERNAL_PROJECT_ADAPTER_OPTIONS: ['custom', 'junly', 'yoola'],
 }));
 
 import { PATCH } from './[canonicalId]/route';
@@ -90,6 +90,45 @@ describe('CMS admin site template routes', () => {
       expect.objectContaining({
         actorId: 'user-1',
         id: 'junly-main',
+      }),
+      { client: 'admin' }
+    );
+  });
+
+  it('always enables chat for custom site templates', async () => {
+    mocks.access.requireCmsRootExternalProjectsAdmin.mockResolvedValue({
+      admin: { client: 'admin' },
+      ok: true,
+      user: { id: 'user-1' },
+    });
+    mocks.store.createCanonicalExternalProject.mockResolvedValue({
+      id: 'connected-site',
+    });
+
+    const response = await POST(
+      new Request('http://localhost/api/v1/admin/external-projects', {
+        body: JSON.stringify({
+          adapter: 'custom',
+          allowed_collections: [],
+          allowed_features: ['sync'],
+          delivery_profile: {},
+          display_name: 'Connected site',
+          id: 'connected-site',
+          is_active: true,
+          metadata: {},
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.store.createCanonicalExternalProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapter: 'custom',
+        allowed_features: ['sync', 'chat'],
       }),
       { client: 'admin' }
     );

--- a/apps/cms/src/app/api/v1/admin/external-projects/route.test.ts
+++ b/apps/cms/src/app/api/v1/admin/external-projects/route.test.ts
@@ -110,7 +110,7 @@ describe('CMS admin site template routes', () => {
         body: JSON.stringify({
           adapter: 'custom',
           allowed_collections: [],
-          allowed_features: ['sync', 'chat', 'chat'],
+          allowed_features: ['sync', 'sync'],
           delivery_profile: {},
           display_name: 'Connected site',
           id: 'connected-site',

--- a/apps/cms/src/app/api/v1/admin/external-projects/route.test.ts
+++ b/apps/cms/src/app/api/v1/admin/external-projects/route.test.ts
@@ -110,7 +110,7 @@ describe('CMS admin site template routes', () => {
         body: JSON.stringify({
           adapter: 'custom',
           allowed_collections: [],
-          allowed_features: ['sync'],
+          allowed_features: ['sync', 'chat', 'chat'],
           delivery_profile: {},
           display_name: 'Connected site',
           id: 'connected-site',

--- a/apps/cms/src/app/api/v1/admin/external-projects/route.ts
+++ b/apps/cms/src/app/api/v1/admin/external-projects/route.ts
@@ -41,12 +41,16 @@ export async function POST(request: Request) {
 
   try {
     const payload = canonicalProjectSchema.parse(body.body);
+    const allowedFeatures =
+      payload.adapter === 'custom'
+        ? [...new Set([...payload.allowed_features, 'chat'])]
+        : payload.allowed_features;
     const project = await createCanonicalExternalProject(
       {
         actorId: access.user.id,
         adapter: payload.adapter,
         allowed_collections: payload.allowed_collections,
-        allowed_features: payload.allowed_features,
+        allowed_features: allowedFeatures,
         delivery_profile: payload.delivery_profile as Json,
         display_name: payload.display_name,
         id: payload.id,

--- a/apps/web/src/lib/external-chat/safe-control-request.test.ts
+++ b/apps/web/src/lib/external-chat/safe-control-request.test.ts
@@ -76,4 +76,15 @@ describe('external chat control destination policy', () => {
   it('supports runtimes without dispatcher lifecycle methods', async () => {
     await expect(closeExternalChatDispatcher({})).resolves.toBeUndefined();
   });
+
+  it.each(['close', 'destroy'] as const)(
+    'does not let a rejected %s mask the request result',
+    async (method) => {
+      await expect(
+        closeExternalChatDispatcher({
+          [method]: vi.fn().mockRejectedValue(new Error('cleanup failed')),
+        })
+      ).resolves.toBeUndefined();
+    }
+  );
 });

--- a/apps/web/src/lib/external-chat/safe-control-request.test.ts
+++ b/apps/web/src/lib/external-chat/safe-control-request.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   assertSafeExternalChatUrl,
+  closeExternalChatDispatcher,
   ExternalChatUrlPolicyError,
   isBlockedExternalChatAddress,
 } from './safe-control-request';
@@ -52,5 +53,27 @@ describe('external chat control destination policy', () => {
     '64:ff9b::808:808',
   ])('allows globally routable address %s', (address) => {
     expect(isBlockedExternalChatAddress(address)).toBe(false);
+  });
+
+  it('closes dispatchers gracefully when supported', async () => {
+    const close = vi.fn();
+    const destroy = vi.fn();
+
+    await closeExternalChatDispatcher({ close, destroy });
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to destroying dispatchers without graceful close', async () => {
+    const destroy = vi.fn();
+
+    await closeExternalChatDispatcher({ destroy });
+
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('supports runtimes without dispatcher lifecycle methods', async () => {
+    await expect(closeExternalChatDispatcher({})).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/lib/external-chat/safe-control-request.ts
+++ b/apps/web/src/lib/external-chat/safe-control-request.ts
@@ -7,6 +7,21 @@ const MAX_CONTROL_RESPONSE_BYTES = 1024 * 1024;
 
 export class ExternalChatUrlPolicyError extends Error {}
 
+type DispatcherLifecycle = {
+  close?: () => Promise<void> | void;
+  destroy?: () => Promise<void> | void;
+};
+
+export async function closeExternalChatDispatcher(
+  dispatcher: DispatcherLifecycle
+) {
+  if (typeof dispatcher.close === 'function') {
+    await dispatcher.close();
+    return;
+  }
+  if (typeof dispatcher.destroy === 'function') await dispatcher.destroy();
+}
+
 function mappedIpv4Address(address: string) {
   const prefix = address.startsWith('64:ff9b::')
     ? '64:ff9b::'
@@ -181,6 +196,6 @@ export async function safeExternalChatFetch(
       statusText: response.statusText,
     });
   } finally {
-    await dispatcher.destroy();
+    await closeExternalChatDispatcher(dispatcher);
   }
 }

--- a/apps/web/src/lib/external-chat/safe-control-request.ts
+++ b/apps/web/src/lib/external-chat/safe-control-request.ts
@@ -15,11 +15,15 @@ type DispatcherLifecycle = {
 export async function closeExternalChatDispatcher(
   dispatcher: DispatcherLifecycle
 ) {
-  if (typeof dispatcher.close === 'function') {
-    await dispatcher.close();
-    return;
+  try {
+    if (typeof dispatcher.close === 'function') {
+      await dispatcher.close();
+      return;
+    }
+    if (typeof dispatcher.destroy === 'function') await dispatcher.destroy();
+  } catch {
+    // Dispatcher cleanup must not replace the request result or primary error.
   }
-  if (typeof dispatcher.destroy === 'function') await dispatcher.destroy();
 }
 
 function mappedIpv4Address(address: string) {


### PR DESCRIPTION
## Summary
- enforce the Chat capability when root admins create custom connected-site templates
- preserve and deduplicate capabilities supplied by the operator
- close external chat request dispatchers only when the runtime exposes a lifecycle method
- cover template capability and dispatcher cleanup behavior with focused tests

## Verification
- CMS admin route tests: 4/4
- safe control request tests: 34/34
- bun type-check:cms
- bun type-check:web
- exact safe-fetch probe against the deployed bridge
- bun check (outside the loopback-restricted sandbox)
- git diff --check