### PR TITLE
perf(vercel): reduce speculative app requests

### DIFF
--- a/apps/docs/build/devops/overview.mdx
+++ b/apps/docs/build/devops/overview.mdx
@@ -66,9 +66,9 @@ Apply these controls in order:
    assets through application functions when a stable CDN URL is available.
 2. Cache only public or safely scoped data. Never apply shared CDN caching to
    authenticated, user-specific, or workspace-private responses.
-3. Shared satellite React Query clients use a 30-second stale window and one
-   retry. Override this only when a surface has a documented freshness or
-   reliability requirement.
+3. Shared Satellite and Nova React Query clients use a 30-second stale window
+   and one retry. Override this only when a surface has a documented freshness
+   or reliability requirement.
 4. Dashboard sidebar links disable viewport prefetch and prefetch on hover or
    keyboard focus. This preserves responsive navigation without invoking every
    visible destination merely because the sidebar rendered.

--- a/apps/docs/build/devops/overview.mdx
+++ b/apps/docs/build/devops/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "DevOps & Deployment"
 description: "The operational map for how Tuturuuu is built, deployed, migrated, and validated."
-updatedAt: "2026-06-21"
+updatedAt: "2026-08-11"
 ---
 
 This section is the runbook for shipping and operating Tuturuuu. It documents the
@@ -43,6 +43,37 @@ released, or recovered.
 - Self-hosted web deployment is Docker-based, and blue/green rollout is the supported rebuild-before-restart path.
 - The TanStack/Rust migration runs in parallel with `apps/web`: `apps/tanstack-web` (TanStack Start) and `apps/backend` (Rust, port `7820`) ship as Docker sidecars and Cloudflare Workers, and the TanStack frontend has Vercel build validation when it points at an HTTPS backend origin. See [TanStack/Rust Local And Deployment](/build/devops/tanstack-rust-local-deploy), [Web Docker Deployment](/build/devops/web-docker-deployment), and the [TanStack/Rust migration](/platform/architecture/tanstack-rust-migration) plan.
 - Secrets live in GitHub Actions secrets/variables or local env files such as `apps/web/.env.local`. They do not belong in the repo.
+
+## Vercel Cost Controls
+
+Start with measured usage instead of applying cache directives globally. The
+following commands identify the expensive projects and inspect a bounded sample
+of production traffic without enabling a paid observability add-on:
+
+```bash
+vercel usage --scope tuturuuu --group-by project --format json
+vercel logs --project <app> --scope tuturuuu --environment production --since 1h --json --no-branch
+```
+
+`vercel metrics` requires Observability Plus. A `payment_required` response is
+an expected limitation when the add-on is disabled; do not enable it solely for
+routine cost diagnosis.
+
+Apply these controls in order:
+
+1. Reduce request count and response size before adding cache writes. Prefer
+   direct-to-storage signed uploads for large payloads and avoid routing public
+   assets through application functions when a stable CDN URL is available.
+2. Cache only public or safely scoped data. Never apply shared CDN caching to
+   authenticated, user-specific, or workspace-private responses.
+3. Shared satellite React Query clients use a 30-second stale window and one
+   retry. Override this only when a surface has a documented freshness or
+   reliability requirement.
+4. Dashboard sidebar links disable viewport prefetch and prefetch on hover or
+   keyboard focus. This preserves responsive navigation without invoking every
+   visible destination merely because the sidebar rendered.
+5. After deployment, compare the same billing window and project grouping.
+   Confirm error rates and latency remain healthy before keeping a cost change.
 
 ## Operational Flow
 

--- a/apps/nova/src/app/[locale]/client-providers.tsx
+++ b/apps/nova/src/app/[locale]/client-providers.tsx
@@ -5,7 +5,14 @@ import { GlobalCommandLauncher } from '@tuturuuu/satellite/command-launcher';
 import { TooltipProvider } from '@tuturuuu/ui/tooltip';
 import type { ReactNode } from 'react';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 30_000,
