### PR TITLE
perf(chat): parallelize historical ingest

### DIFF
--- a/apps/web/src/app/api/v1/integrations/external-chat/events/batch/route.test.ts
+++ b/apps/web/src/app/api/v1/integrations/external-chat/events/batch/route.test.ts
@@ -151,6 +151,40 @@ describe('external chat historical batch', () => {
     );
   });
 
+  it('does not merge visitor lanes when opaque identifiers contain colons', async () => {
+    let active = 0;
+    let maxActive = 0;
+    processEvent.mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return { duplicate: false };
+    });
+    const { POST } = await import('./route');
+    const response = await POST(
+      new Request('http://localhost/events/batch', {
+        body: JSON.stringify({
+          events: [
+            { ...event, agentId: 'a:b', visitorId: 'c' },
+            {
+              ...event,
+              agentId: 'a',
+              eventId: 'message:11',
+              messageId: '11',
+              visitorId: 'b:c',
+            },
+          ],
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(maxActive).toBe(2);
+  });
+
   it('rejects unauthenticated batches', async () => {
     authenticate.mockResolvedValueOnce(null);
     const { POST } = await import('./route');

--- a/apps/web/src/app/api/v1/integrations/external-chat/events/batch/route.test.ts
+++ b/apps/web/src/app/api/v1/integrations/external-chat/events/batch/route.test.ts
@@ -81,6 +81,76 @@ describe('external chat historical batch', () => {
     });
   });
 
+  it('imports independent visitor lanes concurrently within a bounded limit', async () => {
+    let active = 0;
+    let maxActive = 0;
+    processEvent.mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return { duplicate: false };
+    });
+    const events = Array.from({ length: 20 }, (_, index) => ({
+      ...event,
+      eventId: `message:${index}`,
+      messageId: String(index),
+      visitorId: String(index),
+    }));
+    const { POST } = await import('./route');
+    const response = await POST(
+      new Request('http://localhost/events/batch', {
+        body: JSON.stringify({ events }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(processEvent).toHaveBeenCalledTimes(20);
+    expect(maxActive).toBeGreaterThan(1);
+    expect(maxActive).toBeLessThanOrEqual(8);
+  });
+
+  it('preserves source order within each visitor lane', async () => {
+    const completed: string[] = [];
+    processEvent.mockImplementation(async (input) => {
+      if (input.kind === 'message')
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      completed.push(input.eventId);
+      return { duplicate: false };
+    });
+    const stateEvent = {
+      ...event,
+      content: undefined,
+      contentType: undefined,
+      eventId: 'state:10:seen',
+      kind: 'message_state',
+      status: 'seen',
+    };
+    const otherVisitorEvent = {
+      ...event,
+      eventId: 'message:11',
+      messageId: '11',
+      visitorId: '21',
+    };
+    const { POST } = await import('./route');
+    const response = await POST(
+      new Request('http://localhost/events/batch', {
+        body: JSON.stringify({
+          events: [event, stateEvent, otherVisitorEvent],
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(completed.indexOf(event.eventId)).toBeLessThan(
+      completed.indexOf(stateEvent.eventId)
+    );
+  });
+
   it('rejects unauthenticated batches', async () => {
     authenticate.mockResolvedValueOnce(null);
     const { POST } = await import('./route');

--- a/apps/web/src/app/api/v1/integrations/external-chat/events/batch/route.ts
+++ b/apps/web/src/app/api/v1/integrations/external-chat/events/batch/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
     Array<{ event: HistoricalEvent; index: number }>
   >();
   parsed.data.events.forEach((event, index) => {
-    const laneKey = `${event.agentId}:${event.visitorId}`;
+    const laneKey = JSON.stringify([event.agentId, event.visitorId]);
     const lane = lanes.get(laneKey) ?? [];
     lane.push({ event, index });
     lanes.set(laneKey, lane);

--- a/apps/web/src/app/api/v1/integrations/external-chat/events/batch/route.ts
+++ b/apps/web/src/app/api/v1/integrations/external-chat/events/batch/route.ts
@@ -1,10 +1,13 @@
 import { createAdminClient } from '@tuturuuu/supabase/next/server';
+import { Effect, forEachConcurrently } from '@tuturuuu/utils/effect';
 import { NextResponse } from 'next/server';
 import { processExternalChatEnvelope } from '@/lib/external-chat/ingest';
 import { authenticateExternalChatIngest } from '@/lib/external-chat/ingest-auth';
 import { externalChatBatchSchema } from '@/lib/external-chat/schemas';
 import { digestExternalChatBatch } from '@/lib/external-chat/source-events';
 import { safeParseBody } from '@/lib/safe-parse-body';
+
+const HISTORICAL_BATCH_CONCURRENCY = 8;
 
 export async function POST(request: Request) {
   const authentication = await authenticateExternalChatIngest(request);
@@ -32,29 +35,72 @@ export async function POST(request: Request) {
   };
   const results = [];
   const failures: Array<{ code: string; eventId: string }> = [];
-  for (const event of parsed.data.events) {
-    try {
-      const result = await processExternalChatEnvelope(event, context);
-      if (result.conflict) {
-        failures.push({
-          code: 'external_chat_event_payload_mismatch',
-          eventId: event.eventId,
-        });
-      } else if (result.deferred) {
-        failures.push({
-          code: 'external_chat_event_deferred',
-          eventId: event.eventId,
-        });
-      } else {
-        results.push(result);
+  type HistoricalEvent = (typeof parsed.data.events)[number];
+  type HistoricalOutcome = {
+    event: HistoricalEvent;
+    index: number;
+  } & (
+    | {
+        ok: true;
+        result: Awaited<ReturnType<typeof processExternalChatEnvelope>>;
       }
-    } catch (error) {
-      console.error('External chat historical event import failed', {
-        error,
-        eventId: event.eventId,
-        wsId,
+    | { ok: false }
+  );
+  const lanes = new Map<
+    string,
+    Array<{ event: HistoricalEvent; index: number }>
+  >();
+  parsed.data.events.forEach((event, index) => {
+    const laneKey = `${event.agentId}:${event.visitorId}`;
+    const lane = lanes.get(laneKey) ?? [];
+    lane.push({ event, index });
+    lanes.set(laneKey, lane);
+  });
+  const laneOutcomes = await Effect.runPromise(
+    forEachConcurrently(
+      lanes.values(),
+      (lane) =>
+        Effect.promise(async () => {
+          const outcomes: HistoricalOutcome[] = [];
+          for (const item of lane) {
+            try {
+              outcomes.push({
+                ...item,
+                ok: true,
+                result: await processExternalChatEnvelope(item.event, context),
+              });
+            } catch (error) {
+              console.error('External chat historical event import failed', {
+                error,
+                eventId: item.event.eventId,
+                wsId,
+              });
+              outcomes.push({ ...item, ok: false });
+            }
+          }
+          return outcomes;
+        }),
+      { concurrency: HISTORICAL_BATCH_CONCURRENCY }
+    )
+  );
+  for (const outcome of laneOutcomes.flat().sort((a, b) => a.index - b.index)) {
+    if (!outcome.ok) {
+      failures.push({
+        code: 'event_import_failed',
+        eventId: outcome.event.eventId,
       });
-      failures.push({ code: 'event_import_failed', eventId: event.eventId });
+    } else if (outcome.result.conflict) {
+      failures.push({
+        code: 'external_chat_event_payload_mismatch',
+        eventId: outcome.event.eventId,
+      });
+    } else if (outcome.result.deferred) {
+      failures.push({
+        code: 'external_chat_event_deferred',
+        eventId: outcome.event.eventId,
+      });
+    } else {
+      results.push(outcome.result);
     }
   }
 


### PR DESCRIPTION
## Summary
- process silent historical imports in up to eight bounded visitor lanes
- preserve source ordering within each visitor lane so state and deletion events cannot race parent messages
- retain deterministic response ordering, digest behavior, and per-event failure isolation

## Verification
- `bun x vitest run src/app/api/v1/integrations/external-chat/events/batch/route.test.ts` (9 passed)
- `bun x tsc --noEmit --project apps/web/tsconfig.json --pretty false`
- `bun migration:tanstack:manifest` (no manifest diff)
- `bun run build` in `apps/web` (passed with existing ignored local env)
- `bun check` passed all project checks except the unrelated existing release-manifest assertion (`0.17.0` vs `0.17.1`)
- accidental full test invocation passed 2,751 tests; only sandbox localhost `listen EPERM` request-tracker tests failed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes historical external chat batch ingest by running independent visitor lanes concurrently (up to 8). Improves throughput while keeping per-visitor source order, deterministic responses, and correct lane separation when IDs contain colons.

- **Performance**
  - Group events by JSON-encoded `[agentId, visitorId]` and process lanes concurrently using Effect.forEachConcurrently from `@tuturuuu/utils/effect` (`HISTORICAL_BATCH_CONCURRENCY = 8`).
  - Preserve order within each lane and rebuild outcomes by original index to keep digest and response ordering stable.
  - Maintain per-event failure isolation; add `event_import_failed` for thrown errors. Tests verify bounded concurrency, lane ordering, and no lane merging when identifiers contain colons.

<sup>Written for commit d8478d3bd0a1c42e4f62237d492a043a9979a2cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

