### PR TITLE
fix(chat): decode external visitor labels

### DIFF
--- a/packages/ui/src/components/ui/chat/chat-utils.test.ts
+++ b/packages/ui/src/components/ui/chat/chat-utils.test.ts
@@ -163,6 +163,33 @@ describe('chat utils', () => {
     expect(title).toBe('Visitor 42');
   });
 
+  it('decodes external profile and persisted conversation titles', () => {
+    expect(
+      getConversationTitle(
+        conversation({
+          metadata: {
+            displayName: 'Nguyễn Thị Vi&amp;ecirc;n',
+            externalChat: true,
+          },
+          title: 'External visitor',
+          type: 'channel',
+        }),
+        'user-1'
+      )
+    ).toBe('Nguyễn Thị Viên');
+
+    expect(
+      getConversationTitle(
+        conversation({
+          metadata: { externalChat: true },
+          title: 'Nguyễn Thị Vi&ecirc;n',
+          type: 'channel',
+        }),
+        'user-1'
+      )
+    ).toBe('Nguyễn Thị Viên');
+  });
+
   it('builds useful message previews for files and deleted messages', () => {
     expect(
       getLastMessagePreview(
@@ -388,12 +415,12 @@ describe('chat utils', () => {
           ...baseMessage,
           metadata: {
             externalChat: true,
-            externalSender: { displayName: 'Visitor 42' },
+            externalSender: { displayName: 'Visitor &amp;amp; 42' },
           },
         },
         fallback
       )
-    ).toBe('Visitor 42');
+    ).toBe('Visitor & 42');
     expect(
       getChatMessageSenderLabel(
         { ...baseMessage, metadata: { externalChat: true } },

--- a/packages/ui/src/components/ui/chat/utils.ts
+++ b/packages/ui/src/components/ui/chat/utils.ts
@@ -220,7 +220,7 @@ export function getChatMessageSenderLabel(
     const displayName =
       readNonEmptyString(externalSender.displayName) ??
       readNonEmptyString(externalSender.name);
-    if (displayName) return displayName;
+    if (displayName) return decodeExternalChatContent(displayName, true);
   }
 
   return message.metadata?.externalChat === true
@@ -252,11 +252,11 @@ export function getConversationTitle(
     const profileTitle =
       readNonEmptyString(conversation.metadata.displayName) ??
       readNonEmptyString(conversation.metadata.name);
-    if (profileTitle) return profileTitle;
+    if (profileTitle) return decodeExternalChatContent(profileTitle, true);
 
     const persistedTitle = readNonEmptyString(conversation.title);
     if (persistedTitle && !isGenericExternalTitle(persistedTitle)) {
-      return persistedTitle;
+      return decodeExternalChatContent(persistedTitle, true);
     }
 
     const reference = conversation.id


### PR DESCRIPTION
## What
- Decode entity-encoded external visitor names in conversation titles.
- Decode entity-encoded external sender labels in transcripts.
- Preserve native Chat labels unchanged.

## Why
Imported legacy profiles can contain single- or double-encoded HTML entities. Connected Sites therefore displayed labels such as `Nguyễn Thị Vi&ecirc;n` instead of the visitor name operators see in the legacy inbox.

## How
The existing bounded external-content decoder now runs at the external-only label boundaries. Regression tests cover profile titles, persisted titles, and nested sender-name entities.

## Screenshots / recordings
The production symptom is the encoded Connected Sites title `Nguyễn Thị Vi&ecirc;n`; after this change the same stored value renders as `Nguyễn Thị Viên`. The behavior is data-dependent and fully covered by the included UI utility assertions; no layout or styling changes are introduced.

## Verification
- `bun x vitest run src/components/ui/chat/chat-utils.test.ts src/components/ui/chat/external-message-content.test.ts` (25 passed)
- `bun --cwd packages/ui type-check`
- `NEXT_WEBPACK_BUILD=1 bun x next build --webpack` in `apps/chat`
- `bun check`: type-check and Biome passed; sandbox-only localhost binding failures in `apps/web/docker/request-tracker.test.js`
- request-tracker rerun with localhost access: 4 passed
- transient Tasks planner failure rerun: 5 passed