### PR TITLE
fix(tasks): isolate board member query cache

### DIFF
--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-boards/[boardId]/capacity-rules/[ruleId]/route.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-boards/[boardId]/capacity-rules/[ruleId]/route.ts
@@ -8,6 +8,7 @@ import {
   replaceSelectors,
   requireCapacityAccess,
   rulePayload,
+  TASK_CAPACITY_RULE_APP_SESSION_AUTH,
   validateSelectors,
 } from '../_lib';
 
@@ -17,108 +18,114 @@ export const PATCH = withSessionAuth<{
   wsId: string;
   boardId: string;
   ruleId: string;
-}>(async (request, { supabase, user }, rawParams) => {
-  try {
-    const params = paramsSchema.parse(rawParams);
-    const body = capacityRulePatchSchema.parse(await request.json());
-    const manager = await requireCapacityAccess({
-      boardId: params.boardId,
-      rawWsId: params.wsId,
-      supabase,
-      user,
-      write: true,
-    });
-    if ('error' in manager) return manager.error;
-    const current = await (manager.sbAdmin as any)
-      .from('task_capacity_rules')
-      .select('enabled')
-      .eq('id', params.ruleId)
-      .eq('board_id', manager.boardId)
-      .maybeSingle();
-    if (current.error) throw current.error;
-    if (!current.data)
+}>(
+  async (request, { supabase, user }, rawParams) => {
+    try {
+      const params = paramsSchema.parse(rawParams);
+      const body = capacityRulePatchSchema.parse(await request.json());
+      const manager = await requireCapacityAccess({
+        boardId: params.boardId,
+        rawWsId: params.wsId,
+        supabase,
+        user,
+        write: true,
+      });
+      if ('error' in manager) return manager.error;
+      const current = await (manager.sbAdmin as any)
+        .from('task_capacity_rules')
+        .select('enabled')
+        .eq('id', params.ruleId)
+        .eq('board_id', manager.boardId)
+        .maybeSingle();
+      if (current.error) throw current.error;
+      if (!current.data)
+        return NextResponse.json(
+          { error: 'Capacity rule not found' },
+          { status: 404 }
+        );
+      const selectorError = await validateSelectors(manager, body);
+      if (selectorError) return selectorError;
+      await replaceSelectors(manager, params.ruleId, body);
+      const update = await (manager.sbAdmin as any)
+        .from('task_capacity_rules')
+        .update({
+          ...rulePayload(body, user.id),
+          enabled: body.enabled ?? current.data.enabled,
+          disabled_reason: body.enabled === false ? 'manually_disabled' : null,
+        })
+        .eq('id', params.ruleId)
+        .eq('board_id', manager.boardId)
+        .select('id')
+        .maybeSingle();
+      if (update.error) throw update.error;
+      if (!update.data)
+        return NextResponse.json(
+          { error: 'Capacity rule not found' },
+          { status: 404 }
+        );
+      const { data, error } = await loadCapacityRules(manager);
+      if (error) throw error;
+      return NextResponse.json({
+        rule: data?.find(
+          (candidate: { id: string }) => candidate.id === params.ruleId
+        ),
+      });
+    } catch (error) {
+      if (error instanceof z.ZodError || error instanceof SyntaxError)
+        return NextResponse.json(
+          { error: 'Invalid capacity rule payload' },
+          { status: 400 }
+        );
       return NextResponse.json(
-        { error: 'Capacity rule not found' },
-        { status: 404 }
+        { error: 'Failed to update capacity rule' },
+        { status: 500 }
       );
-    const selectorError = await validateSelectors(manager, body);
-    if (selectorError) return selectorError;
-    await replaceSelectors(manager, params.ruleId, body);
-    const update = await (manager.sbAdmin as any)
-      .from('task_capacity_rules')
-      .update({
-        ...rulePayload(body, user.id),
-        enabled: body.enabled ?? current.data.enabled,
-        disabled_reason: body.enabled === false ? 'manually_disabled' : null,
-      })
-      .eq('id', params.ruleId)
-      .eq('board_id', manager.boardId)
-      .select('id')
-      .maybeSingle();
-    if (update.error) throw update.error;
-    if (!update.data)
-      return NextResponse.json(
-        { error: 'Capacity rule not found' },
-        { status: 404 }
-      );
-    const { data, error } = await loadCapacityRules(manager);
-    if (error) throw error;
-    return NextResponse.json({
-      rule: data?.find(
-        (candidate: { id: string }) => candidate.id === params.ruleId
-      ),
-    });
-  } catch (error) {
-    if (error instanceof z.ZodError || error instanceof SyntaxError)
-      return NextResponse.json(
-        { error: 'Invalid capacity rule payload' },
-        { status: 400 }
-      );
-    return NextResponse.json(
-      { error: 'Failed to update capacity rule' },
-      { status: 500 }
-    );
-  }
-});
+    }
+  },
+  { allowAppSessionAuth: TASK_CAPACITY_RULE_APP_SESSION_AUTH }
+);
 
 export const DELETE = withSessionAuth<{
   wsId: string;
   boardId: string;
   ruleId: string;
-}>(async (_request, { supabase, user }, rawParams) => {
-  try {
-    const params = paramsSchema.parse(rawParams);
-    const manager = await requireCapacityAccess({
-      boardId: params.boardId,
-      rawWsId: params.wsId,
-      supabase,
-      user,
-      write: true,
-    });
-    if ('error' in manager) return manager.error;
-    const result = await (manager.sbAdmin as any)
-      .from('task_capacity_rules')
-      .delete()
-      .eq('id', params.ruleId)
-      .eq('board_id', manager.boardId)
-      .select('id')
-      .maybeSingle();
-    if (result.error) throw result.error;
-    if (!result.data)
+}>(
+  async (_request, { supabase, user }, rawParams) => {
+    try {
+      const params = paramsSchema.parse(rawParams);
+      const manager = await requireCapacityAccess({
+        boardId: params.boardId,
+        rawWsId: params.wsId,
+        supabase,
+        user,
+        write: true,
+      });
+      if ('error' in manager) return manager.error;
+      const result = await (manager.sbAdmin as any)
+        .from('task_capacity_rules')
+        .delete()
+        .eq('id', params.ruleId)
+        .eq('board_id', manager.boardId)
+        .select('id')
+        .maybeSingle();
+      if (result.error) throw result.error;
+      if (!result.data)
+        return NextResponse.json(
+          { error: 'Capacity rule not found' },
+          { status: 404 }
+        );
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return NextResponse.json(
+          { error: 'Invalid capacity rule ID' },
+          { status: 400 }
+        );
       return NextResponse.json(
-        { error: 'Capacity rule not found' },
-        { status: 404 }
+        { error: 'Failed to delete capacity rule' },
+        { status: 500 }
       );
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    if (error instanceof z.ZodError)
-      return NextResponse.json(
-        { error: 'Invalid capacity rule ID' },
-        { status: 400 }
-      );
-    return NextResponse.json(
-      { error: 'Failed to delete capacity rule' },
-      { status: 500 }
-    );
-  }
-});
+    }
+  },
+  { allowAppSessionAuth: TASK_CAPACITY_RULE_APP_SESSION_AUTH }
+);

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-boards/[boardId]/capacity-rules/_lib.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-boards/[boardId]/capacity-rules/_lib.ts
@@ -1,3 +1,4 @@
+import { CLI_APP_TARGET_APP } from '@tuturuuu/auth/cli-session';
 import { createAdminClient } from '@tuturuuu/supabase/next/server';
 import type { SupabaseUser } from '@tuturuuu/supabase/next/user';
 import type { TypedSupabaseClient } from '@tuturuuu/supabase/types';
