### PR TITLE
fix(meet): render authenticated root at request time

### DIFF
--- a/apps/meet/src/app/[locale]/(app)/page.tsx
+++ b/apps/meet/src/app/[locale]/(app)/page.tsx
@@ -1,4 +1,5 @@
 import { MeetTogetherPage } from '@tuturuuu/ui/legacy/meet/page';
+import { connection } from 'next/server';
 import { Suspense } from 'react';
 
 interface TumeetPageProps {
@@ -10,6 +11,8 @@ interface TumeetPageProps {
 }
 
 export default async function TumeetPage({ searchParams }: TumeetPageProps) {
+  await connection();
+
   return (
     <Suspense>
       <MeetTogetherPage searchParams={searchParams} path="/plans" />

--- a/apps/meet/src/app/[locale]/layout.test.ts
+++ b/apps/meet/src/app/[locale]/layout.test.ts
@@ -6,6 +6,10 @@ const appLayout = readFileSync(
   new URL('./(app)/layout.tsx', import.meta.url),
   'utf8'
 );
+const appPage = readFileSync(
+  new URL('./(app)/page.tsx', import.meta.url),
+  'utf8'
+);
 
 describe('meet root layout providers', () => {
   it('mounts the nuqs adapter', () => {
@@ -39,5 +43,10 @@ describe('meet root layout providers', () => {
 
   it('keeps the theme provider outside root suspense boundaries', () => {
     expect(layout).not.toContain('<Suspense>');
+  });
+
+  it('renders the authenticated meeting list at request time', () => {
+    expect(appPage).toContain("import { connection } from 'next/server'");
+    expect(appPage).toContain('await connection()');
   });
 });


### PR DESCRIPTION
## Summary
- mark the authenticated Meet root page as request-time under Cache Components
- keep the existing narrow Suspense boundary and theme-provider hydration contract intact
- add a structural regression assertion for the request-time boundary

## Verification
- focused Meet layout test: 5/5 passed
- `bun --filter @tuturuuu/meet type-check`
- Biome on changed files
- `git diff --check`
- `bun check`: type-check and Biome passed; tests were blocked only by sandbox-denied loopback listeners in unrelated `apps/web/docker/request-tracker.test.js`

## Production evidence
Production run 31459545524 compiled Meet successfully, then failed prerendering `/en` because its authenticated Supabase-backed root page lacked `await connection()`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the authenticated Meet root page at request time by awaiting `connection()` from `next/server`, fixing prerender failures for `/en` with Supabase-backed auth. Keeps the existing Suspense boundary and theme-provider hydration, and adds a regression test to lock the request-time behavior.

<sup>Written for commit 0ba1e3d78010b18452dabcb95c06769ee3c16445. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

