### PR TITLE
feat(chat): complete external replica pairing

### DIFF
--- a/apps/cms/messages/en.json
+++ b/apps/cms/messages/en.json
@@ -3453,6 +3453,7 @@
     "ready": "Ready for canary synchronization",
     "ready_description": "Both directions can be tested without changing live authority.",
     "refresh": "Refresh synchronization status",
+    "replica_url": "Modern replica URL",
     "retry": "Retry",
     "rotate_ingest": "Rotate ingest credential",
     "save": "Save chat settings",

--- a/apps/cms/messages/vi.json
+++ b/apps/cms/messages/vi.json
@@ -3453,6 +3453,7 @@
     "ready": "Sẵn sàng đồng bộ canary",
     "ready_description": "Có thể thử cả hai chiều mà không thay đổi hệ thống chính.",
     "refresh": "Làm mới trạng thái đồng bộ hóa",
+    "replica_url": "Địa chỉ bản sao hiện đại",
     "retry": "Thử lại",
     "rotate_ingest": "Xoay thông tin tiếp nhận",
     "save": "Lưu cấu hình chat",

--- a/apps/cms/src/app/[locale]/(dashboard)/[wsId]/chat/settings.tsx
+++ b/apps/cms/src/app/[locale]/(dashboard)/[wsId]/chat/settings.tsx
@@ -36,6 +36,9 @@ export function ConnectedChatSettings({ wsId }: { wsId: string }) {
   const existing = (query.data?.settings ?? {}) as Record<string, unknown>;
   const [enabledOverride, setEnabled] = useState<boolean | null>(null);
   const [baseUrlOverride, setBaseUrl] = useState<string | null>(null);
+  const [replicaBaseUrlOverride, setReplicaBaseUrl] = useState<string | null>(
+    null
+  );
   const [controlSecret, setControlSecret] = useState('');
   const [agentMappingsOverride, setAgentMappings] = useState<string | null>(
     null
@@ -51,6 +54,8 @@ export function ConnectedChatSettings({ wsId }: { wsId: string }) {
   );
   const enabled = enabledOverride ?? existing.enabled === true;
   const baseUrl = baseUrlOverride ?? String(existing.bridgeBaseUrl ?? '');
+  const replicaBaseUrl =
+    replicaBaseUrlOverride ?? String(existing.replicaBaseUrl ?? '');
   const agentMappings =
     agentMappingsOverride ??
     JSON.stringify(existing.agentMappings ?? {}, null, 2);
@@ -85,6 +90,9 @@ export function ConnectedChatSettings({ wsId }: { wsId: string }) {
           existingInboxDefaults,
           recipientUserId
         ),
+        ...(replicaBaseUrl.trim()
+          ? { replicaBaseUrl: replicaBaseUrl.trim() }
+          : {}),
       });
     },
     onError: (error) =>
