### PR TITLE
fix(chat): extend sync control timeout

### DIFF
--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.test.ts
@@ -263,7 +263,8 @@ describe('external chat sync status', () => {
     expect(mocks.requestExternalChatControl).toHaveBeenCalledWith(
       'workspace-1',
       '/control/v1/sync/audit',
-      { runId: localRun.id, stream: 'canonical' }
+      { runId: localRun.id, stream: 'canonical' },
+      { timeoutMs: 60_000 }
     );
     expect(mocks.transitionRun).toHaveBeenCalledWith(
       'external_chat_transition_sync_run',
@@ -300,7 +301,8 @@ describe('external chat sync status', () => {
     expect(mocks.requestExternalChatControl).toHaveBeenCalledWith(
       'workspace-1',
       '/control/v1/sync/start',
-      { agentId: '7', runId: localRun.id, stream: 'canonical' }
+      { agentId: '7', runId: localRun.id, stream: 'canonical' },
+      { timeoutMs: 60_000 }
     );
   });
 
@@ -344,7 +346,8 @@ describe('external chat sync status', () => {
     expect(mocks.requestExternalChatControl).toHaveBeenCalledWith(
       'workspace-1',
       '/control/v1/sync/start',
-      { agentId, runId: localRun.id, stream: 'canonical' }
+      { agentId, runId: localRun.id, stream: 'canonical' },
+      { timeoutMs: 60_000 }
     );
   });
 

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-chat/sync/route.ts
@@ -20,6 +20,7 @@ const actionSchema = z.object({
   runId: z.string().uuid().optional(),
   stream: z.string().min(1).max(80).optional(),
 });
+const syncControlTimeoutMs = 60_000;
 
 export const GET = withSessionAuth<Params>(
   async (_request, auth, params) => {
@@ -144,7 +145,8 @@ export const POST = withSessionAuth<Params>(
           ...(parsed.data.agentId ? { agentId: parsed.data.agentId } : {}),
           runId,
           stream: parsed.data.stream ?? 'canonical',
-        }
+        },
+        { timeoutMs: syncControlTimeoutMs }
       );
       const remoteRun = readRemoteRun(remote, runId);
       const update = buildRunUpdate(

--- a/apps/web/src/lib/external-chat/delivery.test.ts
+++ b/apps/web/src/lib/external-chat/delivery.test.ts
@@ -74,24 +74,29 @@ describe('external chat credential delivery', () => {
 
   it('pairs the bridge with the optional modern replica origin', async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
-    mocks.safeExternalChatFetch.mockResolvedValue(Response.json({ ok: true }));
+    try {
+      mocks.safeExternalChatFetch.mockResolvedValue(
+        Response.json({ ok: true })
+      );
 
-    await configureExternalChatBridge({
-      ingestSecret: 'ingest-secret',
-      pairingTicket: 'pairing-ticket',
-      wsId: 'workspace-1',
-    });
+      await configureExternalChatBridge({
+        ingestSecret: 'ingest-secret',
+        pairingTicket: 'pairing-ticket',
+        wsId: 'workspace-1',
+      });
 
-    const [, request] = mocks.safeExternalChatFetch.mock.calls[0] ?? [];
-    expect(JSON.parse(String(request?.body))).toMatchObject({
-      bindingId: 'workspace-1',
-      controlSecret: 'control-secret',
-      ingestSecret: 'ingest-secret',
-      pairingTicket: 'pairing-ticket',
-      replicaBaseUrl: 'https://chat.example.com',
-    });
-    expect(timeoutSpy).toHaveBeenCalledWith(60_000);
-    timeoutSpy.mockRestore();
+      const [, request] = mocks.safeExternalChatFetch.mock.calls[0] ?? [];
+      expect(JSON.parse(String(request?.body))).toMatchObject({
+        bindingId: 'workspace-1',
+        controlSecret: 'control-secret',
+        ingestSecret: 'ingest-secret',
+        pairingTicket: 'pairing-ticket',
+        replicaBaseUrl: 'https://chat.example.com',
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(60_000);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
   it.each([401, 403])(

--- a/apps/web/src/lib/external-chat/delivery.test.ts
+++ b/apps/web/src/lib/external-chat/delivery.test.ts
@@ -73,6 +73,7 @@ describe('external chat credential delivery', () => {
   });
 
   it('pairs the bridge with the optional modern replica origin', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
     mocks.safeExternalChatFetch.mockResolvedValue(Response.json({ ok: true }));
 
     await configureExternalChatBridge({
@@ -89,6 +90,8 @@ describe('external chat credential delivery', () => {
       pairingTicket: 'pairing-ticket',
       replicaBaseUrl: 'https://chat.example.com',
     });
+    expect(timeoutSpy).toHaveBeenCalledWith(60_000);
+    timeoutSpy.mockRestore();
   });
 
   it.each([401, 403])(

--- a/apps/web/src/lib/external-chat/delivery.ts
+++ b/apps/web/src/lib/external-chat/delivery.ts
@@ -21,6 +21,7 @@ type ExternalThreadRow = {
 };
 
 const MAX_EXTERNAL_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+const EXTERNAL_CHAT_PAIRING_TIMEOUT_MS = 60_000;
 export const EXTERNAL_ATTACHMENT_TYPES = new Set([
   'image/gif',
   'image/jpeg',
@@ -304,7 +305,7 @@ export async function configureExternalChatBridge({
       body,
       headers: { 'content-type': 'application/json' },
       method: 'POST',
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(EXTERNAL_CHAT_PAIRING_TIMEOUT_MS),
     }
   );
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- allow bounded external chat sync controls up to 60 seconds
- keep active-run status refreshes and live delivery paths on their existing tighter timeouts
- cover audit and scoped backfill request options

## Production evidence
- the signed read-only manifest succeeds directly in about 13 seconds over 1.6M+ canonical records
- the Platform route previously aborted the same request at 10 seconds and returned `control_unavailable`

## Verification
- focused sync route tests: 15 passed
- `bun migration:tanstack:manifest` (no manifest diff)
- `bun check` passed
- Web production bundle compiled; prerender then stopped because the local worktree has no Supabase URL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend external chat sync control and bridge pairing timeouts to 60 seconds to prevent premature aborts and reduce `control_unavailable` errors during longer syncs and initial pairing. Status refreshes and live delivery keep their tighter timeouts.

- **Bug Fixes**
  - Pass `{ timeoutMs: 60_000 }` to sync control `audit`, `start`, and scoped backfill.
  - Add `syncControlTimeoutMs` in `route.ts`; update sync tests.
  - Set bridge pairing timeout to 60s via `EXTERNAL_CHAT_PAIRING_TIMEOUT_MS` and `AbortSignal.timeout`; verify the timeout and restore the spy safely in tests.

<sup>Written for commit d6a11bdac7453c20d794b9b26a8e882515420045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

