### PR TITLE
fix(external-chat): allow bridge route alias

### DIFF
--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/config/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/config/route.test.ts
@@ -97,6 +97,25 @@ describe('external chat config route', () => {
     expect(mocks.writeExternalChatSettings).not.toHaveBeenCalled();
   });
 
+  it('allows the established websocket bridge path without opening arbitrary paths', async () => {
+    const settings = {
+      ...validSettings,
+      bridgeBaseUrl: 'https://bridge.example.com/wss',
+    };
+    const { PATCH } = await import('./route');
+    const response = await PATCH(patchRequest(settings) as never, params);
+
+    expect(response.status).toBe(200);
+    expect(mocks.assertSafeExternalChatUrl).toHaveBeenCalledWith(
+      settings.bridgeBaseUrl
+    );
+    expect(mocks.writeExternalChatSettings).toHaveBeenCalledWith(
+      'workspace-1',
+      settings,
+      'user-1'
+    );
+  });
+
   it('rejects a destination blocked by the network safety policy', async () => {
     mocks.assertSafeExternalChatUrl.mockRejectedValue(
       new mocks.ExternalChatUrlPolicyError('blocked')

--- a/apps/web/src/lib/external-chat/schemas.ts
+++ b/apps/web/src/lib/external-chat/schemas.ts
@@ -39,14 +39,14 @@ export const externalChatSettingsSchema = z.object({
           url.protocol === 'https:' &&
           !url.username &&
           !url.password &&
-          url.pathname === '/' &&
+          ['/', '/wss'].includes(url.pathname) &&
           !url.search &&
           !url.hash
         );
       } catch {
         return false;
       }
-    }, 'Bridge URL must be an HTTPS origin without credentials, query, or fragment'),
+    }, 'Bridge URL must be an HTTPS origin or approved bridge path without credentials, query, or fragment'),
   agentMappings: z.record(z.string(), z.string().uuid()).default({}),
   inboxDefaults: inboxDefaultsSchema,
   authorityMode: z


### PR DESCRIPTION
## Summary
- allow exactly the established  bridge path in external chat binding URLs
- continue rejecting arbitrary paths, credentials, query strings, fragments, and unsafe destinations
- cover persistence and network-policy validation through the workspace config API

## Verification
- 54 focused external-chat tests pass
- config route suite: 10/10 pass
- 
   • Packages in scope: @tuturuuu/web
   • Running type-check in 1 packages
   • Remote caching disabled, using shared worktree cache

