### PR TITLE
fix(i18n): restore shared task timer keys

### DIFF
--- a/apps/calendar/messages/en.json
+++ b/apps/calendar/messages/en.json
@@ -2916,6 +2916,7 @@
     "vietnamese-womens-day": "Vietnamese Women's Day",
     "view": "View",
     "view_email": "View Email",
+    "view_task": "View task",
     "view-full-documentation": "View full documentation",
     "view-options": "Columns",
     "visibility_updated": "Visibility updated successfully",

--- a/apps/calendar/messages/vi.json
+++ b/apps/calendar/messages/vi.json
@@ -2916,6 +2916,7 @@
     "vietnamese-womens-day": "Ngày Phụ Nữ Việt Nam",
     "view": "Xem",
     "view_email": "Xem Email",
+    "view_task": "Xem nhiệm vụ",
     "view-full-documentation": "Xem tài liệu đầy đủ",
     "view-options": "Trình bày",
     "visibility_updated": "Đã cập nhật quyền truy cập thành công",

--- a/apps/track/messages/en.json
+++ b/apps/track/messages/en.json
@@ -2411,6 +2411,7 @@
     "failed_to_delete": "Failed to delete",
     "failed_to_delete_tasks": "Failed to delete tasks.",
     "failed_to_restore": "Failed to restore tasks",
+    "failed_to_start_timer": "Couldn’t start the timer",
     "failed_to_stop_timer": "Failed to stop timer",
     "failed_to_update_assignees": "Failed to update assignees: {error}",
     "faq": "Frequently Asked Questions",
@@ -2716,12 +2717,14 @@
     "start_date": "Start date",
     "start_timer": "Start Timer",
     "start_tracking_time": "Start tracking time",
+    "starting_timer": "Starting timer…",
     "starts": "Starts",
     "starts_at": "Starts {date}",
     "status": "Status",
     "status_category": "Status Category",
     "stay-updated": "Stay in the Loop",
     "stop_tracking_time": "Stop tracking",
+    "stopping_timer": "Stopping timer…",
     "stress": "stress",
     "styles": "Styles",
     "submit": "Submit",
@@ -2734,6 +2737,7 @@
     "suggestion-improve": "Suggestion to Improve ",
     "suggestion-placeholder": "Describe the issue and any suggestions you have to improve the situation...",
     "switch_to": "Switch to {theme}",
+    "switch_tracking_to_task": "Switch timer to this task",
     "system": "System",
     "task": "task",
     "task_duplicated_successfully": "Task duplicated successfully",
@@ -2818,8 +2822,11 @@
     "timeline_unscheduled_prompt": "Unscheduled tasks",
     "timeline_view": "Timeline",
     "timeline_zoom": "Timeline zoom",
+    "timer_started": "Timer started",
+    "timer_started_for": "Now tracking {name}.",
     "timer_stopped": "Timer stopped",
     "timer_stopped_for": "Stopped tracking {name}.",
+    "timer_switched_to": "Stopped the previous timer and started {name}.",
     "title": "Title",
     "today": "Today",
     "toggle-columns": "Toggle Columns",