+    },
+  },
+});
 
 export function ClientProviders({ children }: { children: ReactNode }) {
   return (

--- a/packages/satellite/src/providers/client-providers.tsx
+++ b/packages/satellite/src/providers/client-providers.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '@tuturuuu/ui/tooltip';
 import type { LaunchableAppSlug } from '@tuturuuu/utils/launchable-apps';
 import { type ReactNode, Suspense } from 'react';
 import { GlobalCommandLauncher } from '../components/command-launcher';
+import { createSatelliteQueryClient } from './query-client';
 
-const queryClient = new QueryClient();
+const queryClient = createSatelliteQueryClient();
 
 export function ClientProviders({
   children,
@@ -26,7 +26,6 @@ export function ClientProviders({
           </Suspense>
         )}
       </TooltipProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
 }

--- a/packages/satellite/src/providers/query-client.test.ts
+++ b/packages/satellite/src/providers/query-client.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSatelliteQueryClient,
+  SATELLITE_QUERY_STALE_TIME_MS,
+} from './query-client';
+
+describe('createSatelliteQueryClient', () => {
+  it('deduplicates short-lived remounts and bounds failed-request retries', () => {
+    const client = createSatelliteQueryClient();
+
+    expect(client.getDefaultOptions().queries).toMatchObject({
+      retry: 1,
+      staleTime: SATELLITE_QUERY_STALE_TIME_MS,
+    });
+  });
+});

--- a/packages/satellite/src/providers/query-client.ts
+++ b/packages/satellite/src/providers/query-client.ts
@@ -1,0 +1,14 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const SATELLITE_QUERY_STALE_TIME_MS = 30_000;
+
+export function createSatelliteQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 1,
+        staleTime: SATELLITE_QUERY_STALE_TIME_MS,
+      },
+    },
+  });
+}

