### PR TITLE
fix(auth): allow scoped avatar uploads

### DIFF
--- a/apps/tanstack-web/migration/route-overrides.json
+++ b/apps/tanstack-web/migration/route-overrides.json
@@ -1,5 +1,10 @@
 {
   "routes": {
+    "api:/api/v1/users/me/avatar/upload-url:apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.ts": {
+      "status": "legacy-next",
+      "targetOwner": "rust-backend",
+      "note": "Current-user avatar upload URL creation remains on Next.js pending Rust parity. The future Rust handler must preserve session and scoped external app authorization with users:profile:write, the current-user target-app allowlist, the 10 requests per minute rate limit, and the app-session step-up bypass used for delegated profile editing."
+    },
     "api:/api/v1/auth/app-token/invitation-decision:apps/web/src/app/api/v1/auth/app-token/invitation-decision/route.ts": {
       "status": "legacy-next",
       "targetOwner": "rust-backend",

--- a/apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { withSessionAuthMock } = vi.hoisted(() => ({
-  withSessionAuthMock: vi.fn((handler: unknown, _options?: unknown) => handler),
+  withSessionAuthMock: vi.fn((handler: unknown) => handler),
 }));
 
 vi.mock('@/lib/api-auth', () => ({

--- a/apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { withSessionAuthMock } = vi.hoisted(() => ({
-  withSessionAuthMock: vi.fn((handler: unknown) => handler),
+  withSessionAuthMock: vi.fn((handler: unknown, _options?: unknown) => handler),
 }));
 
 vi.mock('@/lib/api-auth', () => ({

--- a/apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.test.ts
+++ b/apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { withSessionAuthMock } = vi.hoisted(() => ({
+  withSessionAuthMock: vi.fn((handler: unknown, _options?: unknown) => handler),
+}));
+
+vi.mock('@/lib/api-auth', () => ({
+  withSessionAuth: (handler: unknown, options?: unknown) =>
+    withSessionAuthMock(handler, options),
+}));
+
+describe('current user avatar upload URL route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('allows profile-write app sessions without broadening storage access', async () => {
+    await import('@/legacy-api-routes/v1/users/me/avatar/upload-url/route');
+
+    expect(withSessionAuthMock).toHaveBeenCalledTimes(1);
+    expect(withSessionAuthMock.mock.calls[0]?.[1]).toEqual({
+      allowAppSessionAuth: [
+        {
+          targetApp: [
+            'ai',
+            'calendar',
+            'chat',
+            'cms',
+            'contacts',
+            'drive',
+            'finance',
+            'forms',
+            'hive',
+            'infra',
+            'inventory',
+            'learn',
+            'mail',
+            'meet',
+            'mind',
+            'mira',
+            'nova',
+            'pay',
+            'rewise',
+            'storefront',
+            'tasks',
+            'teach',
+            'track',
+            'platform',
+          ],
+        },
+        { requiredScope: 'users:profile:write' },
+      ],
+      rateLimit: { windowMs: 60000, maxRequests: 10 },
+      skipAppSessionStepUpChallenge: true,
+    });
+  });
+});

--- a/apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.ts
+++ b/apps/web/src/legacy-api-routes/v1/users/me/avatar/upload-url/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withSessionAuth } from '@/lib/api-auth';
+import { CURRENT_USER_PROFILE_WRITE_APP_SESSION_AUTH } from '../../session-auth';
 
 const PostAvatarUploadSchema = z.object({
   filename: z
@@ -70,7 +71,8 @@ export const POST = withSessionAuth(
   },
   // Upload URL generation — moderate limit to prevent storage abuse
   {
-    allowAppSessionAuth: true,
+    allowAppSessionAuth: CURRENT_USER_PROFILE_WRITE_APP_SESSION_AUTH,
     rateLimit: { windowMs: 60000, maxRequests: 10 },
+    skipAppSessionStepUpChallenge: true,
   }
 );


### PR DESCRIPTION
## Summary
- authorize current-user avatar upload URLs with the existing profile-write app-session policy
- keep the existing upload rate limit and step-up behavior aligned with profile updates
- cover the exact authorization options with a regression test

## Verification
- focused Vitest route test
- bun check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts current-user avatar upload URL creation to scoped app sessions. Previously any app session could request an upload URL; now only sessions from approved target apps or with `users:profile:write` can, preventing broader storage access.

- Applies `CURRENT_USER_PROFILE_WRITE_APP_SESSION_AUTH` to POST `/v1/users/me/avatar/upload-url`, keeps `rateLimit: 10/min`, and sets `skipAppSessionStepUpChallenge: true`.
- Adds a `vitest` route test with typed mocks covering the target-app allowlist, required scope, rate limit, and step-up bypass.
- Marks the route as `legacy-next` in `apps/tanstack-web/migration/route-overrides.json` with guidance to preserve the same auth, rate limit, and step-up behavior in the future Rust handler.

<sup>Written for commit ed6908a59ad9353a9b302e202704259ded985b20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

