### PR TITLE
fix(meet): restore prerender suspense boundary

### DIFF
--- a/apps/meet/src/app/[locale]/(app)/layout.tsx
+++ b/apps/meet/src/app/[locale]/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { Suspense } from 'react';
 import ServerLayout from './server-layout';
 
 interface LayoutProps {
@@ -6,5 +7,9 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  return <ServerLayout>{children}</ServerLayout>;
+  return (
+    <Suspense>
+      <ServerLayout>{children}</ServerLayout>
+    </Suspense>
+  );
 }

--- a/apps/meet/src/app/[locale]/layout.test.ts
+++ b/apps/meet/src/app/[locale]/layout.test.ts
@@ -21,4 +21,20 @@ describe('meet root layout providers', () => {
     expect(adapter).toBeGreaterThan(-1);
     expect(adapter).toBeLessThan(providers);
   });
+
+  it('keeps request-aware providers inside a suspense boundary', () => {
+    expect(layout).toContain(
+      "import { type ReactNode, Suspense } from 'react'"
+    );
+
+    const suspense = layout.indexOf('<Suspense>');
+    const adapter = layout.indexOf('<NuqsAdapter>');
+    const providers = layout.indexOf('<Providers');
+    const suspenseEnd = layout.indexOf('</Suspense>');
+
+    expect(suspense).toBeGreaterThan(-1);
+    expect(suspense).toBeLessThan(adapter);
+    expect(adapter).toBeLessThan(providers);
+    expect(providers).toBeLessThan(suspenseEnd);
+  });
 });

--- a/apps/meet/src/app/[locale]/layout.test.ts
+++ b/apps/meet/src/app/[locale]/layout.test.ts
@@ -2,6 +2,10 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const layout = readFileSync(new URL('./layout.tsx', import.meta.url), 'utf8');
+const appLayout = readFileSync(
+  new URL('./(app)/layout.tsx', import.meta.url),
+  'utf8'
+);
 
 describe('meet root layout providers', () => {
   it('mounts the nuqs adapter', () => {
@@ -22,19 +26,18 @@ describe('meet root layout providers', () => {
     expect(adapter).toBeLessThan(providers);
   });
 
-  it('keeps request-aware providers inside a suspense boundary', () => {
-    expect(layout).toContain(
-      "import { type ReactNode, Suspense } from 'react'"
-    );
+  it('keeps request-aware server layout inside a suspense boundary', () => {
+    expect(appLayout).toContain("import { Suspense } from 'react'");
 
-    const suspense = layout.indexOf('<Suspense>');
-    const adapter = layout.indexOf('<NuqsAdapter>');
-    const providers = layout.indexOf('<Providers');
-    const suspenseEnd = layout.indexOf('</Suspense>');
-
+    const suspense = appLayout.indexOf('<Suspense>');
+    const serverLayout = appLayout.indexOf('<ServerLayout>');
+    const suspenseEnd = appLayout.indexOf('</Suspense>');
     expect(suspense).toBeGreaterThan(-1);
-    expect(suspense).toBeLessThan(adapter);
-    expect(adapter).toBeLessThan(providers);
-    expect(providers).toBeLessThan(suspenseEnd);
+    expect(suspense).toBeLessThan(serverLayout);
+    expect(serverLayout).toBeLessThan(suspenseEnd);
+  });
+
+  it('keeps the theme provider outside root suspense boundaries', () => {
+    expect(layout).not.toContain('<Suspense>');
   });
 });

--- a/apps/meet/src/app/[locale]/layout.tsx
+++ b/apps/meet/src/app/[locale]/layout.tsx
@@ -12,7 +12,7 @@ import { VercelAnalytics, VercelInsights } from '@tuturuuu/vercel';
 import type { Metadata } from 'next';
 import { locale as getRootLocale } from 'next/root-params';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
-import type { ReactNode } from 'react';
+import { type ReactNode, Suspense } from 'react';
 import { Providers } from './providers';
 
 export { viewport } from '@tuturuuu/utils/common/nextjs';
@@ -66,9 +66,11 @@ export default async function RootLayout({ children }: Props) {
       >
         <VercelAnalytics />
         <VercelInsights />
-        <NuqsAdapter>
-          <Providers appName={siteConfig.name}>{children}</Providers>
-        </NuqsAdapter>
+        <Suspense>
+          <NuqsAdapter>
+            <Providers appName={siteConfig.name}>{children}</Providers>
+          </NuqsAdapter>
+        </Suspense>
         <TailwindIndicator />
         <ProductionIndicator />
         <StaffToolbar />

--- a/apps/meet/src/app/[locale]/layout.tsx
+++ b/apps/meet/src/app/[locale]/layout.tsx
@@ -12,7 +12,7 @@ import { VercelAnalytics, VercelInsights } from '@tuturuuu/vercel';
 import type { Metadata } from 'next';
 import { locale as getRootLocale } from 'next/root-params';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
-import { type ReactNode, Suspense } from 'react';
+import type { ReactNode } from 'react';
 import { Providers } from './providers';
 
 export { viewport } from '@tuturuuu/utils/common/nextjs';
@@ -66,11 +66,9 @@ export default async function RootLayout({ children }: Props) {
       >
         <VercelAnalytics />
         <VercelInsights />
-        <Suspense>
-          <NuqsAdapter>
-            <Providers appName={siteConfig.name}>{children}</Providers>
-          </NuqsAdapter>
-        </Suspense>
+        <NuqsAdapter>
+          <Providers appName={siteConfig.name}>{children}</Providers>
+        </NuqsAdapter>
         <TailwindIndicator />
         <ProductionIndicator />
         <StaffToolbar />


### PR DESCRIPTION
## Summary

- wrap Meet's request-aware locale provider tree in Suspense
- add a structural regression test that keeps Nuqs and app providers inside the boundary

## Why

Production workflow 31456502280 built and deployed every affected application except Meet. Next.js Cache Components rejected `/[locale]` during prerender because runtime/request data escaped a Suspense boundary. Comparable satellite root layouts already use this boundary.

## Validation

- focused Meet layout test: 3 passed
- Meet type-check: passed
- Biome on both changed files: passed
- git diff check: passed
- repository check: Meet-related type-check and Biome passed; tests remain blocked by the unrelated finance-core module-resolution baseline

Local application builds were not run because repository policy requires an explicit build request. The PR and production deployment workflows are the authoritative build verification gates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored and narrowed a Suspense boundary around Meet’s request-aware server layout so `/[locale]` prerenders correctly without leaking request data.

- **Bug Fixes**
  - Wrapped `ServerLayout` in `<Suspense>` in `apps/meet/src/app/[locale]/(app)/layout.tsx`.
  - Added tests to assert the boundary surrounds `ServerLayout`, keeps the theme provider outside root boundaries, and preserves `NuqsAdapter` before app `Providers`.
  - Aligns Meet’s layout with other apps that already use this boundary.

<sup>Written for commit e82cda698a4e8f028eaee0cd57ca46186765b36d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

