### PR TITLE
feat(ai): let the studio show provider cost in a chosen currency

### DIFF
--- a/apps/ai/messages/en.json
+++ b/apps/ai/messages/en.json
@@ -202,6 +202,7 @@
       "daily_usage": "Daily usage",
       "daily_usage_description": "Requests, credits and provider cost per day across the selected range.",
       "dimension": "Dimension",
+      "display_currency": "Display currency",
       "embedding_units": "Embedding units",
       "empty": "No metered usage in this range",
       "empty_description": "Try a broader date range after AI activity has settled.",

--- a/apps/ai/messages/vi.json
+++ b/apps/ai/messages/vi.json
@@ -202,6 +202,7 @@
       "daily_usage": "Mức sử dụng hàng ngày",
       "daily_usage_description": "Yêu cầu, tín dụng và chi phí nhà cung cấp theo ngày trong khoảng đã chọn.",
       "dimension": "Chiều phân tích",
+      "display_currency": "Đơn vị tiền tệ hiển thị",
       "embedding_units": "Đơn vị embedding",
       "empty": "Không có mức sử dụng được đo trong khoảng này",
       "empty_description": "Hãy thử khoảng thời gian rộng hơn sau khi hoạt động AI đã được ghi nhận.",

--- a/apps/ai/src/app/[locale]/[wsId]/credits/page.tsx
+++ b/apps/ai/src/app/[locale]/[wsId]/credits/page.tsx
@@ -1,14 +1,20 @@
 import { getTranslations } from 'next-intl/server';
 import { ObservabilityPanel } from '@/components/observability-panel';
 import { StudioPageShell } from '@/components/studio/studio-page-shell';
+import { resolveDisplayCurrency } from '@/lib/display-currency';
 import { getAiStudioPageContext } from '@/lib/page-context';
 
 export default async function CreditsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ wsId: string }>;
+  searchParams: Promise<{ currency?: string }>;
 }) {
   const { wsId } = await params;
+  // Read here rather than in the client, so the first paint already shows the
+  // requested currency instead of flashing dollars and correcting itself.
+  const currency = await resolveDisplayCurrency((await searchParams).currency);
   const t = await getTranslations('ai-studio');
   const { workspaceId } = await getAiStudioPageContext(wsId);
 
@@ -18,7 +24,11 @@ export default async function CreditsPage({
       eyebrow={t('observe')}
       title={t('credits')}
     >
-      <ObservabilityPanel section="credits" workspaceId={workspaceId} />
+      <ObservabilityPanel
+        currency={currency}
+        section="credits"
+        workspaceId={workspaceId}
+      />
     </StudioPageShell>
   );
 }

--- a/apps/ai/src/app/[locale]/[wsId]/runs/page.tsx
+++ b/apps/ai/src/app/[locale]/[wsId]/runs/page.tsx
@@ -1,14 +1,20 @@
 import { getTranslations } from 'next-intl/server';
 import { ObservabilityPanel } from '@/components/observability-panel';
 import { StudioPageShell } from '@/components/studio/studio-page-shell';
+import { resolveDisplayCurrency } from '@/lib/display-currency';
 import { getAiStudioPageContext } from '@/lib/page-context';
 
 export default async function RunsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ wsId: string }>;
