### PR TITLE
fix(chat): restore external inbox display parity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2615,6 +2615,7 @@
         "eventemitter3": "^5.0.4",
         "framer-motion": "^12.43.0",
         "gsap": "^3.15.0",
+        "html-entities": "^2.6.0",
         "html2canvas-pro": "^2.3.3",
         "input-otp": "^1.4.2",
         "katex": "^0.18.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -128,6 +128,7 @@
     "eventemitter3": "^5.0.4",
     "framer-motion": "^12.43.0",
     "gsap": "^3.15.0",
+    "html-entities": "^2.6.0",
     "html2canvas-pro": "^2.3.3",
     "input-otp": "^1.4.2",
     "katex": "^0.18.1",

--- a/packages/ui/src/components/ui/chat/chat-sidebar-items.tsx
+++ b/packages/ui/src/components/ui/chat/chat-sidebar-items.tsx
@@ -38,6 +38,7 @@ export function ConversationRow({
     channel: t('untitled_channel'),
     chat: t('untitled_chat'),
     direct: t('direct_message'),
+    external: t('external_sender'),
     group: t('group_chat'),
   });
   const pinned = isChatConversationPinned(conversation, currentUserId);

--- a/packages/ui/src/components/ui/chat/chat-sidebar-items.tsx
+++ b/packages/ui/src/components/ui/chat/chat-sidebar-items.tsx
@@ -6,6 +6,7 @@ import { cn } from '@tuturuuu/utils/format';
 import { useLocale, useTranslations } from 'next-intl';
 import { Button } from '../button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../tooltip';
