### PR TITLE
test(tanstack): expect canonical English login path

### DIFF
--- a/apps/tanstack-web/e2e/dashboard-auth-gate.noauth.spec.ts
+++ b/apps/tanstack-web/e2e/dashboard-auth-gate.noauth.spec.ts
@@ -8,8 +8,9 @@ import { DEFAULT_LOCALE } from './helpers/public-routes';
  * loader (before any workspace/backend resolution). The gate is fail-closed:
  * when the session cannot be validated — no cookies, or the internal-api
  * `/users/me/profile` call errors/times out/returns non-2xx — `resolveCurrentUser`
- * resolves to `null` and the loader throws `redirect(/{locale}/login?nextUrl=...)`
- * with a 307. See `src/lib/platform/auth-gate.ts`.
+ * resolves to `null` and the loader redirects to the login route with the
+ * original page in `nextUrl`. English then canonicalizes to `/login` under the
+ * platform's as-needed locale policy. See `src/lib/platform/auth-gate.ts`.
  *
  * Because the redirect happens before workspace resolution, these assertions do
  * NOT depend on a reachable Rust/legacy backend or a seeded workspace: an
@@ -83,11 +84,12 @@ test.describe('Dashboard auth gate (unauthenticated)', () => {
 
       const url = new URL(page.url());
 
-      // Landed on the locale-scoped login route, not the gated route.
+      // English canonicalizes to the unprefixed login route under the
+      // platform's as-needed locale policy.
       expect(
         url.pathname,
         `Expected anonymous access to ${target} to redirect to the login route`
-      ).toBe(`/${DEFAULT_LOCALE}/login`);
+      ).toBe('/login');
 
       // The original path is preserved (decoded once) in nextUrl so the user
       // returns to the route after authenticating. Open-redirect-safe: it is a
@@ -110,7 +112,7 @@ test.describe('Dashboard auth gate (unauthenticated)', () => {
     expect(
       url.pathname,
       'Expected anonymous logout access to redirect to the login route'
-    ).toBe(`/${DEFAULT_LOCALE}/login`);
+    ).toBe('/login');
     expect(
       url.searchParams.get('nextUrl'),
       'Expected logout login redirect to preserve the localized return path'

--- a/apps/tanstack-web/e2e/public-users-auth-gate.noauth.spec.ts
+++ b/apps/tanstack-web/e2e/public-users-auth-gate.noauth.spec.ts
@@ -17,7 +17,9 @@ test.describe('Public user profile auth gate (unauthenticated)', () => {
 
     const url = new URL(page.url());
 
-    expect(url.pathname).toBe(`/${DEFAULT_LOCALE}/login`);
+    // English uses the platform's canonical as-needed locale policy, so the
+    // final browser URL omits the default-locale prefix after the auth gate.
+    expect(url.pathname).toBe('/login');
     expect(url.searchParams.get('nextUrl')).toBe(
       '/users/__e2e_missing_handle__'
     );


### PR DESCRIPTION
# Description

Align unauthenticated TanStack E2E assertions with the platform's canonical as-needed locale behavior.

## What?

- Expect English auth redirects to land on `/login`.
- Preserve the existing localized source route and `nextUrl` coverage.
- Update the test documentation to describe canonicalization.

## Why?

The merged CyberShield35 CMS adapter exposed a deterministic main-branch E2E mismatch: the app correctly canonicalizes default-locale English from `/en/login` to `/login`, while the tests still expected the prefixed URL. All 30 failures in the dual-stack migration gate had the same expected/received mismatch.

## How?

Only the two affected Playwright assertions and their explanatory comments change; runtime behavior is unchanged.

## Validation

- `bunx biome check apps/tanstack-web/e2e/public-users-auth-gate.noauth.spec.ts apps/tanstack-web/e2e/dashboard-auth-gate.noauth.spec.ts`
- `bunx vitest run src/lib/platform/locale.test.ts src/lib/platform/auth-gate.test.ts` (28/28)

## Screenshots for proof (must have)

Not applicable: this is a test-only correction for an already-observed canonical redirect. The failed main job records `Expected: "/en/login"` and `Received: "/login"` consistently across the affected cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix unauthenticated auth-gate E2E tests to expect the canonical English login path `/login` instead of `/en/login`, matching the platform’s as-needed locale policy.

- **Bug Fixes**
  - Updated assertions in apps/tanstack-web/e2e/dashboard-auth-gate.noauth.spec.ts and apps/tanstack-web/e2e/public-users-auth-gate.noauth.spec.ts.
  - Kept `nextUrl` checks and added comments to clarify canonicalization.

<sup>Written for commit 107012493f3d05f82f0185d9f4c34b04df87cff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

