### PR TITLE
perf: reduce cross-app Vercel request churn

### DIFF
--- a/apps/contacts/src/components/contacts-query-provider.test.ts
+++ b/apps/contacts/src/components/contacts-query-provider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONTACTS_QUERY_GC_TIME_MS,
+  CONTACTS_QUERY_STALE_TIME_MS,
+  createContactsQueryClient,
+} from './contacts-query-provider';
+
+describe('createContactsQueryClient', () => {
+  it('keeps remounted bootstrap queries warm without focus refetches', () => {
+    expect(
+      createContactsQueryClient().getDefaultOptions().queries
+    ).toMatchObject({
+      gcTime: CONTACTS_QUERY_GC_TIME_MS,
+      refetchOnWindowFocus: false,
+      staleTime: CONTACTS_QUERY_STALE_TIME_MS,
+    });
+  });
+});

--- a/apps/contacts/src/components/contacts-query-provider.test.ts
+++ b/apps/contacts/src/components/contacts-query-provider.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import {
-  CONTACTS_QUERY_GC_TIME_MS,
-  CONTACTS_QUERY_STALE_TIME_MS,
-  createContactsQueryClient,
-} from './contacts-query-provider';
+import { createContactsQueryClient } from './contacts-query-provider';
 
 describe('createContactsQueryClient', () => {
   it('keeps remounted bootstrap queries warm without focus refetches', () => {
     expect(
       createContactsQueryClient().getDefaultOptions().queries
     ).toMatchObject({
-      gcTime: CONTACTS_QUERY_GC_TIME_MS,
+      gcTime: 30 * 60_000,
       refetchOnWindowFocus: false,
-      staleTime: CONTACTS_QUERY_STALE_TIME_MS,
+      staleTime: 5 * 60_000,
     });
   });
 });

--- a/apps/contacts/src/components/contacts-query-provider.tsx
+++ b/apps/contacts/src/components/contacts-query-provider.tsx
@@ -3,17 +3,23 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { type ReactNode, useState } from 'react';
 
+export const CONTACTS_QUERY_STALE_TIME_MS = 5 * 60_000;
+export const CONTACTS_QUERY_GC_TIME_MS = 30 * 60_000;
+
+export function createContactsQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: CONTACTS_QUERY_GC_TIME_MS,
+        refetchOnWindowFocus: false,
+        staleTime: CONTACTS_QUERY_STALE_TIME_MS,
+      },
+    },
+  });
+}
+
 export function ContactsQueryProvider({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 30_000,
-          },
-        },
-      })
-  );
+  const [queryClient] = useState(createContactsQueryClient);
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/apps/track/src/app/[locale]/(dashboard)/[wsId]/components/overview-timer.tsx
+++ b/apps/track/src/app/[locale]/(dashboard)/[wsId]/components/overview-timer.tsx
@@ -39,9 +39,10 @@ export default function OverviewTimer({
       const data = await response.json();
       return data.session ?? null;
     },
-    refetchInterval: 30000,
+    refetchInterval: (query) => (query.state.data ? 60_000 : 5 * 60_000),
+    refetchIntervalInBackground: false,
     initialData: initialRunningSession,
-    staleTime: 60000, // Don't refetch immediately after SSR
+    staleTime: 60_000,
   });
 
   // Derive isRunning from query data

--- a/apps/track/src/app/[locale]/(dashboard)/[wsId]/components/simple-time-tracker-content.tsx
+++ b/apps/track/src/app/[locale]/(dashboard)/[wsId]/components/simple-time-tracker-content.tsx
@@ -44,9 +44,11 @@ export default function SimpleTimeTrackerContent({
       const data = await response.json();
       return data.session;
     },
-    refetchInterval: 30000, // 30 seconds
+    refetchInterval: (query) => (query.state.data ? 60_000 : 5 * 60_000),
+    refetchIntervalInBackground: false,
     initialData: initialData.runningSession,
     enabled: !!currentUser,
+    staleTime: 60_000,
   });
 
   // Use React Query for stats to enable real-time updates
