### PR TITLE
perf(users): dedupe approval filter directory query

### DIFF
--- a/packages/users-ui/src/components/approvals-view-cost.test.ts
+++ b/packages/users-ui/src/components/approvals-view-cost.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync('src/components/approvals-view.tsx', 'utf8');
+
+describe('approval filter directory cost contract', () => {
+  it('shares one bounded user query across recipient and creator filters', () => {
+    expect(source.match(/listWorkspaceBasicUsers\(wsId/g)).toHaveLength(1);
+    expect(source).toContain(
+      "queryKey: ['ws', wsId, 'approvals', 'filter-users']"
+    );
+    expect(source).toContain('listWorkspaceBasicUsers(wsId, { limit: 200 })');
+    expect(source).toContain(')).data');
+    expect(source.match(/filterUsersQuery\.data/g)).toHaveLength(2);
+    expect(source).not.toContain('users?limit=500');
+    expect(source).not.toContain("'filter-creators'");
+  });
+});

--- a/packages/users-ui/src/components/approvals-view.tsx
+++ b/packages/users-ui/src/components/approvals-view.tsx
@@ -15,6 +15,7 @@ import {
   XIcon,
 } from '@tuturuuu/icons';
 import { listAllWorkspaceUserGroups } from '@tuturuuu/internal-api/user-groups';
+import { listWorkspaceBasicUsers } from '@tuturuuu/internal-api/users';
 import { Badge } from '@tuturuuu/ui/badge';
 import { Button } from '@tuturuuu/ui/button';
 import {
@@ -138,48 +139,14 @@ export function ApprovalsView({
     staleTime: 5 * 60 * 1000,
   });
 
-  // Fetch user options for filter (reports only)
-  const usersQuery = useQuery({
-    queryKey: ['ws', wsId, 'approvals', 'filter-users', currentGroupId],
+  // Both report filters use the same workspace directory. A shared query key
+  // prevents duplicate requests and avoids refetching unchanged options when
+  // the selected group changes.
+  const filterUsersQuery = useQuery({
+    queryKey: ['ws', wsId, 'approvals', 'filter-users'],
     enabled: kind === 'reports',
-    queryFn: async () => {
-      const searchParams = new URLSearchParams({
-        limit: '500',
-      });
-      const response = await fetch(
-        `/api/v1/workspaces/${wsId}/users?${searchParams.toString()}`,
-        { cache: 'no-store' }
-      );
-      if (!response.ok) throw new Error('Failed to fetch users');
-      const data = await response.json();
-      const users = Array.isArray(data) ? data : data.data || [];
-      return (users ?? []) as Array<{
-        id: string;
-        full_name: string | null;
-      }>;
-    },
-    staleTime: 5 * 60 * 1000,
-  });
-
-  // Fetch creator options for filter (reports only)
-  const creatorsQuery = useQuery({
-    queryKey: ['ws', wsId, 'approvals', 'filter-creators'],
-    enabled: kind === 'reports',
-    queryFn: async () => {
-      const response = await fetch(
-        `/api/v1/workspaces/${wsId}/users?limit=500`,
-        {
-          cache: 'no-store',
-        }
-      );
-      if (!response.ok) throw new Error('Failed to fetch creators');
-      const data = await response.json();
-      const users = Array.isArray(data) ? data : data.data || [];
-      return (users ?? []) as Array<{
-        id: string;
-        full_name: string | null;
-      }>;
-    },
+    queryFn: async () =>
+      (await listWorkspaceBasicUsers(wsId, { limit: 200 })).data,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -387,7 +354,7 @@ export function ApprovalsView({
                       <SelectItem value="all">
                         {t('filters.allUsers')}
                       </SelectItem>
-                      {(usersQuery.data ?? []).map((user) => (
+                      {(filterUsersQuery.data ?? []).map((user) => (
                         <SelectItem key={user.id} value={user.id}>
                           {user.full_name || t('labels.unknown_user')}
                         </SelectItem>
@@ -422,7 +389,7 @@ export function ApprovalsView({
                       <SelectItem value="all">
                         {t('filters.allCreators')}
                       </SelectItem>
-                      {(creatorsQuery.data ?? []).map((creator) => (
+                      {(filterUsersQuery.data ?? []).map((creator) => (
                         <SelectItem key={creator.id} value={creator.id}>
                           {creator.full_name || t('labels.unknown_user')}
                         </SelectItem>


### PR DESCRIPTION
## Summary
- replace duplicate raw approval-filter directory fetches with one shared internal API query
- cap the requested directory page to the route-supported 200 users
- keep a five-minute client freshness window while avoiding identical group-change refetches
- add a regression contract for the single-query behavior

## Local verification
- `bunx vitest run src/components/approvals-view-cost.test.ts`
- `bun run type-check` in `packages/users-ui`
- scoped Biome check
- `bun run build` in `apps/contacts` (126/126 pages, partial prerender preserved)
- `bun check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated approval filter user directory requests by using a single shared query backed by `listWorkspaceBasicUsers`, cutting duplicate fetches and avoiding refetches on group changes. Capped the page size to 200 to match route support and added a regression test.

- **Refactors**
  - Replaced two directory fetches with one shared query using `@tuturuuu/internal-api/users` `listWorkspaceBasicUsers(wsId, { limit: 200 })`.
  - Unified query key `['ws', wsId, 'approvals', 'filter-users']` to prevent duplicate requests and keep a 5-minute stale time.
  - Added a contract test to assert a single bounded query and removal of the old `'filter-creators'` path.

<sup>Written for commit ea646f1a4ebe1cb7f6f869b156e9706e9975e30e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