@@ -96,6 +104,7 @@ export function ConnectedChatSettings({ wsId }: { wsId: string }) {
     onSuccess: async () => {
       setEnabled(null);
       setBaseUrl(null);
+      setReplicaBaseUrl(null);
       setAgentMappings(null);
       setRecipientUserId(null);
       await refresh();
@@ -208,6 +217,13 @@ export function ConnectedChatSettings({ wsId }: { wsId: string }) {
                 onChange={(event) => setRecipientUserId(event.target.value)}
                 placeholder={t('inbox_recipient_placeholder')}
                 value={recipientUserId}
+              />
+              <Label htmlFor="replica-url">{t('replica_url')}</Label>
+              <Input
+                id="replica-url"
+                onChange={(event) => setReplicaBaseUrl(event.target.value)}
+                placeholder="https://chat.example.com"
+                value={replicaBaseUrl}
               />
             </div>
           </details>

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/config/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/config/route.test.ts
@@ -45,6 +45,7 @@ const validSettings = {
   bridgeBaseUrl: 'https://bridge.example.com',
   enabled: true,
   inboxDefaults: {},
+  replicaBaseUrl: 'https://chat.example.com',
 };
 
 function patchRequest(payload: unknown) {
@@ -125,8 +126,23 @@ describe('external chat config route', () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: 'Bridge URL is not allowed',
+      error: 'External chat URL is not allowed',
     });
+  });
+
+  it('applies the network safety policy to the replica origin', async () => {
+    mocks.assertSafeExternalChatUrl.mockImplementation(async (url: string) => {
+      if (url === validSettings.replicaBaseUrl)
+        throw new mocks.ExternalChatUrlPolicyError('blocked');
+    });
+    const { PATCH } = await import('./route');
+    const response = await PATCH(patchRequest(validSettings) as never, params);
+
+    expect(response.status).toBe(400);
+    expect(mocks.assertSafeExternalChatUrl).toHaveBeenCalledWith(
+      validSettings.replicaBaseUrl
+    );
+    expect(mocks.writeExternalChatSettings).not.toHaveBeenCalled();
   });
 
   it('returns 503 when destination validation is temporarily unavailable', async () => {

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/config/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/config/route.test.ts
@@ -117,6 +117,18 @@ describe('external chat config route', () => {
     );
   });
 
+  it('validates only the bridge when no replica origin is configured', async () => {
+    const { replicaBaseUrl: _replicaBaseUrl, ...settings } = validSettings;
+    const { PATCH } = await import('./route');
+    const response = await PATCH(patchRequest(settings) as never, params);
+
+    expect(response.status).toBe(200);
+    expect(mocks.assertSafeExternalChatUrl).toHaveBeenCalledTimes(1);
+    expect(mocks.assertSafeExternalChatUrl).toHaveBeenCalledWith(
+      settings.bridgeBaseUrl
+    );
+  });
+
   it('rejects a destination blocked by the network safety policy', async () => {
     mocks.assertSafeExternalChatUrl.mockRejectedValue(
       new mocks.ExternalChatUrlPolicyError('blocked')

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/config/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/config/route.ts
@@ -60,7 +60,12 @@ export const PATCH = withSessionAuth<Params>(
     }
     try {
       if (parsed.data.enabled) {
-        await assertSafeExternalChatUrl(parsed.data.bridgeBaseUrl);
+        await Promise.all([
+          assertSafeExternalChatUrl(parsed.data.bridgeBaseUrl),
+          ...(parsed.data.replicaBaseUrl
+            ? [assertSafeExternalChatUrl(parsed.data.replicaBaseUrl)]
+            : []),
+        ]);
       }
     } catch (error) {
       if (!(error instanceof ExternalChatUrlPolicyError)) {
@@ -71,7 +76,7 @@ export const PATCH = withSessionAuth<Params>(
         );
       }
       return NextResponse.json(
-        { error: 'Bridge URL is not allowed' },
+        { error: 'External chat URL is not allowed' },
         { status: 400 }
       );
     }

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.test.ts
@@ -187,6 +187,49 @@ describe('external chat credential verification', () => {
     );
   });
 
+  it('promotes an interrupted unverified ingest rotation without bridge mutation', async () => {
+    const pendingState = {
+      binding: {},
+      credentials: {
+        configuration_revision: 3,
+        control_secret_encrypted: 'stale-encrypted-control',
+        pending_action: 'set_ingest',
+        pending_secret_encrypted: 'encrypted-pending',
+        verified_at: null,
+        verified_revision: null,
+      },
+    };
+    const promotedState = {
+      binding: {},
+      credentials: {
+        configuration_revision: 4,
+        control_secret_encrypted: 'stale-encrypted-control',
+        verified_at: null,
+        verified_revision: null,
+      },
+    };
+    mocks.readExternalChatBinding
+      .mockResolvedValueOnce(pendingState)
+      .mockResolvedValue(promotedState);
+
+    const { POST } = await import('./route');
+    const response = await POST(
+      request({
+        action: 'pair',
+        ingestSecret: 'ingest-secret-value-123456789',
+      }) as never,
+      { params: Promise.resolve({ wsId: 'workspace-1' }) }
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.updateExternalChatBridgeCredential).not.toHaveBeenCalled();
+    expect(mocks.promoteExternalChatCredential).toHaveBeenCalledWith(
+      'workspace-1',
+      'set_ingest',
+      'encrypted-pending'
+    );
+  });
+
   it('replaces an unverified local control credential before re-pairing', async () => {
     mocks.readExternalChatBinding.mockResolvedValue({
       binding: {},

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.test.ts
@@ -161,6 +161,61 @@ describe('external chat credential verification', () => {
     expect(await response.json()).toMatchObject({ secret: 'ecs_test_secret' });
   });
 
+  it('replaces an unverified local control credential before re-pairing', async () => {
+    mocks.readExternalChatBinding.mockResolvedValue({
+      binding: {},
+      credentials: {
+        configuration_revision: 3,
+        control_secret_encrypted: 'stale-encrypted-control',
+        verified_at: null,
+        verified_revision: null,
+      },
+    });
+    const { POST } = await import('./route');
+    const response = await POST(
+      request({
+        action: 'set_control',
+        secret: 'replacement-control-secret',
+      }) as never,
+      { params: Promise.resolve({ wsId: 'workspace-1' }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateExternalChatBridgeCredential).not.toHaveBeenCalled();
+    expect(mocks.promoteExternalChatCredential).toHaveBeenCalledWith(
+      'workspace-1',
+      'rotate_control',
+      'encrypted-pending'
+    );
+  });
+
+  it('requires remote rotation while the current control credential is verified', async () => {
+    mocks.readExternalChatBinding.mockResolvedValue({
+      binding: {},
+      credentials: {
+        configuration_revision: 3,
+        control_secret_encrypted: 'verified-encrypted-control',
+        verified_at: '2026-08-05T00:00:00.000Z',
+        verified_revision: 3,
+      },
+    });
+    const { POST } = await import('./route');
+    const response = await POST(
+      request({
+        action: 'set_control',
+        secret: 'replacement-control-secret',
+      }) as never,
+      { params: Promise.resolve({ wsId: 'workspace-1' }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateExternalChatBridgeCredential).toHaveBeenCalledWith({
+      action: 'rotate_control',
+      secret: 'replacement-control-secret',
+      wsId: 'workspace-1',
+    });
+  });
+
   it('pairs with a transient single-use ticket and verifies before marking ready', async () => {
     mocks.readExternalChatBinding.mockResolvedValue({
       binding: {},

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.test.ts
@@ -137,6 +137,8 @@ describe('external chat credential verification', () => {
       credentials: {
         configuration_revision: 3,
         control_secret_encrypted: 'encrypted',
+        verified_at: '2026-08-05T00:00:00.000Z',
+        verified_revision: 3,
       },
     });
     mocks.updateExternalChatBridgeCredential.mockRejectedValue(
@@ -159,6 +161,30 @@ describe('external chat credential verification', () => {
     );
     expect(mocks.promoteExternalChatCredential).not.toHaveBeenCalled();
     expect(await response.json()).toMatchObject({ secret: 'ecs_test_secret' });
+  });
+
+  it('rotates ingest locally when the binding must be re-paired', async () => {
+    mocks.readExternalChatBinding.mockResolvedValue({
+      binding: {},
+      credentials: {
+        configuration_revision: 3,
+        control_secret_encrypted: 'stale-encrypted-control',
+        verified_at: null,
+        verified_revision: null,
+      },
+    });
+    const { POST } = await import('./route');
+    const response = await POST(request({ action: 'rotate_ingest' }) as never, {
+      params: Promise.resolve({ wsId: 'workspace-1' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateExternalChatBridgeCredential).not.toHaveBeenCalled();
+    expect(mocks.promoteExternalChatCredential).toHaveBeenCalledWith(
+      'workspace-1',
+      'set_ingest',
+      'encrypted-pending'
+    );
   });
 
   it('replaces an unverified local control credential before re-pairing', async () => {

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.ts
@@ -199,7 +199,12 @@ export const POST = withSessionAuth<Params>(
       } catch (error) {
         return credentialMutationErrorResponse(error, current);
       }
-      if (current?.credentials?.control_secret_encrypted) {
+      if (
+        current?.credentials?.control_secret_encrypted &&
+        current.credentials.verified_at &&
+        current.credentials.verified_revision ===
+          current.credentials.configuration_revision
+      ) {
         try {
           await updateExternalChatBridgeCredential({
             action: 'rotate_control',

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.ts
@@ -153,12 +153,7 @@ export const POST = withSessionAuth<Params>(
       } catch (error) {
         return credentialMutationErrorResponse(error, current, issuedSecret);
       }
-      if (
-        current?.credentials?.control_secret_encrypted &&
-        current.credentials.verified_at &&
-        current.credentials.verified_revision ===
-          current.credentials.configuration_revision
-      ) {
+      if (hasVerifiedCurrentControlCredential(current.credentials)) {
         try {
           await updateExternalChatBridgeCredential({
             action: 'set_ingest',
@@ -204,12 +199,7 @@ export const POST = withSessionAuth<Params>(
       } catch (error) {
         return credentialMutationErrorResponse(error, current);
       }
-      if (
-        current?.credentials?.control_secret_encrypted &&
-        current.credentials.verified_at &&
-        current.credentials.verified_revision ===
-          current.credentials.configuration_revision
-      ) {
+      if (hasVerifiedCurrentControlCredential(current.credentials)) {
         try {
           await updateExternalChatBridgeCredential({
             action: 'rotate_control',
@@ -422,7 +412,7 @@ async function reconcilePendingCredential(wsId: string, state: BindingState) {
     wsId,
     credentials.pending_secret_encrypted
   );
-  if (credentials.control_secret_encrypted) {
+  if (hasVerifiedCurrentControlCredential(credentials)) {
     try {
       await updateExternalChatBridgeCredential({
         action: credentials.pending_action,
@@ -447,4 +437,14 @@ async function reconcilePendingCredential(wsId: string, state: BindingState) {
   const refreshed = await readExternalChatBinding(wsId);
   if (!refreshed) throw new Error('Binding disappeared during reconciliation');
   return refreshed;
+}
+
+function hasVerifiedCurrentControlCredential(
+  credentials: BindingState['credentials']
+) {
+  return Boolean(
+    credentials?.control_secret_encrypted &&
+      credentials.verified_at &&
+      credentials.verified_revision === credentials.configuration_revision
+  );
 }

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/credentials/route.ts
@@ -153,7 +153,12 @@ export const POST = withSessionAuth<Params>(
       } catch (error) {
         return credentialMutationErrorResponse(error, current, issuedSecret);
       }
-      if (current?.credentials?.control_secret_encrypted) {
+      if (
+        current?.credentials?.control_secret_encrypted &&
+        current.credentials.verified_at &&
+        current.credentials.verified_revision ===
+          current.credentials.configuration_revision
+      ) {
         try {
           await updateExternalChatBridgeCredential({
             action: 'set_ingest',

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.test.ts
@@ -280,6 +280,46 @@ describe('external chat sync status', () => {
     );
   });
 
+  it('forwards a validated agent scope for a bounded backfill', async () => {
+    mocks.requestExternalChatControl.mockResolvedValueOnce({
+      runId: localRun.id,
+      scope: { agentId: '7' },
+      state: 'running',
+    });
+    const { POST } = await import('./route');
+    const response = await POST(
+      new Request('http://localhost/sync', {
+        body: JSON.stringify({ action: 'start', agentId: '7' }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      }) as never,
+      params
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.requestExternalChatControl).toHaveBeenCalledWith(
+      'workspace-1',
+      '/control/v1/sync/start',
+      { agentId: '7', runId: localRun.id, stream: 'canonical' }
+    );
+  });
+
+  it('rejects an invalid agent scope before creating a run', async () => {
+    const { POST } = await import('./route');
+    const response = await POST(
+      new Request('http://localhost/sync', {
+        body: JSON.stringify({ action: 'start', agentId: 'all' }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      }) as never,
+      params
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.requestExternalChatControl).not.toHaveBeenCalled();
+    expect(mocks.insertRun).not.toHaveBeenCalled();
+  });
+
   it('rejects a stale control result when the run changed concurrently', async () => {
     mocks.requestExternalChatControl.mockResolvedValueOnce({
       runId: localRun.id,

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.test.ts
@@ -304,20 +304,48 @@ describe('external chat sync status', () => {
     );
   });
 
-  it('rejects an invalid agent scope before creating a run', async () => {
+  it.each(['all', '0', '01', '123456789012345678901'])(
+    'rejects invalid agent scope %s before creating a run',
+    async (agentId) => {
+      const { POST } = await import('./route');
+      const response = await POST(
+        new Request('http://localhost/sync', {
+          body: JSON.stringify({ action: 'start', agentId }),
+          headers: { 'content-type': 'application/json' },
+          method: 'POST',
+        }) as never,
+        params
+      );
+
+      expect(response.status).toBe(400);
+      expect(mocks.requestExternalChatControl).not.toHaveBeenCalled();
+      expect(mocks.insertRun).not.toHaveBeenCalled();
+    }
+  );
+
+  it('accepts a 20-digit agent scope', async () => {
+    const agentId = '12345678901234567890';
+    mocks.requestExternalChatControl.mockResolvedValueOnce({
+      runId: localRun.id,
+      scope: { agentId },
+      state: 'running',
+    });
     const { POST } = await import('./route');
     const response = await POST(
       new Request('http://localhost/sync', {
-        body: JSON.stringify({ action: 'start', agentId: 'all' }),
+        body: JSON.stringify({ action: 'start', agentId }),
         headers: { 'content-type': 'application/json' },
         method: 'POST',
       }) as never,
       params
     );
 
-    expect(response.status).toBe(400);
-    expect(mocks.requestExternalChatControl).not.toHaveBeenCalled();
-    expect(mocks.insertRun).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(mocks.requestExternalChatControl).toHaveBeenCalledWith(
+      'workspace-1',
+      '/control/v1/sync/start',
+      { agentId, runId: localRun.id, stream: 'canonical' }
+    );
   });
 
   it('rejects a stale control result when the run changed concurrently', async () => {

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.ts
@@ -13,6 +13,10 @@ import { safeParseBody } from '@/lib/safe-parse-body';
 type Params = { wsId: string };
 const actionSchema = z.object({
   action: z.enum(['audit', 'start', 'resume', 'cancel', 'reconcile']),
+  agentId: z
+    .string()
+    .regex(/^[1-9]\d{0,19}$/)
+    .optional(),
   runId: z.string().uuid().optional(),
   stream: z.string().min(1).max(80).optional(),
 });
@@ -136,7 +140,11 @@ export const POST = withSessionAuth<Params>(
       const remote = await requestExternalChatControl(
         wsId,
         `/control/v1/sync/${parsed.data.action}`,
-        { runId, stream: parsed.data.stream ?? 'canonical' }
+        {
+          ...(parsed.data.agentId ? { agentId: parsed.data.agentId } : {}),
+          runId,
+          stream: parsed.data.stream ?? 'canonical',
+        }
       );
       const remoteRun = readRemoteRun(remote, runId);
       const update = buildRunUpdate(

--- a/apps/web/src/lib/external-chat/delivery.test.ts
+++ b/apps/web/src/lib/external-chat/delivery.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  configureExternalChatBridge,
   prepareExternalChatAttachment,
   updateExternalChatBridgeCredential,
 } from './delivery';
@@ -60,10 +61,33 @@ describe('external chat credential delivery', () => {
           chat: {
             bridgeBaseUrl: 'https://bridge.example.com',
             enabled: true,
+            replicaBaseUrl: 'https://chat.example.com',
           },
         },
       },
-      credentials: { control_secret_encrypted: 'encrypted-control' },
+      credentials: {
+        control_secret_encrypted: 'encrypted-control',
+        ingest_secret_hash: 'a'.repeat(64),
+      },
+    });
+  });
+
+  it('pairs the bridge with the optional modern replica origin', async () => {
+    mocks.safeExternalChatFetch.mockResolvedValue(Response.json({ ok: true }));
+
+    await configureExternalChatBridge({
+      ingestSecret: 'ingest-secret',
+      pairingTicket: 'pairing-ticket',
+      wsId: 'workspace-1',
+    });
+
+    const [, request] = mocks.safeExternalChatFetch.mock.calls[0] ?? [];
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      bindingId: 'workspace-1',
+      controlSecret: 'control-secret',
+      ingestSecret: 'ingest-secret',
+      pairingTicket: 'pairing-ticket',
+      replicaBaseUrl: 'https://chat.example.com',
     });
   });
 

--- a/apps/web/src/lib/external-chat/delivery.ts
+++ b/apps/web/src/lib/external-chat/delivery.ts
@@ -146,6 +146,14 @@ function getBridgeBaseUrl(settings: unknown) {
   return typeof value === 'string' ? value.replace(/\/+$/u, '') : null;
 }
 
+function getReplicaBaseUrl(settings: unknown) {
+  if (!settings || typeof settings !== 'object') return null;
+  const chat = (settings as Record<string, unknown>).chat;
+  if (!chat || typeof chat !== 'object') return null;
+  const value = (chat as Record<string, unknown>).replicaBaseUrl;
+  return typeof value === 'string' ? value.replace(/\/+$/u, '') : null;
+}
+
 function getPublicPlatformUrl() {
   return resolveTuturuuuWebAppUrl({
     env: {
@@ -271,6 +279,7 @@ export async function configureExternalChatBridge({
   const state = await readExternalChatBinding(wsId);
   const controlCiphertext = state?.credentials?.control_secret_encrypted;
   const bridgeBaseUrl = getBridgeBaseUrl(state?.binding.settings);
+  const replicaBaseUrl = getReplicaBaseUrl(state?.binding.settings);
   if (
     !state?.binding.is_enabled ||
     !isExternalChatEnabled(state.binding.settings) ||
@@ -287,6 +296,7 @@ export async function configureExternalChatBridge({
     ingestSecret,
     pairingTicket,
     platformUrl: getPublicPlatformUrl(),
+    ...(replicaBaseUrl ? { replicaBaseUrl } : {}),
   });
   const response = await safeExternalChatFetch(
     `${bridgeBaseUrl}/control/v1/configure`,

--- a/apps/web/src/lib/external-chat/schemas.test.ts
+++ b/apps/web/src/lib/external-chat/schemas.test.ts
@@ -56,6 +56,12 @@ describe('external chat settings', () => {
         replicaBaseUrl: 'http://chat.example.com',
       }).success
     ).toBe(false);
+    expect(
+      externalChatSettingsSchema.safeParse({
+        ...settings,
+        replicaBaseUrl: 'not a URL',
+      }).success
+    ).toBe(false);
   });
 
   it('validates the fallback recipient while preserving dynamic inbox data', () => {

--- a/apps/web/src/lib/external-chat/schemas.test.ts
+++ b/apps/web/src/lib/external-chat/schemas.test.ts
@@ -30,6 +30,34 @@ describe('external chat settings', () => {
     expect(isExternalChatLiveAuthority(settings)).toBe(false);
   });
 
+  it('accepts only a credential-free HTTPS origin for an optional replica', () => {
+    const settings = {
+      agentMappings: {},
+      authorityMode: 'legacy_primary',
+      bridgeBaseUrl: 'https://bridge.example.com',
+      enabled: true,
+      inboxDefaults: {},
+    } as const;
+    expect(
+      externalChatSettingsSchema.safeParse({
+        ...settings,
+        replicaBaseUrl: 'https://chat.example.com',
+      }).success
+    ).toBe(true);
+    expect(
+      externalChatSettingsSchema.safeParse({
+        ...settings,
+        replicaBaseUrl: 'https://chat.example.com/private',
+      }).success
+    ).toBe(false);
+    expect(
+      externalChatSettingsSchema.safeParse({
+        ...settings,
+        replicaBaseUrl: 'http://chat.example.com',
+      }).success
+    ).toBe(false);
+  });
+
   it('validates the fallback recipient while preserving dynamic inbox data', () => {
     const parsed = externalChatSettingsSchema.safeParse({
       agentMappings: {},

--- a/apps/web/src/lib/external-chat/schemas.ts
+++ b/apps/web/src/lib/external-chat/schemas.ts
@@ -127,6 +127,26 @@ export const externalChatSettingsSchema = z.object({
         return false;
       }
     }, 'Bridge URL must be an HTTPS origin or approved bridge path without credentials, query, or fragment'),
+  replicaBaseUrl: z
+    .string()
+    .url()
+    .max(2048)
+    .refine((value) => {
+      try {
+        const url = new URL(value);
+        return (
+          url.protocol === 'https:' &&
+          !url.username &&
+          !url.password &&
+          url.pathname === '/' &&
+          !url.search &&
+          !url.hash
+        );
+      } catch {
+        return false;
+      }
+    }, 'Replica URL must be an HTTPS origin without credentials, query, or fragment')
+    .optional(),
   agentMappings: z.record(z.string(), z.string().uuid()).default({}),
   inboxDefaults: inboxDefaultsSchema,
   authorityMode: z

--- a/packages/internal-api/src/external-chat.ts
+++ b/packages/internal-api/src/external-chat.ts
@@ -47,6 +47,7 @@ export type ExternalChatCredentialAction =
 
 export type ExternalChatSyncAction = {
   action: 'audit' | 'start' | 'resume' | 'cancel' | 'reconcile';
+  agentId?: string;
   runId?: string;
   stream?: string;
 };

--- a/packages/internal-api/src/external-chat.ts
+++ b/packages/internal-api/src/external-chat.ts
@@ -34,6 +34,7 @@ export type ExternalChatSettings = {
   bridgeBaseUrl: string;
   enabled: boolean;
   inboxDefaults: Record<string, unknown> & { recipientUserId?: string };
+  replicaBaseUrl?: string;
 };
 
 export type ExternalChatCredentialAction =


### PR DESCRIPTION
## Summary
- store an optional connector-neutral replica origin on the external chat binding
- validate bridge and replica destinations with the existing HTTPS and network safety policy
- include the replica origin in the signed bridge pairing payload and expose it under CMS developer details
- recover stale unverified control and ingest credentials through one-time re-pairing without weakening verified rotation
- forward a validated agent scope for genuinely bounded historical sync runs

## Verification
- focused external chat config, delivery, credential, and sync-route tests
- Chat/CMS/Web type checks
- CMS and Web production builds
- i18n sort/check
- migration manifest unchanged
- bun check