+import { getChatMessageDisplayContent } from './external-message-content';
 import {
   getChatConversationQueueDetails,
   getChatMessageSenderLabel,
@@ -160,25 +161,29 @@ export function SearchResultList({
 
   return (
     <div className="h-full space-y-1 overflow-y-auto p-2">
-      {messages.map((message) => (
-        <button
-          className="w-full rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
-          key={message.id}
-          onClick={() => onSelectConversation(message.conversationId)}
-          type="button"
-        >
-          <span className="block truncate font-medium text-sm">
-            {getChatMessageSenderLabel(message, {
-              assistant: t('assistant_name'),
-              external: t('external_sender'),
-              unknown: t('unknown_sender'),
-            })}
-          </span>
-          <span className="mt-1 line-clamp-2 text-muted-foreground text-xs">
-            {message.content}
-          </span>
-        </button>
-      ))}
+      {messages.map((message) => {
+        const displayContent = getChatMessageDisplayContent(message);
+
+        return (
+          <button
+            className="w-full rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+            key={message.id}
+            onClick={() => onSelectConversation(message.conversationId)}
+            type="button"
+          >
+            <span className="block truncate font-medium text-sm">
+              {getChatMessageSenderLabel(message, {
+                assistant: t('assistant_name'),
+                external: t('external_sender'),
+                unknown: t('unknown_sender'),
+              })}
+            </span>
+            <span className="mt-1 line-clamp-2 text-muted-foreground text-xs">
+              {displayContent}
+            </span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/packages/ui/src/components/ui/chat/chat-utils.test.ts
+++ b/packages/ui/src/components/ui/chat/chat-utils.test.ts
@@ -171,6 +171,21 @@ describe('chat utils', () => {
     ).toBe('message_deleted');
   });
 
+  it('decodes external message previews without changing native previews', () => {
+    const encoded = 'T&ocirc;i &#273;&atilde; g&#7917;i tin';
+
+    expect(
+      getLastMessagePreview({
+        ...baseMessage,
+        content: encoded,
+        metadata: { externalChat: true },
+      })
+    ).toBe('Tôi đã gửi tin');
+    expect(getLastMessagePreview({ ...baseMessage, content: encoded })).toBe(
+      encoded
+    );
+  });
+
   it('formats file sizes for attachment rows', () => {
     expect(formatFileSize(0)).toBe('0 B');
     expect(formatFileSize(2048)).toBe('2.0 KB');
@@ -380,6 +395,21 @@ describe('chat utils', () => {
       preview: 'Need help with this page',
       timestamp: '2026-08-05T07:15:00.000Z',
     });
+  });
+
+  it('decodes connected-site queue previews using conversation scope', () => {
+    const details = getChatConversationQueueDetails(
+      conversation({
+        latestMessage: {
+          ...baseMessage,
+          content: 'T&ocirc;i &#273;&atilde; g&#7917;i tin',
+          metadata: { status: 'seen' },
+        },
+        metadata: { externalChat: true },
+      })
+    );
+
+    expect(details.preview).toBe('Tôi đã gửi tin');
   });
 
   it('normalizes connected-site delivery and deletion states', () => {

--- a/packages/ui/src/components/ui/chat/chat-utils.test.ts
+++ b/packages/ui/src/components/ui/chat/chat-utils.test.ts
@@ -134,6 +134,35 @@ describe('chat utils', () => {
     expect(title).toBe('Ada Lovelace');
   });
 
+  it('gives unnamed external conversations a stable pseudonymous title', () => {
+    const title = getConversationTitle(
+      conversation({
+        id: 'a7d12840-f72d-48f2-8057-a1ea15aecd29',
+        metadata: { externalChat: true },
+        title: 'External visitor',
+        type: 'channel',
+      }),
+      'user-1',
+      { external: 'Website visitor' }
+    );
+
+    expect(title).toBe('Website visitor #AECD29');
+  });
+
+  it('prefers an external profile name over a persisted generic title', () => {
+    const title = getConversationTitle(
+      conversation({
+        metadata: { displayName: 'Visitor 42', externalChat: true },
+        title: 'External visitor',
+        type: 'channel',
+      }),
+      'user-1',
+      { external: 'Website visitor' }
+    );
+
+    expect(title).toBe('Visitor 42');
+  });
+
   it('builds useful message previews for files and deleted messages', () => {
     expect(
       getLastMessagePreview(

--- a/packages/ui/src/components/ui/chat/chat-workspace.tsx
+++ b/packages/ui/src/components/ui/chat/chat-workspace.tsx
@@ -325,6 +325,7 @@ export function ChatWorkspace({
         channel: t('untitled_channel'),
         chat: t('untitled_chat'),
         direct: t('direct_message'),
+        external: t('external_sender'),
         group: t('group_chat'),
       })
     : t('title');

--- a/packages/ui/src/components/ui/chat/external-message-content.test.ts
+++ b/packages/ui/src/components/ui/chat/external-message-content.test.ts
@@ -12,6 +12,15 @@ describe('getChatMessageDisplayContent', () => {
     ).toBe('Tôi đã gửi tin & chờ phản hồi.');
   });
 
+  it('decodes bounded nested entities from double-encoded legacy rows', () => {
+    expect(
+      getChatMessageDisplayContent({
+        content: 'Kh&aacute;m trực tiếp &amp;amp; mang theo kết quả',
+        metadata: { externalChat: true },
+      })
+    ).toBe('Khám trực tiếp & mang theo kết quả');
+  });
+
   it('leaves native chat content unchanged', () => {
     expect(
       getChatMessageDisplayContent({

--- a/packages/ui/src/components/ui/chat/external-message-content.test.ts
+++ b/packages/ui/src/components/ui/chat/external-message-content.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getChatMessageDisplayContent } from './external-message-content';
+
+describe('getChatMessageDisplayContent', () => {
+  it('decodes named and numeric entities for external chat messages', () => {
+    expect(
+      getChatMessageDisplayContent({
+        content:
+          'T&ocirc;i &#273;&atilde; g&#7917;i tin &amp; ch&#7901; ph&#7843;n h&#7891;i.',
+        metadata: { externalChat: true },
+      })
+    ).toBe('Tôi đã gửi tin & chờ phản hồi.');
+  });
+
+  it('leaves native chat content unchanged', () => {
+    expect(
+      getChatMessageDisplayContent({
+        content: 'Keep &amp; exactly as authored',
+        metadata: {},
+      })
+    ).toBe('Keep &amp; exactly as authored');
+  });
+
+  it('returns decoded markup as text content rather than an HTML contract', () => {
+    expect(
+      getChatMessageDisplayContent({
+        content: '&lt;img src=x onerror=alert(1)&gt;',
+        metadata: { externalChat: true },
+      })
+    ).toBe('<img src=x onerror=alert(1)>');
+  });
+});

--- a/packages/ui/src/components/ui/chat/external-message-content.ts
+++ b/packages/ui/src/components/ui/chat/external-message-content.ts
@@ -1,13 +1,21 @@
 import type { ChatMessage } from '@tuturuuu/internal-api';
 import { decode } from 'html-entities';
 
+const MAX_ENTITY_DECODE_PASSES = 3;
+
 export function decodeExternalChatContent(
   content: string,
   externalChat: boolean
 ) {
-  return externalChat
-    ? decode(content, { level: 'html5', scope: 'body' })
-    : content;
+  if (!externalChat) return content;
+
+  let displayContent = content;
+  for (let pass = 0; pass < MAX_ENTITY_DECODE_PASSES; pass += 1) {
+    const decoded = decode(displayContent, { level: 'html5', scope: 'body' });
+    if (decoded === displayContent) break;
+    displayContent = decoded;
+  }
+  return displayContent;
 }
 
 export function getChatMessageDisplayContent(

--- a/packages/ui/src/components/ui/chat/external-message-content.ts
+++ b/packages/ui/src/components/ui/chat/external-message-content.ts
@@ -1,0 +1,20 @@
+import type { ChatMessage } from '@tuturuuu/internal-api';
+import { decode } from 'html-entities';
+
+export function decodeExternalChatContent(
+  content: string,
+  externalChat: boolean
+) {
+  return externalChat
+    ? decode(content, { level: 'html5', scope: 'body' })
+    : content;
+}
+
+export function getChatMessageDisplayContent(
+  message: Pick<ChatMessage, 'content' | 'metadata'>
+) {
+  return decodeExternalChatContent(
+    message.content,
+    message.metadata.externalChat === true
+  );
+}

--- a/packages/ui/src/components/ui/chat/message-bubble.tsx
+++ b/packages/ui/src/components/ui/chat/message-bubble.tsx
@@ -26,6 +26,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../popover';
 import { toast } from '../sonner';
 import { AiMessageParts } from './ai-message-parts';
 import { getAiMessagePartsFromMetadata } from './ai-message-render-utils';
+import { getChatMessageDisplayContent } from './external-message-content';
 import { MessageAttachmentButton } from './message-attachment-button';
 import { MessageLinkPreviews, MessageText } from './message-links';
 import {
@@ -259,6 +260,7 @@ function MessageContent({
   const t = useTranslations('chat');
   const aiParts = getAiMessagePartsFromMetadata(message.metadata);
   const externalAttachment = readExternalAttachment(message.metadata);
+  const displayContent = getChatMessageDisplayContent(message);
 
   return (
     <div
@@ -284,10 +286,10 @@ function MessageContent({
                   textFallback={message.content}
                 />
               ) : (
-                <MessageText content={message.content} />
+                <MessageText content={displayContent} />
               )}
               <MessageLinkPreviews
-                content={message.content}
+                content={displayContent}
                 conversationId={message.conversationId}
                 isOwnMessage={isOwnMessage}
                 wsId={wsId}

--- a/packages/ui/src/components/ui/chat/message-links.test.tsx
+++ b/packages/ui/src/components/ui/chat/message-links.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MessageText } from './message-links';
+
+describe('MessageText', () => {
+  it('renders HTML-like message content as inert text', () => {
+    const { container } = render(
+      <MessageText content="<img src=x onerror=alert(1)>" />
+    );
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toBe('<img src=x onerror=alert(1)>');
+  });
+});

--- a/packages/ui/src/components/ui/chat/utils.ts
+++ b/packages/ui/src/components/ui/chat/utils.ts
@@ -4,6 +4,10 @@ import type {
   ChatMessage,
   ChatUserProfile,
 } from '@tuturuuu/internal-api';
+import {
+  decodeExternalChatContent,
+  getChatMessageDisplayContent,
+} from './external-message-content';
 
 export type ChatConversationScope = 'external' | 'personal' | 'workspaces';
 export type ChatConversationArchiveFilter = 'active' | 'all' | 'archived';
@@ -102,6 +106,12 @@ export function getChatConversationQueueDetails(
 ) {
   const latestMessage = conversation.latestMessage;
   const phone = readNonEmptyString(conversation.metadata.phone);
+  const previewContent = latestMessage
+    ? decodeExternalChatContent(
+        latestMessage.content,
+        conversation.metadata.externalChat === true
+      )
+    : null;
 
   return {
     deliveryState: latestMessage
@@ -110,7 +120,7 @@ export function getChatConversationQueueDetails(
     phone,
     preview: latestMessage?.deletedAt
       ? null
-      : (readNonEmptyString(latestMessage?.content) ??
+      : (readNonEmptyString(previewContent) ??
         readNonEmptyString(latestMessage?.attachments[0]?.filename)),
     timestamp: latestMessage?.createdAt ?? conversation.updatedAt,
   };
@@ -412,7 +422,8 @@ export function getLastMessagePreview(
   if (message.deletedAt) return labels.messageDeleted ?? '';
   if (message.kind === 'system')
     return labels.systemEvent ?? labels.message ?? '';
-  if (message.content.trim()) return message.content.trim();
+  const displayContent = getChatMessageDisplayContent(message).trim();
+  if (displayContent) return displayContent;
   if (message.attachments.length > 0) {
     return message.attachments[0]?.filename ?? labels.attachment ?? '';
   }

--- a/packages/ui/src/components/ui/chat/utils.ts
+++ b/packages/ui/src/components/ui/chat/utils.ts
@@ -244,9 +244,29 @@ export function getConversationTitle(
     channel?: string;
     chat?: string;
     direct?: string;
+    external?: string;
     group?: string;
   }
 ) {
+  if (conversation.metadata.externalChat === true) {
+    const profileTitle =
+      readNonEmptyString(conversation.metadata.displayName) ??
+      readNonEmptyString(conversation.metadata.name);
+    if (profileTitle) return profileTitle;
+
+    const persistedTitle = readNonEmptyString(conversation.title);
+    if (persistedTitle && !isGenericExternalTitle(persistedTitle)) {
+      return persistedTitle;
+    }
+
+    const reference = conversation.id
+      .replaceAll('-', '')
+      .slice(-6)
+      .toUpperCase();
+    const label = fallback?.external ?? fallback?.channel ?? 'External visitor';
+    return reference ? `${label} #${reference}` : label;
+  }
+
   if (conversation.title) return conversation.title;
 
   if (conversation.type === 'direct') {
@@ -265,6 +285,11 @@ export function getConversationTitle(
   if (conversation.type === 'group') return fallback?.group ?? 'Group chat';
 
   return fallback?.chat ?? 'Untitled chat';
+}
+
+function isGenericExternalTitle(title: string) {
+  const normalized = title.trim().toLowerCase();
+  return normalized === 'external visitor' || normalized === 'website visitor';
 }
 
 export function getCurrentChatConversationMember(


### PR DESCRIPTION
## Summary
- decode single- and double-encoded HTML character references only for external chat display text
- keep canonical message bodies unchanged and render decoded markup as inert React text
- align transcript, queue preview, message preview, link extraction, and search results
- distinguish unnamed external visitors with a stable pseudonymous reference derived from the native conversation UUID

## Verification
- `bun --filter @tuturuuu/ui test` (810 passed before follow-ups)
- focused display parity tests (25 passed after follow-ups)
- `bun --filter @tuturuuu/ui type-check`
- `bun type-check:chat`
- `bun check` type-check and Biome passed; one unrelated satellite test timed out and passed 7/7 in isolation
- local Chat build reached Next compilation; sandbox blocked Turbopack worker port binding, so CI is the production-build signal