@@ -14,6 +15,10 @@ export const capacityParamsSchema = z.object({
   wsId: z.string().min(1),
   boardId: z.guid(),
 });
+
+export const TASK_CAPACITY_RULE_APP_SESSION_AUTH = {
+  targetApp: [CLI_APP_TARGET_APP, 'tasks'],
+} as const;
 
 export const capacityRuleSchema = z.object({
   name: z.string().trim().min(1).max(120),

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-boards/[boardId]/capacity-rules/route.auth.test.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-boards/[boardId]/capacity-rules/route.auth.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  withSessionAuth: vi.fn((handler: unknown, _options?: unknown) => handler),
+}));
+
+vi.mock('@/lib/api-auth', () => ({
+  withSessionAuth: mocks.withSessionAuth,
+}));
+
+describe('task capacity rule route authentication', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.withSessionAuth.mockImplementation(
+      (handler: unknown, _options?: unknown) => handler
+    );
+  });
+
+  it('allows Tasks and CLI app sessions for every capacity endpoint', async () => {
+    await import('./route');
+    await import('./[ruleId]/route');
+
+    expect(mocks.withSessionAuth).toHaveBeenCalledTimes(4);
+    for (const call of mocks.withSessionAuth.mock.calls) {
+      expect(call[1]).toEqual({
+        allowAppSessionAuth: {
+          targetApp: expect.arrayContaining(['tasks', 'platform']),
+        },
+      });
+    }
+  });
+});

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-boards/[boardId]/capacity-rules/route.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-boards/[boardId]/capacity-rules/route.ts
@@ -8,6 +8,7 @@ import {
   replaceSelectors,
   requireCapacityAccess,
   rulePayload,
+  TASK_CAPACITY_RULE_APP_SESSION_AUTH,
   validateSelectors,
 } from './_lib';
 
