### PR TITLE
fix(chat): mount query state adapter

### DIFF
--- a/apps/chat/src/app/[locale]/layout.test.ts
+++ b/apps/chat/src/app/[locale]/layout.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('root layout query-state adapter', () => {
+  it('mounts the Next nuqs adapter above shared satellite UI', () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, 'layout.tsx'),
+      'utf8'
+    );
+    const adapterStart = source.indexOf('<NuqsAdapter>');
+    const providers = source.indexOf('<Providers>');
+    const children = source.indexOf('{children}');
+    const versionBadge = source.indexOf('<SatelliteVersionBadge');
+    const adapterEnd = source.indexOf('</NuqsAdapter>');
+
+    expect(source).toContain("from '@tuturuuu/ui/nuqs-adapter'");
+    expect(adapterStart).toBeGreaterThan(-1);
+    expect(adapterStart).toBeLessThan(providers);
+    expect(adapterStart).toBeLessThan(children);
+    expect(adapterStart).toBeLessThan(versionBadge);
+    expect(adapterEnd).toBeGreaterThan(providers);
+    expect(adapterEnd).toBeGreaterThan(children);
+    expect(adapterEnd).toBeGreaterThan(versionBadge);
+  });
+});

--- a/apps/chat/src/app/[locale]/layout.tsx
+++ b/apps/chat/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { SatelliteVersionBadge } from '@tuturuuu/satellite/version-badge';
 import { ProductionIndicator } from '@tuturuuu/ui/custom/production-indicator';
 import { StaffToolbar } from '@tuturuuu/ui/custom/staff-toolbar';
 import { TailwindIndicator } from '@tuturuuu/ui/custom/tailwind-indicator';
+import { NuqsAdapter } from '@tuturuuu/ui/nuqs-adapter';
 import { Toaster } from '@tuturuuu/ui/sonner';
 import { font, generateCommonMetadata } from '@tuturuuu/utils/common/nextjs';
 import { cn } from '@tuturuuu/utils/format';
@@ -73,14 +74,16 @@ export default async function RootLayout({ children, params }: Props) {
           <VercelAnalytics />
           <VercelInsights />
           <Suspense>
-            <Providers>
-              <NextIntlClientProvider>
-                {children}
-                <Suspense fallback={null}>
-                  <SatelliteVersionBadge appName="Chat" />
-                </Suspense>
-              </NextIntlClientProvider>
-            </Providers>
+            <NuqsAdapter>
+              <Providers>
+                <NextIntlClientProvider>
+                  {children}
+                  <Suspense fallback={null}>
+                    <SatelliteVersionBadge appName="Chat" />
+                  </Suspense>
+                </NextIntlClientProvider>
+              </Providers>
+            </NuqsAdapter>
           </Suspense>
           <TailwindIndicator />
           <ProductionIndicator />

--- a/packages/ui/src/components/ui/nuqs-adapter.tsx
+++ b/packages/ui/src/components/ui/nuqs-adapter.tsx
@@ -1,0 +1,1 @@
+export { NuqsAdapter } from 'nuqs/adapters/next/app';


### PR DESCRIPTION
## Summary
- mount the Next.js nuqs adapter above Chat client providers
- declare the app-level nuqs dependency used by the adapter
- add a regression test for adapter coverage and provider ordering

## Root cause
Authenticated Browser verification reproduced the recovery boundary and captured `NUQS-404`: shared satellite navigation uses nuqs hooks, but Chat had no framework adapter.

## Verification
- `bun run test` in `apps/chat` (14 passed)
- `bun type-check:chat`
- `bun check`
- production Browser reproduction confirmed before fix

## Production verification
- pending CI build, protected merge, production sync, and repeated Browser reloads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the Next `nuqs` adapter at the Chat app root (via `@tuturuuu/ui/nuqs-adapter`) to fix broken query-state hooks and stop NUQS-404 during satellite navigation. Restores stable routing and removes recovery boundary hits.

- **Bug Fixes**
  - Wraps the root layout with `<NuqsAdapter>` above `<Providers>`, children, and `SatelliteVersionBadge`.
  - Adds a regression test to verify adapter import and ordering.

- **Refactors**
  - Adds `@tuturuuu/ui/nuqs-adapter` to re-export the Next adapter for shared use.

<sup>Written for commit 8e62a4c63cd14c42a21ce757e5dab1ab547cd214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