--- a/packages/ui/src/components/ui/custom/nav-link.test.tsx
+++ b/packages/ui/src/components/ui/custom/nav-link.test.tsx
@@ -7,10 +7,12 @@ import { NavLink } from './nav-link';
 
 const navigationState = vi.hoisted(() => ({
   pathname: '/personal/tasks',
+  prefetch: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
   usePathname: () => navigationState.pathname,
+  useRouter: () => ({ prefetch: navigationState.prefetch }),
 }));
 
 vi.mock('next-intl', () => ({
@@ -51,7 +53,38 @@ function renderNavLink(
 describe('NavLink', () => {
   beforeEach(() => {
     navigationState.pathname = '/personal/tasks';
+    navigationState.prefetch.mockReset();
     vi.restoreAllMocks();
+  });
+
+  it('prefetches internal routes only after navigation intent', () => {
+    renderNavLink({
+      href: '/personal/tasks/boards',
+      title: 'Boards',
+    });
+
+    const link = screen.getByRole('link', { name: 'Boards' });
+    expect(navigationState.prefetch).not.toHaveBeenCalled();
+
+    fireEvent.mouseEnter(link);
+    fireEvent.focus(link);
+
+    expect(navigationState.prefetch).toHaveBeenCalledTimes(1);
+    expect(navigationState.prefetch).toHaveBeenCalledWith(
+      '/personal/tasks/boards'
+    );
+  });
+
+  it('does not prefetch external routes', () => {
+    renderNavLink({
+      external: true,
+      href: 'https://docs.tuturuuu.com',
+      title: 'Docs',
+    });
+
+    fireEvent.mouseEnter(screen.getByRole('link', { name: 'Docs' }));
+
+    expect(navigationState.prefetch).not.toHaveBeenCalled();
   });
 
   it('matches wildcard aliases even when the primary route is exact', () => {

--- a/packages/ui/src/components/ui/custom/nav-link.test.tsx
+++ b/packages/ui/src/components/ui/custom/nav-link.test.tsx
@@ -87,6 +87,20 @@ describe('NavLink', () => {
     expect(navigationState.prefetch).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['protocol-relative', '//docs.tuturuuu.com/guide'],
+    ['email', 'mailto:support@tuturuuu.com'],
+    ['telephone', 'tel:+84123456789'],
+  ])('does not prefetch %s URLs', (_label, href) => {
+    renderNavLink({ href, title: 'External destination' });
+
+    fireEvent.mouseEnter(
+      screen.getByRole('link', { name: 'External destination' })
+    );
+
+    expect(navigationState.prefetch).not.toHaveBeenCalled();
+  });
+
   it('matches wildcard aliases even when the primary route is exact', () => {
     navigationState.pathname = '/personal/tasks/boards/board-1';
 

--- a/packages/ui/src/components/ui/custom/nav-link.tsx
+++ b/packages/ui/src/components/ui/custom/nav-link.tsx
@@ -58,7 +58,7 @@ function getComparablePath(
       ? new URL(target)
       : new URL(target, base);
 
-    if (isAbsoluteHttpUrl(target) && url.origin !== base) return null;
+    if (url.origin !== base) return null;
 
     return url.pathname;
   } catch {

--- a/packages/ui/src/components/ui/custom/nav-link.tsx
+++ b/packages/ui/src/components/ui/custom/nav-link.tsx
@@ -12,9 +12,9 @@ import {
 import { getWorkspaceConfigIdList } from '@tuturuuu/internal-api';
 import { cn } from '@tuturuuu/utils/format';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Badge } from '../badge';
 import { Button } from '../button';
 import {
@@ -103,6 +103,7 @@ export function NavLink({
 }: NavLinkProps) {
   const t = useTranslations();
   const pathname = usePathname();
+  const router = useRouter();
   const {
     title,
     icon,
@@ -338,6 +339,27 @@ export function NavLink({
         })()
       : href;
 
+  const prefetchedHrefRef = useRef<string | null>(null);
+  const prefetchOnIntent = () => {
+    if (
+      !effectiveHref ||
+      newTab ||
+      link.external ||
+      isDisabled ||
+      isResolvingHref ||
+      hasSubMenu ||
+      archivedItems.length > 0 ||
+      !getComparablePath(effectiveHref)
+    ) {
+      return;
+    }
+
+    if (prefetchedHrefRef.current === effectiveHref) return;
+
+    prefetchedHrefRef.current = effectiveHref;
+    router.prefetch(effectiveHref);
+  };
+
   const commonProps = {
     className: cn(
       'group/navlink flex w-full cursor-pointer items-center justify-between rounded-md p-2 font-medium text-sm',
@@ -388,6 +410,8 @@ export function NavLink({
         onClick();
       }
     },
+    onFocus: prefetchOnIntent,
+    onMouseEnter: prefetchOnIntent,
   };
 
   const linkElement =
@@ -425,6 +449,7 @@ export function NavLink({
     ) : effectiveHref && !isDisabled ? (
       <Link
         href={effectiveHref}
+        prefetch={false}
         {...commonProps}
         target={newTab ? '_blank' : '_self'}
       >


### PR DESCRIPTION
## Summary
- replace sidebar viewport prefetching with hover/focus intent prefetching
- apply a 30-second stale window and one retry to shared satellite queries and Nova
- remove production-mounted React Query devtools from the shared satellite provider
- document Vercel usage auditing and safe cache controls

## Validation
- focused navigation tests: 8 passed
- satellite query policy test: 1 passed
- scoped Biome: passed
- git diff --check: passed
- bun check: blocked by pre-existing finance-core module resolution and unrelated UI type errors; Biome passed

## Cost rationale
Current Vercel usage is dominated by Fast Origin Transfer, CPU, and provisioned memory. These changes reduce speculative route requests and duplicate client refetch/retry traffic without weakening authenticated cache boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce speculative app requests on Vercel by prefetching only on navigation intent and tightening client caching. Prefetch is now limited to internal routes and deduped to cut Fast Origin Transfer, CPU, and memory without weakening authenticated cache boundaries.

- **Refactors**
  - Sidebar links disable viewport prefetch; prefetch on hover/focus via `next/navigation` router, skip external/protocol-relative/mailto/tel URLs, and dedupe per href, with tests.
  - Set `staleTime: 30_000` and `retry: 1` for queries in `apps/nova` and shared satellite via `createSatelliteQueryClient` (tested) using `@tanstack/react-query`.
  - Removed production-mounted `@tanstack/react-query-devtools` from the shared provider.
  - Expanded docs on Vercel usage auditing and safe cache controls in `apps/docs/build/devops/overview.mdx`.

<sup>Written for commit b8cf61c86727817faff1f28da768fee4b3e52e68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