@@ -39,7 +40,8 @@ export const GET = withSessionAuth<{ wsId: string; boardId: string }>(
         { status: 500 }
       );
     }
-  }
+  },
+  { allowAppSessionAuth: TASK_CAPACITY_RULE_APP_SESSION_AUTH }
 );
 
 export const POST = withSessionAuth<{ wsId: string; boardId: string }>(
@@ -103,5 +105,6 @@ export const POST = withSessionAuth<{ wsId: string; boardId: string }>(
         { status: 500 }
       );
     }
-  }
+  },
+  { allowAppSessionAuth: TASK_CAPACITY_RULE_APP_SESSION_AUTH }
 );

--- a/packages/tasks-ui/src/tu-do/boards/__tests__/board-share-dialog.test.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/__tests__/board-share-dialog.test.tsx
@@ -90,7 +90,7 @@ function renderBoardShareDialog() {
     },
   });
 
-  return render(
+  const result = render(
     <QueryClientProvider client={queryClient}>
       <BoardShareDialog
         board={{ id: 'board-1', name: 'Tasks' }}
@@ -100,6 +100,8 @@ function renderBoardShareDialog() {
       />
     </QueryClientProvider>
   );
+
+  return { ...result, queryClient };
 }
 
 describe('BoardShareDialog', () => {
@@ -174,7 +176,7 @@ describe('BoardShareDialog', () => {
   });
 
   it('fetches viewable members only when the workspace section opens', async () => {
-    renderBoardShareDialog();
+    const { queryClient } = renderBoardShareDialog();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -191,6 +193,20 @@ describe('BoardShareDialog', () => {
     });
     expect(await screen.findByText('Project Manager')).toBeInTheDocument();
     expect(screen.getByText('pm@example.com')).toBeInTheDocument();
+    expect(
+      queryClient.getQueryData([
+        'task-board-share-viewable-members',
+        'ws-1',
+        'board-1',
+      ])
+    ).toEqual(expect.objectContaining({ members: expect.any(Array) }));
+    expect(
+      queryClient.getQueryData([
+        'task-board-viewable-members',
+        'ws-1',
+        'board-1',
+      ])
+    ).toBeUndefined();
   });
 
   it('does not crash when viewable members payload is missing members', async () => {

--- a/packages/tasks-ui/src/tu-do/boards/board-share-settings-panel.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/board-share-settings-panel.tsx
@@ -77,7 +77,9 @@ export function BoardShareSettingsPanel({
     retry: shouldRetryShareRequest,
   });
   const viewableMembersQuery = useQuery({
-    queryKey: ['task-board-viewable-members', wsId, board.id] as const,
+    // Keep the full access response separate from the bulk-assignee cache,
+    // which stores a normalized WorkspaceMember array under a similar key.
+    queryKey: ['task-board-share-viewable-members', wsId, board.id] as const,
     queryFn: ({ signal }) =>
       listWorkspaceTaskBoardViewableMembers(
         wsId,

--- a/packages/tasks-ui/src/tu-do/boards/boardId/kanban/data/use-bulk-resources.test.ts
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/kanban/data/use-bulk-resources.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from 'vitest';
-import { normalizeWorkspaceMemberList } from './use-bulk-resources';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { Workspace } from '@tuturuuu/types';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  normalizeWorkspaceMemberList,
+  useBulkResources,
+} from './use-bulk-resources';
+
+vi.mock('@tuturuuu/internal-api', () => ({
+  listWorkspaceLabels: vi.fn(async () => []),
+  listWorkspaceTaskProjects: vi.fn(async () => []),
+}));
+
+vi.mock('@tuturuuu/internal-api/tasks', () => ({
+  listWorkspaceTaskBoardViewableMembers: vi.fn(async () => ({ members: [] })),
+}));
+
+vi.mock('@tuturuuu/ui/hooks/use-workspace-members', () => ({
+  useWorkspaceMembers: vi.fn(() => ({ data: [] })),
+}));
 
 describe('normalizeWorkspaceMemberList', () => {
   it('preserves valid member arrays', () => {
@@ -14,4 +34,37 @@ describe('normalizeWorkspaceMemberList', () => {
       expect(normalizeWorkspaceMemberList(value)).toEqual([]);
     }
   );
+});
+
+describe('useBulkResources', () => {
+  it('normalizes a conflicting board-member cache value before merging', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      ['task-board-viewable-members', 'workspace-1', 'board-1'],
+      { members: [{ user_id: 'member-1' }] }
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(
+      () =>
+        useBulkResources({
+          boardId: 'board-1',
+          canUseBoardAssignees: true,
+          assigneeMemberSource: 'board',
+          workspace: {
+            id: 'workspace-1',
+            personal: false,
+          } as Workspace,
+          isMultiSelectMode: true,
+          selectedCount: 1,
+        }),
+      { wrapper }
+    );
+
+    expect(result.current.workspaceMembers).toEqual([]);
+    expect(Array.isArray(result.current.workspaceMembers)).toBe(true);
+  });
 });

--- a/packages/tasks-ui/src/tu-do/boards/boardId/kanban/data/use-bulk-resources.test.ts
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/kanban/data/use-bulk-resources.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeWorkspaceMemberList } from './use-bulk-resources';
+
+describe('normalizeWorkspaceMemberList', () => {
+  it('preserves valid member arrays', () => {
+    const members = [{ id: 'member-1', user_id: 'member-1' }];
+
+    expect(normalizeWorkspaceMemberList(members)).toBe(members);
+  });
+
+  it.each([undefined, null, {}, { members: [] }, 'invalid'])(
+    'returns an empty array for a non-array cache value',
+    (value) => {
+      expect(normalizeWorkspaceMemberList(value)).toEqual([]);
+    }
+  );
+});

--- a/packages/tasks-ui/src/tu-do/boards/boardId/kanban/data/use-bulk-resources.ts
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/kanban/data/use-bulk-resources.ts
@@ -12,6 +12,12 @@ import {
   type WorkspaceMember,
 } from '@tuturuuu/ui/hooks/use-workspace-members';
 
+export function normalizeWorkspaceMemberList(
+  value: unknown
+): WorkspaceMember[] {
+  return Array.isArray(value) ? (value as WorkspaceMember[]) : [];
+}
+
 export function useBulkResources({
   boardId,
   canUseBoardAssignees,
@@ -60,16 +66,16 @@ export function useBulkResources({
     canUseBoardAssignees !== false && isMultiSelectMode && selectedCount > 0;
   const effectiveAssigneeMemberSource =
     assigneeMemberSource ?? (workspace.personal ? 'board' : 'workspace');
-  const { data: workspaceMembersData = [] } = useWorkspaceMembers(
-    workspace.id,
-    {
-      enabled:
-        !!workspace.id &&
-        shouldLoadMembers &&
-        effectiveAssigneeMemberSource !== 'board',
-    }
+  const { data: workspaceMembersResult } = useWorkspaceMembers(workspace.id, {
+    enabled:
+      !!workspace.id &&
+      shouldLoadMembers &&
+      effectiveAssigneeMemberSource !== 'board',
+  });
+  const workspaceMembersData = normalizeWorkspaceMemberList(
+    workspaceMembersResult
   );
-  const { data: boardViewableMembers = [] } = useQuery({
+  const { data: boardViewableMembersResult } = useQuery({
     queryKey: ['task-board-viewable-members', workspace.id, boardId],
     queryFn: async (): Promise<WorkspaceMember[]> => {
       if (!workspace.id || !boardId) return [];
@@ -96,6 +102,9 @@ export function useBulkResources({
       effectiveAssigneeMemberSource !== 'workspace',
     staleTime: 5 * 60 * 1000,
   });
+  const boardViewableMembers = normalizeWorkspaceMemberList(
+    boardViewableMembersResult
+  );
   const workspaceMembers: WorkspaceMember[] = [
     ...workspaceMembersData,
     ...boardViewableMembers.filter(


### PR DESCRIPTION
## Summary
- isolate the sharing member-access response from the bulk-assignee React Query cache
- defensively normalize member cache values before array operations
- allow Tasks and CLI app sessions to access Capacity rule endpoints
- add hook-level cache-conflict and route-auth regression coverage

## Production evidence
- expanding Workspace members with access returned HTTP 200, then crashed with `TypeError: filter is not a function` from `useBulkResources`
- Capacity settings returned HTTP 403 `Workspace access denied` because the new routes did not opt into Tasks app-session authentication

## Validation
- Tasks UI focused tests: 7 passed after review follow-up; 12 sharing tests passed previously
- Tasks UI type-check: passed
- Tasks app route-auth test: passed
- Tasks app type-check: passed
- Biome check: passed
- local Tasks production build was blocked only by sandbox port binding (`EPERM`); PR CI provides the normal production runner

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in board sharing by isolating the member query cache and normalizing member data. Also enables Tasks and CLI app sessions to use capacity rule APIs to resolve 403 errors.

- **Bug Fixes**
  - Isolated share view members under `task-board-share-viewable-members` to avoid conflicts with bulk-assignee cache.
  - Added `normalizeWorkspaceMemberList` in `useBulkResources` to guard against non-array cache values (prevents “filter is not a function”).
  - Allowed app-session auth for all capacity rule endpoints via `TASK_CAPACITY_RULE_APP_SESSION_AUTH` (Tasks + CLI).
  - Added tests for route auth and member cache normalization; updated board-share dialog test to verify cache separation.

<sup>Written for commit 0ab7d86365d80d4b864b15e98ef1bc8ffb355d3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