@tuturuuu/masonry:build: cache hit, replaying logs 24db34455fec9107
@tuturuuu/devbox:build: cache hit, replaying logs 9f0ba1bc4fdfb6a0
@tuturuuu/masonry:type-check: cache hit, replaying logs cb461eac6f45c91f
@tuturuuu/types:build: cache hit, replaying logs 221bb2fd1ddbed50
@tuturuuu/realtime:type-check: cache hit, replaying logs 3ef86fcdf40e59c5
@tuturuuu/offline:type-check: cache hit, replaying logs 6ce30ae748618b82
@tuturuuu/devbox:type-check: cache hit, replaying logs 352fbf248fd885c0
@tuturuuu/turnstile:type-check: cache hit, replaying logs f689da40a384c313
@tuturuuu/legal:type-check: cache hit, replaying logs 1fc9503984208171
@tuturuuu/transactional:type-check: cache hit, replaying logs 64fdf13083083b74
@tuturuuu/masonry:build: $ tsc --project tsconfig.build.json
@tuturuuu/devbox:build: $ tsc --project tsconfig.json
@tuturuuu/types:type-check: cache hit, replaying logs b4e71300ca20818c
@tuturuuu/icons:type-check: cache hit, replaying logs 361365c90a8467d8
@tuturuuu/transactional:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/offline:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/legal:type-check: $ tsc --project tsconfig.json
@tuturuuu/turnstile:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/types:build: $ tsc --project tsconfig.build.json
@tuturuuu/devbox:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/icons:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/types:type-check: $ tsc --project tsconfig.build.json
@tuturuuu/masonry:type-check: $ tsc --project tsconfig.build.json
@tuturuuu/realtime:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/supabase:build: cache hit, replaying logs faeeeeb9306060d9
@tuturuuu/supabase:build: $ tsc --build
@tuturuuu/microsoft:type-check: cache hit, replaying logs 43d8c0996c1aefef
@tuturuuu/google:type-check: cache hit, replaying logs 796e1e9260d08256
@tuturuuu/microsoft:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/vercel:type-check: cache hit, replaying logs fd707123c3d122f3
@tuturuuu/vercel:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/google:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/supabase:type-check: cache hit, replaying logs 70ebd9a75d775f6d
@tuturuuu/hooks:type-check: cache hit, replaying logs 9435062880f7979d
@tuturuuu/supabase:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/hooks:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/internal-api:type-check: cache hit, replaying logs 0091cd289de65367
@tuturuuu/internal-api:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/internal-api:build: cache hit, replaying logs e6ed32b0344abc6d
@tuturuuu/internal-api:build: $ tsc --project tsconfig.build.json
@tuturuuu/utils:type-check: cache hit, replaying logs f25259973b49fb82
@tuturuuu/utils:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/storage-core:type-check: cache hit, replaying logs d0eb4d54450feb15
@tuturuuu/storage-core:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/email-service:type-check: cache hit, replaying logs cee34ad3dffd841e
@tuturuuu/email-service:type-check: $ tsc --project tsconfig.typecheck.json
tuturuuu:build: cache hit, replaying logs 3803f1fdb8e3c7a9
@tuturuuu/trigger:type-check: cache hit, replaying logs 3e67ae97f9c0e8d7
tuturuuu:build: $ tsc --project tsconfig.build.json
@tuturuuu/ai:type-check: cache hit, replaying logs 7656ad6bc1f5369a
@tuturuuu/payment-core:type-check: cache hit, replaying logs f0ca4b27f960162c
@tuturuuu/ai:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/payment-core:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/trigger:type-check: $ tsc --project tsconfig.typecheck.json
tuturuuu:type-check: cache hit, replaying logs 030aba9b400c5714
tuturuuu:type-check: $ tsc --project tsconfig.build.json
@tuturuuu/apis:type-check: cache hit, replaying logs ec1fd832e1356730
@tuturuuu/apis:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/education-core:type-check: cache hit, replaying logs e8d8a24c8d1655a3
@tuturuuu/tasks-api:type-check: cache hit, replaying logs 20ea5bfb390db32e
@tuturuuu/education-core:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/mind-core:type-check: cache hit, replaying logs 707d8f61df474552
@tuturuuu/tasks-api:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/ui:type-check: cache hit, replaying logs ee9270e1d3d10a9a
@tuturuuu/mind-core:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/ui:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/mind-ui:type-check: cache hit, replaying logs 1490059a5e9a3421
@tuturuuu/tasks-ui:type-check: cache hit, replaying logs cf8a709f4fa678f3
@tuturuuu/auth:type-check: cache hit, replaying logs 0bf99e81f28e2792
@tuturuuu/mind-ui:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/auth:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/tasks-ui:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/finance-core:type-check: cache hit, replaying logs b31116d2f16f5136
@tuturuuu/finance-core:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/satellite:type-check: cache hit, replaying logs 8ef4caee87b1368e
@tuturuuu/satellite:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/inventory-core:type-check: cache hit, replaying logs 53e7ec17c6563146
@tuturuuu/inventory-core:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/hive-ui:type-check: cache hit, replaying logs 780dfe00b78bbfd9
@tuturuuu/users-core:type-check: cache hit, replaying logs fe173a68ea0434f1
@tuturuuu/hive-ui:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/users-core:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/users-ui:type-check: cache hit, replaying logs e36ef30ee3e16cb5
@tuturuuu/users-ui:type-check: $ tsc --project tsconfig.typecheck.json
@tuturuuu/web:type-check: cache hit, replaying logs 21e8b7c06724d250
@tuturuuu/web:type-check: [0m[2m[35m$[0m [2m[1mnode ../../scripts/run-tsc-build.js --build[0m

 Tasks:    43 successful, 43 total
Cached:    43 cached, 43 total
  Time:    633ms >>> FULL TURBO passes (43 tasks)
- Biome and focused formatter checks pass
- [36m[1mRunning all checks...[0m

[2m━━━ tests ━━━[0m
[2m━━━ type-check ━━━[0m
[2m━━━ biome ━━━[0m
[2m━━━ server-console ━━━[0m
[2m━━━ internal-app-auth ━━━[0m
[2m━━━ satellite-cookie-auth ━━━[0m
[2m━━━ offline-worker-wiring ━━━[0m
[2m━━━ multi-account-vault-owner ━━━[0m
[2m━━━ tanstack-api-access ━━━[0m
[2m━━━ legacy-api-route-wrappers ━━━[0m
[2m━━━ mobile-ios-project-settings ━━━[0m
[2m━━━ mobile-api-mappings ━━━[0m
[2m━━━ script-tests ━━━[0m

[2m━━━ i18n-check ━━━[0m
[2m━━━ i18n-key-parity ━━━[0m
[2m━━━ i18n-sort ━━━[0m
[2m━━━ i18n-namespace-check ━━━[0m
[2m━━━ migration-timestamps ━━━[0m


[31m[1mSome checks failed:[0m
[32mPASS[0m tests
[32mPASS[0m type-check
[32mPASS[0m biome
[32mPASS[0m server-console
[32mPASS[0m internal-app-auth
[32mPASS[0m satellite-cookie-auth
[32mPASS[0m offline-worker-wiring
[32mPASS[0m multi-account-vault-owner
[32mPASS[0m tanstack-api-access
[32mPASS[0m legacy-api-route-wrappers
[32mPASS[0m mobile-ios-project-settings
[32mPASS[0m mobile-api-mappings
[31mFAIL[0m script-tests
[32mPASS[0m i18n-check
[32mPASS[0m i18n-key-parity
[32mPASS[0m i18n-sort
[32mPASS[0m i18n-namespace-check
[32mPASS[0m migration-timestamps owned checks pass; unrelated TanStack migration-doc count tests are stale on current main
- local real web build was not run because the execution approval gate rejected it; CI build remains required

Legacy authority remains unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the `/wss` bridge route alias in external chat `bridgeBaseUrl` while preserving strict URL validation (HTTPS only, no creds/query/fragment, no arbitrary paths). Adds a config-route test to confirm persistence and network-policy checks via the workspace settings API.

<sup>Written for commit b259d9de7bc3a49e7a4cf0af5c28b91b2f343d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

