### PR TITLE
feat(tasks): add task list settings shortcuts

### DIFF
--- a/apps/calendar/messages/en.json
+++ b/apps/calendar/messages/en.json
@@ -2535,6 +2535,7 @@
     "list_name_in_progress": "In Progress",
     "list_name_review": "Review",
     "list_name_to_do": "To Do",
+    "list_settings": "List settings",
     "list_tooltip": "List:",
     "list_view": "List",
     "lms": "LMS",

--- a/apps/calendar/messages/vi.json
+++ b/apps/calendar/messages/vi.json
@@ -2535,6 +2535,7 @@
     "list_name_in_progress": "Đang thực hiện",
     "list_name_review": "Chờ duyệt",
     "list_name_to_do": "Cần làm",
+    "list_settings": "Cài đặt danh sách",
     "list_tooltip": "Danh sách:",
     "list_view": "Danh sách",
     "lms": "LMS",

--- a/apps/tanstack-web/src/messages/en.json
+++ b/apps/tanstack-web/src/messages/en.json
@@ -4275,6 +4275,7 @@
     "list_name_in_progress": "In Progress",
     "list_name_review": "Review",
     "list_name_to_do": "To Do",
+    "list_settings": "List settings",
     "list_tooltip": "List:",
     "list_view": "List",
     "lms": "LMS",

--- a/apps/tanstack-web/src/messages/vi.json
+++ b/apps/tanstack-web/src/messages/vi.json
@@ -4275,6 +4275,7 @@
     "list_name_in_progress": "Đang thực hiện",
     "list_name_review": "Chờ duyệt",
     "list_name_to_do": "Cần làm",
+    "list_settings": "Cài đặt danh sách",
     "list_tooltip": "Danh sách:",
     "list_view": "Danh sách",
     "lms": "LMS",

--- a/apps/tasks/messages/en.json
+++ b/apps/tasks/messages/en.json
@@ -2585,6 +2585,7 @@
     "list_name_in_progress": "In Progress",
     "list_name_review": "Review",
     "list_name_to_do": "To Do",
+    "list_settings": "List settings",
     "list_tooltip": "List:",
     "list_view": "List",
     "lms": "LMS",

--- a/apps/tasks/messages/vi.json
+++ b/apps/tasks/messages/vi.json
@@ -2585,6 +2585,7 @@
     "list_name_in_progress": "Đang thực hiện",
     "list_name_review": "Chờ duyệt",
     "list_name_to_do": "Cần làm",
+    "list_settings": "Cài đặt danh sách",
     "list_tooltip": "Danh sách:",
     "list_view": "Danh sách",
     "lms": "LMS",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4629,6 +4629,7 @@
     "list_name_in_progress": "In Progress",
     "list_name_review": "Review",
     "list_name_to_do": "To Do",
+    "list_settings": "List settings",
     "list_tooltip": "List:",
     "list_view": "List",
     "lms": "LMS",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4629,6 +4629,7 @@
     "list_name_in_progress": "Đang thực hiện",
     "list_name_review": "Chờ duyệt",
     "list_name_to_do": "Cần làm",
+    "list_settings": "Cài đặt danh sách",
     "list_tooltip": "Danh sách:",
     "list_view": "Danh sách",
     "lms": "LMS",

--- a/packages/tasks-ui/src/tu-do/boards/boardId/__tests__/list-actions.test.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/__tests__/list-actions.test.tsx
@@ -38,6 +38,22 @@ vi.mock('../board-selector', () => ({
   BoardSelector: () => null,
 }));
 