@@ -7806,6 +7813,9 @@
     "progress": {
       "log_entry": "Log progress",
       "recent_entries": "Recent entries"
+    },
+    "quicklog": {
+      "open": "Log progress"
     },
     "schema_unavailable": "Task progress needs the latest database migration before it can load.",
     "stats": {

--- a/apps/track/messages/vi.json
+++ b/apps/track/messages/vi.json
@@ -2411,6 +2411,7 @@
     "failed_to_delete": "Không thể xóa",
     "failed_to_delete_tasks": "Không thể xóa công việc.",
     "failed_to_restore": "Không thể khôi phục công việc",
+    "failed_to_start_timer": "Không thể bắt đầu tính giờ",
     "failed_to_stop_timer": "Không thể dừng tính giờ",
     "failed_to_update_assignees": "Không thể cập nhật người thực hiện: {error}",
     "faq": "Câu hỏi thường gặp",
@@ -2716,12 +2717,14 @@
     "start_date": "Ngày bắt đầu",
     "start_timer": "Bắt đầu hẹn giờ",
     "start_tracking_time": "Bắt đầu tính giờ",
+    "starting_timer": "Đang bắt đầu tính giờ…",
     "starts": "Bắt đầu",
     "starts_at": "Bắt đầu {date}",
     "status": "Trạng thái",
     "status_category": "Nhóm trạng thái",
     "stay-updated": "Cập nhật thường xuyên",
     "stop_tracking_time": "Dừng tính giờ",
+    "stopping_timer": "Đang dừng tính giờ…",
     "stress": "căng thẳng",
     "styles": "Kiểu dáng",
     "submit": "Gửi",
@@ -2734,6 +2737,7 @@
     "suggestion-improve": "Đề xuất cải thiện",
     "suggestion-placeholder": "Mô tả vấn đề và bất kỳ đề xuất nào bạn có để cải thiện tình hình...",
     "switch_to": "Chuyển sang chế độ {theme}",
+    "switch_tracking_to_task": "Chuyển bộ tính giờ sang công việc này",
     "system": "Hệ thống",
     "task": "công việc",
     "task_duplicated_successfully": "Đã nhân bản công việc thành công",
@@ -2818,8 +2822,11 @@
     "timeline_unscheduled_prompt": "Công việc chưa lên lịch",
     "timeline_view": "Dòng thời gian",
     "timeline_zoom": "Thu phóng dòng thời gian",
+    "timer_started": "Đã bắt đầu tính giờ",
+    "timer_started_for": "Đang theo dõi {name}.",
     "timer_stopped": "Đã dừng tính giờ",
     "timer_stopped_for": "Đã dừng theo dõi {name}.",
+    "timer_switched_to": "Đã dừng bộ tính giờ trước và bắt đầu {name}.",
     "title": "Tiêu đề",
     "today": "Hôm nay",
     "toggle-columns": "Hiển thị cột",
@@ -7806,6 +7813,9 @@
     "progress": {
       "log_entry": "Ghi tiến độ",
       "recent_entries": "Ghi nhận gần đây"
+    },
+    "quicklog": {
+      "open": "Ghi tiến độ"
     },
     "schema_unavailable": "Tiến độ công việc cần migration cơ sở dữ liệu mới nhất trước khi tải.",
     "stats": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5101,6 +5101,7 @@
     "vietnamese-womens-day": "Vietnamese Women's Day",
     "view": "View",
     "view_email": "View Email",
+    "view_task": "View task",
     "view-full-documentation": "View full documentation",
     "view-options": "Columns",
     "visibility_updated": "Visibility updated successfully",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -5101,6 +5101,7 @@
     "vietnamese-womens-day": "Ngày Phụ Nữ Việt Nam",
     "view": "Xem",
     "view_email": "Xem Email",
+    "view_task": "Xem nhiệm vụ",
     "view-full-documentation": "Xem tài liệu đầy đủ",
     "view-options": "Trình bày",
     "visibility_updated": "Đã cập nhật quyền truy cập thành công",


### PR DESCRIPTION
## Summary
- restore shared task timer translations required by web and calendar
- add task timer and quick-log translations required by track
- restore the post-merge namespace validation gate

## Validation
- node scripts/i18n-namespace-check.js
- python3 -m json.tool for all six touched message files
- bun x biome check for all six touched message files
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores shared task timer i18n keys and adds missing Track timer/Quick Log strings in English and Vietnamese to eliminate fallback/missing labels. Also re-enables the post-merge i18n namespace validation to prevent future gaps.

- Old: Web/Calendar lacked `view_task`; Track lacked timer and Quick Log strings, leading to placeholders. New: All keys present across apps; consistent EN/VI translations. Side effect: the namespace check blocks merges with missing keys.

**Review notes**
- Changes are limited to six JSON files; no runtime logic changes.
- New keys include: `view_task`, `failed_to_start_timer`, `starting_timer`, `stopping_timer`, `switch_tracking_to_task`, `timer_started`, `timer_started_for`, `timer_switched_to`, and `quicklog.open`. Verify placeholders like `{name}` remain intact.

**Rollout**
- No migration required. If you add or rename message keys, update all app namespaces and run `node scripts/i18n-namespace-check.js` locally; CI will fail on mismatches.

<sup>Written for commit fdc26b758cfbc74fbfee9d6d7c39be90577d1593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

