### PR TITLE
fix(meet): nest runtime work under suspense

### DIFF
--- a/apps/meet/src/app/[locale]/(app)/page.tsx
+++ b/apps/meet/src/app/[locale]/(app)/page.tsx
@@ -10,12 +10,16 @@ interface TumeetPageProps {
   }>;
 }
 
-export default async function TumeetPage({ searchParams }: TumeetPageProps) {
-  await connection();
-
+export default function TumeetPage({ searchParams }: TumeetPageProps) {
   return (
     <Suspense>
-      <MeetTogetherPage searchParams={searchParams} path="/plans" />
+      <RequestTimeMeetPage searchParams={searchParams} />
     </Suspense>
   );
+}
+
+async function RequestTimeMeetPage({ searchParams }: TumeetPageProps) {
+  await connection();
+
+  return <MeetTogetherPage searchParams={searchParams} path="/plans" />;
 }

--- a/apps/meet/src/app/[locale]/layout.test.ts
+++ b/apps/meet/src/app/[locale]/layout.test.ts
@@ -49,7 +49,7 @@ describe('meet root layout providers', () => {
     expect(appPage).toContain("import { connection } from 'next/server'");
     expect(appPage).toContain('await connection()');
 
-    const suspense = appPage.indexOf('<Suspense>');
+    const suspense = appPage.match(/<Suspense(?:\s[^>]*)?>/)?.index ?? -1;
     const requestTimePage = appPage.indexOf(
       '<RequestTimeMeetPage searchParams={searchParams} />'
     );

--- a/apps/meet/src/app/[locale]/layout.test.ts
+++ b/apps/meet/src/app/[locale]/layout.test.ts
@@ -48,5 +48,16 @@ describe('meet root layout providers', () => {
   it('renders the authenticated meeting list at request time', () => {
     expect(appPage).toContain("import { connection } from 'next/server'");
     expect(appPage).toContain('await connection()');
+
+    const suspense = appPage.indexOf('<Suspense>');
+    const requestTimePage = appPage.indexOf(
+      '<RequestTimeMeetPage searchParams={searchParams} />'
+    );
+    const suspenseEnd = appPage.indexOf('</Suspense>');
+    const connectionCall = appPage.indexOf('await connection()');
+    expect(suspense).toBeGreaterThan(-1);
+    expect(suspense).toBeLessThan(requestTimePage);
+    expect(requestTimePage).toBeLessThan(suspenseEnd);
+    expect(connectionCall).toBeGreaterThan(suspenseEnd);
   });
 });


### PR DESCRIPTION
## Summary
- keep the route shell synchronous so it can establish Suspense before request-time work executes
- move `connection()` and the authenticated meeting query into a dedicated async child inside that boundary
- extend the structural regression test to verify the boundary ordering

## Verification
- focused Meet layout test: 5/5 passed
- `bun --filter @tuturuuu/meet type-check`
- Biome on changed files
- `git diff --check`
- `bun check`: type-check and Biome passed; tests were blocked only by sandbox-denied loopback listeners in unrelated `apps/web/docker/request-tracker.test.js`

## Production evidence
Production run 31462150275 reports `connection()` outside Suspense because it executed in the page component before that component returned its own boundary. This change moves it beneath that boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move request-time Meet logic under Suspense so the route shell renders synchronously and `connection()` runs inside the boundary. This fixes the production case where `connection()` executed before Suspense.

- **Bug Fixes**
  - Made the page component synchronous to establish the Suspense boundary first.
  - Added an async `RequestTimeMeetPage` child that calls `connection()` and then renders `MeetTogetherPage`.
  - Extended the layout test to assert boundary ordering and tolerate `<Suspense>` props (import from `next/server`).

<sup>Written for commit 1ccaea29dd0ebae06d1c5be5b98f8754e938bc0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