+vi.mock('../../capacity-rules-settings', () => ({
+  CapacityRulesSettings: ({
+    initialListId,
+    lists,
+  }: {
+    initialListId?: string;
+    lists: TaskList[];
+  }) => (
+    <div
+      data-list-count={lists.length}
+      data-selected-list={initialListId}
+      data-testid="capacity-rules-settings"
+    />
+  ),
+}));
+
 vi.mock('@tuturuuu/ui/sonner', () => ({
   toast: {
     error: vi.fn(),
@@ -69,6 +85,15 @@ vi.mock('@tuturuuu/ui/dropdown-menu', () => ({
     </button>
   ),
   DropdownMenuSeparator: () => null,
+  DropdownMenuSub: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuSubTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 const baseList: TaskList = {
@@ -99,6 +124,7 @@ const baseTask: Task = {
 };
 
 function renderListActions(options?: {
+  lists?: TaskList[];
   tasks?: Task[];
   isEditOpen?: boolean;
   onEditOpenChange?: (open: boolean) => void;
@@ -120,6 +146,7 @@ function renderListActions(options?: {
         listId="list-1"
         listName="To Do"
         listStatus="not_started"
+        lists={options?.lists}
         tasks={options?.tasks ?? []}
         boardId="board-1"
         wsId="ws-1"
@@ -171,6 +198,30 @@ describe('ListActions', () => {
 
     expect(onEditOpenChange).not.toHaveBeenCalledWith(false);
     expect(toast.error).toHaveBeenCalledWith('Rename failed');
+  });
+
+  it('opens capacity settings preselected to the current task list', () => {
+    const secondList: TaskList = {
+      ...baseList,
+      id: 'list-2',
+      name: 'Doing',
+      position: 1,
+      status: 'active',
+    };
+    renderListActions({ lists: [baseList, secondList] });
+
+    expect(
+      screen.getByRole('button', { name: 'list_settings' })
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'ws-board-templates.capacity.title',
+      })
+    );
+
+    const capacitySettings = screen.getByTestId('capacity-rules-settings');
+    expect(capacitySettings).toHaveAttribute('data-selected-list', 'list-1');
+    expect(capacitySettings).toHaveAttribute('data-list-count', '2');
   });
 
   it('removes the list and its tasks from cache and broadcasts delete on success', async () => {

--- a/packages/tasks-ui/src/tu-do/boards/boardId/board-column.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/board-column.tsx
@@ -943,6 +943,7 @@ export function BoardColumn({
                   listName={column.name}
                   listStatus={column.status}
                   listColor={column.color as SupportedColor}
+                  lists={availableLists}
                   tasks={tasks}
                   boardId={boardId}
                   wsId={wsId}

--- a/packages/tasks-ui/src/tu-do/boards/boardId/list-actions.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/list-actions.tsx
@@ -3,8 +3,10 @@ import {
   Archive,
   ArrowRightLeft,
   CheckSquare,
+  Gauge,
   MoreHorizontal,
   Pencil,
+  Settings2,
   Trash,
 } from '@tuturuuu/icons';
 import {
@@ -30,6 +32,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@tuturuuu/ui/dropdown-menu';
 import { toast } from '@tuturuuu/ui/sonner';
@@ -40,12 +45,14 @@ import { useBoardBroadcast } from '../../shared/board-broadcast-context';
 import { EditListDialog } from '../../shared/edit-list-dialog';
 import { isTaskListNameExistsError } from '../../shared/task-board-errors';
 import { BoardSelector } from '../board-selector';
+import { CapacityRulesSettings } from '../capacity-rules-settings';
 
 interface Props {
   listId: string;
   listName: string;
   listStatus?: TaskBoardStatus;
   listColor?: SupportedColor;
+  lists?: TaskList[];
   tasks?: Task[];
   boardId?: string;
   wsId?: string;
@@ -60,6 +67,7 @@ export function ListActions({
   listName,
   listStatus,
   listColor,
+  lists = [],
   tasks = [],
   boardId = '',
   wsId,
@@ -73,6 +81,7 @@ export function ListActions({
   const canManageList = Boolean(wsId && boardId);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
+  const [isCapacityDialogOpen, setIsCapacityDialogOpen] = useState(false);
   const [isMoveAllDialogOpen, setIsMoveAllDialogOpen] = useState(false);
 
   const queryClient = useQueryClient();
@@ -81,6 +90,26 @@ export function ListActions({
   const allowedStatuses = useMemo<TaskBoardStatus[]>(() => {
     return ['documents', 'not_started', 'active', 'review', 'done', 'closed'];
   }, []);
+  const capacityLists = useMemo<TaskList[]>(
+    () =>
+      lists.length > 0
+        ? lists
+        : [
+            {
+              archived: false,
+              board_id: boardId,
+              color: listColor ?? 'GRAY',
+              created_at: '',
+              creator_id: '',
+              deleted: false,
+              id: listId,
+              name: listName,
+              position: 0,
+              status: listStatus ?? 'not_started',
+            },
+          ],
+    [boardId, listColor, listId, listName, listStatus, lists]
+  );
 
   const moveAllTasksFromListMutation = useMoveAllTasksFromList(
     boardId,
@@ -361,14 +390,24 @@ export function ListActions({
             <MoreHorizontal className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent align="end" className="w-56">
           {canManageList && (
-            <DropdownMenuItem onClick={() => onEditOpenChange(true)}>
-              <div className="h-4 w-4">
-                <Pencil className="h-4 w-4" />
-              </div>
-              {t('edit')}
-            </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <Settings2 className="h-4 w-4" />
+                {t('list_settings')}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-52">
+                <DropdownMenuItem onClick={() => onEditOpenChange(true)}>
+                  <Pencil className="h-4 w-4" />
+                  {t('edit_list')}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setIsCapacityDialogOpen(true)}>
+                  <Gauge className="h-4 w-4" />
+                  {taskBoardT('ws-board-templates.capacity.title')}
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
           )}
           {tasks.length > 0 && onSelectAll && (
             <>
@@ -422,6 +461,30 @@ export function ListActions({
           )}
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <Dialog
+        open={canManageList && isCapacityDialogOpen}
+        onOpenChange={setIsCapacityDialogOpen}
+      >
+        <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-5xl">
+          <DialogHeader className="sr-only">
+            <DialogTitle>
+              {taskBoardT('ws-board-templates.capacity.title')} · {listName}
+            </DialogTitle>
+            <DialogDescription>
+              {taskBoardT('ws-board-templates.capacity.description')}
+            </DialogDescription>
+          </DialogHeader>
+          {wsId && (
+            <CapacityRulesSettings
+              boardId={boardId}
+              initialListId={listId}
+              lists={capacityLists}
+              wsId={wsId}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
 
       <Dialog
         open={canManageList && isDeleteDialogOpen}

--- a/packages/tasks-ui/src/tu-do/boards/capacity-rules-settings.test.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/capacity-rules-settings.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { TaskList } from '@tuturuuu/types/primitives/TaskList';
+import { describe, expect, it, vi } from 'vitest';
+import { CapacityRulesSettings } from './capacity-rules-settings';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@tuturuuu/internal-api/tasks', () => ({
+  createWorkspaceTaskBoardCapacityRule: vi.fn(),
+  deleteWorkspaceTaskBoardCapacityRule: vi.fn(),
+  listWorkspaceLabels: vi.fn().mockResolvedValue([]),
+  listWorkspaceTaskBoardCapacityRules: vi.fn().mockResolvedValue({ rules: [] }),
+  listWorkspaceTaskProjects: vi.fn().mockResolvedValue([]),
+  updateWorkspaceTaskBoardCapacityRule: vi.fn(),
+}));
+
+const readyList: TaskList = {
+  archived: false,
+  board_id: 'board-1',
+  color: 'GREEN',
+  created_at: '2026-08-06T00:00:00.000Z',
+  creator_id: 'user-1',
+  deleted: false,
+  id: 'list-ready',
+  name: 'Ready',
+  position: 0,
+  status: 'active',
+};
+
+function renderCapacitySettings(props?: { initialListId?: string }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CapacityRulesSettings
+        boardId="board-1"
+        initialListId={props?.initialListId}
+        lists={[readyList]}
+        wsId="ws-1"
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe('CapacityRulesSettings', () => {
+  it('starts a new rule with the contextual task list selected', () => {
+    renderCapacitySettings({ initialListId: readyList.id });
+
+    expect(screen.getByLabelText('name')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ready' })).toHaveClass(
+      'bg-primary'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'add' }));
+
+    expect(screen.getByRole('button', { name: 'Ready' })).toHaveClass(
+      'bg-primary'
+    );
+  });
+
+  it('keeps the board settings view collapsed without a contextual list', () => {
+    renderCapacitySettings();
+
+    expect(screen.queryByLabelText('name')).not.toBeInTheDocument();
+  });
+});

--- a/packages/tasks-ui/src/tu-do/boards/capacity-rules-settings.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/capacity-rules-settings.tsx
@@ -32,17 +32,19 @@ function browserOptions() {
 
 export function CapacityRulesSettings({
   boardId,
+  initialListId,
   lists,
   wsId,
 }: {
   boardId: string;
+  initialListId?: string;
   lists: TaskList[];
   wsId: string;
 }) {
   const t = useTranslations('ws-board-templates.capacity');
   const queryClient = useQueryClient();
   const queryKey = ['task-capacity-rules', wsId, boardId] as const;
-  const [creating, setCreating] = useState(false);
+  const [creating, setCreating] = useState(Boolean(initialListId));
   const [editingId, setEditingId] = useState<string | null>(null);
   const [name, setName] = useState('');
   const [limit, setLimit] = useState(5);
@@ -56,9 +58,37 @@ export function CapacityRulesSettings({
   const [projectMatchMode, setProjectMatchMode] =
     useState<TaskCapacityMatchMode>('any');
   const [search, setSearch] = useState('');
-  const [listIds, setListIds] = useState<string[]>([]);
+  const [listIds, setListIds] = useState<string[]>(
+    initialListId ? [initialListId] : []
+  );
   const [labelIds, setLabelIds] = useState<string[]>([]);
   const [projectIds, setProjectIds] = useState<string[]>([]);
+
+  function resetDraft() {
+    setEditingId(null);
+    setName('');
+    setLimit(5);
+    setMetric('task_count');
+    setEnforcement('soft');
+    setCountingMode('active');
+    setLabelMatchMode('any');
+    setProjectMatchMode('any');
+    setSearch('');
+    setListIds(initialListId ? [initialListId] : []);
+    setLabelIds([]);
+    setProjectIds([]);
+  }
+
+  function toggleCreateEditor() {
+    if (creating) {
+      setCreating(false);
+      resetDraft();
+      return;
+    }
+
+    resetDraft();
+    setCreating(true);
+  }
 
   const rulesQuery = useQuery({
     queryKey,
@@ -145,11 +175,7 @@ export function CapacityRulesSettings({
     },
     onSuccess: () => {
       setCreating(false);
-      setEditingId(null);
-      setName('');
-      setListIds([]);
-      setLabelIds([]);
-      setProjectIds([]);
+      resetDraft();
       void refresh();
       toast.success(t('saved'));
     },
@@ -198,11 +224,7 @@ export function CapacityRulesSettings({
           <h3 className="font-semibold">{t('title')}</h3>
           <p className="text-muted-foreground text-sm">{t('description')}</p>
         </div>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => setCreating((value) => !value)}
-        >
+        <Button size="sm" variant="outline" onClick={toggleCreateEditor}>
           <Plus className="h-4 w-4" />
           {t('add')}
         </Button>
@@ -439,7 +461,7 @@ export function CapacityRulesSettings({
               variant="ghost"
               onClick={() => {
                 setCreating(false);
-                setEditingId(null);
+                resetDraft();
               }}
             >
               {t('cancel')}


### PR DESCRIPTION
## Summary
- add a first-class List settings submenu to Kanban column ellipsis menus
- expose Edit list and a focused Capacity editor from that submenu
- preselect the current list while retaining all board lists for multi-list capacity rules
- add English and Vietnamese translations across all Tasks UI consumers

## Validation
- focused Tasks UI tests: 5 passed
- Tasks UI type-check: passed
- i18n check, key parity, namespace check, and sort check: passed
- elevated bun check: product tests, type-check, Biome, auth guards, i18n, and migration checks passed; unrelated Release Please script assertion on origin/main remains (0.17.0 versus 0.17.1)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a List settings submenu to Kanban column actions with quick access to Edit list and a focused Capacity rules editor. The capacity editor preselects the current list and includes English/Vietnamese strings across apps.

- **New Features**
  - Add “List settings” submenu in the column menu with Edit list and Capacity rules.
  - Open capacity rules in a dialog, preselected to the current list; keep all board lists available for multi-list rules.
  - Add `list_settings` i18n keys (EN/VI) in `apps/calendar`, `apps/tasks`, `apps/web`, and `apps/tanstack-web`.

- **Refactors**
  - `CapacityRulesSettings` now accepts `initialListId`, starts in create mode when present, and uses a `resetDraft()` + toggle for simpler state management.
  - `ListActions` passes `lists` to capacity settings and wires the new dialog; tests cover list preselection and list count.

<sup>Written for commit 50031dac99961f35ab88aa6b286c4f11d23df7cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

