### PR TITLE
fix(ci): unblock release auto-merge with Flutter and a push-token gate

### DIFF
--- a/.github/workflows/release-please-auto-merge.yaml
+++ b/.github/workflows/release-please-auto-merge.yaml
@@ -34,8 +34,10 @@ jobs:
   merge:
     name: Merge release-please and align production
     runs-on: ubuntu-latest
-    # `bun git-release-please` runs the full repo check before committing.
-    timeout-minutes: 90
+    # `bun git-release-please` runs the full repo check before committing, and
+    # every release bumps apps/mobile/pubspec.yaml, so the Flutter suite runs
+    # too.
+    timeout-minutes: 120
     permissions:
       contents: write
     steps:
@@ -110,6 +112,31 @@ jobs:
             echo "needs_sync=${needs_sync}"
           } >> "$GITHUB_OUTPUT"
 
+      # Checked before the ~40 minutes of install, build and `bun check` that
+      # follow, because none of it can land without this. `main` and
+      # `production` are covered by a ruleset whose only bypass actor is
+      # OrganizationAdmin, so `github.token` is refused by the remote with
+      # `GH013: Changes must be made through a pull request`. Granting the
+      # Actions app a bypass instead would not work either: pushes made with
+      # `GITHUB_TOKEN` do not trigger `push` workflows, so the production push
+      # would skip the Vercel production planner and the next Release Please
+      # run.
+      - name: Require a token that can push protected branches
+        if: (steps.plan.outputs.should_merge == 'true' || steps.plan.outputs.needs_sync == 'true') && inputs.dry_run != true
+        shell: bash
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${RELEASE_PLEASE_TOKEN}" ]; then
+            echo "RELEASE_PLEASE_TOKEN is configured."
+            exit 0
+          fi
+
+          echo "::error::RELEASE_PLEASE_TOKEN is not configured, so this run fell back to GITHUB_TOKEN and its push to main would be rejected. Add a repository secret named RELEASE_PLEASE_TOKEN holding a personal access token (repo + workflow scopes) owned by an organization admin, then re-run this workflow."
+          exit 1
+
       - name: Install dependencies
         if: steps.plan.outputs.should_merge == 'true'
         run: bash scripts/ci/run-with-backoff.sh bun install --frozen-lockfile
@@ -128,6 +155,28 @@ jobs:
           command: bun turbo:local run build --concurrency=4 --filter=@tuturuuu/types --filter=@tuturuuu/supabase --filter=@tuturuuu/masonry --filter=@tuturuuu/internal-api --filter=tuturuuu
           token: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production') && secrets.TURBO_TOKEN || '' }}
           team: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production') && (vars.TURBO_TEAM || secrets.TURBO_TEAM) || '' }}
+
+      # Release-please bumps apps/mobile/pubspec.yaml on every release, so
+      # `touchesMobile()` in scripts/git-release-please.js is always true and
+      # `bun check` is followed by `bun check:mobile` — dart-format,
+      # flutter-analyze and flutter-test. Without a Flutter toolchain all three
+      # exit 127 and the merge never reaches the push. Keep the version pin in
+      # step with mobile.yaml.
+      - name: Setup Flutter
+        if: steps.plan.outputs.should_merge == 'true'
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.44.x"
+          channel: stable
+          cache: true
+          pub-cache: true
+
+      # `generate: true` in pubspec.yaml means this also runs gen-l10n, which
+      # flutter-analyze needs before it can resolve lib/l10n/gen.
+      - name: Install mobile dependencies
+        if: steps.plan.outputs.should_merge == 'true'
+        working-directory: apps/mobile
+        run: flutter pub get
 
       - name: Configure git identity
         if: steps.plan.outputs.should_merge == 'true'

--- a/apps/docs/build/devops/github-actions-runbook.mdx
+++ b/apps/docs/build/devops/github-actions-runbook.mdx
@@ -534,9 +534,28 @@ Day-of-month cron stepping restarts each month, so the 31st and the 1st can land
 a day apart. That is harmless here precisely because an empty run does nothing.
 
 The job checks out `main` with `fetch-depth: 0` and
