### PR TITLE
fix(ci): tolerate a release branch GitHub already deleted

### DIFF
--- a/.github/workflows/release-please-auto-merge.yaml
+++ b/.github/workflows/release-please-auto-merge.yaml
@@ -242,6 +242,29 @@ jobs:
             exit 0
           fi
 
+          # Deleting a branch that is already gone is success, not failure.
+          # Pushing production closes the release PR, and GitHub deletes the
+          # head branch itself moments later — after the fetch below and
+          # sometimes mid-step, so no amount of re-checking first removes the
+          # race. Only a delete that failed while the branch is still on origin
+          # is a real error.
+          delete_remote_branch() {
+            local target="$1"
+
+            if git push origin --delete "${target}" 2>&1; then
+              echo "Deleted origin/${target}."
+              return 0
+            fi
+
+            if git ls-remote --exit-code --heads origin "${target}" >/dev/null 2>&1; then
+              echo "::error::Could not delete origin/${target}; it is still on origin."
+              return 1
+            fi
+
+            echo "origin/${target} was already deleted, most likely by the merged pull request."
+            return 0
+          }
+
           git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'
 
           if ! git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
@@ -251,8 +274,7 @@ jobs:
             echo "::warning::origin/${branch} is not merged into main; leaving it in place."
             exit 0
           else
-            echo "Deleting origin/${branch}."
-            git push origin --delete "${branch}"
+            delete_remote_branch "${branch}"
           fi
 
           # The overflow notes branch is metadata for that same release and is
@@ -280,8 +302,7 @@ jobs:
             exit 0
           fi
 
-          echo "Deleting origin/${notes}."
-          git push origin --delete "${notes}"
+          delete_remote_branch "${notes}"
 
       - name: Write run summary
         if: always()

--- a/scripts/ci/release-please-auto-merge.test.js
+++ b/scripts/ci/release-please-auto-merge.test.js
@@ -199,12 +199,12 @@ test('release merge deletes both release-please branches once they are merged', 
 
   assert.match(
     cleanupStep,
-    /git push origin --delete "\$\{branch\}"/,
+    /delete_remote_branch "\$\{branch\}"/,
     'the merged release branch must be deleted from origin'
   );
   assert.match(
     cleanupStep,
-    /git push origin --delete "\$\{notes\}"/,
+    /delete_remote_branch "\$\{notes\}"/,
     'the overflow release-notes branch must be deleted from origin too'
   );
   assert.match(
@@ -228,6 +228,33 @@ test('release merge deletes both release-please branches once they are merged', 
         '- name: Verify main and production point at the same commit'
       ),
     'branches may only be deleted after main and production are verified aligned'
+  );
+});
+
+test('release merge treats an already-deleted branch as success', () => {
+  // Pushing production closes the release PR and GitHub deletes the head
+  // branch itself, moments after this step's fetch. Run 31070227736 failed on
+  // exactly that: `cannot lock ref ... unable to resolve reference`. Checking
+  // first cannot close the race, so the delete has to be tolerant instead.
+  const cleanupStep = workflow.slice(
+    workflow.indexOf('- name: Delete merged release-please branches'),
+    workflow.indexOf('- name: Write run summary')
+  );
+
+  assert.match(
+    cleanupStep,
+    /git ls-remote --exit-code --heads origin "\$\{target\}"/,
+    'a failed delete must be re-checked against origin rather than assumed fatal'
+  );
+  assert.match(
+    cleanupStep,
+    /::error::Could not delete origin\/\$\{target\}; it is still on origin\./,
+    'a delete that failed while the branch still exists is a real error'
+  );
+  assert.match(
+    cleanupStep,
+    /was already deleted, most likely by the merged pull request/,
+    'a branch that is already gone must not fail the run'
   );
 });
 


### PR DESCRIPTION
## Why

[Run 31070227736](https://github.com/tutur3u/platform/actions/runs/31070227736) was the **first auto-merge run ever to get past the push**. It merged the release, synced `production`, verified alignment — and then failed on cleanup:

```
! [remote rejected] release-please--branches--production
  (cannot lock ref 'refs/heads/release-please--branches--production':
   unable to resolve reference 'refs/heads/release-please--branches--production')
```

Pushing `production` closes the release pull request, and GitHub deletes the head branch itself moments later — after this step's own `git fetch --prune`, and sometimes mid-step. The existing `show-ref` guard runs before that window opens, so it cannot close the race.

This is pre-existing, not a regression: it had simply never been reachable, because no run had ever completed the push. Left alone, **every successful release from now on ends red** with the release itself already correctly landed — the worst kind of red, since it trains people to ignore the run.

## What changed

Both deletions now go through `delete_remote_branch`, which re-checks `origin` when the push fails:

- push succeeds → deleted
- push fails and `git ls-remote` no longer sees the branch → the merged PR deleted it; success
- push fails and the branch is **still** on origin → a real error, still fails the run

Checking before deleting can't fix this — the branch can vanish between the check and the push. Tolerating the specific "it's already gone" outcome is the only thing that closes it.

## Verification

- Extracted the function body straight out of the workflow YAML (not a copy) and drove it against a stubbed `git` across all three cases: `0`, `0`, `1` respectively.
- `scripts/ci/release-please-auto-merge.test.js` 17/17, including a new assertion pinning the re-check and both outcomes.
- `bun check` green.

## Context

Third and final piece, after #5089 (Flutter + token gate) and #5090 (auto-approve). With `RELEASE_PLEASE_TOKEN` now installed, run 31070227736 confirmed the rest of the chain works end to end — `main` and `production` are aligned at `49f6f0675f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the auto-merge workflow where GitHub deletes the release branch right after the PR merges, causing cleanup to fail. Cleanup now treats an already-deleted branch as success so successful releases finish green.

- **Bug Fixes**
  - Route both deletions through `delete_remote_branch`: try `git push origin --delete`, and on failure re-check with `git ls-remote`; if the branch is gone, succeed; if it still exists, fail.
  - Updated tests to cover all three outcomes (delete succeeds, already gone, real failure) and assert the new function is used.

<sup>Written for commit 885c494719d0b9c286ffda6cea9bc89cb7e17bb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

