### PR TITLE
fix(chat): defer workspace layout to request time

### DIFF
--- a/apps/chat/src/app/[locale]/(dashboard)/[wsId]/layout.test.ts
+++ b/apps/chat/src/app/[locale]/(dashboard)/[wsId]/layout.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('workspace layout request boundary', () => {
+  it('enters request-time rendering before reading authenticated state', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/app/[locale]/(dashboard)/[wsId]/layout.tsx'),
+      'utf8'
+    );
+    const connectionCall = source.indexOf('await connection();');
+    const sessionRead = source.indexOf('requireChatUser()');
+    const cookieRead = source.indexOf('cookies()');
+    const headerRead = source.indexOf('headers()');
+
+    expect(connectionCall).toBeGreaterThan(-1);
+    expect(connectionCall).toBeLessThan(sessionRead);
+    expect(connectionCall).toBeLessThan(cookieRead);
+    expect(connectionCall).toBeLessThan(headerRead);
+  });
+});

--- a/apps/chat/src/app/[locale]/(dashboard)/[wsId]/layout.test.ts
+++ b/apps/chat/src/app/[locale]/(dashboard)/[wsId]/layout.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 describe('workspace layout request boundary', () => {
   it('enters request-time rendering before reading authenticated state', () => {
     const source = readFileSync(
-      resolve(process.cwd(), 'src/app/[locale]/(dashboard)/[wsId]/layout.tsx'),
+      resolve(import.meta.dirname, 'layout.tsx'),
       'utf8'
     );
     const connectionCall = source.indexOf('await connection();');

--- a/apps/chat/src/app/[locale]/(dashboard)/[wsId]/layout.tsx
+++ b/apps/chat/src/app/[locale]/(dashboard)/[wsId]/layout.tsx
@@ -15,6 +15,7 @@ import { toWorkspaceSlug } from '@tuturuuu/utils/constants';
 import { getWorkspace } from '@tuturuuu/utils/workspace-helper';
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { connection } from 'next/server';
 import { type ReactNode, Suspense } from 'react';
 import { requireChatUser } from '@/lib/access';
 import { getDefaultChatConversationScope } from './chat-default-scope';
@@ -29,6 +30,8 @@ interface LayoutProps {
 }
 
 export default async function Layout({ children, params }: LayoutProps) {
+  await connection();
+
   const [{ wsId: id }, user, cookieStore, requestHeaders] = await Promise.all([
     params,
     requireChatUser(),


### PR DESCRIPTION
## Summary
- opt the authenticated Chat workspace layout into request-time rendering before reading session, cookies, or headers
- add a regression test that preserves the request-boundary ordering

## Verification
- `bun run test` in `apps/chat` (13 passed)
- `bun type-check:chat`
- `bun check`

## Production verification
- pending CI build, merge, and authenticated Browser reload checks on `/personal`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer the authenticated workspace layout to request-time by calling `await connection()` from `next/server` before reading auth, cookies, or headers. Adds a regression test to lock this ordering for Chat pages.

- **Bug Fixes**
  - Call `connection()` at the top of `apps/chat/src/app/[locale]/(dashboard)/[wsId]/layout.tsx` before `requireChatUser()`, `cookies()`, and `headers()`.
  - Add `layout.test.ts` to assert the request-time boundary and resolve the layout fixture from the module directory for stability.

<sup>Written for commit 78ea3ba50f80fe8b64c170e02d409110333c3512. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