-`secrets.RELEASE_PLEASE_TOKEN`, falling back to `github.token`. The token must be
-able to push to `main` and `production`; with only the default token the push
-fails against branch protection. Top-level `permissions` is `{}` and
+`secrets.RELEASE_PLEASE_TOKEN`, falling back to `github.token`. The fallback
+cannot complete a release: the `Protected branches` ruleset covers `main` and
+`production` and its only bypass actor is `OrganizationAdmin`, so a run on
+`github.token` merges cleanly and then dies on
+`GH013: Changes must be made through a pull request`. `RELEASE_PLEASE_TOKEN`
+must therefore hold a personal access token (`repo` + `workflow` scopes) owned
+by an organization admin. Granting the Actions app a ruleset bypass is **not**
+an alternative: pushes made with `GITHUB_TOKEN` do not trigger `push`
+workflows, so the `production` push would silently skip
+`Vercel Production Deployment Planner` and the next `Release Please` run and
+stall the release chain. A run that would need to push checks for the secret up
+front and fails with an actionable error, rather than discovering it after
+`bun check`.
+
+The job also installs Flutter (`3.44.x`, the same pin as `mobile.yaml`) and runs
+`flutter pub get` in `apps/mobile` before the merge. Release Please bumps
+`apps/mobile/pubspec.yaml` on every release, so `touchesMobile()` in
+`scripts/git-release-please.js` is always true and `bun check` is always
+followed by `bun check:mobile`; without a toolchain `dart-format`,
+`flutter-analyze` and `flutter-test` all exit `127`.
+
+Top-level `permissions` is `{}` and
 `contents: write` is granted on the job alone, and `concurrency` is grouped with
 `cancel-in-progress: false` because cancelling a half-finished release merge
 would leave `main` and `production` split. Use the `dry_run` dispatch input to

--- a/plugins/tuturuuu/skills/tuturuuu-development-tooling/references/ci-tooling-patterns.md
+++ b/plugins/tuturuuu/skills/tuturuuu-development-tooling/references/ci-tooling-patterns.md
@@ -143,6 +143,22 @@ formatting behavior, or repo-wide verification.
 - Keep the Release Please token fallback ordered as
   `secrets.RELEASE_PLEASE_TOKEN || github.token`; the bot token is still needed
   for generated PRs and releases to trigger downstream workflows.
+- `RELEASE_PLEASE_TOKEN` must be a PAT (`repo` + `workflow`) owned by an
+  organization admin. Ruleset `Protected branches` covers `main` and
+  `production` with only `OrganizationAdmin` as a bypass actor, so a run that
+  falls back to `github.token` merges fine and then dies on
+  `GH013: Changes must be made through a pull request`. Do not "fix" this by
+  giving the Actions app a ruleset bypass: `GITHUB_TOKEN` pushes do not trigger
+  `push` workflows, so the `production` push would skip the Vercel production
+  planner and the next Release Please run. Gate any workflow that will push
+  protected branches on the secret being present, before the expensive steps —
+  discovering it after `bun check` wastes ~40 minutes per run.
+- Any CI job that runs `bun git-release-please` needs a Flutter toolchain
+  (`subosito/flutter-action@v2`, pinned to the same version as `mobile.yaml`,
+  plus `flutter pub get` in `apps/mobile`). Release Please bumps
+  `apps/mobile/pubspec.yaml` on every release, so `touchesMobile()` is always
+  true and `bun check:mobile` always runs; `flutter pub get` also covers the
+  `generate: true` gen-l10n step that `flutter-analyze` needs.
 - Keep the Release Please overflow recovery step before
   `googleapis/release-please-action@v5`. It runs
   `node scripts/ci/release-please-overflow-recovery.js --target-branch production`

