### PR TITLE
perf(vercel): reduce realtime fallback polling

### DIFF
--- a/apps/docs/build/devops/overview.mdx
+++ b/apps/docs/build/devops/overview.mdx
@@ -69,6 +69,11 @@ Apply these controls in order:
 3. Shared Satellite and Nova React Query clients use a 30-second stale window
    and one retry. Override this only when a surface has a documented freshness
    or reliability requirement.
+   Realtime-backed notification counts use a 15-minute fallback poll and a
+   5-minute stale window. Active timers render elapsed time locally and use
+   1-minute running / 5-minute idle reconciliation. Keep mutations and realtime
+   events invalidating their query keys immediately instead of shortening these
+   safety-net intervals.
 4. Dashboard sidebar links disable viewport prefetch and prefetch on hover or
    keyboard focus. This preserves responsive navigation without invoking every
    visible destination merely because the sidebar rendered.

--- a/apps/web/src/components/command/quick-time-tracker.tsx
+++ b/apps/web/src/components/command/quick-time-tracker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { activeTimerSessionQueryOptions } from '@tuturuuu/hooks/hooks/use-active-timer-session';
 import {
   CheckCircle,
   CheckSquare,
@@ -71,39 +72,11 @@ export function QuickTimeTracker({
     return () => observer.disconnect();
   }, []);
 
-  const { data: runningSession, isLoading: isLoadingSession } = useQuery({
-    queryKey: ['running-time-session', wsId],
-    queryFn: async () => {
-      const response = await fetch(
-        `/api/v1/workspaces/${wsId}/time-tracking/sessions?type=running`,
-        { cache: 'no-store' }
-      );
-      if (!response.ok) throw new Error('Failed to fetch running session');
-      const data = await response.json();
-      return data.session;
-    },
-    // Optimized refetch strategy:
-    // - Only refetch when visible and there's a running session
-    // - Use longer interval (10 seconds instead of 1 second)
-    // - Disable refetch when window is not focused
-    refetchInterval: (query) => {
-      // Only poll if there's a running session and component is visible
-      if (
-        query.state.data &&
-        isVisible &&
-        document.visibilityState === 'visible'
-      ) {
-        // Progressive polling: increase interval based on session duration
-        const sessionDuration = elapsedTime;
-        if (sessionDuration < 300) return 10000; // First 5 minutes: 10s
-        if (sessionDuration < 1800) return 30000; // 5-30 minutes: 30s
-        return 60000; // After 30 minutes: 60s
-      }
-      return false; // No polling
-    },
-    refetchOnWindowFocus: true,
-    staleTime: 5000, // Consider data fresh for 5 seconds
-  });
+  // The sidebar owns fallback polling for this shared query. This observer
+  // receives the same cache updates without scheduling a second interval.
+  const { data: runningSession, isLoading: isLoadingSession } = useQuery(
+    activeTimerSessionQueryOptions(wsId)
+  );
 
   // Fetch recent sessions for "Continue Last" functionality
   const { data: recentSessions } = useQuery({

--- a/packages/hooks/src/hooks/use-active-timer-session.ts
+++ b/packages/hooks/src/hooks/use-active-timer-session.ts
@@ -1,10 +1,14 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import type { SessionWithRelations } from '../types/time-tracker';
 
-export function useActiveTimerSession(wsId: string | null) {
-  return useQuery({
+export const ACTIVE_TIMER_RUNNING_FALLBACK_INTERVAL_MS = 60_000;
+export const ACTIVE_TIMER_IDLE_FALLBACK_INTERVAL_MS = 5 * 60_000;
+export const ACTIVE_TIMER_STALE_TIME_MS = 30_000;
+
+export function activeTimerSessionQueryOptions(wsId: string | null) {
+  return queryOptions({
     queryKey: ['running-time-session', wsId],
     queryFn: async () => {
       if (!wsId) return null;
@@ -20,14 +24,22 @@ export function useActiveTimerSession(wsId: string | null) {
       return data.session as SessionWithRelations | null;
     },
     enabled: !!wsId,
-    // Optimized refetch strategy for sidebar
+    refetchOnWindowFocus: true,
+    staleTime: ACTIVE_TIMER_STALE_TIME_MS,
+  });
+}
+
+export function useActiveTimerSession(wsId: string | null) {
+  return useQuery({
+    ...activeTimerSessionQueryOptions(wsId),
+    // Mutations invalidate this query immediately, while the elapsed timer ticks
+    // locally. Poll only as a cross-device/disconnected-realtime safety net.
     refetchInterval: (query) => {
       const hasRunningSession = query.state.data;
-      // If there's a running session, refresh every 30 seconds
-      // If no running session, refresh every 2 minutes to check for new sessions
-      return hasRunningSession ? 30000 : 120000;
+      return hasRunningSession
+        ? ACTIVE_TIMER_RUNNING_FALLBACK_INTERVAL_MS
+        : ACTIVE_TIMER_IDLE_FALLBACK_INTERVAL_MS;
     },
-    refetchOnWindowFocus: true,
-    staleTime: 0, // Always consider data stale to ensure immediate updates when invalidated
+    refetchIntervalInBackground: false,
   });
 }

--- a/packages/ui/src/hooks/__tests__/use-notifications-subscription.test.tsx
+++ b/packages/ui/src/hooks/__tests__/use-notifications-subscription.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   __resetNotificationSubscriptionRegistryForTests,
   UNREAD_COUNT_FALLBACK_INTERVAL_MS,
+  UNREAD_COUNT_STALE_TIME_MS,
   useInfiniteNotifications,
   useNotificationSubscription,
   useUnreadCount,
@@ -16,6 +17,7 @@ import {
 
 type RealtimePayload = {
   new?: {
+    read_at?: string | null;
     data?: {
       action_taken?: boolean;
     };
@@ -126,8 +128,15 @@ describe('useNotificationSubscription', () => {
       wrapper: createWrapper(queryClient),
     });
 
+    const queryOptions = queryClient.getQueryCache().find({
+      queryKey: ['notifications', 'unread-count', 'all'],
+    })?.options as { refetchInterval?: number; staleTime?: number } | undefined;
+
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(UNREAD_COUNT_FALLBACK_INTERVAL_MS).toBe(5 * 60 * 1000);
+    expect(queryOptions?.staleTime).toBe(UNREAD_COUNT_STALE_TIME_MS);
+    expect(queryOptions?.refetchInterval).toBe(
+      UNREAD_COUNT_FALLBACK_INTERVAL_MS
+    );
   });
 
   it('shares one realtime channel across multiple consumers for the same user', async () => {
@@ -155,6 +164,30 @@ describe('useNotificationSubscription', () => {
     second.unmount();
 
     expect(removeChannelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates unread counts for read-state-only realtime updates', async () => {
+    const queryClient = createQueryClient();
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    const subscription = renderHook(
+      () => useNotificationSubscription(null, 'user-1'),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => {
+      expect(postgresCallbacks).toHaveLength(3);
+    });
+
+    postgresCallbacks[1]?.({ new: { read_at: new Date().toISOString() } });
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ['notifications'],
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ['notifications', 'unread-count'],
+    });
+
+    subscription.unmount();
   });
 
   it('invalidates every mounted query client from the shared subscription', async () => {

--- a/packages/ui/src/hooks/use-notifications.ts
+++ b/packages/ui/src/hooks/use-notifications.ts
@@ -91,7 +91,8 @@ interface NotificationSubscriptionEntry {
   supabase: SupabaseClient;
 }
 
-export const UNREAD_COUNT_FALLBACK_INTERVAL_MS = 5 * 60 * 1000;
+export const UNREAD_COUNT_STALE_TIME_MS = 5 * 60 * 1000;
+export const UNREAD_COUNT_FALLBACK_INTERVAL_MS = 15 * 60 * 1000;
 
 const notificationSubscriptionRegistry = new Map<
   string,
@@ -164,12 +165,7 @@ function createNotificationSubscriptionEntry(
         table: 'notifications',
         filter: `user_id=eq.${userId}`,
       },
-      (payload) => {
-        const newRecord = payload.new as Notification;
-        if (newRecord?.data?.action_taken) {
-          invalidateQueries();
-        }
-      }
+      invalidateQueries
     )
     .on(
       'postgres_changes',
@@ -348,7 +344,7 @@ export function useUnreadCount(
       return data.count as number;
     },
     enabled: options?.enabled ?? true,
-    staleTime: 60_000,
+    staleTime: UNREAD_COUNT_STALE_TIME_MS,
     // Realtime invalidation is the primary update path. Keep a low-frequency
     // refresh as a safety net for disconnected or suspended browser sessions.
     refetchInterval: UNREAD_COUNT_FALLBACK_INTERVAL_MS,


### PR DESCRIPTION
## Summary
- keep notification badges realtime-first while reducing fallback requests by 67% across Platform, Contacts, Finance, and Tasks
- reduce active-timer reconciliation requests by 50-60% while preserving immediate mutation invalidation, focus refresh, and local elapsed-time rendering
- document the shared Vercel cost-control intervals

## Measured context
- current usage: Fast Origin Transfer $6.59, Fluid CPU/memory $5.67, Function Invocations $0.61
- Platform and Contacts contribute about $5.43 of origin transfer

## Verification
- `bun --filter @tuturuuu/ui test src/hooks/__tests__/use-notifications-subscription.test.tsx` (4 passed)
- `bun --filter @tuturuuu/hooks type-check`
- `bun check`: type-check and Biome passed; 2,797 web tests passed; localhost-only request-tracker tests hit sandbox EPERM
- `bun --filter @tuturuuu/web test docker/request-tracker.test.js` outside sandbox (4 passed)
- production builds passed locally for Platform (747 pages), Contacts (126), Finance (89), and Tasks (85)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce fallback polling for realtime-backed notifications and active timers to cut Vercel origin transfer and function invocations while preserving instant updates via realtime and mutation invalidations. Notifications move from 5m poll/1m stale to 15m poll/5m stale and now invalidate unread counts on read-state-only events; active timers move from 10–60s running/2m idle with background polling and 0 stale to 60s running/5m idle, no background polling, 30s stale, with elapsed time rendered locally.

- `@tuturuuu/ui`: exports `UNREAD_COUNT_STALE_TIME_MS`; sets `UNREAD_COUNT_FALLBACK_INTERVAL_MS` to 15m; subscription now invalidates on inserts and read-state-only updates; tests assert 5m stale/15m poll and invalidation.
- `@tuturuuu/hooks`: adds `activeTimerSessionQueryOptions` plus `ACTIVE_TIMER_*` interval constants; sets 30s stale and refetchInterval 60s running / 5m idle; disables background polling; focus refresh and mutation invalidation remain.
- Web: Quick Time Tracker uses `activeTimerSessionQueryOptions(wsId)` and no longer schedules its own interval; it consumes shared cache updates from sidebar-owned polling.
- Docs: DevOps overview documents these safety-net intervals and the rationale.

Operational impact: Background tabs stop polling; worst-case safety-net delays increase (unread count up to 15m; timers up to 1–5m) if realtime is disconnected, but focus and any mutation still refresh immediately.

<sup>Written for commit e9e44a4eb17c971beb9e1b737c4580466e427be5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

