### PR TITLE
fix(external-projects): let a broader scope answer for a narrower one

### DIFF
--- a/apps/web/src/lib/external-projects/access.test.ts
+++ b/apps/web/src/lib/external-projects/access.test.ts
@@ -165,6 +165,35 @@ describe('external project app-token scope checks', () => {
       )
     ).toBe(false);
   });
+
+  it('lets a broader scope answer for a narrower one', () => {
+    // `manage` is the right to change the content model, which nobody can
+    // exercise without also reading and publishing. Requiring the narrow scope
+    // by name meant an app granted everything could do nothing, and no
+    // permission change fixed it because the grant was never what was missing.
+    for (const mode of ['read', 'publish', 'manage'] as const) {
+      expect(
+        appTokenHasRequiredScope(
+          { ...baseClaims, scopes: ['external-projects:manage'] },
+          mode
+        )
+      ).toBe(true);
+    }
+
+    expect(
+      appTokenHasRequiredScope(
+        { ...baseClaims, scopes: ['external-projects:publish'] },
+        'read'
+      )
+    ).toBe(true);
+    // Narrower still cannot answer for broader.
+    expect(
+      appTokenHasRequiredScope(
+        { ...baseClaims, scopes: ['external-projects:publish'] },
+        'manage'
+      )
+    ).toBe(false);
+  });
 });
 
 type CanonicalProjectFixture = {

--- a/apps/web/src/lib/external-projects/access.ts
+++ b/apps/web/src/lib/external-projects/access.ts
@@ -661,16 +661,25 @@ export function appTokenHasRequiredScope(
     return false;
   }
 
-  const requiredScope =
+  // Broader scopes answer for narrower ones. `manage` is the right to change the
+  // content model, which nobody can exercise without also reading and
+  // publishing — yet a token holding it was refused a plain read. An app granted
+  // everything could therefore do nothing, and no permission change fixed it,
+  // because the grant was never what was missing.
+  const acceptedScopes =
     mode === 'read'
-      ? 'external-projects:read'
+      ? [
+          'external-projects:read',
+          'external-projects:publish',
+          'external-projects:manage',
+        ]
       : mode === 'publish'
-        ? 'external-projects:publish'
-        : 'external-projects:manage';
+        ? ['external-projects:publish', 'external-projects:manage']
+        : ['external-projects:manage'];
 
   return (
     claims.scopes.includes('external-projects:*') ||
-    claims.scopes.includes(requiredScope)
+    acceptedScopes.some((scope) => claims.scopes.includes(scope))
   );
 }
 


### PR DESCRIPTION
## Problem

An app token holding `external-projects:manage` is refused a plain read.

`appTokenHasRequiredScope` compares against exactly one scope per mode:

```ts
const requiredScope =
  mode === 'read' ? 'external-projects:read'
  : mode === 'publish' ? 'external-projects:publish'
  : 'external-projects:manage';
```

So `manage` — the right to change the content model, which nobody can exercise
without also reading and publishing — does not satisfy `read`. An app granted
everything can do nothing, and no amount of permission granting fixes it,
because the grant was never what was missing.

## How it showed up

CyberShield35 hit this on every CMS call. Uploading an article cover failed with
a bare `403 {"error":"Forbidden"}` from `external-projects/collections`, with the
session provably holding `external-projects:manage`. Workspace member defaults
were already 116/116 Administrator, so it looked like a permission problem that
had no permission left to grant.

Downstream, that meant scraped article images could never be re-hosted into CMS
storage, so they kept pointing at expiring third-party CDN URLs — which Zalo then
refused with `photo_url ... is invalid`, blocking publication.

## Change

Each mode accepts any scope at least as broad as itself. Narrower still cannot
answer for broader: `publish` does not grant `manage`. `external-projects:*`
keeps working as before.

## Tests

`apps/web/src/lib/external-projects/access.test.ts` — 16 pass, including a new
case covering the hierarchy in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broader `external-projects` scopes now satisfy narrower modes, fixing 403s when tokens with `external-projects:manage` perform reads or publishes. This restores CMS flows like uploading article covers that were blocked by strict scope checks.

- **Bug Fixes**
  - Updated `appTokenHasRequiredScope` to accept broader scopes per mode: read accepts `read|publish|manage`, publish accepts `publish|manage`, manage requires `manage`.
  - `external-projects:*` behavior unchanged.
  - Added tests for the scope hierarchy in `apps/web/src/lib/external-projects/access.test.ts`.

<sup>Written for commit 94dbee6493511a9764aeecb8f6fe63ba7402a3fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