--- a/scripts/ci/release-please-auto-merge.test.js
+++ b/scripts/ci/release-please-auto-merge.test.js
@@ -108,6 +108,80 @@ test('release merge builds the dist-only packages before running bun check', () 
   }
 });
 
+test('release merge installs the Flutter toolchain bun check:mobile needs', () => {
+  // Release-please bumps apps/mobile/pubspec.yaml on every release, so
+  // touchesMobile() in scripts/git-release-please.js is always true and the
+  // merge runs dart-format, flutter-analyze and flutter-test. A runner with no
+  // Flutter exits 127 on all three (run 30891619937).
+  const flutterIndex = workflow.indexOf('- name: Setup Flutter');
+
+  assert.ok(flutterIndex !== -1, 'the Flutter toolchain must be installed');
+  assert.ok(
+    flutterIndex < workflow.indexOf('- name: Merge release-please branch'),
+    'Flutter must be installed before bun check:mobile runs'
+  );
+  assert.match(
+    workflow,
+    /- name: Install mobile dependencies\n {8}if: steps\.plan\.outputs\.should_merge == 'true'\n {8}working-directory: apps\/mobile\n {8}run: flutter pub get/,
+    'flutter-analyze and flutter-test need pub get (and the gen-l10n it runs)'
+  );
+});
+
+test('release merge pins the same Flutter version as the mobile workflow', () => {
+  const mobileWorkflow = fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'mobile.yaml'),
+    'utf8'
+  );
+  const mobileVersion = mobileWorkflow.match(/flutter-version: "([^"]+)"/)?.[1];
+
+  assert.ok(mobileVersion, 'mobile.yaml must pin a Flutter version');
+  assert.match(
+    workflow,
+    new RegExp(`flutter-version: "${mobileVersion.replaceAll('.', '\\.')}"`),
+    'the release merge must check mobile with the version mobile CI uses'
+  );
+});
+
+test('release merge fails fast when it has no token that can push', () => {
+  // main and production are covered by a ruleset whose only bypass actor is
+  // OrganizationAdmin, so a run that falls back to github.token cannot push.
+  // Finding that out after bun check has already run wastes ~40 minutes.
+  const gateIndex = workflow.indexOf(
+    '- name: Require a token that can push protected branches'
+  );
+
+  assert.ok(gateIndex !== -1, 'a run that cannot push must say so up front');
+  assert.ok(
+    gateIndex < workflow.indexOf('- name: Install dependencies'),
+    'the token gate must run before the expensive steps'
+  );
+  assert.ok(
+    gateIndex > workflow.indexOf('- name: Resolve work to do'),
+    'a run with nothing to merge or sync must not need a token at all'
+  );
+
+  const gateStep = workflow.slice(
+    gateIndex,
+    workflow.indexOf('- name: Install dependencies')
+  );
+
+  assert.match(
+    gateStep,
+    /RELEASE_PLEASE_TOKEN: \$\{\{ secrets\.RELEASE_PLEASE_TOKEN \}\}/,
+    'the secret must reach the script through the environment'
+  );
+  assert.match(
+    gateStep,
+    /inputs\.dry_run != true/,
+    'a dry run pushes nothing, so it must not require the token'
+  );
+  assert.match(
+    gateStep,
+    /::error::RELEASE_PLEASE_TOKEN is not configured/,
+    'the failure must name the secret to create'
+  );
+});
+
 test('release merge deletes both release-please branches once they are merged', () => {
   const cleanupIndex = workflow.indexOf(
     '- name: Delete merged release-please branches'


### PR DESCRIPTION
## Why

The scheduled `Release Please Auto Merge` workflow has **never completed a real release**. Its one green run ([30157074415](https://github.com/tutur3u/platform/actions/runs/30157074415)) was a no-op with nothing to merge. Two independent failures, either one fatal on its own:

**1. `dart: command not found`** ([run 30891619937](https://github.com/tutur3u/platform/actions/runs/30891619937))

Release Please bumps `apps/mobile/pubspec.yaml` on every release, so `touchesMobile()` in `scripts/git-release-please.js` is always true and the merge runs `bun check:mobile`. The job installed Bun and Node only, so `dart-format`, `flutter-analyze` and `flutter-test` all exited `127`. This is not a one-off — it now fires on every release.

**2. The push is rejected** ([30341613283](https://github.com/tutur3u/platform/actions/runs/30341613283), [30616812876](https://github.com/tutur3u/platform/actions/runs/30616812876))

`main` and `production` are covered by the `Protected branches` ruleset, whose only bypass actor is `OrganizationAdmin`. `RELEASE_PLEASE_TOKEN` is not configured, so the job falls back to `GITHUB_TOKEN`, merges cleanly, and then dies in `bun git-sync`:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## What changed

- **Setup Flutter** (`3.44.x`, the same pin as `mobile.yaml`) + `flutter pub get` in `apps/mobile`, gated on `should_merge`. `pub get` also covers the `generate: true` gen-l10n step `flutter-analyze` needs.
- **Token gate** right after the plan step. A run that will push and has no `RELEASE_PLEASE_TOKEN` now fails in about a minute with an error naming the secret to create, instead of after ~40 minutes of install, build and `bun check`. Dry runs are exempt — they never push.
- `timeout-minutes` 90 → 120 to cover the added mobile suite.
- Docs: the runbook and the tooling skill reference now record why the PAT must be org-admin-owned.

Granting the Actions app a ruleset bypass is deliberately **not** the fix here: pushes made with `GITHUB_TOKEN` do not trigger `push` workflows, so the `production` push would silently skip `Vercel Production Deployment Planner` and the next `Release Please` run and stall the release chain.

## Tests

Three new assertions in `scripts/ci/release-please-auto-merge.test.js`: Flutter is installed before the merge step, its version is tied to `mobile.yaml` so the two cannot drift, and the token gate sits before the expensive steps with dry-run exempted. 16/16 in that file, plus the 71 assertions in `check-workflow-config`, `ci-cache-policy` and `release-workflows`.

## Verification

`bun check` green on this branch (19/19).

Release PR #5076 was landed separately with the same scripts CI runs (`bun git-release-please`, full `bun check` + `bun check:mobile` including all 520 mobile tests) — merge commit `ebb1ae4d75`, `main` and `production` aligned, and the production push correctly triggered `Vercel Production Deployment Planner` and `Release Please`.

## Follow-up required by an owner

This PR makes the workflow correct, but it cannot push until `RELEASE_PLEASE_TOKEN` exists: a classic PAT with `repo` + `workflow` scopes, owned by an organization admin, added as a repository secret. Until then the gate will fail the run fast and say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the scheduled release auto-merge by installing Flutter for mobile checks and adding a fast-fail gate for missing `RELEASE_PLEASE_TOKEN`. Prevents `dart`/Flutter 127 errors and avoids long runs that would be rejected by protected branches.

- **Bug Fixes**
  - CI: Setup Flutter `3.44.x` via `subosito/flutter-action@v2` and run `flutter pub get` in `apps/mobile` before merging; version is pinned to `mobile.yaml`.
  - CI: Add early gate that requires `RELEASE_PLEASE_TOKEN` for real pushes (dry runs exempt) and raise timeout to 120 minutes.
  - Docs/Tests: Update runbook and tooling references; add tests for Flutter setup, version pin, and gate order.

- **Migration**
  - Add a repo secret `RELEASE_PLEASE_TOKEN` with a PAT (`repo` + `workflow`) owned by an Organization Admin so pushes to `main`/`production` pass rulesets. Do not grant a ruleset bypass to the Actions app; `GITHUB_TOKEN` pushes won’t trigger `push` workflows.

<sup>Written for commit 71f2a3af3272c8cf5ac87083cf6249beb7cc2832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