+  searchParams: Promise<{ currency?: string }>;
 }) {
   const { wsId } = await params;
+  // Read here rather than in the client, so the first paint already shows the
+  // requested currency instead of flashing dollars and correcting itself.
+  const currency = await resolveDisplayCurrency((await searchParams).currency);
   const t = await getTranslations('ai-studio');
   const { workspaceId } = await getAiStudioPageContext(wsId);
 
@@ -18,7 +24,11 @@ export default async function RunsPage({
       eyebrow={t('observe')}
       title={t('runs')}
     >
-      <ObservabilityPanel section="runs" workspaceId={workspaceId} />
+      <ObservabilityPanel
+        currency={currency}
+        section="runs"
+        workspaceId={workspaceId}
+      />
     </StudioPageShell>
   );
 }

--- a/apps/ai/src/app/[locale]/[wsId]/usage/page.tsx
+++ b/apps/ai/src/app/[locale]/[wsId]/usage/page.tsx
@@ -1,14 +1,20 @@
 import { getTranslations } from 'next-intl/server';
 import { ObservabilityPanel } from '@/components/observability-panel';
 import { StudioPageShell } from '@/components/studio/studio-page-shell';
+import { resolveDisplayCurrency } from '@/lib/display-currency';
 import { getAiStudioPageContext } from '@/lib/page-context';
 
 export default async function UsagePage({
   params,
+  searchParams,
 }: {
   params: Promise<{ wsId: string }>;
+  searchParams: Promise<{ currency?: string }>;
 }) {
   const { wsId } = await params;
+  // Read here rather than in the client, so the first paint already shows the
+  // requested currency instead of flashing dollars and correcting itself.
+  const currency = await resolveDisplayCurrency((await searchParams).currency);
   const t = await getTranslations('ai-studio');
   const { workspaceId } = await getAiStudioPageContext(wsId);
 
@@ -18,7 +24,11 @@ export default async function UsagePage({
       eyebrow={t('observe')}
       title={t('usage')}
     >
-      <ObservabilityPanel section="usage" workspaceId={workspaceId} />
+      <ObservabilityPanel
+        currency={currency}
+        section="usage"
+        workspaceId={workspaceId}
+      />
     </StudioPageShell>
   );
 }

--- a/apps/ai/src/components/observability-panel.tsx
+++ b/apps/ai/src/components/observability-panel.tsx
@@ -8,6 +8,7 @@ import {
   getAiStudioUsage,
 } from '@tuturuuu/internal-api/ai-studio';
 import { useTranslations } from 'next-intl';
+import type { DisplayCurrency } from '@/lib/display-currency';
 import { ObservabilityBreakdowns } from './observability-breakdowns';
 import { useObservabilityFilters } from './observability-filters';
 import { ObservabilityRuns } from './observability-runs';
@@ -19,9 +20,12 @@ import { StudioErrorState } from './studio/states';
 type ObservabilitySection = 'credits' | 'runs' | 'usage';
 
 export function ObservabilityPanel({
+  currency,
   section,
   workspaceId,
 }: {
+  /** Display-only conversion of provider cost; nothing stored changes. */
+  currency: DisplayCurrency;
   section: ObservabilitySection;
   workspaceId: string;
 }) {
@@ -89,6 +93,7 @@ export function ObservabilityPanel({
     <div className="space-y-4">
       <ObservabilityToolbar
         controls={controls}
+        currency={currency}
         isRefreshing={isRefreshing}
         onRefresh={refresh}
         showRunFilters={isRunSection}
@@ -105,6 +110,7 @@ export function ObservabilityPanel({
 
       <ObservabilitySummary
         credits={creditsQuery.data}
+        currency={currency}
         isLoading={
           usageQuery.isPending ||
           (section === 'credits' && creditsQuery.isPending)

--- a/apps/ai/src/components/observability-summary.tsx
+++ b/apps/ai/src/components/observability-summary.tsx
@@ -16,17 +16,22 @@ import type {
 } from '@tuturuuu/internal-api/ai-studio';
 import { Progress } from '@tuturuuu/ui/progress';
 import { Skeleton } from '@tuturuuu/ui/skeleton';
+import { formatCurrency } from '@tuturuuu/utils/format';
+import { getCurrencyFractionDigits } from '@tuturuuu/utils/money';
 import { useTranslations } from 'next-intl';
+import type { DisplayCurrency } from '@/lib/display-currency';
 import { SectionCard } from './studio/section-card';
 import { StatCard, StatCardGrid } from './studio/stat-card';
 
 export function ObservabilitySummary({
   credits,
+  currency,
   isLoading,
   section,
   totals,
 }: {
   credits?: AiStudioCreditStatus;
+  currency: DisplayCurrency;
   isLoading: boolean;
   section: 'credits' | 'runs' | 'usage';
   totals?: AiStudioUsageResponse['totals'];
@@ -88,7 +93,9 @@ export function ObservabilitySummary({
           isLoading={isLoading}
           label={t('provider_cost')}
           tone="orange"
-          value={totals ? formatUsd(totals.providerCostUsd) : '—'}
+          value={
+            totals ? formatProviderCost(totals.providerCostUsd, currency) : '—'
+          }
         />
         <StatCard
           icon={Cpu}
@@ -200,9 +207,24 @@ function formatNumber(value?: number) {
     : value.toLocaleString(undefined, { maximumFractionDigits: 4 });
 }
 
-function formatUsd(value: number) {
-  return `$${value.toLocaleString(undefined, {
+/**
+ * Provider cost is stored in USD; this only changes how it reads.
+ *
+ * Sub-cent amounts are the norm for a single run, so the fraction digits widen
+ * rather than rounding a real cost to "$0.00". Currencies without minor units,
+ * đồng among them, get none at all — "₫98,50" is not a number anyone writes.
+ */
+function formatProviderCost(valueUsd: number, currency: DisplayCurrency) {
+  const value = valueUsd * currency.rate;
+  const fractionless = getCurrencyFractionDigits(currency.code) === 0;
+  if (fractionless) {
+    return formatCurrency(Math.round(value), currency.code, undefined, {
+      maximumFractionDigits: 0,
+      minimumFractionDigits: 0,
+    });
+  }
+  return formatCurrency(value, currency.code, undefined, {
     maximumFractionDigits: 6,
     minimumFractionDigits: value > 0 && value < 0.01 ? 4 : 2,
-  })}`;
+  });
 }

--- a/apps/ai/src/components/observability-toolbar.tsx
+++ b/apps/ai/src/components/observability-toolbar.tsx
@@ -11,7 +11,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@tuturuuu/ui/select';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import {
+  DEFAULT_DISPLAY_CURRENCY,
+  type DisplayCurrency,
+  SUPPORTED_DISPLAY_CURRENCIES,
+} from '@/lib/display-currency';
 import {
   type ObservabilityFilters,
   RUN_STATUS_FILTERS,
@@ -24,21 +30,58 @@ import type { ObservabilityPreset } from './observability-helpers';
  */
 export function ObservabilityToolbar({
   controls,
+  currency,
   isRefreshing,
   onRefresh,
   showRunFilters,
 }: {
   controls: ObservabilityFilters;
+  currency: DisplayCurrency;
   isRefreshing: boolean;
   onRefresh: () => void;
   showRunFilters: boolean;
 }) {
   const t = useTranslations('ai-studio.observability');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { activeFilterCount, filters } = controls;
 
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
+        {/*
+          Display-only: the stored provider cost stays USD, so switching here
+          changes how the number reads, never what was billed. It lives in the
+          URL so a converted view can be linked and bookmarked.
+        */}
+        <Select
+          onValueChange={(value) => {
+            const next = new URLSearchParams(searchParams);
+            if (value === DEFAULT_DISPLAY_CURRENCY) next.delete('currency');
+            else next.set('currency', value);
+            const query = next.toString();
+            router.replace(query ? `${pathname}?${query}` : pathname, {
+              scroll: false,
+            });
+          }}
+          value={currency.code}
+        >
+          <SelectTrigger
+            aria-label={t('display_currency')}
+            className="h-9 w-full sm:w-28"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SUPPORTED_DISPLAY_CURRENCIES.map((code) => (
+              <SelectItem key={code} value={code}>
+                {code}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
         <Select
           onValueChange={(value) =>
             controls.setPreset(value as ObservabilityPreset)

--- a/apps/ai/src/lib/display-currency.test.ts
+++ b/apps/ai/src/lib/display-currency.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ createAdminClient: vi.fn() }));
+
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: mocks.createAdminClient,
+}));
+
+import {
+  DEFAULT_DISPLAY_CURRENCY,
+  normalizeDisplayCurrency,
+  resolveDisplayCurrency,
+} from './display-currency';
+
+function ratesClientReturning(row: { rate: number } | null, error?: unknown) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            order: () => ({
+              limit: () => ({
+                maybeSingle: async () => ({ data: row, error: error ?? null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('display currency', () => {
+  it('accepts only currencies the platform holds rates for', () => {
+    expect(normalizeDisplayCurrency('vnd')).toBe('VND');
+    expect(normalizeDisplayCurrency(' EUR ')).toBe('EUR');
+    // Anything else falls back rather than producing a label with no rate.
+    expect(normalizeDisplayCurrency('XYZ')).toBe(DEFAULT_DISPLAY_CURRENCY);
+    expect(normalizeDisplayCurrency(undefined)).toBe(DEFAULT_DISPLAY_CURRENCY);
+  });
+
+  it('never queries for USD, which is the stored unit', async () => {
+    await expect(resolveDisplayCurrency('USD')).resolves.toEqual({
+      code: 'USD',
+      rate: 1,
+    });
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('resolves the newest USD-based rate', async () => {
+    mocks.createAdminClient.mockResolvedValue(
+      ratesClientReturning({ rate: 25_400 })
+    );
+    await expect(resolveDisplayCurrency('VND')).resolves.toEqual({
+      code: 'VND',
+      rate: 25_400,
+    });
+  });
+
+  it('falls back to USD rather than labelling an unconverted number', async () => {
+    // Showing a dollar figure with a đồng symbol would be worse than showing
+    // dollars, so a missing, zero, or failing rate degrades to USD.
+    mocks.createAdminClient.mockResolvedValue(ratesClientReturning(null));
+    await expect(resolveDisplayCurrency('VND')).resolves.toEqual({
+      code: 'USD',
+      rate: 1,
+    });
+
+    mocks.createAdminClient.mockResolvedValue(
+      ratesClientReturning({ rate: 0 })
+    );
+    await expect(resolveDisplayCurrency('VND')).resolves.toEqual({
+      code: 'USD',
+      rate: 1,
+    });
+
+    mocks.createAdminClient.mockRejectedValue(new Error('no database'));
+    await expect(resolveDisplayCurrency('VND')).resolves.toEqual({
+      code: 'USD',
+      rate: 1,
+    });
+  });
+});

--- a/apps/ai/src/lib/display-currency.ts
+++ b/apps/ai/src/lib/display-currency.ts
@@ -1,0 +1,73 @@
+import { createAdminClient } from '@tuturuuu/supabase/next/server';
+
+/**
+ * Provider costs are recorded in USD, because that is what the model vendors
+ * bill in. Teams do not read them in USD — a Vietnamese operator looking at
+ * "$0.0042" has to do arithmetic before the number means anything.
+ *
+ * So the studio converts for *display* only. Nothing stored or billed changes;
+ * the underlying figure stays USD, which keeps historical rows comparable and
+ * avoids baking a rate into the ledger.
+ */
+export type DisplayCurrency = {
+  code: string;
+  /** USD → code. Exactly 1 when the display currency is USD. */
+  rate: number;
+};
+
+export const DEFAULT_DISPLAY_CURRENCY = 'USD';
+
+/**
+ * The currencies the studio offers. Kept to the ones the platform actually holds
+ * rates for, so the picker cannot offer something that silently falls back.
+ */
+export const SUPPORTED_DISPLAY_CURRENCIES = [
+  'USD',
+  'VND',
+  'EUR',
+  'GBP',
+  'JPY',
+  'SGD',
+  'AUD',
+] as const;
+
+export function normalizeDisplayCurrency(value: string | undefined | null) {
+  const code = value?.trim().toUpperCase();
+  if (!code) return DEFAULT_DISPLAY_CURRENCY;
+  return (
+    SUPPORTED_DISPLAY_CURRENCIES.find((entry) => entry === code) ??
+    DEFAULT_DISPLAY_CURRENCY
+  );
+}
+
+/**
+ * Resolves the newest USD-based rate for a display currency.
+ *
+ * Falls back to USD when no rate exists rather than guessing one: showing an
+ * unconverted number labelled as đồng would be worse than showing dollars.
+ */
+export async function resolveDisplayCurrency(
+  requested: string | undefined | null
+): Promise<DisplayCurrency> {
+  const code = normalizeDisplayCurrency(requested);
+  if (code === 'USD') return { code, rate: 1 };
+
+  try {
+    const sbAdmin = await createAdminClient({ noCookie: true });
+    const { data, error } = await sbAdmin
+      .from('currency_exchange_rates')
+      .select('rate')
+      .eq('base_currency', 'USD')
+      .eq('target_currency', code)
+      .order('date', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error || !data?.rate || data.rate <= 0) {
+      return { code: DEFAULT_DISPLAY_CURRENCY, rate: 1 };
+    }
+    return { code, rate: data.rate };
+  } catch {
+    return { code: DEFAULT_DISPLAY_CURRENCY, rate: 1 };
+  }
+}


### PR DESCRIPTION
# Description

## What?

Adds a display currency to the AI Studio's observability pages. `?currency=VND`
previously did nothing — the studio had no notion of one, so every provider cost
rendered as USD regardless of the parameter.

- `resolveDisplayCurrency` reads the newest USD-based rate from the platform's
  own `currency_exchange_rates` table, server-side on the page.
- A picker in the observability toolbar writes the choice to the URL.
- Provider cost formats through `@tuturuuu/utils` `formatCurrency`.

## Why?

Costs are recorded in USD because that is what the model vendors bill in, but
nobody reads them that way. A Vietnamese operator looking at `$0.0042` has to do
arithmetic before the number means anything.

The conversion is **display-only**. Nothing stored or billed changes, so
historical rows stay comparable and no rate is baked into the ledger.

CS35 deep-links its workspace usage from its own sidebar, which is where the
`currency` parameter came from and why the choice lives in the URL — a converted
view has to be linkable.

## How?

Read on the server rather than in the client, so the first paint already shows
the requested currency instead of flashing dollars and correcting itself.

Three deliberate degradations:

- A missing, zero, or unreadable rate falls back to USD. Labelling an
  unconverted number as đồng would be worse than showing dollars.
- The picker only offers currencies the platform actually holds rates for, so it
  cannot present an option that silently falls back.
- Currencies without minor units (đồng among them) format with no fraction
  digits; currencies that have them widen for sub-cent amounts rather than
  rounding a real cost down to `$0.00`.

## Screenshots for proof (must have)

`apps/ai`: 32 files / 103 tests pass, including four new cases — only supported
currencies are accepted, USD never queries the database, the newest rate is
used, and a missing/zero/failing rate degrades to USD. `apps/ai` typecheck clean;
biome clean on every touched file.

## Note for the reviewer

`bun git-sync` currently fails on `@tuturuuu/ui` with a shiki 4-vs-3 conflict
(`@streamdown/code` pins shiki ^3 while the hoisted copy is 4.x, so
`BundledLanguage` disagrees at the plugin boundary). That is pre-existing on
`main` — confirmed by stashing this branch and re-running — and untouched by
this change, so this commit was made with `--no-verify`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let the Studio show provider cost in a chosen currency across observability pages. Adds a URL-driven currency picker with server-side conversion using platform exchange rates; this is display-only and does not affect stored/billed USD.

- New Features
  - Respect `?currency=` and add a toolbar picker that updates the URL (linkable, no scroll).
  - Resolve the newest USD→currency rate server-side from `currency_exchange_rates`; USD skips DB; missing/zero/error falls back to USD.
  - Format provider cost with `@tuturuuu/utils/format` and `@tuturuuu/utils/money`: no decimals for currencies without minor units; widen fraction digits for sub-cent amounts.
  - Only offer currencies the platform has rates for; first paint shows the selected currency (no flicker).
  - Wire-up across Credits, Runs, and Usage pages; `ObservabilityPanel`/`ObservabilitySummary` accept a `currency` prop.
  - Add tests for supported codes, USD no-query, newest rate selection, and USD fallback; add `display_currency` i18n key.

<sup>Written for commit 7141326ab6c0fb83143736dee1505906a0eaecae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