@@ -65,7 +67,8 @@ export default function SimpleTimeTrackerContent({
         data.stats || { todayTime: 0, weekTime: 0, monthTime: 0, streak: 0 }
       );
     },
-    refetchInterval: 60000, // 1 minute (less frequent than running session)
+    refetchInterval: 5 * 60_000,
+    refetchIntervalInBackground: false,
     initialData: initialData.stats || {
       todayTime: 0,
       weekTime: 0,
@@ -73,7 +76,7 @@ export default function SimpleTimeTrackerContent({
       streak: 0,
     },
     enabled: !!currentUser,
-    staleTime: 30000, // 30 seconds
+    staleTime: 5 * 60_000,
   });
 
   const [currentSession, setCurrentSession] =

--- a/apps/track/src/app/[locale]/(dashboard)/[wsId]/components/time-tracker-content.tsx
+++ b/apps/track/src/app/[locale]/(dashboard)/[wsId]/components/time-tracker-content.tsx
@@ -94,7 +94,6 @@ export default function TimeTrackerContent({
     [t]
   );
 
-  // Use React Query for running session to sync with command palette
   const { data: runningSessionFromQuery } = useQuery({
     queryKey: ['running-time-session', wsId],
     queryFn: async () => {
@@ -106,9 +105,11 @@ export default function TimeTrackerContent({
       const data = await response.json();
       return data.session;
     },
-    refetchInterval: 30000, // 30 seconds
+    refetchInterval: (query) => (query.state.data ? 60_000 : 5 * 60_000),
+    refetchIntervalInBackground: false,
     initialData: initialData.runningSession,
     enabled: !!currentUser,
+    staleTime: 60_000,
   });
 
   const [currentSession, setCurrentSession] =
@@ -120,7 +121,6 @@ export default function TimeTrackerContent({
     initialData.recentSessions || []
   );
 
-  // Sync React Query data with local state
   useEffect(() => {
     if (currentUser && runningSessionFromQuery !== undefined) {
       setCurrentSession(runningSessionFromQuery);

--- a/apps/track/src/app/[locale]/(dashboard)/[wsId]/components/time-tracker-content.tsx
+++ b/apps/track/src/app/[locale]/(dashboard)/[wsId]/components/time-tracker-content.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/a11y/noSvgWithoutTitle: <> */
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   CheckCircle,
   CheckSquare,
@@ -73,6 +73,7 @@ export default function TimeTrackerContent({
   workspace,
 }: TimeTrackerContentProps) {
   const t = useTranslations('time-tracker.content');
+  const queryClient = useQueryClient();
 
   const currentUserId = currentUser?.id || null;
 
@@ -95,7 +96,7 @@ export default function TimeTrackerContent({
   );
 
   const { data: runningSessionFromQuery } = useQuery({
-    queryKey: ['running-time-session', wsId],
+    queryKey: ['running-time-session', wsId, currentUserId],
     queryFn: async () => {
       const response = await fetch(
         `/api/v1/workspaces/${wsId}/time-tracking/sessions?type=running`,
@@ -318,14 +319,6 @@ export default function TimeTrackerContent({
             fallback: { categories: [] },
           },
           {
-            name: 'running',
-            call: () =>
-              apiCall(
-                `/api/v1/workspaces/${wsId}/time-tracking/sessions?type=running`
-              ),
-            fallback: { session: null },
-          },
-          {
             name: 'recent',
             call: () =>
               apiCall(
@@ -359,8 +352,8 @@ export default function TimeTrackerContent({
         );
 
         // Process results with fallbacks for failed calls
-        const [categoriesRes, runningRes, recentRes, _statsRes, tasksRes] =
-          results.map((result, index) => {
+        const [categoriesRes, recentRes, _statsRes, tasksRes] = results.map(
+          (result, index) => {
             if (result.status === 'fulfilled') {
               return result.value;
             } else {
@@ -378,30 +371,14 @@ export default function TimeTrackerContent({
               }
               return fallback;
             }
-          });
+          }
+        );
 
         if (!isMountedRef.current) return;
 
         setCategories(categoriesRes.categories || []);
         setRecentSessions(recentRes.sessions || []);
         setTasks(tasksRes.tasks || []);
-
-        if (runningRes.session) {
-          setCurrentSession(runningRes.session);
-          setIsRunning(true);
-          const elapsed = Math.max(
-            0,
-            Math.floor(
-              (Date.now() - new Date(runningRes.session.start_time).getTime()) /
-                1000
-            )
-          );
-          setElapsedTime(elapsed);
-        } else {
-          setCurrentSession(null);
-          setIsRunning(false);
-          setElapsedTime(0);
-        }
 
         setRetryCount(0);
       } catch (error) {
@@ -465,6 +442,10 @@ export default function TimeTrackerContent({
         );
 
         setCurrentSession(response.session);
+        queryClient.setQueryData(
+          ['running-time-session', wsId, currentUserId],
+          response.session
+        );
         setIsRunning(true);
         setElapsedTime(0);
         await fetchData();
@@ -476,7 +457,7 @@ export default function TimeTrackerContent({
         toast.error(t('toast.failedToStart'));
       }
     },
-    [wsId, apiCall, currentUserId, categories, fetchData, t]
+    [wsId, apiCall, currentUserId, categories, fetchData, queryClient, t]
   );
 
   // Auto-refresh with exponential backoff and visibility check
@@ -1098,7 +1079,12 @@ export default function TimeTrackerContent({
               setIsRunning={setIsRunning}
               categories={categories}
               tasks={tasks}
-              onSessionUpdate={() => fetchData(false)}
+              onSessionUpdate={() => {
+                void queryClient.invalidateQueries({
+                  queryKey: ['running-time-session', wsId, currentUserId],
+                });
+                void fetchData(false);
+              }}
               formatTime={formatTime}
               formatDuration={formatDuration}
               apiCall={apiCall}
@@ -1175,6 +1161,10 @@ export default function TimeTrackerContent({
                     );
 
                     setCurrentSession(response.session);
+                    queryClient.setQueryData(
+                      ['running-time-session', wsId, currentUserId],
+                      response.session
+                    );
                     setIsRunning(true);
                     setElapsedTime(0);
                     await fetchData();

--- a/apps/web/src/hooks/use-current-user-profile.ts
+++ b/apps/web/src/hooks/use-current-user-profile.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getCurrentUserProfile } from '@tuturuuu/internal-api';
+import { InternalApiError } from '@tuturuuu/internal-api/client';
 import type { CurrentUserProfileResponse } from '@tuturuuu/internal-api/users';
 
 export const currentUserProfileQueryKey = ['user', 'me'] as const;
@@ -17,8 +18,14 @@ export function useCurrentUserProfile(options?: {
     queryFn: async () => {
       try {
         return await getCurrentUserProfile();
-      } catch {
-        return null;
+      } catch (error) {
+        if (
+          error instanceof InternalApiError &&
+          (error.status === 401 || error.status === 404)
+        ) {
+          return null;
+        }
+        throw error;
       }
     },
     enabled: options?.enabled ?? true,

--- a/apps/web/src/hooks/use-current-user-profile.ts
+++ b/apps/web/src/hooks/use-current-user-profile.ts
@@ -22,8 +22,8 @@ export function useCurrentUserProfile(options?: {
       }
     },
     enabled: options?.enabled ?? true,
-    staleTime: 60 * 1000,
-    gcTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/web/src/trpc/query.ts
+++ b/apps/web/src/trpc/query.ts
@@ -20,7 +20,9 @@ export function makeQueryClient(options?: MakeQueryClientOptions) {
     mutationCache: options?.mutationCache,
     defaultOptions: {
       queries: {
-        staleTime: 30 * 1000,
+        gcTime: 30 * 60 * 1000,
+        refetchOnWindowFocus: false,
+        staleTime: 5 * 60 * 1000,
         retry: (failureCount, error) => {
           // Retry rate-limited requests up to 3 times
           if (isRateLimitError(error)) return failureCount < 3;

--- a/packages/hive-ui/src/components/access-request-card.test.tsx
+++ b/packages/hive-ui/src/components/access-request-card.test.tsx
@@ -58,7 +58,7 @@ describe('AccessRequestCard', () => {
     vi.useRealTimers();
   });
 
-  it('requests Hive access and polls every 5 seconds until approved', async () => {
+  it('requests Hive access and polls pending requests every 30 seconds', async () => {
     vi.mocked(getMyHiveAccessRequestStatus)
       .mockResolvedValueOnce({
         hasAccess: false,
@@ -122,7 +122,7 @@ describe('AccessRequestCard', () => {
     });
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(30_000);
       await vi.advanceTimersByTimeAsync(0);
     });
     await act(async () => {

--- a/packages/hive-ui/src/components/access-request-card.tsx
+++ b/packages/hive-ui/src/components/access-request-card.tsx
@@ -36,8 +36,10 @@ export function AccessRequestCard({
   const statusQuery = useQuery({
     queryFn: () => getMyHiveAccessRequestStatus(),
     queryKey: HIVE_ACCESS_STATUS_QUERY_KEY,
-    refetchInterval: (query) => (query.state.data?.hasAccess ? false : 5_000),
-    refetchIntervalInBackground: true,
+    refetchInterval: (query) =>
+      query.state.data?.status === 'pending' ? 30_000 : false,
+    refetchIntervalInBackground: false,
+    staleTime: 30_000,
   });
   const requestMutation = useMutation({
     mutationFn: () => requestHiveAccess({ note: note.trim() || null }),

--- a/packages/satellite/src/components/app-guide-overlay.tsx
+++ b/packages/satellite/src/components/app-guide-overlay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowRight, Check, Compass, X } from '@tuturuuu/icons';
 import {
   getConnectedOnboardingProgress,
@@ -29,15 +29,19 @@ function browserAppSlug() {
 }
 
 const STEPS = ['discover', 'try', 'continue'] as const;
+const CONNECTED_ONBOARDING_QUERY_KEY = ['connected-onboarding'] as const;
 
 export function AppGuideOverlay() {
   const t = useTranslations('onboarding_guide');
+  const queryClient = useQueryClient();
   const [appSlug, setAppSlug] = useState<string | null>(null);
   const [step, setStep] = useState(0);
   const progress = useQuery({
-    queryKey: ['connected-onboarding'],
+    queryKey: CONNECTED_ONBOARDING_QUERY_KEY,
     queryFn: () => getConnectedOnboardingProgress(),
-    staleTime: 60_000,
+    gcTime: 60 * 60_000,
+    refetchOnWindowFocus: false,
+    staleTime: 30 * 60_000,
   });
 
   useEffect(() => {
@@ -70,9 +74,11 @@ export function AppGuideOverlay() {
 
   const close = () => {
     setAppSlug(null);
-    void updateConnectedOnboardingProgress({ replay_app: null }).catch(
-      () => null
-    );
+    void updateConnectedOnboardingProgress({ replay_app: null })
+      .then((nextProgress) =>
+        queryClient.setQueryData(CONNECTED_ONBOARDING_QUERY_KEY, nextProgress)
+      )
+      .catch(() => null);
   };
 
   const complete = () => {
@@ -84,7 +90,11 @@ export function AppGuideOverlay() {
     void updateConnectedOnboardingProgress({
       completed_missions: [...completed],
       replay_app: null,
-    }).catch(() => null);
+    })
+      .then((nextProgress) =>
+        queryClient.setQueryData(CONNECTED_ONBOARDING_QUERY_KEY, nextProgress)
+      )
+      .catch(() => null);
   };
 
   return (

--- a/packages/satellite/src/providers/query-client.test.ts
+++ b/packages/satellite/src/providers/query-client.test.ts
@@ -1,19 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import {
-  createSatelliteQueryClient,
-  SATELLITE_QUERY_GC_TIME_MS,
-  SATELLITE_QUERY_STALE_TIME_MS,
-} from './query-client';
+import { createSatelliteQueryClient } from './query-client';
 
 describe('createSatelliteQueryClient', () => {
   it('deduplicates short-lived remounts and bounds failed-request retries', () => {
     const client = createSatelliteQueryClient();
 
     expect(client.getDefaultOptions().queries).toMatchObject({
-      gcTime: SATELLITE_QUERY_GC_TIME_MS,
+      gcTime: 30 * 60_000,
       refetchOnWindowFocus: false,
       retry: 1,
-      staleTime: SATELLITE_QUERY_STALE_TIME_MS,
+      staleTime: 5 * 60_000,
     });
   });
 });

--- a/packages/satellite/src/providers/query-client.test.ts
+++ b/packages/satellite/src/providers/query-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   createSatelliteQueryClient,
+  SATELLITE_QUERY_GC_TIME_MS,
   SATELLITE_QUERY_STALE_TIME_MS,
 } from './query-client';
 
@@ -9,6 +10,8 @@ describe('createSatelliteQueryClient', () => {
     const client = createSatelliteQueryClient();
 
     expect(client.getDefaultOptions().queries).toMatchObject({
+      gcTime: SATELLITE_QUERY_GC_TIME_MS,
+      refetchOnWindowFocus: false,
       retry: 1,
       staleTime: SATELLITE_QUERY_STALE_TIME_MS,
     });

--- a/packages/satellite/src/providers/query-client.ts
+++ b/packages/satellite/src/providers/query-client.ts
@@ -1,12 +1,15 @@
 import { QueryClient } from '@tanstack/react-query';
 
-export const SATELLITE_QUERY_STALE_TIME_MS = 30_000;
+export const SATELLITE_QUERY_STALE_TIME_MS = 5 * 60_000;
+export const SATELLITE_QUERY_GC_TIME_MS = 30 * 60_000;
 
 export function createSatelliteQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
         retry: 1,
+        gcTime: SATELLITE_QUERY_GC_TIME_MS,
+        refetchOnWindowFocus: false,
         staleTime: SATELLITE_QUERY_STALE_TIME_MS,
       },
     },

--- a/packages/tasks-ui/src/tu-do/shared/__tests__/board-client.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/__tests__/board-client.test.tsx
@@ -307,8 +307,8 @@ describe('BoardClient', () => {
     expect(revalidateLoadedListsMock).toHaveBeenCalledTimes(1);
   });
 
-  it('throttles focus-driven list revalidation for thirty seconds', async () => {
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100_000);
+  it('throttles focus-driven list revalidation for five minutes', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: {
@@ -337,7 +337,7 @@ describe('BoardClient', () => {
       expect(revalidateLoadedListsMock).toHaveBeenCalledTimes(1);
     });
 
-    nowSpy.mockReturnValue(101_500);
+    nowSpy.mockReturnValue(1_001_500);
 
     await act(async () => {
       window.dispatchEvent(new Event('focus'));
@@ -345,7 +345,15 @@ describe('BoardClient', () => {
 
     expect(revalidateLoadedListsMock).toHaveBeenCalledTimes(1);
 
-    nowSpy.mockReturnValue(130_000);
+    nowSpy.mockReturnValue(1_299_999);
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(revalidateLoadedListsMock).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockReturnValue(1_300_000);
 
     await act(async () => {
       window.dispatchEvent(new Event('focus'));

--- a/packages/tasks-ui/src/tu-do/shared/board-client.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/board-client.tsx
@@ -27,7 +27,7 @@ import { dispatchRecentSidebarVisit } from './recent-sidebar-events';
 import { TaskBoardLoadingState } from './task-board-loading-state';
 import { useProgressiveBoardLoader } from './use-progressive-board-loader';
 
-const BOARD_REVALIDATE_COOLDOWN_MS = 30_000;
+const BOARD_REVALIDATE_COOLDOWN_MS = 5 * 60_000;
 
 interface Props {
   boardId: string;

--- a/packages/tasks-ui/src/tu-do/shared/board-views.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/board-views.tsx
@@ -521,7 +521,7 @@ export function BoardViews({
       void queryClient.prefetchQuery({
         queryKey: ['tasks-full', board.id, taskFilterKey],
         queryFn: fetchBoardTasks,
-        staleTime: 0,
+        staleTime: 5 * 60_000,
       });
     },
     [board.id, fetchBoardTasks, localTaskState, queryClient, taskFilterKey]
@@ -571,8 +571,8 @@ export function BoardViews({
     queryKey: ['tasks-full', board.id, taskFilterKey],
     enabled: !localTaskState && shouldEagerLoadTasks,
     queryFn: fetchBoardTasks,
-    refetchOnMount: 'always',
-    staleTime: 0,
+    refetchOnMount: false,
+    staleTime: 5 * 60_000,
   });
 
   const initialTaskLists = useMemo(

--- a/packages/ui/src/components/ui/custom/workspace-select-invitations.tsx
+++ b/packages/ui/src/components/ui/custom/workspace-select-invitations.tsx
@@ -31,8 +31,9 @@ export function useWorkspaceInvitations({
     queryKey: ['workspace-invitations', ...(cacheScope ? [cacheScope] : [])],
     queryFn: async () => (await listWorkspaceInvitations()).invitations,
     enabled,
+    gcTime: 30 * 60_000,
     retry: 1,
-    staleTime: 30_000,
+    staleTime: 5 * 60_000,
   });
   const invitations = query.data ?? [];
   const mutation = useMutation({

--- a/packages/ui/src/hooks/use-calendar-sync.tsx
+++ b/packages/ui/src/hooks/use-calendar-sync.tsx
@@ -240,7 +240,7 @@ export const CalendarSyncProvider = ({
     queryKey: ['workspace-calendars', wsId],
     enabled: !hasExternalEvents && !!wsId,
     queryFn: () => listWorkspaceCalendars(wsId),
-    staleTime: 30_000,
+    staleTime: 5 * 60_000,
   });
   const enabledWorkspaceCalendarIds = useMemo(
     () =>
@@ -438,12 +438,11 @@ export const CalendarSyncProvider = ({
     [isVisibleInCurrentRange]
   );
 
-  // Fetch database events with caching
   const { data: fetchedData, isLoading: isDatabaseLoading } = useQuery({
     queryKey: ['databaseCalendarEvents', wsId, activeCacheKey],
     enabled: !hasExternalEvents && !!wsId && dates.length > 0,
-    staleTime: 30000, // Consider data fresh for 30 seconds
-    gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes
+    staleTime: 2 * 60_000,
+    gcTime: 30 * 60_000,
     queryFn: async () => {
       if (!activeCacheKey) return null;
 
@@ -515,7 +514,8 @@ export const CalendarSyncProvider = ({
         return cachedData?.dbEvents ?? [];
       }
     },
-    refetchInterval: 60000, // Reduced from 30s to 60s to lower load
+    refetchInterval: 5 * 60_000,
+    refetchIntervalInBackground: false,
   });
 
   // Legacy direct Google fetch/reconcile is disabled. Provider inbound sync is
@@ -523,18 +523,17 @@ export const CalendarSyncProvider = ({
   const { isLoading: isGoogleLoading } = useQuery({
     queryKey: ['googleCalendarEvents', wsId, activeCacheKey],
     enabled: false,
-    staleTime: 30000, // Consider data fresh for 30 seconds
-    gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes
+    staleTime: 2 * 60_000,
+    gcTime: 30 * 60_000,
     queryFn: async () => null,
-    refetchInterval: 60000, // Reduced from 30s to 60s to lower load
   });
 
   // Fetch habit calendar events to identify which events are habits
   const { data: habitEventData } = useQuery({
     queryKey: ['habitCalendarEvents', wsId, activeCacheKey],
     enabled: !hasExternalEvents && !!wsId && dates.length > 0,
-    staleTime: 60000, // Consider data fresh for 1 minute
-    gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes
+    staleTime: 2 * 60_000,
+    gcTime: 30 * 60_000,
     queryFn: async () => {
       const startDate = dayjs(dates[0]).startOf('day');
       const endDate = dayjs(dates[dates.length - 1])
@@ -571,7 +570,8 @@ export const CalendarSyncProvider = ({
         };
       }
     },
-    refetchInterval: 60000, // Refetch every minute
+    refetchInterval: 5 * 60_000,
+    refetchIntervalInBackground: false,
   });
 
   // Helper to check if dates have actually changed

--- a/packages/ui/src/hooks/use-calendar-sync.tsx
+++ b/packages/ui/src/hooks/use-calendar-sync.tsx
@@ -511,7 +511,7 @@ export const CalendarSyncProvider = ({
           lastSyncTime: new Date(),
         });
 
-        return cachedData?.dbEvents ?? [];
+        throw err instanceof Error ? err : new Error(errorMessage);
       }
     },
     refetchInterval: 5 * 60_000,

--- a/packages/utils/src/next-config.test.ts
+++ b/packages/utils/src/next-config.test.ts
@@ -8,6 +8,7 @@ import {
   isTuturuuuTurbopackRustReactCompilerEnabled,
   resolveTuturuuuInfrastructureAppUrl,
   resolveTuturuuuWebAppUrl,
+  TUTURUUU_NEXT_IMAGE_MINIMUM_CACHE_TTL_SECONDS,
   TUTURUUU_NEXT_IMAGE_REMOTE_PATTERNS,
   TUTURUUU_NEXT_OPTIMIZE_PACKAGE_IMPORTS,
   trimTrailingSlashes,
@@ -25,6 +26,9 @@ describe('createTuturuuuNextConfig', () => {
     expect(config.experimental?.turbopackRustReactCompiler).toBe(true);
     expect(config.images?.remotePatterns).toEqual(
       TUTURUUU_NEXT_IMAGE_REMOTE_PATTERNS
+    );
+    expect(config.images?.minimumCacheTTL).toBe(
+      TUTURUUU_NEXT_IMAGE_MINIMUM_CACHE_TTL_SECONDS
     );
     expect(config.poweredByHeader).toBe(false);
     expect(config.reactCompiler).toBe(true);
@@ -198,6 +202,7 @@ describe('createTuturuuuNextConfig', () => {
       partialPrefetching: false,
       reactCompiler: false,
       transpilePackages: ['@tuturuuu/ui'],
+      images: { minimumCacheTTL: 86_400 },
       experimental: {
         cpus: 2,
         turbopackFileSystemCacheForBuild: false,
@@ -213,6 +218,7 @@ describe('createTuturuuuNextConfig', () => {
     expect(config.partialPrefetching).toBe(false);
     expect(config.reactCompiler).toBe(true);
     expect(config.transpilePackages).toEqual(['@tuturuuu/ui']);
+    expect(config.images?.minimumCacheTTL).toBe(86_400);
     expect(config.experimental?.cpus).toBe(2);
     expect(config.experimental?.turbopackFileSystemCacheForBuild).toBe(false);
     expect(config.experimental?.turbopackRustReactCompiler).toBe(false);

--- a/packages/utils/src/next-config.ts
+++ b/packages/utils/src/next-config.ts
@@ -38,6 +38,8 @@ export const TUTURUUU_NEXT_IMAGE_REMOTE_PATTERNS = [
   },
 ] satisfies NextImageRemotePattern[];
 
+export const TUTURUUU_NEXT_IMAGE_MINIMUM_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60;
+
 const TUTURUUU_ANTI_FRAMING_SOURCE =
   '/:path((?!api/v1/workspaces/[^/]+/external-projects/assets/[^/]+/webgl(?:/|$)).*)';
 
@@ -112,6 +114,9 @@ export function createTuturuuuNextConfig(config: NextConfig = {}): NextConfig {
     ),
     images: {
       ...imageConfig,
+      minimumCacheTTL:
+        imageConfig.minimumCacheTTL ??
+        TUTURUUU_NEXT_IMAGE_MINIMUM_CACHE_TTL_SECONDS,
       remotePatterns: mergeRemotePatterns(
         TUTURUUU_NEXT_IMAGE_REMOTE_PATTERNS,
         imageConfig.remotePatterns


### PR DESCRIPTION
## Summary
- extend shared image and query cache lifetimes across Platform and satellite apps
- reduce task-board, calendar, timer, and Hive polling while preserving realtime and mutation-driven refreshes
- add regression coverage for shared Contacts and satellite cache defaults

## Production log evidence
- Platform bootstrap endpoints and onboarding/unread queries repeat across sessions
- Tasks repeatedly refetches loaded task lists on focus/view remounts
- Contacts and Finance repeat the same workspace/profile/config bootstrap queries

## Validation
- `bun check` (all gates passed)
- 51 focused tests across Utils, Satellite, Contacts, Tasks UI, UI calendar, and Hive UI
- production builds passed: Contacts, Tasks, Finance, Track
- Platform compiled successfully; local prerender remains environment-gated because the isolated worktree has no Supabase build credentials (production secret pull intentionally not performed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce cross-app Vercel request churn by extending caches, throttling polling, and disabling focus/background refetches while keeping UI fresh via mutation-driven cache updates. Previously frequent 5–30s polls and focus remount refetches; now shared defaults use 5m staleTime, 30m gcTime, and no window-focus refetch, with timers/calendars polling only when needed.

- Shared React Query defaults: `apps/web` TRPC, `packages/satellite`, and `apps/contacts` use staleTime: 5m, gcTime: 30m, refetchOnWindowFocus: false; expose `createContactsQueryClient` and Satellite constants; tests added/updated.
- Timers (`apps/track`): running session polls 60s when active, 5m when idle; disable background polling; scope query keys by user; on start/stop setQueryData and invalidate to keep UI in sync; stats poll 5m with 5m stale.
- Calendar (`packages/ui`): workspace calendars stale 5m; database/habit events stale ~2m, gc 30m; poll 5m in foreground only.
- Hive access (`packages/hive-ui`): poll pending status every 30s; disable background polling; tests updated.
- Tasks (`packages/tasks-ui`): board revalidate cooldown 5m; task list queries use 5m stale and avoid refetchOnMount; tests updated.
- Satellite onboarding (`packages/satellite`): overlay uses 30m stale, 60m gc, no focus refetch; update cache via `useQueryClient` after progress changes.
- Web profile and invitations: stale 5m, gc 30m; profile query now returns null only on 401/404 and rethrows other errors.
- Static assets (`packages/utils`): default Next `images.minimumCacheTTL` to 7 days, configurable; tests updated.

**Review focus**
- Confirm mutations update caches and refresh views: timer start/stop, calendar sync, Hive approval, onboarding overlay progress.
- Validate no UX regressions with disabled focus/background refetch: timer drift (~60s while running), task board visibility, onboarding overlay state.
- Check test stability with longer intervals and new cache defaults.

<sup>Written for commit 0e2e953aec5f9e28c443379e17ea362f8a373995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

