### PR TITLE
feat(command): build task-first command center

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ CLI, documentation, local services, and deployment tooling behind that system.
 <!-- tanstack-rust-migration-progress:start -->
 _Generated from `apps/tanstack-web/migration/route-manifest.json`. Refresh with `bun migration:tanstack:readme` after route ownership changes._
 
-![Overall migration progress](https://img.shields.io/static/v1?color=fb8c00&label=Overall&message=28.41%25+terminal&style=flat-square) ![Rust backend migration progress](https://img.shields.io/static/v1?color=cf222e&label=Rust+backend&message=13.34%25+terminal&style=flat-square) ![TanStack Start migration progress](https://img.shields.io/static/v1?color=1f6feb&label=TanStack+Start&message=70.09%25+terminal&style=flat-square)
+![Overall migration progress](https://img.shields.io/static/v1?color=fb8c00&label=Overall&message=28.38%25+terminal&style=flat-square) ![Rust backend migration progress](https://img.shields.io/static/v1?color=cf222e&label=Rust+backend&message=13.32%25+terminal&style=flat-square) ![TanStack Start migration progress](https://img.shields.io/static/v1?color=1f6feb&label=TanStack+Start&message=70.09%25+terminal&style=flat-square)
 
 | Track | Progress | Terminal | Migrated | Removed | Remaining |
 | --- | --- | ---: | ---: | ---: | ---: |
-| Overall | `[######--------------]` 28.41% | 229 / 806 | 215 | 14 | 577 |
-| Rust backend | `[###-----------------]` 13.34% | 79 / 592 | 67 | 12 | 513 |
+| Overall | `[######--------------]` 28.38% | 229 / 807 | 215 | 14 | 578 |
+| Rust backend | `[###-----------------]` 13.32% | 79 / 593 | 67 | 12 | 514 |
 | TanStack Start | `[##############------]` 70.09% | 150 / 214 | 148 | 2 | 64 |
 
 <details>
@@ -34,7 +34,7 @@ _Generated from `apps/tanstack-web/migration/route-manifest.json`. Refresh with 
 
 | Kind | Progress | Terminal | Remaining |
 | --- | --- | ---: | ---: |
-| api | `[##--------------]` 12.78% | 74 / 579 | 505 |
+| api | `[##--------------]` 12.76% | 74 / 580 | 506 |
 | page | `[###########-----]` 66.89% | 101 / 151 | 50 |
 | layout | `[#############---]` 79.66% | 47 / 59 | 12 |
 | cron | `[####------------]` 25% | 2 / 8 | 6 |

--- a/apps/docs/platform/architecture/tanstack-rust-migration-plan.mdx
+++ b/apps/docs/platform/architecture/tanstack-rust-migration-plan.mdx
@@ -22,16 +22,16 @@ source of truth. The latest local snapshot on 2026-08-03 is:
 
 | Status | Count |
 | --- | ---: |
-| `legacy-next` | 577 |
+| `legacy-next` | 578 |
 | `migrated` | 215 |
 | `accepted-removal` | 14 |
-| Total tracked artifacts | 806 |
+| Total tracked artifacts | 807 |
 
 Remaining legacy artifacts are concentrated in API/backend ownership:
 
 | Kind | Remaining legacy artifacts |
 | --- | ---: |
-| API | 505 |
+| API | 506 |
 | Cron | 6 |
 | Error boundary | 1 |
 | Loading boundary | 1 |

--- a/apps/docs/platform/architecture/tanstack-rust-migration-plan.mdx
+++ b/apps/docs/platform/architecture/tanstack-rust-migration-plan.mdx
@@ -38,7 +38,7 @@ Remaining legacy artifacts are concentrated in API/backend ownership:
 | tRPC | 1 |
 | Route handler | 1 |
 | Page | 50 |
-| Layout | 11 |
+| Layout | 12 |
 
 The production target is:
 

--- a/apps/docs/platform/architecture/tanstack-rust-migration.mdx
+++ b/apps/docs/platform/architecture/tanstack-rust-migration.mdx
@@ -409,10 +409,10 @@ Current inventory:
 
 - `151` pages
 - `59` layouts
-- `592` route handler artifacts
+- `593` route handler artifacts
 - `8` cron handlers
-- `806` total tracked route artifacts
-- `215` migrated artifacts, `229` terminal artifacts, and `577` remaining
+- `807` total tracked route artifacts
+- `215` migrated artifacts, `229` terminal artifacts, and `578` remaining
   legacy-owned artifacts in the checked manifest
 
 Regenerate it after adding or removing legacy routes:

--- a/apps/tanstack-web/migration/route-manifest.json
+++ b/apps/tanstack-web/migration/route-manifest.json
@@ -6,12 +6,12 @@
         "acceptedRemoval": 12,
         "key": "api",
         "label": "api",
-        "legacyNext": 505,
+        "legacyNext": 506,
         "migrated": 62,
-        "percentComplete": 12.78,
-        "remaining": 505,
+        "percentComplete": 12.76,
+        "remaining": 506,
         "terminal": 74,
-        "total": 579,
+        "total": 580,
         "unknownStatus": 0
       },
       {
@@ -116,12 +116,12 @@
         "acceptedRemoval": 12,
         "key": "rust-backend",
         "label": "Rust backend",
-        "legacyNext": 513,
+        "legacyNext": 514,
         "migrated": 67,
-        "percentComplete": 13.34,
-        "remaining": 513,
+        "percentComplete": 13.32,
+        "remaining": 514,
         "terminal": 79,
-        "total": 592,
+        "total": 593,
         "unknownStatus": 0
       },
       {
@@ -323,12 +323,12 @@
       "acceptedRemoval": 14,
       "key": "total",
       "label": "All route artifacts",
-      "legacyNext": 577,
+      "legacyNext": 578,
       "migrated": 215,
-      "percentComplete": 28.41,
-      "remaining": 577,
+      "percentComplete": 28.38,
+      "remaining": 578,
       "terminal": 229,
-      "total": 806,
+      "total": 807,
       "unknownStatus": 0
     }
   },
@@ -3188,6 +3188,15 @@
       "methods": ["GET"],
       "routePath": "/api/v1/workspaces/:wsId/external-projects/delivery",
       "sourceFile": "apps/web/src/legacy-api-routes/v1/workspaces/[wsId]/external-projects/delivery/route.ts",
+      "status": "legacy-next",
+      "targetOwner": "rust-backend"
+    },
+    {
+      "id": "api:/api/v1/workspaces/:wsId/external-projects/email-policy:apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/email-policy/route.ts",
+      "kind": "api",
+      "methods": ["GET", "PUT"],
+      "routePath": "/api/v1/workspaces/:wsId/external-projects/email-policy",
+      "sourceFile": "apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/email-policy/route.ts",
       "status": "legacy-next",
       "targetOwner": "rust-backend"
     },
@@ -7693,20 +7702,20 @@
     }
   ],
   "summary": {
-    "apiRoutes": 579,
+    "apiRoutes": 580,
     "cronRoutes": 8,
     "layouts": 59,
     "pages": 151,
-    "routeHandlers": 592,
+    "routeHandlers": 593,
     "methodCounts": {
-      "GET": 294,
+      "GET": 295,
       "HEAD": 4,
       "POST": 292,
-      "PUT": 53,
+      "PUT": 54,
       "PATCH": 62,
       "DELETE": 99,
       "OPTIONS": 23
     },
-    "total": 806
+    "total": 807
   }
 }

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/tasks/search/route.test.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/tasks/search/route.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const RAW_WORKSPACE_ID = 'personal';
 const NORMALIZED_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => {
   return {
     createAdminClient: vi.fn(),
     createMeteredTextEmbedding: vi.fn(),
+    from: vi.fn(),
     normalizeWorkspaceId: vi.fn(),
     rpc: vi.fn(),
     serverLoggerError: vi.fn(),
@@ -88,7 +89,20 @@ describe('workspace task search route', () => {
     vi.resetModules();
     vi.clearAllMocks();
 
-    mocks.createAdminClient.mockResolvedValue({ rpc: mocks.rpc });
+    mocks.createAdminClient.mockResolvedValue({
+      from: mocks.from,
+      rpc: mocks.rpc,
+    });
+    mocks.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          in: vi.fn().mockResolvedValue({
+            data: [{ task_id: 'task-1' }],
+            error: null,
+          }),
+        })),
+      })),
+    });
     mocks.normalizeWorkspaceId.mockResolvedValue(NORMALIZED_WORKSPACE_ID);
     mocks.verifyWorkspaceMembershipType.mockResolvedValue({
       membershipType: 'MEMBER',
@@ -102,10 +116,6 @@ describe('workspace task search route', () => {
       data: [{ id: 'task-1', name: 'Deadline review', similarity: 0.9 }],
       error: null,
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it('allows CLI and Tasks app-session auth with read rate limiting', async () => {
@@ -163,7 +173,15 @@ describe('workspace task search route', () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      tasks: [{ id: 'task-1', name: 'Deadline review', similarity: 0.9 }],
+      tasks: [
+        {
+          completed: false,
+          id: 'task-1',
+          is_assigned_to_current_user: true,
+          name: 'Deadline review',
+          similarity: 0.9,
+        },
+      ],
     });
     expect(mocks.createMeteredTextEmbedding).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -264,7 +282,15 @@ describe('workspace task search route', () => {
     await expect(response.json()).resolves.toEqual({
       message: 'Task hybrid search fell back to text search',
       reason: 'credits_unavailable',
-      tasks: [{ id: 'task-1', name: 'Deadline review', similarity: 0.9 }],
+      tasks: [
+        {
+          completed: false,
+          id: 'task-1',
+          is_assigned_to_current_user: true,
+          name: 'Deadline review',
+          similarity: 0.9,
+        },
+      ],
     });
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       'Task hybrid search falling back to text search',

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/tasks/search/route.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/tasks/search/route.ts
@@ -175,6 +175,34 @@ export const POST = withSessionAuth<Params>(
         );
       }
 
+      const tasks = data ?? [];
+      const taskIds = tasks.map((task) => task.id);
+      const assignedTaskIds = new Set<string>();
+
+      if (taskIds.length > 0) {
+        const { data: assignments, error: assignmentsError } = await sbAdmin
+          .from('task_assignees')
+          .select('task_id')
+          .eq('user_id', user.id)
+          .in('task_id', taskIds);
+
+        if (assignmentsError) {
+          console.error('Error loading task search assignments', {
+            error: assignmentsError,
+            userId: user.id,
+            wsId,
+          });
+          return NextResponse.json(
+            { message: 'Error loading task search assignments' },
+            { status: 500 }
+          );
+        }
+
+        for (const assignment of assignments ?? []) {
+          assignedTaskIds.add(assignment.task_id);
+        }
+      }
+
       return NextResponse.json({
         ...(fallbackReason
           ? {
@@ -182,7 +210,11 @@ export const POST = withSessionAuth<Params>(
               reason: fallbackReason,
             }
           : {}),
-        tasks: data ?? [],
+        tasks: tasks.map((task) => ({
+          ...task,
+          completed: Boolean(task.completed_at),
+          is_assigned_to_current_user: assignedTaskIds.has(task.id),
+        })),
       });
     } catch (error) {
       console.error('Error in task search', error);

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4301,6 +4301,7 @@
     "result_count_plural": "{count} results",
     "search_placeholder": "Search commands, tasks, or navigate...",
     "search_placeholder_power": "Find tasks, pages, and actions — use #, /, or >",
+    "search_placeholder_tasks": "Find tasks, apps, and actions — use #, @, or >",
     "searching_tasks": "Searching tasks...",
     "smart_actions": "Smart Actions",
     "sort": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4300,6 +4300,7 @@
     "result_count": "{count} result",
     "result_count_plural": "{count} results",
     "search_placeholder": "Search commands, tasks, or navigate...",
+    "search_placeholder_navigation": "Find pages, apps, and actions — use /, @, or >",
     "search_placeholder_power": "Find tasks, pages, and actions — use #, /, or >",
     "search_placeholder_tasks": "Find tasks, apps, and actions — use #, @, or >",
     "searching_tasks": "Searching tasks...",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4220,11 +4220,36 @@
     "clear_recent_title": "Clear Recent Items",
     "commands": "Commands",
     "continue": "Continue",
+    "create_from_query": "Create “{query}”",
     "create_in_product": "Create in {product}",
     "create_in_product_description": "Start a new {product} workflow from the command palette.",
     "create_task": "Create task \"{taskName}\"",
     "create_task_tip": "Tip: Press ⌘↵ to quickly create a task",
     "current_theme": "Current",
+    "description": "Search, act, and move without leaving your flow.",
+    "empty": {
+      "description": "Start typing, choose a tab, or use a power prefix.",
+      "no_matches": "No matches for “{query}”. Refine the filters or create it as a task.",
+      "title": "Nothing surfaced yet"
+    },
+    "filters": {
+      "label": "Filter",
+      "priority": {
+        "all": "Any priority",
+        "critical": "Critical",
+        "high": "High",
+        "low": "Low",
+        "normal": "Normal"
+      },
+      "status": {
+        "all": "Any status",
+        "assigned": "Assigned to me",
+        "completed": "Completed",
+        "due-soon": "Due soon",
+        "open": "Open",
+        "overdue": "Overdue"
+      }
+    },
     "generic_action_name_label": "Name",
     "generic_action_name_placeholder": "Name this {product} item",
     "generic_action_notes_label": "Notes",
@@ -4233,8 +4258,10 @@
     "inline_action_description": "Add the quick details here, then continue in {product} to finish the product-specific fields.",
     "keyboard_hints": {
       "clear_recent": "clear recent",
+      "create": "create task",
       "esc_to_close": "Press Esc to close",
       "navigate": "navigate",
+      "open": "open",
       "select": "select",
       "to_close": "to close",
       "to_toggle": "to toggle"
@@ -4253,6 +4280,11 @@
     "open_item_description": "Navigate to {item}.",
     "overdue": "Overdue",
     "personal": "Personal",
+    "power_hints": {
+      "actions": "actions",
+      "pages": "pages",
+      "tasks": "tasks"
+    },
     "powered_by": "Powered by Tuturuuu Search",
     "priority": {
       "critical": "Critical",
@@ -4266,8 +4298,36 @@
     "result_count": "{count} result",
     "result_count_plural": "{count} results",
     "search_placeholder": "Search commands, tasks, or navigate...",
+    "search_placeholder_power": "Find tasks, pages, and actions — use #, /, or >",
     "searching_tasks": "Searching tasks...",
     "smart_actions": "Smart Actions",
+    "sort": {
+      "due": "Due date",
+      "newest": "Newest",
+      "priority": "Priority",
+      "relevance": "Best match"
+    },
+    "tabs": {
+      "actions": "Actions",
+      "all": "All",
+      "apps": "Apps",
+      "label": "Search category",
+      "navigate": "Pages",
+      "tasks": "Tasks"
+    },
+    "task_actions": {
+      "completed": "Task completed",
+      "copy_link": "Copy task link",
+      "due": "Due {date}",
+      "link_copied": "Task link copied",
+      "link_copy_failed": "Could not copy the task link",
+      "mark_complete": "Complete task",
+      "mark_open": "Reopen task",
+      "reopened": "Task reopened",
+      "update_failed": "Could not update this task"
+    },
+    "task_first": "Task first",
+    "task_results": "{count} tasks",
     "tasks": "Tasks",
     "title": "Command Center",
     "try_searching": "Try searching for tasks, pages, or actions",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4241,6 +4241,7 @@
         "low": "Low",
         "normal": "Normal"
       },
+      "priority_label": "Priority filter",
       "status": {
         "all": "Any status",
         "assigned": "Assigned to me",
@@ -4248,7 +4249,8 @@
         "due-soon": "Due soon",
         "open": "Open",
         "overdue": "Overdue"
-      }
+      },
+      "status_label": "Status filter"
     },
     "generic_action_name_label": "Name",
     "generic_action_name_placeholder": "Name this {product} item",
@@ -4303,6 +4305,7 @@
     "smart_actions": "Smart Actions",
     "sort": {
       "due": "Due date",
+      "label": "Sort tasks",
       "newest": "Newest",
       "priority": "Priority",
       "relevance": "Best match"
@@ -4327,7 +4330,7 @@
       "update_failed": "Could not update this task"
     },
     "task_first": "Task first",
-    "task_results": "{count} tasks",
+    "task_results": "{count, plural, one {# task} other {# tasks}}",
     "tasks": "Tasks",
     "title": "Command Center",
     "try_searching": "Try searching for tasks, pages, or actions",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4300,6 +4300,7 @@
     "result_count": "{count} kết quả",
     "result_count_plural": "{count} kết quả",
     "search_placeholder": "Tìm lệnh, nhiệm vụ, hoặc điều hướng...",
+    "search_placeholder_navigation": "Tìm trang, ứng dụng và thao tác — dùng /, @ hoặc >",
     "search_placeholder_power": "Tìm nhiệm vụ, trang và thao tác — dùng #, / hoặc >",
     "search_placeholder_tasks": "Tìm nhiệm vụ, ứng dụng và thao tác — dùng #, @ hoặc >",
     "searching_tasks": "Đang tìm nhiệm vụ...",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4220,11 +4220,36 @@
     "clear_recent_title": "Xóa Mục Gần Đây",
     "commands": "Lệnh",
     "continue": "Tiếp tục",
+    "create_from_query": "Tạo “{query}”",
     "create_in_product": "Tạo trong {product}",
     "create_in_product_description": "Bắt đầu một quy trình {product} mới từ bảng lệnh.",
     "create_task": "Tạo nhiệm vụ \"{taskName}\"",
     "create_task_tip": "Mẹo: Nhấn ⌘↵ để nhanh chóng tạo nhiệm vụ",
     "current_theme": "Hiện tại",
+    "description": "Tìm kiếm, thao tác và di chuyển mà không ngắt mạch công việc.",
+    "empty": {
+      "description": "Nhập từ khóa, chọn một tab hoặc dùng tiền tố tìm kiếm nhanh.",
+      "no_matches": "Không có kết quả cho “{query}”. Hãy điều chỉnh bộ lọc hoặc tạo thành công việc.",
+      "title": "Chưa tìm thấy kết quả"
+    },
+    "filters": {
+      "label": "Lọc",
+      "priority": {
+        "all": "Mọi ưu tiên",
+        "critical": "Khẩn cấp",
+        "high": "Cao",
+        "low": "Thấp",
+        "normal": "Bình thường"
+      },
+      "status": {
+        "all": "Mọi trạng thái",
+        "assigned": "Giao cho tôi",
+        "completed": "Đã hoàn thành",
+        "due-soon": "Sắp đến hạn",
+        "open": "Đang mở",
+        "overdue": "Quá hạn"
+      }
+    },
     "generic_action_name_label": "Tên",
     "generic_action_name_placeholder": "Đặt tên cho mục {product} này",
     "generic_action_notes_label": "Ghi chú",
@@ -4233,8 +4258,10 @@
     "inline_action_description": "Thêm nhanh thông tin tại đây, rồi tiếp tục trong {product} để hoàn tất các trường riêng của sản phẩm.",
     "keyboard_hints": {
       "clear_recent": "xóa gần đây",
+      "create": "tạo công việc",
       "esc_to_close": "Nhấn Esc để đóng",
       "navigate": "điều hướng",
+      "open": "mở",
       "select": "chọn",
       "to_close": "để đóng",
       "to_toggle": "để chuyển đổi"
@@ -4253,6 +4280,11 @@
     "open_item_description": "Điều hướng đến {item}.",
     "overdue": "Quá hạn",
     "personal": "Cá Nhân",
+    "power_hints": {
+      "actions": "thao tác",
+      "pages": "trang",
+      "tasks": "công việc"
+    },
     "powered_by": "Được hỗ trợ bởi tìm kiếm ngữ nghĩa",
     "priority": {
       "critical": "Khẩn Cấp",
@@ -4266,8 +4298,36 @@
     "result_count": "{count} kết quả",
     "result_count_plural": "{count} kết quả",
     "search_placeholder": "Tìm lệnh, nhiệm vụ, hoặc điều hướng...",
+    "search_placeholder_power": "Tìm công việc, trang và thao tác — dùng #, / hoặc >",
     "searching_tasks": "Đang tìm nhiệm vụ...",
     "smart_actions": "Hành Động Thông Minh",
+    "sort": {
+      "due": "Hạn chót",
+      "newest": "Mới nhất",
+      "priority": "Ưu tiên",
+      "relevance": "Phù hợp nhất"
+    },
+    "tabs": {
+      "actions": "Thao tác",
+      "all": "Tất cả",
+      "apps": "Ứng dụng",
+      "label": "Danh mục tìm kiếm",
+      "navigate": "Trang",
+      "tasks": "Công việc"
+    },
+    "task_actions": {
+      "completed": "Đã hoàn thành công việc",
+      "copy_link": "Sao chép liên kết công việc",
+      "due": "Đến hạn {date}",
+      "link_copied": "Đã sao chép liên kết công việc",
+      "link_copy_failed": "Không thể sao chép liên kết công việc",
+      "mark_complete": "Hoàn thành công việc",
+      "mark_open": "Mở lại công việc",
+      "reopened": "Đã mở lại công việc",
+      "update_failed": "Không thể cập nhật công việc này"
+    },
+    "task_first": "Ưu tiên công việc",
+    "task_results": "{count} công việc",
     "tasks": "Nhiệm Vụ",
     "title": "Trung Tâm Lệnh",
     "try_searching": "Thử tìm kiếm nhiệm vụ, trang, hoặc hành động",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4301,6 +4301,7 @@
     "result_count_plural": "{count} kết quả",
     "search_placeholder": "Tìm lệnh, nhiệm vụ, hoặc điều hướng...",
     "search_placeholder_power": "Tìm nhiệm vụ, trang và thao tác — dùng #, / hoặc >",
+    "search_placeholder_tasks": "Tìm nhiệm vụ, ứng dụng và thao tác — dùng #, @ hoặc >",
     "searching_tasks": "Đang tìm nhiệm vụ...",
     "smart_actions": "Hành Động Thông Minh",
     "sort": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -4229,7 +4229,7 @@
     "description": "Tìm kiếm, thao tác và di chuyển mà không ngắt mạch công việc.",
     "empty": {
       "description": "Nhập từ khóa, chọn một tab hoặc dùng tiền tố tìm kiếm nhanh.",
-      "no_matches": "Không có kết quả cho “{query}”. Hãy điều chỉnh bộ lọc hoặc tạo thành công việc.",
+      "no_matches": "Không có kết quả cho “{query}”. Hãy điều chỉnh bộ lọc hoặc tạo thành nhiệm vụ.",
       "title": "Chưa tìm thấy kết quả"
     },
     "filters": {
@@ -4241,6 +4241,7 @@
         "low": "Thấp",
         "normal": "Bình thường"
       },
+      "priority_label": "Lọc theo ưu tiên",
       "status": {
         "all": "Mọi trạng thái",
         "assigned": "Giao cho tôi",
@@ -4248,7 +4249,8 @@
         "due-soon": "Sắp đến hạn",
         "open": "Đang mở",
         "overdue": "Quá hạn"
-      }
+      },
+      "status_label": "Lọc theo trạng thái"
     },
     "generic_action_name_label": "Tên",
     "generic_action_name_placeholder": "Đặt tên cho mục {product} này",
@@ -4258,7 +4260,7 @@
     "inline_action_description": "Thêm nhanh thông tin tại đây, rồi tiếp tục trong {product} để hoàn tất các trường riêng của sản phẩm.",
     "keyboard_hints": {
       "clear_recent": "xóa gần đây",
-      "create": "tạo công việc",
+      "create": "tạo nhiệm vụ",
       "esc_to_close": "Nhấn Esc để đóng",
       "navigate": "điều hướng",
       "open": "mở",
@@ -4283,7 +4285,7 @@
     "power_hints": {
       "actions": "thao tác",
       "pages": "trang",
-      "tasks": "công việc"
+      "tasks": "nhiệm vụ"
     },
     "powered_by": "Được hỗ trợ bởi tìm kiếm ngữ nghĩa",
     "priority": {
@@ -4298,11 +4300,12 @@
     "result_count": "{count} kết quả",
     "result_count_plural": "{count} kết quả",
     "search_placeholder": "Tìm lệnh, nhiệm vụ, hoặc điều hướng...",
-    "search_placeholder_power": "Tìm công việc, trang và thao tác — dùng #, / hoặc >",
+    "search_placeholder_power": "Tìm nhiệm vụ, trang và thao tác — dùng #, / hoặc >",
     "searching_tasks": "Đang tìm nhiệm vụ...",
     "smart_actions": "Hành Động Thông Minh",
     "sort": {
       "due": "Hạn chót",
+      "label": "Sắp xếp nhiệm vụ",
       "newest": "Mới nhất",
       "priority": "Ưu tiên",
       "relevance": "Phù hợp nhất"
@@ -4313,21 +4316,21 @@
       "apps": "Ứng dụng",
       "label": "Danh mục tìm kiếm",
       "navigate": "Trang",
-      "tasks": "Công việc"
+      "tasks": "Nhiệm vụ"
     },
     "task_actions": {
-      "completed": "Đã hoàn thành công việc",
-      "copy_link": "Sao chép liên kết công việc",
+      "completed": "Đã hoàn thành nhiệm vụ",
+      "copy_link": "Sao chép liên kết nhiệm vụ",
       "due": "Đến hạn {date}",
-      "link_copied": "Đã sao chép liên kết công việc",
-      "link_copy_failed": "Không thể sao chép liên kết công việc",
-      "mark_complete": "Hoàn thành công việc",
-      "mark_open": "Mở lại công việc",
-      "reopened": "Đã mở lại công việc",
-      "update_failed": "Không thể cập nhật công việc này"
+      "link_copied": "Đã sao chép liên kết nhiệm vụ",
+      "link_copy_failed": "Không thể sao chép liên kết nhiệm vụ",
+      "mark_complete": "Hoàn thành nhiệm vụ",
+      "mark_open": "Mở lại nhiệm vụ",
+      "reopened": "Đã mở lại nhiệm vụ",
+      "update_failed": "Không thể cập nhật nhiệm vụ này"
     },
-    "task_first": "Ưu tiên công việc",
-    "task_results": "{count} công việc",
+    "task_first": "Ưu tiên nhiệm vụ",
+    "task_results": "{count} nhiệm vụ",
     "tasks": "Nhiệm Vụ",
     "title": "Trung Tâm Lệnh",
     "try_searching": "Thử tìm kiếm nhiệm vụ, trang, hoặc hành động",

--- a/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
+++ b/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
@@ -26,6 +26,7 @@ export function UserNavCommandLauncher({
   wsId,
 }: UserNavCommandLauncherProps) {
   const t = useTranslations('command_palette');
+  const launcherT = useTranslations('command_launcher');
   const commandNavItems = useMemo<CommandLauncherNavItem[]>(
     () =>
       flattenNavigation(navLinks).map((item) => ({
@@ -70,13 +71,25 @@ export function UserNavCommandLauncher({
         all: t('tabs.all'),
         apps: t('tabs.apps'),
         categories: t('tabs.label'),
+        current: launcherT('current'),
         empty: t('no_results'),
         emptyDescription: t('try_searching'),
+        errorWorkspaces: launcherT('error_workspaces'),
+        guest: launcherT('guest'),
         loadingWorkspaces: t('loading_workspaces'),
+        match: launcherT('match'),
+        navigate: launcherT('navigate'),
         navigation: t('tabs.navigate'),
+        open: launcherT('open'),
+        openApp: launcherT('open_app'),
+        openWorkspace: launcherT('open_workspace'),
+        personal: launcherT('personal'),
         placeholder: t('search_placeholder_power'),
+        searchHint: launcherT('search_hint'),
+        select: launcherT('select'),
         tasks: t('tabs.tasks'),
         title: t('title'),
+        workspaces: launcherT('workspaces'),
       }}
       navItems={commandNavItems}
       workspacePathResolver={resolvePlatformWorkspacePath}

--- a/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
+++ b/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
@@ -84,7 +84,9 @@ export function UserNavCommandLauncher({
         openApp: launcherT('open_app'),
         openWorkspace: launcherT('open_workspace'),
         personal: launcherT('personal'),
-        placeholder: t('search_placeholder_power'),
+        placeholder: commandNavItems.length
+          ? t('search_placeholder_power')
+          : t('search_placeholder_tasks'),
         searchHint: launcherT('search_hint'),
         select: launcherT('select'),
         tasks: t('tabs.tasks'),

--- a/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
+++ b/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
@@ -53,6 +53,7 @@ export function UserNavCommandLauncher({
       currentApp="platform"
       currentWorkspaceId={wsId}
       defaultTab={wsId ? 'tasks' : 'all'}
+      enableTasks={Boolean(wsId)}
       extraSections={({ activeTab, onClose, query, setQuery }) => (
         <PlatformCommandExtraSections
           activeTab={activeTab}

--- a/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
+++ b/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tuturuuu/satellite/command-launcher';
 import type { Workspace } from '@tuturuuu/types';
 import { toWorkspaceSlug } from '@tuturuuu/utils/constants';
+import { useTranslations } from 'next-intl';
 import { useCallback, useMemo } from 'react';
 import { PlatformCommandExtraSections } from '@/components/command/platform-extra-sections';
 import { flattenNavigation } from '@/components/command/utils/use-navigation-data';
@@ -24,6 +25,7 @@ export function UserNavCommandLauncher({
   workspace,
   wsId,
 }: UserNavCommandLauncherProps) {
+  const t = useTranslations('command_palette');
   const commandNavItems = useMemo<CommandLauncherNavItem[]>(
     () =>
       flattenNavigation(navLinks).map((item) => ({
@@ -50,8 +52,10 @@ export function UserNavCommandLauncher({
     <GlobalCommandLauncher
       currentApp="platform"
       currentWorkspaceId={wsId}
-      extraSections={({ onClose, query, setQuery }) => (
+      defaultTab={wsId ? 'tasks' : 'all'}
+      extraSections={({ activeTab, onClose, query, setQuery }) => (
         <PlatformCommandExtraSections
+          activeTab={activeTab}
           navLinks={navLinks}
           onApplySearch={setQuery}
           onClose={onClose}
@@ -60,6 +64,19 @@ export function UserNavCommandLauncher({
           workspaceName={workspace?.name}
         />
       )}
+      labels={{
+        actions: t('tabs.actions'),
+        all: t('tabs.all'),
+        apps: t('tabs.apps'),
+        categories: t('tabs.label'),
+        empty: t('no_results'),
+        emptyDescription: t('try_searching'),
+        loadingWorkspaces: t('loading_workspaces'),
+        navigation: t('tabs.navigate'),
+        placeholder: t('search_placeholder_power'),
+        tasks: t('tabs.tasks'),
+        title: t('title'),
+      }}
       navItems={commandNavItems}
       workspacePathResolver={resolvePlatformWorkspacePath}
     />

--- a/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
+++ b/apps/web/src/app/[locale]/user-nav-command-launcher.tsx
@@ -15,7 +15,7 @@ import type { NavLink } from '@/components/navigation';
 interface UserNavCommandLauncherProps {
   locale?: string;
   navLinks: (NavLink | null)[];
-  workspace?: Workspace | null;
+  workspace?: (Workspace & { joined?: boolean }) | null;
   wsId?: string;
 }
 
@@ -27,6 +27,7 @@ export function UserNavCommandLauncher({
 }: UserNavCommandLauncherProps) {
   const t = useTranslations('command_palette');
   const launcherT = useTranslations('command_launcher');
+  const canUseWorkspaceTasks = Boolean(wsId && workspace?.joined !== false);
   const commandNavItems = useMemo<CommandLauncherNavItem[]>(
     () =>
       flattenNavigation(navLinks).map((item) => ({
@@ -53,8 +54,8 @@ export function UserNavCommandLauncher({
     <GlobalCommandLauncher
       currentApp="platform"
       currentWorkspaceId={wsId}
-      defaultTab={wsId ? 'tasks' : 'all'}
-      enableTasks={Boolean(wsId)}
+      defaultTab={canUseWorkspaceTasks ? 'tasks' : 'all'}
+      enableTasks={canUseWorkspaceTasks}
       extraSections={({ activeTab, onClose, query, setQuery }) => (
         <PlatformCommandExtraSections
           activeTab={activeTab}
@@ -62,7 +63,7 @@ export function UserNavCommandLauncher({
           onApplySearch={setQuery}
           onClose={onClose}
           query={query}
-          workspaceId={wsId}
+          workspaceId={canUseWorkspaceTasks ? wsId : undefined}
           workspaceName={workspace?.name}
         />
       )}
@@ -84,9 +85,11 @@ export function UserNavCommandLauncher({
         openApp: launcherT('open_app'),
         openWorkspace: launcherT('open_workspace'),
         personal: launcherT('personal'),
-        placeholder: commandNavItems.length
-          ? t('search_placeholder_power')
-          : t('search_placeholder_tasks'),
+        placeholder: canUseWorkspaceTasks
+          ? commandNavItems.length
+            ? t('search_placeholder_power')
+            : t('search_placeholder_tasks')
+          : t('search_placeholder_navigation'),
         searchHint: launcherT('search_hint'),
         select: launcherT('select'),
         tasks: t('tabs.tasks'),

--- a/apps/web/src/components/command/command-center-chrome.tsx
+++ b/apps/web/src/components/command/command-center-chrome.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { CornerDownLeft, ListTodo, Plus, Sparkles } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { useTranslations } from 'next-intl';
+import type { ReactNode } from 'react';
+
+export function CommandCenterHeader({
+  modKey,
+  workspaceName,
+}: {
+  modKey: string;
+  workspaceName?: string;
+}) {
+  const t = useTranslations('command_palette');
+  return (
+    <div className="flex items-center justify-between gap-4 border-b bg-muted/15 px-4 py-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-xl border bg-background shadow-xs">
+          <ListTodo className="size-4.5 text-primary" />
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="truncate font-semibold text-sm">{t('title')}</h2>
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 font-medium text-[10px] text-primary uppercase tracking-wide">
+              {t('task_first')}
+            </span>
+          </div>
+          <p className="truncate text-muted-foreground text-xs">
+            {workspaceName ?? t('description')}
+          </p>
+        </div>
+      </div>
+      <kbd className="hidden h-6 shrink-0 items-center gap-1 rounded-md border bg-background px-2 font-mono text-[10px] text-muted-foreground shadow-xs sm:inline-flex">
+        {modKey} K
+      </kbd>
+    </div>
+  );
+}
+
+export function CommandCenterEmpty({
+  canCreateTask,
+  onCreateTask,
+  query,
+}: {
+  canCreateTask: boolean;
+  onCreateTask: () => void;
+  query: string;
+}) {
+  const t = useTranslations('command_palette');
+  const trimmedQuery = query.trim();
+  return (
+    <div className="flex flex-col items-center gap-4 px-6 py-14 text-center">
+      <div className="flex size-12 items-center justify-center rounded-2xl border bg-muted/40 shadow-xs">
+        <Sparkles className="size-5 text-muted-foreground" />
+      </div>
+      <div className="max-w-sm space-y-1">
+        <p className="font-medium">{t('empty.title')}</p>
+        <p className="text-muted-foreground text-sm">
+          {trimmedQuery
+            ? t('empty.no_matches', { query: trimmedQuery })
+            : t('empty.description')}
+        </p>
+      </div>
+      {canCreateTask && trimmedQuery ? (
+        <Button type="button" size="sm" onClick={onCreateTask}>
+          <Plus className="size-4" />
+          {t('create_from_query', { query: trimmedQuery.slice(0, 36) })}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export function CommandCenterFooter({ modKey }: { modKey: string }) {
+  const t = useTranslations('command_palette');
+  return (
+    <div className="flex min-h-10 items-center justify-between gap-3 overflow-x-auto border-t bg-muted/20 px-4 py-2 text-muted-foreground text-xs">
+      <div className="flex shrink-0 items-center gap-3">
+        <Hint keys="↑↓" label={t('keyboard_hints.navigate')} />
+        <Hint
+          icon={<CornerDownLeft className="size-3" />}
+          label={t('keyboard_hints.open')}
+        />
+        <Hint keys={`${modKey}↵`} label={t('keyboard_hints.create')} />
+      </div>
+      <div className="hidden shrink-0 items-center gap-2 md:flex">
+        <Prefix prefix="#" label={t('power_hints.tasks')} />
+        <Prefix prefix="/" label={t('power_hints.pages')} />
+        <Prefix prefix=">" label={t('power_hints.actions')} />
+      </div>
+    </div>
+  );
+}
+
+function Hint({
+  icon,
+  keys,
+  label,
+}: {
+  icon?: ReactNode;
+  keys?: string;
+  label: string;
+}) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <kbd className="flex min-h-5 min-w-5 items-center justify-center rounded border bg-background px-1 font-mono text-[10px]">
+        {icon ?? keys}
+      </kbd>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function Prefix({ prefix, label }: { prefix: string; label: string }) {
+  return (
+    <span>
+      <kbd className="mr-1 rounded border bg-background px-1 font-mono text-[10px]">
+        {prefix}
+      </kbd>
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/components/command/command-palette.css
+++ b/apps/web/src/components/command/command-palette.css
@@ -1,95 +1,15 @@
-/* Enhanced Command Palette Animations */
 .command-palette-enter {
-  animation: commandPaletteSlideIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  animation: command-palette-enter 180ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.command-palette-exit {
-  animation: commandPaletteSlideOut 0.2s cubic-bezier(0.4, 0, 1, 1);
+.command-center-surface {
+  animation: command-center-content-enter 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-@keyframes commandPaletteSlideIn {
+@keyframes command-palette-enter {
   from {
     opacity: 0;
-    transform: scale(0.94) translateY(-20px);
-    filter: blur(4px);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-    filter: blur(0);
-  }
-}
-
-@keyframes commandPaletteSlideOut {
-  from {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-    filter: blur(0);
-  }
-  to {
-    opacity: 0;
-    transform: scale(0.94) translateY(-20px);
-    filter: blur(4px);
-  }
-}
-
-/* Enhanced Page transition animations */
-.command-page-enter {
-  animation: pageSlideIn 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.command-page-exit {
-  animation: pageSlideOut 0.2s cubic-bezier(0.4, 0, 1, 1);
-}
-
-@keyframes pageSlideIn {
-  from {
-    opacity: 0;
-    transform: translateX(15px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0) scale(1);
-  }
-}
-
-@keyframes pageSlideOut {
-  from {
-    opacity: 1;
-    transform: translateX(0) scale(1);
-  }
-  to {
-    opacity: 0;
-    transform: translateX(-15px) scale(0.98);
-  }
-}
-
-/* Enhanced Loading state animations */
-.command-loading-pulse {
-  animation: enhancedPulse 2s ease-in-out infinite;
-}
-
-@keyframes enhancedPulse {
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.6;
-    transform: scale(1.02);
-  }
-}
-
-/* Smooth message entry animations */
-.message-enter {
-  animation: messageSlideIn 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-@keyframes messageSlideIn {
-  from {
-    opacity: 0;
-    transform: translateY(20px) scale(0.95);
+    transform: translateY(-8px) scale(0.985);
   }
   to {
     opacity: 1;
@@ -97,132 +17,18 @@
   }
 }
 
-/* Suggestion card hover effects */
-.suggestion-card {
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.suggestion-card:hover {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow:
-    0 8px 25px -5px rgba(0, 0, 0, 0.1),
-    0 8px 10px -6px rgba(0, 0, 0, 0.1);
-}
-
-.suggestion-card:active {
-  transform: translateY(0) scale(0.98);
-}
-
-/* Typing indicator animation */
-.typing-indicator {
-  animation: typingBounce 1.4s infinite ease-in-out;
-}
-
-.typing-indicator:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.typing-indicator:nth-child(3) {
-  animation-delay: 0.4s;
-}
-
-@keyframes typingBounce {
-  0%,
-  60%,
-  100% {
-    transform: translateY(0);
-    opacity: 0.4;
+@keyframes command-center-content-enter {
+  from {
+    opacity: 0;
   }
-  30% {
-    transform: translateY(-8px);
+  to {
     opacity: 1;
   }
 }
 
-/* Enhanced glow effects */
-.glow-primary {
-  box-shadow: 0 0 20px rgba(var(--primary), 0.3);
-  animation: glowPulse 2s ease-in-out infinite alternate;
-}
-
-@keyframes glowPulse {
-  from {
-    box-shadow: 0 0 20px rgba(var(--primary), 0.2);
-  }
-  to {
-    box-shadow: 0 0 30px rgba(var(--primary), 0.4);
-  }
-}
-
-/* Smooth scroll behavior */
-.command-messages {
-  scroll-behavior: smooth;
-}
-
-/* Focus states */
-.focus-visible {
-  outline: 2px solid rgba(var(--primary), 0.5);
-  outline-offset: 2px;
-}
-
-/* Loading shimmer effect */
-.shimmer {
-  background: linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 0.2) 20%,
-    rgba(255, 255, 255, 0.5) 60%,
-    rgba(255, 255, 255, 0)
-  );
-  animation: shimmer 2s infinite;
-}
-
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
-}
-
-/* Enhanced backdrop blur */
-.backdrop-enhanced {
-  backdrop-filter: blur(20px) saturate(180%);
-  background: rgba(255, 255, 255, 0.8);
-}
-
-@media (prefers-color-scheme: dark) {
-  .backdrop-enhanced {
-    background: rgba(0, 0, 0, 0.8);
-  }
-}
-
-/* Responsive improvements */
-@media (max-width: 640px) {
-  .command-palette-enter {
-    animation: commandPaletteMobileSlideIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  }
-
-  @keyframes commandPaletteMobileSlideIn {
-    from {
-      opacity: 0;
-      transform: translateY(50px) scale(0.95);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-  }
-}
-
-/* Accessibility improvements */
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms;
-    animation-iteration-count: 1;
-    transition-duration: 0.01ms;
+  .command-palette-enter,
+  .command-center-surface {
+    animation: none;
   }
 }

--- a/apps/web/src/components/command/command-search-controls.tsx
+++ b/apps/web/src/components/command/command-search-controls.tsx
@@ -60,10 +60,9 @@ export function CommandSearchControls({
 
   return (
     <div className="border-b bg-muted/20">
-      <div
-        className="flex gap-1 overflow-x-auto px-3 pt-2"
-        role="tablist"
+      <fieldset
         aria-label={t('tabs.label')}
+        className="m-0 flex min-w-0 gap-1 overflow-x-auto border-0 px-3 pt-2"
       >
         {TABS.map(({ icon: Icon, key }, index) => {
           const selected = activeTab === key;
@@ -71,8 +70,7 @@ export function CommandSearchControls({
             <Button
               key={key}
               type="button"
-              role="tab"
-              aria-selected={selected}
+              aria-pressed={selected}
               variant="ghost"
               size="sm"
               onClick={() => onTabChange(key)}
@@ -95,7 +93,7 @@ export function CommandSearchControls({
             </Button>
           );
         })}
-      </div>
+      </fieldset>
 
       {showTaskControls ? (
         <div className="flex items-center gap-2 overflow-x-auto border-t px-3 py-2">
@@ -107,7 +105,10 @@ export function CommandSearchControls({
             value={status}
             onValueChange={(value) => onStatusChange(value as TaskStatusFilter)}
           >
-            <SelectTrigger className="h-8 w-auto min-w-32 border-border/70 bg-background/80 px-2.5 text-xs shadow-none">
+            <SelectTrigger
+              aria-label={t('filters.status_label')}
+              className="h-8 w-auto min-w-32 border-border/70 bg-background/80 px-2.5 text-xs shadow-none"
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -133,7 +134,10 @@ export function CommandSearchControls({
               onPriorityChange(value as TaskPriorityFilter)
             }
           >
-            <SelectTrigger className="h-8 w-auto min-w-28 border-border/70 bg-background/80 px-2.5 text-xs shadow-none">
+            <SelectTrigger
+              aria-label={t('filters.priority_label')}
+              className="h-8 w-auto min-w-28 border-border/70 bg-background/80 px-2.5 text-xs shadow-none"
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -152,7 +156,10 @@ export function CommandSearchControls({
               value={sort}
               onValueChange={(value) => onSortChange(value as TaskSort)}
             >
-              <SelectTrigger className="h-8 w-auto min-w-28 border-border/70 bg-background/80 px-2.5 text-xs shadow-none">
+              <SelectTrigger
+                aria-label={t('sort.label')}
+                className="h-8 w-auto min-w-28 border-border/70 bg-background/80 px-2.5 text-xs shadow-none"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent align="end">

--- a/apps/web/src/components/command/command-search-controls.tsx
+++ b/apps/web/src/components/command/command-search-controls.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import {
+  ArrowUpDown,
+  Compass,
+  ListTodo,
+  Search,
+  SlidersHorizontal,
+  Sparkles,
+} from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@tuturuuu/ui/select';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import type {
+  CommandTab,
+  TaskPriorityFilter,
+  TaskSort,
+  TaskStatusFilter,
+} from './utils/command-task-results';
+
+interface CommandSearchControlsProps {
+  activeTab: CommandTab;
+  priority: TaskPriorityFilter;
+  sort: TaskSort;
+  status: TaskStatusFilter;
+  taskCount: number;
+  onPriorityChange: (priority: TaskPriorityFilter) => void;
+  onSortChange: (sort: TaskSort) => void;
+  onStatusChange: (status: TaskStatusFilter) => void;
+  onTabChange: (tab: CommandTab) => void;
+}
+
+const TABS = [
+  { icon: ListTodo, key: 'tasks' },
+  { icon: Search, key: 'all' },
+  { icon: Compass, key: 'navigate' },
+  { icon: Sparkles, key: 'actions' },
+] as const;
+
+export function CommandSearchControls({
+  activeTab,
+  priority,
+  sort,
+  status,
+  taskCount,
+  onPriorityChange,
+  onSortChange,
+  onStatusChange,
+  onTabChange,
+}: CommandSearchControlsProps) {
+  const t = useTranslations('command_palette');
+  const showTaskControls = activeTab === 'tasks' || activeTab === 'all';
+
+  return (
+    <div className="border-b bg-muted/20">
+      <div
+        className="flex gap-1 overflow-x-auto px-3 pt-2"
+        role="tablist"
+        aria-label={t('tabs.label')}
+      >
+        {TABS.map(({ icon: Icon, key }, index) => {
+          const selected = activeTab === key;
+          return (
+            <Button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              variant="ghost"
+              size="sm"
+              onClick={() => onTabChange(key)}
+              className={cn(
+                'relative h-9 shrink-0 gap-2 rounded-b-none border-transparent px-3 text-muted-foreground',
+                selected &&
+                  'border-border border-b-background bg-background text-foreground shadow-xs'
+              )}
+            >
+              <Icon className="size-4" />
+              {t(`tabs.${key}`)}
+              {key === 'tasks' && taskCount > 0 ? (
+                <span className="rounded-full bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] text-primary">
+                  {taskCount}
+                </span>
+              ) : null}
+              <span className="hidden font-mono text-[10px] opacity-50 sm:inline">
+                {index + 1}
+              </span>
+            </Button>
+          );
+        })}
+      </div>
+
+      {showTaskControls ? (
+        <div className="flex items-center gap-2 overflow-x-auto border-t px-3 py-2">
+          <div className="flex shrink-0 items-center gap-1.5 text-muted-foreground text-xs">
+            <SlidersHorizontal className="size-3.5" />
+            <span>{t('filters.label')}</span>
+          </div>
+          <Select
+            value={status}
+            onValueChange={(value) => onStatusChange(value as TaskStatusFilter)}
+          >
+            <SelectTrigger className="h-8 w-auto min-w-32 border-border/70 bg-background/80 px-2.5 text-xs shadow-none">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(
+                [
+                  'all',
+                  'open',
+                  'assigned',
+                  'overdue',
+                  'due-soon',
+                  'completed',
+                ] as const
+              ).map((value) => (
+                <SelectItem key={value} value={value}>
+                  {t(`filters.status.${value}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={priority}
+            onValueChange={(value) =>
+              onPriorityChange(value as TaskPriorityFilter)
+            }
+          >
+            <SelectTrigger className="h-8 w-auto min-w-28 border-border/70 bg-background/80 px-2.5 text-xs shadow-none">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(['all', 'critical', 'high', 'normal', 'low'] as const).map(
+                (value) => (
+                  <SelectItem key={value} value={value}>
+                    {t(`filters.priority.${value}`)}
+                  </SelectItem>
+                )
+              )}
+            </SelectContent>
+          </Select>
+          <div className="ml-auto flex shrink-0 items-center gap-1.5 text-muted-foreground text-xs">
+            <ArrowUpDown className="size-3.5" />
+            <Select
+              value={sort}
+              onValueChange={(value) => onSortChange(value as TaskSort)}
+            >
+              <SelectTrigger className="h-8 w-auto min-w-28 border-border/70 bg-background/80 px-2.5 text-xs shadow-none">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="end">
+                {(['relevance', 'due', 'priority', 'newest'] as const).map(
+                  (value) => (
+                    <SelectItem key={value} value={value}>
+                      {t(`sort.${value}`)}
+                    </SelectItem>
+                  )
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/command/index.tsx
+++ b/apps/web/src/components/command/index.tsx
@@ -3,6 +3,7 @@
 import { CommandDialog } from '@tuturuuu/ui/command';
 import { resolveWorkspaceId } from '@tuturuuu/utils/constants';
 import { useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import * as React from 'react';
 import type { NavLink } from '@/components/navigation';
 import './command-palette.css';
@@ -23,6 +24,7 @@ type LegacyProps = {
 };
 
 export function CommandPalette(props: CommandPaletteProps & LegacyProps) {
+  const t = useTranslations('command_palette');
   const { open } = props;
   const setOpenAction = React.useCallback<
     React.Dispatch<React.SetStateAction<boolean>>
@@ -46,20 +48,13 @@ export function CommandPalette(props: CommandPaletteProps & LegacyProps) {
     return null;
   }, [wsId]);
 
-  // Keyboard shortcut: CMD/CTRL+K to toggle
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-        // Check if user is typing in an input field
-        const activeElement = document.activeElement;
-        if (
-          activeElement instanceof HTMLInputElement ||
-          activeElement instanceof HTMLTextAreaElement ||
-          activeElement?.getAttribute('contenteditable') === 'true'
-        ) {
-          return;
-        }
-
+      if (
+        !e.repeat &&
+        e.key.toLowerCase() === 'k' &&
+        (e.metaKey || e.ctrlKey)
+      ) {
         e.preventDefault();
         e.stopPropagation();
         setOpenAction((currentOpen: boolean) => !currentOpen);
@@ -76,8 +71,11 @@ export function CommandPalette(props: CommandPaletteProps & LegacyProps) {
       open={open}
       onOpenChange={setOpenAction}
       showCloseButton={false}
-      contentClassName="sm:max-w-4xl w-[min(96vw,1024px)] backdrop-blur-sm"
-      aria-label="Command Center"
+      title={t('title')}
+      description={t('description')}
+      commandProps={{ loop: true, shouldFilter: false }}
+      contentClassName="command-palette-enter w-[min(96vw,1120px)] border-border/70 bg-background/95 shadow-2xl backdrop-blur-xl sm:max-w-5xl"
+      aria-label={t('title')}
     >
       <CommandMode
         wsId={workspaceId}

--- a/apps/web/src/components/command/index.tsx
+++ b/apps/web/src/components/command/index.tsx
@@ -75,7 +75,6 @@ export function CommandPalette(props: CommandPaletteProps & LegacyProps) {
       description={t('description')}
       commandProps={{ loop: true, shouldFilter: false }}
       contentClassName="command-palette-enter w-[min(96vw,1120px)] border-border/70 bg-background/95 shadow-2xl backdrop-blur-xl sm:max-w-5xl"
-      aria-label={t('title')}
     >
       <CommandMode
         wsId={workspaceId}

--- a/apps/web/src/components/command/modes/command-mode.tsx
+++ b/apps/web/src/components/command/modes/command-mode.tsx
@@ -1,156 +1,132 @@
 'use client';
 
-import { Plus, Sparkles } from '@tuturuuu/icons';
-import { Button } from '@tuturuuu/ui/button';
-import {
-  Command,
-  CommandEmpty,
-  CommandInput,
-  CommandList,
-} from '@tuturuuu/ui/command';
+import { CommandEmpty, CommandInput, CommandList } from '@tuturuuu/ui/command';
 import { usePlatform } from '@tuturuuu/utils/hooks/use-platform';
+import { useTranslations } from 'next-intl';
 import * as React from 'react';
 import type { NavLink } from '@/components/navigation';
 import { CommandActionPanel } from '../action-panel';
 import { AddTaskForm } from '../add-task-form';
+import {
+  CommandCenterEmpty,
+  CommandCenterFooter,
+  CommandCenterHeader,
+} from '../command-center-chrome';
+import { CommandSearchControls } from '../command-search-controls';
 import { NavigationSection } from '../sections/navigation-section';
 import { ProductActionsSection } from '../sections/product-actions-section';
 import { QuickActionsSection } from '../sections/quick-actions-section';
 import { RecentSection } from '../sections/recent-section';
 import { TaskSection } from '../sections/task-section';
 import { WorkspaceSection } from '../sections/workspace-section';
+import type { CommandAction } from '../utils/command-actions';
 import {
-  buildCommandActions,
-  type CommandAction,
-} from '../utils/command-actions';
+  type CommandTab,
+  filterAndSortTasks,
+  parseCommandQuery,
+  type TaskPriorityFilter,
+  type TaskSort,
+  type TaskStatusFilter,
+} from '../utils/command-task-results';
 import { addRecentSearch, clearAllRecent } from '../utils/recent-items';
+import { useCommandTaskUpdate } from '../utils/use-command-task-update';
 import { useNavigationData } from '../utils/use-navigation-data';
 import { useTaskSearch } from '../utils/use-task-search';
 import { useWorkspaceSearch } from '../utils/use-workspace-search';
 
 interface CommandModeProps {
-  wsId: string | null;
   navLinks: (NavLink | null)[];
   onClose: () => void;
+  wsId: string | null;
 }
 
 export function CommandMode({ wsId, navLinks, onClose }: CommandModeProps) {
+  const t = useTranslations('command_palette');
+  const { modKey } = usePlatform();
   const [query, setQuery] = React.useState('');
-  const [showTaskForm, setShowTaskForm] = React.useState(false);
-  const [defaultTaskName, setDefaultTaskName] = React.useState('');
+  const [activeTab, setActiveTab] = React.useState<CommandTab>(
+    wsId ? 'tasks' : 'all'
+  );
+  const [status, setStatus] = React.useState<TaskStatusFilter>('all');
+  const [priority, setPriority] = React.useState<TaskPriorityFilter>('all');
+  const [sort, setSort] = React.useState<TaskSort>('relevance');
+  const [taskDraft, setTaskDraft] = React.useState<string | null>(null);
   const [recentRefreshKey, setRecentRefreshKey] = React.useState(0);
   const [selectedAction, setSelectedAction] =
     React.useState<CommandAction | null>(null);
-  const { modKey } = usePlatform();
 
-  // Prepare navigation data
+  const parsed = React.useMemo(() => parseCommandQuery(query), [query]);
+  const routedTab = parsed.tab ?? activeTab;
+  const searchQuery = React.useDeferredValue(parsed.query);
   const flattenedNav = useNavigationData(navLinks);
-  const commandActions = React.useMemo(
-    () => buildCommandActions(flattenedNav),
-    [flattenedNav]
+  const showTasks = Boolean(
+    wsId && (routedTab === 'tasks' || routedTab === 'all')
   );
-
-  // Search tasks
   const { tasks, isLoading: isLoadingTasks } = useTaskSearch(
     wsId,
-    query,
-    true // enabled
+    searchQuery,
+    showTasks
   );
-
-  // Fetch workspaces
   const { workspaces, isLoading: isLoadingWorkspaces } = useWorkspaceSearch(
-    true // enabled
+    routedTab === 'all' || routedTab === 'navigate'
+  );
+  const currentWorkspace = workspaces.find(
+    (workspace) => workspace.id === wsId
+  );
+  const visibleTasks = React.useMemo(
+    () => filterAndSortTasks(tasks, { priority, sort, status }),
+    [priority, sort, status, tasks]
   );
 
-  // Get current workspace name for context
-  const currentWorkspace = React.useMemo(
-    () => workspaces.find((ws) => ws.id === wsId),
-    [workspaces, wsId]
-  );
+  const updateTask = useCommandTaskUpdate(wsId);
 
-  // Track search queries
-  const prevQueryRef = React.useRef('');
   React.useEffect(() => {
-    const trimmedQuery = query.trim();
-    if (trimmedQuery && trimmedQuery !== prevQueryRef.current) {
-      // Debounce adding to recent searches
-      const timer = setTimeout(() => {
-        addRecentSearch(trimmedQuery);
-        prevQueryRef.current = trimmedQuery;
-      }, 1000);
-      return () => clearTimeout(timer);
-    }
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    const timer = window.setTimeout(() => addRecentSearch(trimmed), 1000);
+    return () => window.clearTimeout(timer);
   }, [query]);
 
-  // Handle quick task creation
-  const handleCreateTask = React.useCallback(
-    (taskName: string) => {
-      if (!wsId) return;
-      setDefaultTaskName(taskName);
-      setShowTaskForm(true);
-    },
-    [wsId]
-  );
+  const openTaskForm = React.useCallback(() => {
+    if (wsId && parsed.query.trim()) setTaskDraft(parsed.query.trim());
+  }, [parsed.query, wsId]);
 
-  // Handle keyboard shortcuts at input level
-  const handleInputKeyDown = React.useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // Ctrl+X to clear recent items (no confirmation)
-      if (e.key === 'x' && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
-        e.preventDefault();
-        e.stopPropagation();
-        clearAllRecent();
-        setRecentRefreshKey((prev) => prev + 1);
-        return;
-      }
-      // Ctrl+Enter to quickly create task from query
-      if (
-        e.key === 'Enter' &&
-        (e.ctrlKey || e.metaKey) &&
-        query.trim() &&
-        wsId
-      ) {
-        e.preventDefault();
-        e.stopPropagation();
-        handleCreateTask(query.trim());
-        return;
-      }
-    },
-    [query, wsId, handleCreateTask]
-  );
-
-  // Reset to command mode when closing task form
-  const handleCloseTaskForm = () => {
-    setShowTaskForm(false);
-    setDefaultTaskName('');
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const usesMod = event.metaKey || event.ctrlKey;
+    if (usesMod && event.key === 'Enter' && parsed.query.trim() && wsId) {
+      event.preventDefault();
+      openTaskForm();
+      return;
+    }
+    if (usesMod && event.key.toLowerCase() === 'x') {
+      event.preventDefault();
+      clearAllRecent();
+      setRecentRefreshKey((value) => value + 1);
+      return;
+    }
+    if (usesMod && ['1', '2', '3', '4'].includes(event.key)) {
+      event.preventDefault();
+      const tab = (['tasks', 'all', 'navigate', 'actions'] as const)[
+        Number(event.key) - 1
+      ];
+      if (tab) setActiveTab(tab);
+    }
   };
 
-  const handleClosePalette = () => {
-    setSelectedAction(null);
-    onClose();
-  };
-
-  // Calculate result counts for display
-  const hasQuery = query.trim().length > 0;
-  const totalResults =
-    flattenedNav.length +
-    commandActions.length +
-    (tasks?.length || 0) +
-    (workspaces?.length || 0);
-
-  // Show task form if in task creation mode
-  if (showTaskForm && wsId) {
+  if (taskDraft && wsId) {
     return (
-      <div className="flex h-[70vh] min-h-125 flex-col">
+      <div className="flex h-[82dvh] max-h-185 min-h-120 flex-col">
         <div className="border-b px-4 py-3">
-          <h2 className="font-semibold text-lg">Create Task</h2>
+          <h2 className="font-semibold text-sm">
+            {t('create_task', { taskName: taskDraft })}
+          </h2>
         </div>
-        <div className="flex-1 overflow-auto">
+        <div className="min-h-0 flex-1 overflow-auto">
           <AddTaskForm
-            wsId={wsId}
-            setOpen={handleCloseTaskForm}
+            defaultTaskName={taskDraft}
             setIsLoading={() => {}}
-            defaultTaskName={defaultTaskName}
+            setOpen={() => setTaskDraft(null)}
+            wsId={wsId}
           />
         </div>
       </div>
@@ -161,167 +137,105 @@ export function CommandMode({ wsId, navLinks, onClose }: CommandModeProps) {
     return (
       <CommandActionPanel
         action={selectedAction}
-        wsId={wsId}
         onBack={() => setSelectedAction(null)}
-        onClose={handleClosePalette}
+        onClose={onClose}
+        wsId={wsId}
       />
     );
   }
 
+  const hasQuery = searchQuery.trim().length > 0;
+  const showNavigation = routedTab === 'all' || routedTab === 'navigate';
+  const showActions = routedTab === 'all' || routedTab === 'actions';
+
   return (
-    <div className="flex h-[70vh] min-h-125 flex-col">
-      {/* Header with result count */}
-      <div className="border-b px-4 py-3">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="font-semibold text-lg">Command Center</h2>
-            {hasQuery && (
-              <p className="text-muted-foreground text-sm">
-                {totalResults} result{totalResults !== 1 ? 's' : ''}
-              </p>
+    <div className="command-center-surface flex h-[82dvh] max-h-185 min-h-120 flex-col">
+      <CommandCenterHeader
+        modKey={modKey}
+        workspaceName={currentWorkspace?.name}
+      />
+      <CommandInput
+        autoFocus
+        className="h-14 border-none text-base"
+        onKeyDown={handleInputKeyDown}
+        onValueChange={setQuery}
+        placeholder={t('search_placeholder_power')}
+        value={query}
+      />
+      <CommandSearchControls
+        activeTab={routedTab}
+        onPriorityChange={setPriority}
+        onSortChange={setSort}
+        onStatusChange={setStatus}
+        onTabChange={setActiveTab}
+        priority={priority}
+        sort={sort}
+        status={status}
+        taskCount={visibleTasks.length}
+      />
+
+      <CommandList className="max-h-none min-h-0 flex-1 scroll-py-2 px-1 py-1">
+        <CommandEmpty>
+          <CommandCenterEmpty
+            canCreateTask={Boolean(
+              wsId && (routedTab === 'tasks' || routedTab === 'all')
             )}
-          </div>
-          <div className="flex items-center gap-2 text-muted-foreground text-xs">
-            <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-medium font-mono opacity-100">
-              <span className="text-xs">{modKey}</span>K
-            </kbd>
-            <span>to toggle</span>
-            <span className="text-muted-foreground/50">•</span>
-            <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-medium font-mono opacity-100">
-              <span className="text-xs">ESC</span>
-            </kbd>
-            <span>to close</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Command Interface */}
-      <Command className="flex-1 rounded-none border-none" shouldFilter={false}>
-        <CommandInput
-          placeholder="Search commands, tasks, or navigate..."
-          value={query}
-          onValueChange={setQuery}
-          onKeyDown={handleInputKeyDown}
-          className="border-none"
-        />
-
-        <CommandList className="max-h-none">
-          <CommandEmpty>
-            <div className="flex flex-col items-center gap-3 py-8 text-center">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-                <Sparkles className="h-6 w-6 text-muted-foreground" />
-              </div>
-              <div className="space-y-1">
-                <p className="font-medium">No results found</p>
-                <p className="text-muted-foreground text-sm">
-                  {hasQuery ? (
-                    <>
-                      No matches for "
-                      <span className="font-medium">{query}</span>"
-                    </>
-                  ) : (
-                    'Try searching for tasks, pages, or actions'
-                  )}
-                </p>
-              </div>
-              {hasQuery && wsId && (
-                <Button
-                  onClick={() => handleCreateTask(query.trim())}
-                  size="sm"
-                  className="gap-2"
-                >
-                  <Plus className="h-4 w-4" />
-                  Create task "{query.trim().slice(0, 30)}
-                  {query.trim().length > 30 ? '...' : ''}"
-                </Button>
-              )}
-              {hasQuery && (
-                <p className="text-muted-foreground text-xs">
-                  Tip: Press{' '}
-                  <kbd className="rounded border bg-muted px-1 font-mono text-[10px]">
-                    {modKey}↵
-                  </kbd>{' '}
-                  to quickly create a task
-                </p>
-              )}
-            </div>
-          </CommandEmpty>
-
-          {/* Recent Items (shown when no query) */}
-          {!hasQuery && (
-            <RecentSection
-              key={recentRefreshKey}
-              query={query}
-              onSelect={onClose}
-              onApplySearch={setQuery}
-            />
-          )}
-
-          {/* Quick Actions (shown when no query) */}
-          <QuickActionsSection query={query} onSelect={onClose} />
-
-          {/* Product Smart Actions */}
-          <ProductActionsSection
-            navItems={flattenedNav}
-            query={query}
-            onOpenAction={setSelectedAction}
-            onSelect={onClose}
+            onCreateTask={openTaskForm}
+            query={parsed.query}
           />
+        </CommandEmpty>
 
-          {/* Workspace Results */}
-          <WorkspaceSection
-            workspaces={workspaces}
-            isLoading={isLoadingWorkspaces}
-            query={query}
+        {!hasQuery && routedTab === 'all' ? (
+          <RecentSection
+            key={recentRefreshKey}
+            onApplySearch={setQuery}
             onSelect={onClose}
+            query={searchQuery}
           />
+        ) : null}
 
-          {/* Navigation Results */}
-          <NavigationSection
-            navItems={flattenedNav}
-            query={query}
-            onSelect={onClose}
-          />
-
-          {/* Task Results */}
+        {showTasks && wsId ? (
           <TaskSection
-            tasks={tasks}
+            busyTaskId={updateTask.isPending ? updateTask.variables?.id : null}
             isLoading={isLoadingTasks}
-            workspaceName={currentWorkspace?.name}
-            query={query}
             onSelect={onClose}
+            onToggleComplete={(task) => updateTask.mutate(task)}
+            query={searchQuery}
+            tasks={visibleTasks}
+            workspaceName={currentWorkspace?.name}
+            wsId={wsId}
           />
-        </CommandList>
-      </Command>
+        ) : null}
 
-      {/* Footer with hints */}
-      <div className="border-t bg-muted/30 px-4 py-2">
-        <div className="flex items-center justify-between text-muted-foreground text-xs">
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-1.5">
-              <kbd className="pointer-events-none inline-flex h-4 select-none items-center gap-1 rounded border bg-background px-1 font-medium font-mono">
-                ↑↓
-              </kbd>
-              <span>navigate</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <kbd className="pointer-events-none inline-flex h-4 select-none items-center gap-1 rounded border bg-background px-1 font-medium font-mono">
-                ↵
-              </kbd>
-              <span>select</span>
-            </div>
-            {!hasQuery && (
-              <div className="flex items-center gap-1.5">
-                <kbd className="pointer-events-none inline-flex h-4 select-none items-center gap-1 rounded border bg-background px-1 font-medium font-mono">
-                  {modKey}X
-                </kbd>
-                <span>clear recent</span>
-              </div>
-            )}
-          </div>
-          <span className="text-[10px]">Powered by Tuturuuu Search</span>
-        </div>
-      </div>
+        {showActions ? (
+          <>
+            <QuickActionsSection onSelect={onClose} query={searchQuery} />
+            <ProductActionsSection
+              navItems={flattenedNav}
+              onOpenAction={setSelectedAction}
+              onSelect={onClose}
+              query={searchQuery}
+            />
+          </>
+        ) : null}
+
+        {showNavigation ? (
+          <>
+            <WorkspaceSection
+              isLoading={isLoadingWorkspaces}
+              onSelect={onClose}
+              query={searchQuery}
+              workspaces={workspaces}
+            />
+            <NavigationSection
+              navItems={flattenedNav}
+              onSelect={onClose}
+              query={searchQuery}
+            />
+          </>
+        ) : null}
+      </CommandList>
+      <CommandCenterFooter modKey={modKey} />
     </div>
   );
 }

--- a/apps/web/src/components/command/modes/command-mode.tsx
+++ b/apps/web/src/components/command/modes/command-mode.tsx
@@ -65,7 +65,8 @@ export function CommandMode({ wsId, navLinks, onClose }: CommandModeProps) {
   const { tasks, isLoading: isLoadingTasks } = useTaskSearch(
     wsId,
     searchQuery,
-    showTasks
+    showTasks,
+    { priority, sort, status }
   );
   const { workspaces, isLoading: isLoadingWorkspaces } = useWorkspaceSearch(
     routedTab === 'all' || routedTab === 'navigate'

--- a/apps/web/src/components/command/platform-extra-sections.tsx
+++ b/apps/web/src/components/command/platform-extra-sections.tsx
@@ -45,7 +45,8 @@ export function PlatformCommandExtraSections({
   const { isLoading: isLoadingTasks, tasks } = useTaskSearch(
     workspaceId ?? null,
     query,
-    Boolean(workspaceId && (activeTab === 'tasks' || activeTab === 'all'))
+    Boolean(workspaceId && (activeTab === 'tasks' || activeTab === 'all')),
+    { priority, sort, status }
   );
   const visibleTasks = useMemo(
     () => filterAndSortTasks(tasks, { priority, sort, status }),

--- a/apps/web/src/components/command/platform-extra-sections.tsx
+++ b/apps/web/src/components/command/platform-extra-sections.tsx
@@ -1,16 +1,27 @@
 'use client';
 
+import type { CommandLauncherTab } from '@tuturuuu/satellite/command-launcher';
 import { useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
 import type { NavLink } from '@/components/navigation';
 import { ProductActionsSection } from './sections/product-actions-section';
 import { QuickActionsSection } from './sections/quick-actions-section';
 import { RecentSection } from './sections/recent-section';
 import { TaskSection } from './sections/task-section';
+import { TaskSearchToolbar } from './task-search-toolbar';
 import type { CommandAction } from './utils/command-actions';
+import {
+  filterAndSortTasks,
+  type TaskPriorityFilter,
+  type TaskSort,
+  type TaskStatusFilter,
+} from './utils/command-task-results';
+import { useCommandTaskUpdate } from './utils/use-command-task-update';
 import { useNavigationData } from './utils/use-navigation-data';
 import { useTaskSearch } from './utils/use-task-search';
 
 export function PlatformCommandExtraSections({
+  activeTab,
   navLinks,
   onClose,
   onApplySearch,
@@ -18,6 +29,7 @@ export function PlatformCommandExtraSections({
   workspaceId,
   workspaceName,
 }: {
+  activeTab: CommandLauncherTab;
   navLinks: (NavLink | null)[];
   onApplySearch: (query: string) => void;
   onClose: () => void;
@@ -26,12 +38,20 @@ export function PlatformCommandExtraSections({
   workspaceName?: string | null;
 }) {
   const router = useRouter();
+  const [status, setStatus] = useState<TaskStatusFilter>('all');
+  const [priority, setPriority] = useState<TaskPriorityFilter>('all');
+  const [sort, setSort] = useState<TaskSort>('relevance');
   const flattenedNav = useNavigationData(navLinks);
   const { isLoading: isLoadingTasks, tasks } = useTaskSearch(
     workspaceId ?? null,
     query,
-    Boolean(workspaceId)
+    Boolean(workspaceId && (activeTab === 'tasks' || activeTab === 'all'))
   );
+  const visibleTasks = useMemo(
+    () => filterAndSortTasks(tasks, { priority, sort, status }),
+    [priority, sort, status, tasks]
+  );
+  const updateTask = useCommandTaskUpdate(workspaceId ?? null);
 
   const handleOpenAction = (action: CommandAction) => {
     router.push(action.targetHref);
@@ -40,27 +60,48 @@ export function PlatformCommandExtraSections({
 
   return (
     <>
-      {!query.trim() && (
+      {(activeTab === 'tasks' || activeTab === 'all') && workspaceId ? (
+        <TaskSearchToolbar
+          onPriorityChange={setPriority}
+          onSortChange={setSort}
+          onStatusChange={setStatus}
+          priority={priority}
+          sort={sort}
+          status={status}
+        />
+      ) : null}
+      {activeTab === 'all' || activeTab === 'tasks' ? (
+        workspaceId ? (
+          <TaskSection
+            busyTaskId={updateTask.isPending ? updateTask.variables?.id : null}
+            isLoading={isLoadingTasks}
+            onSelect={onClose}
+            onToggleComplete={(task) => updateTask.mutate(task)}
+            query={query}
+            tasks={visibleTasks}
+            workspaceName={workspaceName ?? undefined}
+            wsId={workspaceId}
+          />
+        ) : null
+      ) : null}
+      {!query.trim() && activeTab === 'all' && (
         <RecentSection
           query={query}
           onApplySearch={onApplySearch}
           onSelect={onClose}
         />
       )}
-      <QuickActionsSection query={query} onSelect={onClose} />
-      <ProductActionsSection
-        navItems={flattenedNav}
-        onOpenAction={handleOpenAction}
-        onSelect={onClose}
-        query={query}
-      />
-      <TaskSection
-        isLoading={isLoadingTasks}
-        onSelect={onClose}
-        query={query}
-        tasks={tasks}
-        workspaceName={workspaceName ?? undefined}
-      />
+      {activeTab === 'all' || activeTab === 'actions' ? (
+        <>
+          <QuickActionsSection query={query} onSelect={onClose} />
+          <ProductActionsSection
+            navItems={flattenedNav}
+            onOpenAction={handleOpenAction}
+            onSelect={onClose}
+            query={query}
+          />
+        </>
+      ) : null}
     </>
   );
 }

--- a/apps/web/src/components/command/sections/navigation-section.tsx
+++ b/apps/web/src/components/command/sections/navigation-section.tsx
@@ -4,6 +4,7 @@ import { ChevronRight } from '@tuturuuu/icons';
 import { Badge } from '@tuturuuu/ui/badge';
 import { CommandGroup, CommandItem } from '@tuturuuu/ui/command';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import * as React from 'react';
 import { addRecentPage, getRecencyBoost } from '../utils/recent-items';
 import { searchItems } from '../utils/search-scoring';
@@ -25,6 +26,7 @@ export function NavigationSection({
   onSelect,
 }: NavigationSectionProps) {
   const router = useRouter();
+  const t = useTranslations('command_palette');
 
   // Search through navigation items with recency boost
   const results = React.useMemo(() => {
@@ -138,7 +140,7 @@ export function NavigationSection({
         const heading =
           hasQuery && category
             ? `${category} (${categoryResults.length})`
-            : 'Navigation';
+            : t('navigation');
 
         return (
           <CommandGroup key={category || 'navigation'} heading={heading}>

--- a/apps/web/src/components/command/sections/task-section.tsx
+++ b/apps/web/src/components/command/sections/task-section.tsx
@@ -1,274 +1,85 @@
 'use client';
 
-import {
-  AlertTriangle,
-  ArrowDown,
-  ArrowRight,
-  ArrowUp,
-  Calendar,
-  CheckCircle2,
-  Circle,
-  Clock,
-  ExternalLink,
-} from '@tuturuuu/icons';
-import { Badge } from '@tuturuuu/ui/badge';
+import { Loader2 } from '@tuturuuu/icons';
 import { CommandGroup, CommandItem } from '@tuturuuu/ui/command';
 import { dispatchRequestOpenTask } from '@tuturuuu/ui/lib/task-open-events';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
+import { useTranslations } from 'next-intl';
+import { TaskResultItem } from '../task-result-item';
 import { addRecentTask } from '../utils/recent-items';
 import type { TaskSearchResult } from '../utils/use-task-search';
 
-dayjs.extend(relativeTime);
-
 interface TaskSectionProps {
-  tasks: TaskSearchResult[];
+  busyTaskId?: string | null;
   isLoading: boolean;
-  workspaceName?: string;
-  query: string;
   onSelect?: () => void;
+  onToggleComplete: (task: TaskSearchResult) => void;
+  query: string;
+  tasks: TaskSearchResult[];
+  workspaceName?: string;
+  wsId: string;
 }
 
-// Priority icon mapping
-const priorityConfig = {
-  critical: {
-    icon: AlertTriangle,
-    color: 'text-dynamic-red',
-    bgColor: 'bg-dynamic-red/10',
-    label: 'Critical',
-  },
-  high: {
-    icon: ArrowUp,
-    color: 'text-dynamic-orange',
-    bgColor: 'bg-dynamic-orange/10',
-    label: 'High',
-  },
-  normal: {
-    icon: ArrowRight,
-    color: 'text-dynamic-blue',
-    bgColor: 'bg-dynamic-blue/10',
-    label: 'Normal',
-  },
-  low: {
-    icon: ArrowDown,
-    color: 'text-dynamic-gray',
-    bgColor: 'bg-dynamic-gray/10',
-    label: 'Low',
-  },
-};
-
-// List status configuration
-const listStatusConfig = {
-  not_started: {
-    color: 'text-dynamic-gray',
-    bgColor: 'bg-dynamic-gray/10',
-    label: 'Not Started',
-  },
-  active: {
-    color: 'text-dynamic-blue',
-    bgColor: 'bg-dynamic-blue/10',
-    label: 'Active',
-  },
-  done: {
-    color: 'text-dynamic-green',
-    bgColor: 'bg-dynamic-green/10',
-    label: 'Done',
-  },
-  closed: {
-    color: 'text-dynamic-purple',
-    bgColor: 'bg-dynamic-purple/10',
-    label: 'Closed',
-  },
-};
-
 export function TaskSection({
-  tasks,
+  busyTaskId,
   isLoading,
-  workspaceName,
-  query,
   onSelect,
+  onToggleComplete,
+  query,
+  tasks,
+  workspaceName,
+  wsId,
 }: TaskSectionProps) {
+  const t = useTranslations('command_palette');
+  const now = new Date();
+
   if (isLoading) {
     return (
-      <CommandGroup heading="Tasks">
-        <CommandItem
-          disabled
-          className="justify-center text-muted-foreground text-sm"
-        >
-          <div className="flex items-center gap-2">
-            <div className="h-3 w-3 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
-            Searching tasks...
-          </div>
+      <CommandGroup heading={t('tasks')}>
+        <CommandItem disabled className="justify-center py-8">
+          <Loader2 className="size-4 animate-spin" />
+          {t('searching_tasks')}
         </CommandItem>
       </CommandGroup>
     );
   }
 
-  if (tasks.length === 0) {
-    return query.trim() ? (
-      <CommandGroup heading="Tasks">
-        <CommandItem
-          disabled
-          className="justify-center text-muted-foreground text-sm"
-        >
-          No tasks found matching "{query}"
-        </CommandItem>
-      </CommandGroup>
-    ) : null;
-  }
+  if (tasks.length === 0) return null;
 
   const handleTaskSelect = (task: TaskSearchResult) => {
-    // Track in recent items
     addRecentTask(task.id, task.name, task.board_name ?? undefined);
-
-    // Close command palette
     onSelect?.();
-
-    dispatchRequestOpenTask({ taskId: task.id });
+    dispatchRequestOpenTask({ taskId: task.id, wsId });
   };
 
-  const headingText = query.trim()
-    ? `Tasks${workspaceName ? ` • ${workspaceName}` : ''}`
-    : `Recent Tasks${workspaceName ? ` • ${workspaceName}` : ''}`;
+  const heading = query.trim()
+    ? t('task_results', { count: tasks.length })
+    : t('recent_tasks');
 
   return (
-    <CommandGroup heading={headingText}>
-      {tasks.map((task) => {
-        const priority = task.priority ? priorityConfig[task.priority] : null;
-        const listStatus = task.list_status
-          ? listStatusConfig[task.list_status as keyof typeof listStatusConfig]
-          : null;
-        const isOverdue =
-          task.end_date && dayjs(task.end_date).isBefore(dayjs());
-        const isDueSoon =
-          !isOverdue &&
-          task.end_date &&
-          dayjs(task.end_date).diff(dayjs(), 'day') <= 3;
-
-        return (
-          <CommandItem
-            key={task.id}
-            value={`task-${task.id}-${task.name}`}
-            onSelect={() => handleTaskSelect(task)}
-            className="flex items-start gap-3 py-3"
-          >
-            {/* Status Icon */}
-            <div className="mt-0.5 shrink-0">
-              {task.completed ? (
-                <CheckCircle2 className="h-4 w-4 text-dynamic-green" />
-              ) : (
-                <Circle className="h-4 w-4 text-muted-foreground" />
-              )}
-            </div>
-
-            {/* Content */}
-            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-              {/* Task Name */}
-              <div className="flex items-start gap-2">
-                <span
-                  className={`flex-1 font-medium leading-tight ${task.completed ? 'line-through opacity-60' : ''}`}
-                >
-                  {task.name}
-                </span>
-                {task.is_assigned_to_current_user && (
-                  <Badge variant="outline" className="shrink-0 text-[10px]">
-                    Assigned to you
-                  </Badge>
-                )}
-              </div>
-
-              {/* Board and List Context */}
-              <div className="flex flex-wrap items-center gap-1.5 text-muted-foreground text-xs">
-                {task.board_name && (
-                  <>
-                    <span>{task.board_name}</span>
-                    {task.list_name && (
-                      <>
-                        <span>›</span>
-                        <span>{task.list_name}</span>
-                      </>
-                    )}
-                  </>
-                )}
-              </div>
-
-              {/* Metadata Row */}
-              <div className="flex flex-wrap items-center gap-2">
-                {/* List Status */}
-                {listStatus && (
-                  <div
-                    className={`flex items-center gap-1 rounded-md px-2 py-0.5 text-xs ${listStatus.bgColor}`}
-                  >
-                    <Circle
-                      className={`h-2 w-2 fill-current ${listStatus.color}`}
-                    />
-                    <span className={listStatus.color}>{listStatus.label}</span>
-                  </div>
-                )}
-
-                {/* Priority */}
-                {priority && (
-                  <div
-                    className={`flex items-center gap-1 rounded-md px-2 py-0.5 text-xs ${priority.bgColor}`}
-                  >
-                    <priority.icon className={`h-3 w-3 ${priority.color}`} />
-                    <span className={priority.color}>{priority.label}</span>
-                  </div>
-                )}
-
-                {/* Due Date */}
-                {task.end_date && (
-                  <div
-                    className={`flex items-center gap-1 rounded-md px-2 py-0.5 text-xs ${
-                      isOverdue
-                        ? 'bg-dynamic-red/10 text-dynamic-red'
-                        : isDueSoon
-                          ? 'bg-dynamic-orange/10 text-dynamic-orange'
-                          : 'bg-muted text-muted-foreground'
-                    }`}
-                  >
-                    <Clock className="h-3 w-3" />
-                    <span>
-                      {isOverdue ? 'Overdue' : dayjs(task.end_date).fromNow()}
-                    </span>
-                  </div>
-                )}
-
-                {/* Created Date */}
-                {task.created_at && (
-                  <div className="flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-muted-foreground text-xs">
-                    <Calendar className="h-3 w-3" />
-                    <span>Created {dayjs(task.created_at).fromNow()}</span>
-                  </div>
-                )}
-
-                {/* Assignees */}
-                {task.assignees && task.assignees.length > 0 && (
-                  <div className="flex -space-x-1">
-                    {task.assignees.slice(0, 3).map((assignee) => (
-                      <div
-                        key={assignee.id}
-                        className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-background bg-muted font-medium text-[10px]"
-                        title={assignee.display_name || 'User'}
-                      >
-                        {assignee.display_name?.[0]?.toUpperCase() || '?'}
-                      </div>
-                    ))}
-                    {task.assignees.length > 3 && (
-                      <div className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-background bg-muted text-[10px]">
-                        +{task.assignees.length - 3}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* External Link Icon */}
-            <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          </CommandItem>
-        );
-      })}
+    <CommandGroup
+      heading={
+        <div className="flex items-center justify-between gap-3">
+          <span>{heading}</span>
+          {workspaceName ? (
+            <span className="max-w-48 truncate font-normal text-[10px] opacity-70">
+              {workspaceName}
+            </span>
+          ) : null}
+        </div>
+      }
+      className="px-1 py-2"
+    >
+      {tasks.map((task) => (
+        <TaskResultItem
+          key={task.id}
+          task={task}
+          wsId={wsId}
+          now={now}
+          busy={busyTaskId === task.id}
+          onOpen={handleTaskSelect}
+          onToggleComplete={onToggleComplete}
+        />
+      ))}
     </CommandGroup>
   );
 }

--- a/apps/web/src/components/command/task-result-item.tsx
+++ b/apps/web/src/components/command/task-result-item.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowRight,
+  ArrowUp,
+  Check,
+  CheckCircle2,
+  Circle,
+  Clock,
+  Copy,
+  Loader2,
+} from '@tuturuuu/icons';
+import { Badge } from '@tuturuuu/ui/badge';
+import { Button } from '@tuturuuu/ui/button';
+import { CommandItem } from '@tuturuuu/ui/command';
+import { cn } from '@tuturuuu/utils/format';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { getTasksAppUrlClient } from '@/lib/tasks-app-url-client';
+import { isTaskDueSoon, isTaskOverdue } from './utils/command-task-results';
+import type { TaskSearchResult } from './utils/use-task-search';
+
+dayjs.extend(relativeTime);
+
+const PRIORITY_ICON = {
+  critical: AlertTriangle,
+  high: ArrowUp,
+  normal: ArrowRight,
+  low: ArrowDown,
+} as const;
+
+interface TaskResultItemProps {
+  busy: boolean;
+  now: Date;
+  onOpen: (task: TaskSearchResult) => void;
+  onToggleComplete: (task: TaskSearchResult) => void;
+  task: TaskSearchResult;
+  wsId: string;
+}
+
+export function TaskResultItem({
+  busy,
+  now,
+  onOpen,
+  onToggleComplete,
+  task,
+  wsId,
+}: TaskResultItemProps) {
+  const t = useTranslations('command_palette');
+  const overdue = isTaskOverdue(task, now);
+  const dueSoon = isTaskDueSoon(task, now);
+  const PriorityIcon = task.priority ? PRIORITY_ICON[task.priority] : null;
+
+  const copyTaskLink = async () => {
+    try {
+      const url = getTasksAppUrlClient(`/${wsId}/tasks/${task.id}`);
+      await navigator.clipboard.writeText(url);
+      toast.success(t('task_actions.link_copied'));
+    } catch {
+      toast.error(t('task_actions.link_copy_failed'));
+    }
+  };
+
+  return (
+    <CommandItem
+      value={`task-${task.id}-${task.name}-${task.board_name ?? ''}-${task.list_name ?? ''}`}
+      onSelect={() => onOpen(task)}
+      className="group mx-1 my-0.5 items-start gap-3 rounded-lg border border-transparent px-3 py-2.5 data-[selected=true]:border-border data-[selected=true]:bg-accent/70"
+    >
+      <button
+        type="button"
+        disabled={busy}
+        aria-label={
+          task.completed
+            ? t('task_actions.mark_open')
+            : t('task_actions.mark_complete')
+        }
+        onPointerDown={(event) => event.preventDefault()}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onToggleComplete(task);
+        }}
+        className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition hover:bg-primary/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+      >
+        {busy ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : task.completed ? (
+          <CheckCircle2 className="size-5 text-primary" />
+        ) : (
+          <Circle className="size-5" />
+        )}
+      </button>
+
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn(
+              'truncate font-medium text-sm',
+              task.completed && 'text-muted-foreground line-through'
+            )}
+          >
+            {task.name}
+          </span>
+          {task.is_assigned_to_current_user ? (
+            <Badge variant="outline" className="shrink-0 px-1.5 text-[10px]">
+              {t('assigned_to_you')}
+            </Badge>
+          ) : null}
+        </div>
+
+        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-xs">
+          {task.board_name ? (
+            <span className="max-w-48 truncate">
+              {task.board_name}
+              {task.list_name ? ` / ${task.list_name}` : ''}
+            </span>
+          ) : null}
+          {PriorityIcon && task.priority ? (
+            <span className="flex items-center gap-1">
+              <PriorityIcon className="size-3" />
+              {t(`priority.${task.priority}`)}
+            </span>
+          ) : null}
+          {task.end_date ? (
+            <span
+              className={cn(
+                'flex items-center gap-1',
+                overdue && 'font-medium text-destructive',
+                dueSoon && 'font-medium text-primary'
+              )}
+            >
+              <Clock className="size-3" />
+              {overdue
+                ? t('overdue')
+                : t('task_actions.due', {
+                    date: dayjs(task.end_date).fromNow(),
+                  })}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 group-data-[selected=true]:opacity-100">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={t('task_actions.copy_link')}
+          className="size-7"
+          onPointerDown={(event) => event.preventDefault()}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void copyTaskLink();
+          }}
+        >
+          <Copy className="size-3.5" />
+        </Button>
+        <span className="hidden items-center gap-1 rounded border bg-background px-1.5 py-1 font-mono text-[10px] text-muted-foreground sm:flex">
+          <Check className="size-3" />
+          {t('keyboard_hints.open')}
+        </span>
+      </div>
+    </CommandItem>
+  );
+}

--- a/apps/web/src/components/command/task-result-item.tsx
+++ b/apps/web/src/components/command/task-result-item.tsx
@@ -15,11 +15,11 @@ import {
 import { Badge } from '@tuturuuu/ui/badge';
 import { Button } from '@tuturuuu/ui/button';
 import { CommandItem } from '@tuturuuu/ui/command';
+import { toast } from '@tuturuuu/ui/sonner';
 import { cn } from '@tuturuuu/utils/format';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useTranslations } from 'next-intl';
-import { toast } from 'sonner';
 import { getTasksAppUrlClient } from '@/lib/tasks-app-url-client';
 import { isTaskDueSoon, isTaskOverdue } from './utils/command-task-results';
 import type { TaskSearchResult } from './utils/use-task-search';

--- a/apps/web/src/components/command/task-search-toolbar.tsx
+++ b/apps/web/src/components/command/task-search-toolbar.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { ArrowUpDown, SlidersHorizontal } from '@tuturuuu/icons';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@tuturuuu/ui/select';
+import { useTranslations } from 'next-intl';
+import type {
+  TaskPriorityFilter,
+  TaskSort,
+  TaskStatusFilter,
+} from './utils/command-task-results';
+
+export function TaskSearchToolbar({
+  onPriorityChange,
+  onSortChange,
+  onStatusChange,
+  priority,
+  sort,
+  status,
+}: {
+  onPriorityChange: (value: TaskPriorityFilter) => void;
+  onSortChange: (value: TaskSort) => void;
+  onStatusChange: (value: TaskStatusFilter) => void;
+  priority: TaskPriorityFilter;
+  sort: TaskSort;
+  status: TaskStatusFilter;
+}) {
+  const t = useTranslations('command_palette');
+  return (
+    <div className="flex items-center gap-2 overflow-x-auto border-b bg-muted/20 px-3 py-2">
+      <div className="flex shrink-0 items-center gap-1.5 text-muted-foreground text-xs">
+        <SlidersHorizontal className="size-3.5" />
+        <span>{t('filters.label')}</span>
+      </div>
+      <Select
+        value={status}
+        onValueChange={(value) => onStatusChange(value as TaskStatusFilter)}
+      >
+        <SelectTrigger className="h-8 w-auto min-w-32 bg-background/80 px-2.5 text-xs shadow-none">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {(
+            [
+              'all',
+              'open',
+              'assigned',
+              'overdue',
+              'due-soon',
+              'completed',
+            ] as const
+          ).map((value) => (
+            <SelectItem key={value} value={value}>
+              {t(`filters.status.${value}`)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        value={priority}
+        onValueChange={(value) => onPriorityChange(value as TaskPriorityFilter)}
+      >
+        <SelectTrigger className="h-8 w-auto min-w-28 bg-background/80 px-2.5 text-xs shadow-none">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {(['all', 'critical', 'high', 'normal', 'low'] as const).map(
+            (value) => (
+              <SelectItem key={value} value={value}>
+                {t(`filters.priority.${value}`)}
+              </SelectItem>
+            )
+          )}
+        </SelectContent>
+      </Select>
+      <div className="ml-auto flex shrink-0 items-center gap-1.5 text-muted-foreground text-xs">
+        <ArrowUpDown className="size-3.5" />
+        <Select
+          value={sort}
+          onValueChange={(value) => onSortChange(value as TaskSort)}
+        >
+          <SelectTrigger className="h-8 w-auto min-w-28 bg-background/80 px-2.5 text-xs shadow-none">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent align="end">
+            {(['relevance', 'due', 'priority', 'newest'] as const).map(
+              (value) => (
+                <SelectItem key={value} value={value}>
+                  {t(`sort.${value}`)}
+                </SelectItem>
+              )
+            )}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/command/task-search-toolbar.tsx
+++ b/apps/web/src/components/command/task-search-toolbar.tsx
@@ -41,7 +41,10 @@ export function TaskSearchToolbar({
         value={status}
         onValueChange={(value) => onStatusChange(value as TaskStatusFilter)}
       >
-        <SelectTrigger className="h-8 w-auto min-w-32 bg-background/80 px-2.5 text-xs shadow-none">
+        <SelectTrigger
+          aria-label={t('filters.status_label')}
+          className="h-8 w-auto min-w-32 bg-background/80 px-2.5 text-xs shadow-none"
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -65,7 +68,10 @@ export function TaskSearchToolbar({
         value={priority}
         onValueChange={(value) => onPriorityChange(value as TaskPriorityFilter)}
       >
-        <SelectTrigger className="h-8 w-auto min-w-28 bg-background/80 px-2.5 text-xs shadow-none">
+        <SelectTrigger
+          aria-label={t('filters.priority_label')}
+          className="h-8 w-auto min-w-28 bg-background/80 px-2.5 text-xs shadow-none"
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -84,7 +90,10 @@ export function TaskSearchToolbar({
           value={sort}
           onValueChange={(value) => onSortChange(value as TaskSort)}
         >
-          <SelectTrigger className="h-8 w-auto min-w-28 bg-background/80 px-2.5 text-xs shadow-none">
+          <SelectTrigger
+            aria-label={t('sort.label')}
+            className="h-8 w-auto min-w-28 bg-background/80 px-2.5 text-xs shadow-none"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent align="end">

--- a/apps/web/src/components/command/utils/command-task-results.test.ts
+++ b/apps/web/src/components/command/utils/command-task-results.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterAndSortTasks,
+  isTaskDueSoon,
+  isTaskOverdue,
+  parseCommandQuery,
+} from './command-task-results';
+import type { TaskSearchResult } from './use-task-search';
+
+const NOW = new Date('2026-08-26T12:00:00.000Z');
+
+function task(
+  id: string,
+  overrides: Partial<TaskSearchResult> = {}
+): TaskSearchResult {
+  return {
+    created_at: '2026-08-20T12:00:00.000Z',
+    id,
+    name: `Task ${id}`,
+    priority: 'normal',
+    ...overrides,
+  };
+}
+
+describe('parseCommandQuery', () => {
+  it.each([
+    ['# fix login', 'tasks', 'fix login'],
+    ['> toggle theme', 'actions', 'toggle theme'],
+    ['/ settings', 'navigate', 'settings'],
+    ['plain search', null, 'plain search'],
+  ] as const)('routes %s to %s', (query, tab, normalizedQuery) => {
+    expect(parseCommandQuery(query)).toEqual({
+      query: normalizedQuery,
+      tab,
+    });
+  });
+});
+
+describe('task result controls', () => {
+  const tasks = [
+    task('critical', {
+      created_at: '2026-08-25T12:00:00.000Z',
+      end_date: '2026-08-25T12:00:00.000Z',
+      is_assigned_to_current_user: true,
+      priority: 'critical',
+    }),
+    task('soon', {
+      end_date: '2026-08-28T12:00:00.000Z',
+      priority: 'high',
+    }),
+    task('later', {
+      created_at: '2026-08-01T12:00:00.000Z',
+      end_date: '2026-09-10T12:00:00.000Z',
+      priority: 'low',
+    }),
+    task('done', { completed: true, priority: 'critical' }),
+  ];
+
+  it('distinguishes overdue and due-soon tasks', () => {
+    expect(isTaskOverdue(tasks[0]!, NOW)).toBe(true);
+    expect(isTaskDueSoon(tasks[1]!, NOW)).toBe(true);
+    expect(isTaskDueSoon(tasks[2]!, NOW)).toBe(false);
+  });
+
+  it('combines status and priority filters', () => {
+    expect(
+      filterAndSortTasks(
+        tasks,
+        { priority: 'critical', sort: 'relevance', status: 'assigned' },
+        NOW
+      ).map(({ id }) => id)
+    ).toEqual(['critical']);
+  });
+
+  it('sorts due dates with undated tasks last', () => {
+    expect(
+      filterAndSortTasks(
+        tasks,
+        { priority: 'all', sort: 'due', status: 'open' },
+        NOW
+      ).map(({ id }) => id)
+    ).toEqual(['critical', 'soon', 'later']);
+  });
+
+  it('sorts by priority and creation time', () => {
+    expect(
+      filterAndSortTasks(tasks, {
+        priority: 'all',
+        sort: 'priority',
+        status: 'open',
+      }).map(({ id }) => id)
+    ).toEqual(['critical', 'soon', 'later']);
+
+    expect(
+      filterAndSortTasks(tasks, {
+        priority: 'all',
+        sort: 'newest',
+        status: 'open',
+      }).map(({ id }) => id)
+    ).toEqual(['critical', 'soon', 'later']);
+  });
+});

--- a/apps/web/src/components/command/utils/command-task-results.ts
+++ b/apps/web/src/components/command/utils/command-task-results.ts
@@ -1,0 +1,131 @@
+import type { TaskSearchResult } from './use-task-search';
+
+export type CommandTab = 'tasks' | 'all' | 'navigate' | 'actions';
+export type TaskStatusFilter =
+  | 'all'
+  | 'open'
+  | 'assigned'
+  | 'overdue'
+  | 'due-soon'
+  | 'completed';
+export type TaskPriorityFilter = 'all' | 'critical' | 'high' | 'normal' | 'low';
+export type TaskSort = 'relevance' | 'due' | 'priority' | 'newest';
+
+export interface TaskResultControls {
+  priority: TaskPriorityFilter;
+  sort: TaskSort;
+  status: TaskStatusFilter;
+}
+
+const PRIORITY_RANK = {
+  critical: 0,
+  high: 1,
+  normal: 2,
+  low: 3,
+} as const;
+
+export function parseCommandQuery(query: string): {
+  query: string;
+  tab: CommandTab | null;
+} {
+  const trimmed = query.trimStart();
+  const prefix = trimmed[0];
+
+  if (prefix === '>') {
+    return { query: trimmed.slice(1).trimStart(), tab: 'actions' };
+  }
+
+  if (prefix === '/') {
+    return { query: trimmed.slice(1).trimStart(), tab: 'navigate' };
+  }
+
+  if (prefix === '#') {
+    return { query: trimmed.slice(1).trimStart(), tab: 'tasks' };
+  }
+
+  return { query, tab: null };
+}
+
+export function isTaskOverdue(task: TaskSearchResult, now: Date): boolean {
+  return Boolean(
+    !task.completed &&
+      task.end_date &&
+      new Date(task.end_date).getTime() < now.getTime()
+  );
+}
+
+export function isTaskDueSoon(task: TaskSearchResult, now: Date): boolean {
+  if (task.completed || !task.end_date) return false;
+
+  const dueAt = new Date(task.end_date).getTime();
+  const difference = dueAt - now.getTime();
+  return difference >= 0 && difference <= 3 * 24 * 60 * 60 * 1000;
+}
+
+function matchesStatus(
+  task: TaskSearchResult,
+  status: TaskStatusFilter,
+  now: Date
+): boolean {
+  switch (status) {
+    case 'open':
+      return !task.completed;
+    case 'assigned':
+      return Boolean(task.is_assigned_to_current_user && !task.completed);
+    case 'overdue':
+      return isTaskOverdue(task, now);
+    case 'due-soon':
+      return isTaskDueSoon(task, now);
+    case 'completed':
+      return Boolean(task.completed);
+    default:
+      return true;
+  }
+}
+
+function compareDates(
+  first: string | null | undefined,
+  second: string | null | undefined,
+  direction: 'asc' | 'desc'
+): number {
+  if (!first && !second) return 0;
+  if (!first) return 1;
+  if (!second) return -1;
+
+  const difference = new Date(first).getTime() - new Date(second).getTime();
+  return direction === 'asc' ? difference : -difference;
+}
+
+export function filterAndSortTasks(
+  tasks: TaskSearchResult[],
+  controls: TaskResultControls,
+  now = new Date()
+): TaskSearchResult[] {
+  const filtered = tasks.filter((task) => {
+    const matchesPriority =
+      controls.priority === 'all' || task.priority === controls.priority;
+    return matchesPriority && matchesStatus(task, controls.status, now);
+  });
+
+  return filtered.toSorted((first, second) => {
+    if (controls.sort === 'due') {
+      return compareDates(first.end_date, second.end_date, 'asc');
+    }
+
+    if (controls.sort === 'priority') {
+      const firstRank = first.priority
+        ? PRIORITY_RANK[first.priority]
+        : Number.MAX_SAFE_INTEGER;
+      const secondRank = second.priority
+        ? PRIORITY_RANK[second.priority]
+        : Number.MAX_SAFE_INTEGER;
+      return firstRank - secondRank;
+    }
+
+    if (controls.sort === 'newest') {
+      return compareDates(first.created_at, second.created_at, 'desc');
+    }
+
+    return 0;
+  });
+}

--- a/apps/web/src/components/command/utils/use-command-task-update.ts
+++ b/apps/web/src/components/command/utils/use-command-task-update.ts
@@ -2,8 +2,8 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateWorkspaceTask } from '@tuturuuu/internal-api/tasks';
+import { toast } from '@tuturuuu/ui/sonner';
 import { useTranslations } from 'next-intl';
-import { toast } from 'sonner';
 import { commandTaskQueryKey, type TaskSearchResult } from './use-task-search';
 
 export function useCommandTaskUpdate(wsId: string | null) {

--- a/apps/web/src/components/command/utils/use-command-task-update.ts
+++ b/apps/web/src/components/command/utils/use-command-task-update.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateWorkspaceTask } from '@tuturuuu/internal-api/tasks';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { commandTaskQueryKey, type TaskSearchResult } from './use-task-search';
+
+export function useCommandTaskUpdate(wsId: string | null) {
+  const t = useTranslations('command_palette');
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (task: TaskSearchResult) => {
+      if (!wsId) throw new Error('Workspace is required');
+      await updateWorkspaceTask(wsId, task.id, { completed: !task.completed });
+      return task;
+    },
+    onSuccess: async (task) => {
+      toast.success(
+        task.completed
+          ? t('task_actions.reopened')
+          : t('task_actions.completed')
+      );
+      await queryClient.invalidateQueries({
+        queryKey: commandTaskQueryKey(wsId),
+      });
+    },
+    onError: () => toast.error(t('task_actions.update_failed')),
+  });
+}

--- a/apps/web/src/components/command/utils/use-task-search.test.ts
+++ b/apps/web/src/components/command/utils/use-task-search.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCommandTaskListOptions,
+  shouldUseFilteredTaskList,
+} from './use-task-search';
+
+describe('command task server controls', () => {
+  it('pushes assignment, priority, and sorting ahead of the API limit', () => {
+    expect(
+      buildCommandTaskListOptions(
+        'launch',
+        { priority: 'critical', sort: 'priority', status: 'assigned' },
+        new Date('2026-08-26T08:00:00.000Z')
+      )
+    ).toEqual({
+      assignedToMe: true,
+      closed: 'exclude',
+      completed: 'exclude',
+      limit: 40,
+      priorities: ['critical'],
+      q: 'launch',
+      sortBy: 'priority-high',
+    });
+  });
+
+  it('bounds due-soon results on the server before truncation', () => {
+    expect(
+      buildCommandTaskListOptions(
+        '',
+        { priority: 'all', sort: 'due', status: 'due-soon' },
+        new Date('2026-08-26T08:00:00.000Z')
+      )
+    ).toEqual({
+      closed: 'exclude',
+      completed: 'exclude',
+      dueDateFrom: '2026-08-26T08:00:00.000Z',
+      dueDateTo: '2026-08-29T08:00:00.000Z',
+      limit: 30,
+      priorities: undefined,
+      q: undefined,
+      sortBy: 'due-date-asc',
+    });
+  });
+
+  it('keeps semantic search only when no server controls are active', () => {
+    expect(shouldUseFilteredTaskList('launch', 'all', 'all', 'relevance')).toBe(
+      false
+    );
+    expect(
+      shouldUseFilteredTaskList('launch', 'overdue', 'all', 'relevance')
+    ).toBe(true);
+    expect(shouldUseFilteredTaskList('', 'overdue', 'all', 'relevance')).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/src/components/command/utils/use-task-search.ts
+++ b/apps/web/src/components/command/utils/use-task-search.ts
@@ -1,10 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 import {
+  type ListWorkspaceTasksOptions,
   listWorkspaceTasks,
   searchWorkspaceTasks,
   type WorkspaceTaskSearchResult,
 } from '@tuturuuu/internal-api/tasks';
 import * as React from 'react';
+import type {
+  TaskPriorityFilter,
+  TaskResultControls,
+  TaskSort,
+  TaskStatusFilter,
+} from './command-task-results';
 
 export type TaskSearchResult = WorkspaceTaskSearchResult;
 
@@ -51,33 +58,119 @@ export function normalizeCommandTask(
   };
 }
 
+function getServerSort(sort: TaskSort): ListWorkspaceTasksOptions['sortBy'] {
+  switch (sort) {
+    case 'due':
+      return 'due-date-asc';
+    case 'priority':
+      return 'priority-high';
+    default:
+      return 'created-date-desc';
+  }
+}
+
+function getStatusOptions(
+  status: TaskStatusFilter,
+  now: Date
+): ListWorkspaceTasksOptions {
+  switch (status) {
+    case 'open':
+      return { closed: 'exclude', completed: 'exclude' };
+    case 'assigned':
+      return {
+        assignedToMe: true,
+        closed: 'exclude',
+        completed: 'exclude',
+      };
+    case 'overdue':
+      return {
+        closed: 'exclude',
+        completed: 'exclude',
+        dueDateTo: now.toISOString(),
+      };
+    case 'due-soon': {
+      const dueSoonCutoff = new Date(now);
+      dueSoonCutoff.setDate(dueSoonCutoff.getDate() + 3);
+      return {
+        closed: 'exclude',
+        completed: 'exclude',
+        dueDateFrom: now.toISOString(),
+        dueDateTo: dueSoonCutoff.toISOString(),
+      };
+    }
+    case 'completed':
+      return { completed: 'only' };
+    default:
+      return {};
+  }
+}
+
+export function buildCommandTaskListOptions(
+  query: string,
+  controls: TaskResultControls,
+  now = new Date()
+): ListWorkspaceTasksOptions {
+  return {
+    ...getStatusOptions(controls.status, now),
+    limit: query ? 40 : 30,
+    priorities: controls.priority === 'all' ? undefined : [controls.priority],
+    q: query || undefined,
+    sortBy: getServerSort(controls.sort),
+  };
+}
+
+export function shouldUseFilteredTaskList(
+  query: string,
+  status: TaskStatusFilter,
+  priority: TaskPriorityFilter,
+  sort: TaskSort
+): boolean {
+  return Boolean(
+    query && (status !== 'all' || priority !== 'all' || sort !== 'relevance')
+  );
+}
+
 /**
  * Hook for searching tasks in the workspace
  */
 export function useTaskSearch(
   wsId: string | null,
   query: string,
-  enabled: boolean
+  enabled: boolean,
+  controls: TaskResultControls
 ) {
   const debouncedQuery = useDebounced(query.trim(), 300);
   const hasQuery = debouncedQuery.length > 0;
+  const useFilteredTaskList = shouldUseFilteredTaskList(
+    debouncedQuery,
+    controls.status,
+    controls.priority,
+    controls.sort
+  );
 
   // Only enable queries if wsId is a valid UUID (not legacy identifiers like "internal" or "personal")
   const isValidWorkspace = isValidUUID(wsId);
 
   // Fetch recent/all tasks when no query
   const recentTasksQuery = useQuery({
-    queryKey: [...commandTaskQueryKey(wsId), 'recent'],
+    queryKey: [
+      ...commandTaskQueryKey(wsId),
+      'list',
+      debouncedQuery,
+      controls.status,
+      controls.priority,
+      controls.sort,
+    ],
     queryFn: async () => {
       if (!wsId) return [];
 
-      const data = await listWorkspaceTasks(wsId, {
-        limit: 30,
-        sortBy: 'created-date-desc',
-      });
+      const data = await listWorkspaceTasks(
+        wsId,
+        buildCommandTaskListOptions(debouncedQuery, controls)
+      );
       return (data.tasks ?? []).map((task) => normalizeCommandTask(task));
     },
-    enabled: enabled && !hasQuery && isValidWorkspace,
+    enabled: enabled && (!hasQuery || useFilteredTaskList) && isValidWorkspace,
     staleTime: 30000, // 30 seconds
   });
 
@@ -95,12 +188,12 @@ export function useTaskSearch(
 
       return (data.tasks || []).map((task) => normalizeCommandTask(task));
     },
-    enabled: enabled && hasQuery && isValidWorkspace,
+    enabled: enabled && hasQuery && !useFilteredTaskList && isValidWorkspace,
     staleTime: 30000, // 30 seconds
   });
 
   // Return appropriate query based on whether there's a search query
-  if (hasQuery) {
+  if (hasQuery && !useFilteredTaskList) {
     return {
       tasks: searchTasksQuery.data || [],
       isLoading: searchTasksQuery.isLoading,

--- a/apps/web/src/components/command/utils/use-task-search.ts
+++ b/apps/web/src/components/command/utils/use-task-search.ts
@@ -42,6 +42,15 @@ export const commandTaskQueryKey = (wsId: string | null) => [
   wsId,
 ];
 
+export function normalizeCommandTask(
+  task: WorkspaceTaskSearchResult
+): TaskSearchResult {
+  return {
+    ...task,
+    completed: task.completed ?? Boolean(task.completed_at),
+  };
+}
+
 /**
  * Hook for searching tasks in the workspace
  */
@@ -66,7 +75,7 @@ export function useTaskSearch(
         limit: 30,
         sortBy: 'created-date-desc',
       });
-      return data.tasks as TaskSearchResult[];
+      return data.tasks.map((task) => normalizeCommandTask(task));
     },
     enabled: enabled && !hasQuery && isValidWorkspace,
     staleTime: 30000, // 30 seconds
@@ -84,7 +93,7 @@ export function useTaskSearch(
         mode: 'hybrid',
       });
 
-      return (data.tasks || []) as TaskSearchResult[];
+      return (data.tasks || []).map((task) => normalizeCommandTask(task));
     },
     enabled: enabled && hasQuery && isValidWorkspace,
     staleTime: 30000, // 30 seconds

--- a/apps/web/src/components/command/utils/use-task-search.ts
+++ b/apps/web/src/components/command/utils/use-task-search.ts
@@ -75,7 +75,7 @@ export function useTaskSearch(
         limit: 30,
         sortBy: 'created-date-desc',
       });
-      return data.tasks.map((task) => normalizeCommandTask(task));
+      return (data.tasks ?? []).map((task) => normalizeCommandTask(task));
     },
     enabled: enabled && !hasQuery && isValidWorkspace,
     staleTime: 30000, // 30 seconds

--- a/apps/web/src/components/command/utils/use-task-search.ts
+++ b/apps/web/src/components/command/utils/use-task-search.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import {
+  listWorkspaceTasks,
   searchWorkspaceTasks,
   type WorkspaceTaskSearchResult,
 } from '@tuturuuu/internal-api/tasks';
 import * as React from 'react';
-import { getTasksAppUrlClient } from '@/lib/tasks-app-url-client';
 
 export type TaskSearchResult = WorkspaceTaskSearchResult;
 
@@ -37,6 +37,11 @@ function useDebounced<T>(value: T, delay: number): T {
   return debouncedValue;
 }
 
+export const commandTaskQueryKey = (wsId: string | null) => [
+  'command-center-tasks',
+  wsId,
+];
+
 /**
  * Hook for searching tasks in the workspace
  */
@@ -53,24 +58,15 @@ export function useTaskSearch(
 
   // Fetch recent/all tasks when no query
   const recentTasksQuery = useQuery({
-    queryKey: ['command-palette-recent-tasks', wsId],
+    queryKey: [...commandTaskQueryKey(wsId), 'recent'],
     queryFn: async () => {
       if (!wsId) return [];
 
-      const response = await fetch(
-        getTasksAppUrlClient(`/api/v1/workspaces/${wsId}/tasks?limit=20`),
-        {
-          cache: 'no-store',
-          credentials: 'include',
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch recent tasks');
-      }
-
-      const data = await response.json();
-      return (data.tasks || []) as TaskSearchResult[];
+      const data = await listWorkspaceTasks(wsId, {
+        limit: 30,
+        sortBy: 'created-date-desc',
+      });
+      return data.tasks as TaskSearchResult[];
     },
     enabled: enabled && !hasQuery && isValidWorkspace,
     staleTime: 30000, // 30 seconds
@@ -78,13 +74,14 @@ export function useTaskSearch(
 
   // Semantic search when query exists
   const searchTasksQuery = useQuery({
-    queryKey: ['command-palette-search-tasks', wsId, debouncedQuery],
+    queryKey: [...commandTaskQueryKey(wsId), 'search', debouncedQuery],
     queryFn: async () => {
       if (!wsId || !debouncedQuery) return [];
 
       const data = await searchWorkspaceTasks(wsId, {
         query: debouncedQuery,
-        matchCount: 20,
+        matchCount: 40,
+        mode: 'hybrid',
       });
 
       return (data.tasks || []) as TaskSearchResult[];

--- a/apps/web/src/components/settings/settings-dialog-shortcuts.test.tsx
+++ b/apps/web/src/components/settings/settings-dialog-shortcuts.test.tsx
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import type { Workspace } from '@tuturuuu/types';
+import type { WorkspaceUser } from '@tuturuuu/types/primitives/WorkspaceUser';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsDialogHost } from '../../app/[locale]/settings-dialog-host';
@@ -467,13 +469,13 @@ describe('settings dialog shortcut', () => {
       <UserNavClient
         locale="en"
         renderSettingsDialog={false}
-        user={user as any}
+        user={user as unknown as WorkspaceUser}
         workspace={
           {
             id: 'workspace-1',
             joined: false,
             name: 'Guest workspace',
-          } as any
+          } as unknown as Workspace
         }
       />
     );
@@ -496,13 +498,13 @@ describe('settings dialog shortcut', () => {
       <UserNavClient
         locale="en"
         renderSettingsDialog={false}
-        user={user as any}
+        user={user as unknown as WorkspaceUser}
         workspace={
           {
             id: 'workspace-1',
             joined: true,
             name: 'Member workspace',
-          } as any
+          } as unknown as Workspace
         }
       />
     );

--- a/apps/web/src/components/settings/settings-dialog-shortcuts.test.tsx
+++ b/apps/web/src/components/settings/settings-dialog-shortcuts.test.tsx
@@ -64,6 +64,10 @@ vi.mock('@tuturuuu/ui/avatar', () => ({
   AvatarImage: () => null,
 }));
 
+vi.mock('@tuturuuu/ui/custom/workspace-select', () => ({
+  WorkspaceSelect: () => null,
+}));
+
 vi.mock('@tuturuuu/ui/dialog', () => ({
   Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   DialogContent: ({
@@ -455,6 +459,64 @@ describe('settings dialog shortcut', () => {
 
     await waitFor(() => {
       expect(globalCommandLauncherMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('disables workspace task search for guest-only workspace access', async () => {
+    render(
+      <UserNavClient
+        locale="en"
+        renderSettingsDialog={false}
+        user={user as any}
+        workspace={
+          {
+            id: 'workspace-1',
+            joined: false,
+            name: 'Guest workspace',
+          } as any
+        }
+      />
+    );
+
+    await waitFor(() => {
+      expect(globalCommandLauncherMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultTab: 'all',
+          enableTasks: false,
+          labels: expect.objectContaining({
+            placeholder: 'search_placeholder_navigation',
+          }),
+        })
+      );
+    });
+  });
+
+  it('keeps task-first search for joined workspaces', async () => {
+    render(
+      <UserNavClient
+        locale="en"
+        renderSettingsDialog={false}
+        user={user as any}
+        workspace={
+          {
+            id: 'workspace-1',
+            joined: true,
+            name: 'Member workspace',
+          } as any
+        }
+      />
+    );
+
+    await waitFor(() => {
+      expect(globalCommandLauncherMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultTab: 'tasks',
+          enableTasks: true,
+          labels: expect.objectContaining({
+            placeholder: 'search_placeholder_tasks',
+          }),
+        })
+      );
     });
   });
 });

--- a/packages/email-service/src/email-service.ts
+++ b/packages/email-service/src/email-service.ts
@@ -657,7 +657,6 @@ export class EmailService {
       '@tuturuuu/supabase/next/server'
     );
     const sbAdmin = (await createAdminClient()) as SupabaseClient<Database>;
-
     const credentialWorkspaceId = options?.credentialWorkspaceId ?? wsId;
     const { data: dbCredentials, error } = await sbAdmin
       .from('workspace_email_credentials')
@@ -690,7 +689,6 @@ export class EmailService {
         );
       }
     }
-
     const workspaceRateLimits = await getWorkspaceEmailRateLimitOverrides(
       sbAdmin,
       wsId

--- a/packages/internal-api/src/tasks-credentials.test.ts
+++ b/packages/internal-api/src/tasks-credentials.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { updateWorkspaceTask } from './tasks';
+
+describe('workspace task credentials', () => {
+  it('includes credentials when updating a task across app origins', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ task: { id: 'task-1' } }),
+      ok: true,
+      status: 200,
+    });
+
+    await updateWorkspaceTask(
+      'ws-1',
+      'task-1',
+      { completed: true },
+      {
+        baseUrl: 'https://internal.example.com',
+        fetch: fetchMock as unknown as typeof fetch,
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://internal.example.com/api/v1/workspaces/ws-1/tasks/task-1',
+      expect.objectContaining({
+        body: JSON.stringify({ completed: true }),
+        credentials: 'include',
+        method: 'PUT',
+      })
+    );
+  });
+});

--- a/packages/internal-api/src/tasks.test.ts
+++ b/packages/internal-api/src/tasks.test.ts
@@ -593,11 +593,11 @@ describe('workspace board internal-api helpers', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'https://internal.example.com/api/v1/workspaces/ws-1/tasks?listStatuses=not_started%2Cactive&limit=50&completed=exclude&closed=exclude&forTimeTracking=true&includeArchivedBoards=true',
       expect.objectContaining({
-        cache: 'no-store',
         credentials: 'include',
       })
     );
   });
+
   it('lists workspace tasks with non-document project link statuses', async () => {
     const fetchMock = vi
       .fn()

--- a/packages/internal-api/src/tasks.test.ts
+++ b/packages/internal-api/src/tasks.test.ts
@@ -157,7 +157,6 @@ describe('workspace board internal-api helpers', () => {
       })
     );
   });
-
   it('searches workspace tasks through the semantic search route', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       createJsonResponse({
@@ -190,6 +189,7 @@ describe('workspace board internal-api helpers', () => {
           mode: 'text',
         }),
         cache: 'no-store',
+        credentials: 'include',
       })
     );
   });
@@ -594,10 +594,10 @@ describe('workspace board internal-api helpers', () => {
       'https://internal.example.com/api/v1/workspaces/ws-1/tasks?listStatuses=not_started%2Cactive&limit=50&completed=exclude&closed=exclude&forTimeTracking=true&includeArchivedBoards=true',
       expect.objectContaining({
         cache: 'no-store',
+        credentials: 'include',
       })
     );
   });
-
   it('lists workspace tasks with non-document project link statuses', async () => {
     const fetchMock = vi
       .fn()

--- a/packages/internal-api/src/tasks.ts
+++ b/packages/internal-api/src/tasks.ts
@@ -2105,10 +2105,10 @@ export async function updateWorkspaceTask(
       },
       body: JSON.stringify(payload),
       cache: 'no-store',
+      credentials: 'include',
     }
   );
 }
-
 export async function deleteWorkspaceTask(
   workspaceId: string,
   taskId: string,

--- a/packages/internal-api/src/tasks.ts
+++ b/packages/internal-api/src/tasks.ts
@@ -463,6 +463,7 @@ export interface WorkspaceTaskSearchResult {
   }[];
   board_name?: string | null;
   completed?: boolean;
+  completed_at?: string | null;
   created_at?: string | null;
   description?: string | null;
   end_date?: string | null;
@@ -489,7 +490,6 @@ export interface SearchWorkspaceTasksResponse {
   reason?: string;
   tasks: WorkspaceTaskSearchResult[];
 }
-
 function joinQueryList(values?: string[]) {
   return values && values.length > 0 ? values.join(',') : undefined;
 }
@@ -1698,10 +1698,10 @@ export async function listWorkspaceTasks(
         includeListCounts: options?.includeListCounts,
       },
       cache: 'no-store',
+      credentials: 'include',
     }
   );
 }
-
 export async function searchWorkspaceTasks(
   workspaceId: string,
   payload: SearchWorkspaceTasksPayload,
@@ -1717,10 +1717,10 @@ export async function searchWorkspaceTasks(
       },
       body: JSON.stringify(payload),
       cache: 'no-store',
+      credentials: 'include',
     }
   );
 }
-
 export async function listTaskBoardStatusTemplates(
   options?: InternalApiClientOptions
 ) {

--- a/packages/satellite/src/components/command-launcher/command-launcher-items.tsx
+++ b/packages/satellite/src/components/command-launcher/command-launcher-items.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import {
+  ArrowRight,
+  Building2,
+  Check,
+  ExternalLink,
+  Globe2,
+  PanelTop,
+  Search,
+  User,
+} from '@tuturuuu/icons';
+import { Badge } from '@tuturuuu/ui/badge';
+import { CommandItem } from '@tuturuuu/ui/command';
+import type { LaunchableApp } from '@tuturuuu/utils/launchable-apps';
+import type { ReactNode } from 'react';
+import type {
+  CommandLauncherNavItem,
+  GlobalCommandLauncherLabels,
+  LauncherWorkspace,
+} from './global-command-launcher';
+
+export function AppCommandItem({
+  app,
+  isCurrent,
+  labels,
+  matchContext,
+  onSelect,
+}: {
+  app: LaunchableApp;
+  isCurrent: boolean;
+  labels: GlobalCommandLauncherLabels;
+  matchContext: string | null;
+  onSelect: () => void;
+}) {
+  return (
+    <CommandItem
+      className="min-h-13 rounded-lg border border-transparent px-2.5 data-[selected=true]:border-border"
+      onSelect={onSelect}
+      value={`app-${app.slug}-${app.title}`}
+    >
+      <ItemIcon icon={<Globe2 className="size-4" />} />
+      <ItemText
+        badge={isCurrent ? labels.current : undefined}
+        subtitle={matchContext ?? app.productionUrl}
+        title={app.title}
+      />
+      <ItemAction label={labels.openApp} />
+    </CommandItem>
+  );
+}
+
+export function WorkspaceCommandItem({
+  isCurrent,
+  labels,
+  matchContext,
+  onSelect,
+  workspace,
+}: {
+  isCurrent: boolean;
+  labels: GlobalCommandLauncherLabels;
+  matchContext: string | null;
+  onSelect: () => void;
+  workspace: LauncherWorkspace;
+}) {
+  const accessType = 'access_type' in workspace ? workspace.access_type : null;
+  return (
+    <CommandItem
+      className="min-h-13 rounded-lg border border-transparent px-2.5 data-[selected=true]:border-border"
+      onSelect={onSelect}
+      value={`workspace-${workspace.id}-${workspace.name}`}
+    >
+      <ItemIcon
+        icon={
+          workspace.personal ? (
+            <User className="size-4" />
+          ) : (
+            <Building2 className="size-4" />
+          )
+        }
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-medium">
+            {workspace.name || workspace.id}
+          </span>
+          {isCurrent ? <StatusBadge label={labels.current} /> : null}
+          {workspace.personal ? <StatusBadge label={labels.personal} /> : null}
+          {accessType === 'guest' ? <StatusBadge label={labels.guest} /> : null}
+        </div>
+        <p className="truncate text-muted-foreground text-xs">
+          {matchContext ?? workspace.id}
+        </p>
+      </div>
+      <span className="hidden text-muted-foreground text-xs sm:inline">
+        {labels.openWorkspace}
+      </span>
+      {isCurrent ? (
+        <Check className="size-4" />
+      ) : (
+        <ArrowRight className="size-4" />
+      )}
+    </CommandItem>
+  );
+}
+
+export function NavigationCommandItem({
+  item,
+  labels,
+  matchContext,
+  onSelect,
+}: {
+  item: CommandLauncherNavItem;
+  labels: GlobalCommandLauncherLabels;
+  matchContext: string | null;
+  onSelect: () => void;
+}) {
+  return (
+    <CommandItem
+      className="min-h-13 rounded-lg border border-transparent px-2.5 data-[selected=true]:border-border"
+      onSelect={onSelect}
+      value={`nav-${item.href}-${item.title}`}
+    >
+      <ItemIcon icon={item.icon ?? <PanelTop className="size-4" />} />
+      <ItemText
+        external={item.external}
+        subtitle={matchContext ?? item.subtitle ?? item.href}
+        title={item.title}
+      />
+      <ItemAction label={labels.open} />
+    </CommandItem>
+  );
+}
+
+export function EmptyState({
+  labels,
+  query,
+}: {
+  labels: GlobalCommandLauncherLabels;
+  query: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 px-6 py-12 text-center">
+      <div className="flex size-12 items-center justify-center rounded-xl border bg-muted/60 shadow-xs">
+        <Search className="size-5 text-muted-foreground" />
+      </div>
+      <div className="space-y-1">
+        <p className="font-medium">{labels.empty}</p>
+        <p className="text-muted-foreground text-sm">
+          {query ? `“${query}”` : labels.emptyDescription}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemIcon({ icon }: { icon: ReactNode }) {
+  return (
+    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-muted/60">
+      {icon}
+    </div>
+  );
+}
+
+function ItemText({
+  badge,
+  external,
+  subtitle,
+  title,
+}: {
+  badge?: string;
+  external?: boolean;
+  subtitle: string;
+  title: string;
+}) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <span className="truncate font-medium">{title}</span>
+        {external ? (
+          <ExternalLink className="size-3 text-muted-foreground" />
+        ) : null}
+        {badge ? <StatusBadge label={badge} /> : null}
+      </div>
+      <p className="truncate text-muted-foreground text-xs">{subtitle}</p>
+    </div>
+  );
+}
+
+function ItemAction({ label }: { label: string }) {
+  return (
+    <>
+      <span className="hidden text-muted-foreground text-xs sm:inline">
+        {label}
+      </span>
+      <ArrowRight className="size-4" />
+    </>
+  );
+}
+
+function StatusBadge({ label }: { label: string }) {
+  return (
+    <Badge
+      className="h-5 rounded-md px-1.5 text-[10px] uppercase"
+      variant="outline"
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/packages/satellite/src/components/command-launcher/command-launcher-tabs.tsx
+++ b/packages/satellite/src/components/command-launcher/command-launcher-tabs.tsx
@@ -44,11 +44,13 @@ export function parseLauncherQuery(query: string): {
 export function CommandLauncherTabs({
   activeTab,
   ariaLabel,
+  availableTabs = COMMAND_LAUNCHER_TABS,
   labels,
   onChange,
 }: {
   activeTab: CommandLauncherTab;
   ariaLabel: string;
+  availableTabs?: readonly CommandLauncherTab[];
   labels: Record<CommandLauncherTab, string>;
   onChange: (tab: CommandLauncherTab) => void;
 }) {
@@ -58,31 +60,33 @@ export function CommandLauncherTabs({
       className="flex gap-1 overflow-x-auto border-b bg-muted/20 px-3 pt-2"
       role="tablist"
     >
-      {TAB_DEFINITIONS.map(({ icon: Icon, key, shortcut }) => {
-        const selected = activeTab === key;
-        return (
-          <Button
-            aria-selected={selected}
-            className={cn(
-              'h-9 shrink-0 gap-2 rounded-b-none border-transparent px-3 text-muted-foreground',
-              selected &&
-                'border-border border-b-background bg-background text-foreground shadow-xs'
-            )}
-            key={key}
-            onClick={() => onChange(key)}
-            role="tab"
-            size="sm"
-            type="button"
-            variant="ghost"
-          >
-            <Icon className="size-4" />
-            {labels[key]}
-            <span className="hidden font-mono text-[10px] opacity-50 sm:inline">
-              {shortcut}
-            </span>
-          </Button>
-        );
-      })}
+      {TAB_DEFINITIONS.filter(({ key }) => availableTabs.includes(key)).map(
+        ({ icon: Icon, key }, index) => {
+          const selected = activeTab === key;
+          return (
+            <Button
+              aria-selected={selected}
+              className={cn(
+                'h-9 shrink-0 gap-2 rounded-b-none border-transparent px-3 text-muted-foreground',
+                selected &&
+                  'border-border border-b-background bg-background text-foreground shadow-xs'
+              )}
+              key={key}
+              onClick={() => onChange(key)}
+              role="tab"
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              <Icon className="size-4" />
+              {labels[key]}
+              <span className="hidden font-mono text-[10px] opacity-50 sm:inline">
+                {index + 1}
+              </span>
+            </Button>
+          );
+        }
+      )}
     </div>
   );
 }
@@ -94,3 +98,6 @@ export const COMMAND_LAUNCHER_TABS: readonly CommandLauncherTab[] = [
   'apps',
   'actions',
 ];
+
+export const COMMAND_LAUNCHER_TABS_WITHOUT_TASKS: readonly CommandLauncherTab[] =
+  ['all', 'navigation', 'apps', 'actions'];

--- a/packages/satellite/src/components/command-launcher/command-launcher-tabs.tsx
+++ b/packages/satellite/src/components/command-launcher/command-launcher-tabs.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Boxes, Compass, ListTodo, Search, Sparkles } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { cn } from '@tuturuuu/utils/format';
+
+export type CommandLauncherTab =
+  | 'tasks'
+  | 'all'
+  | 'navigation'
+  | 'apps'
+  | 'actions';
+
+const TAB_DEFINITIONS = [
+  { icon: ListTodo, key: 'tasks', shortcut: '1' },
+  { icon: Search, key: 'all', shortcut: '2' },
+  { icon: Compass, key: 'navigation', shortcut: '3' },
+  { icon: Boxes, key: 'apps', shortcut: '4' },
+  { icon: Sparkles, key: 'actions', shortcut: '5' },
+] as const;
+
+export function parseLauncherQuery(query: string): {
+  query: string;
+  tab: CommandLauncherTab | null;
+} {
+  const trimmed = query.trimStart();
+  const prefix = trimmed[0];
+  const tab =
+    prefix === '#'
+      ? 'tasks'
+      : prefix === '/'
+        ? 'navigation'
+        : prefix === '@'
+          ? 'apps'
+          : prefix === '>'
+            ? 'actions'
+            : null;
+
+  return tab
+    ? { query: trimmed.slice(1).trimStart(), tab }
+    : { query, tab: null };
+}
+
+export function CommandLauncherTabs({
+  activeTab,
+  ariaLabel,
+  labels,
+  onChange,
+}: {
+  activeTab: CommandLauncherTab;
+  ariaLabel: string;
+  labels: Record<CommandLauncherTab, string>;
+  onChange: (tab: CommandLauncherTab) => void;
+}) {
+  return (
+    <div
+      aria-label={ariaLabel}
+      className="flex gap-1 overflow-x-auto border-b bg-muted/20 px-3 pt-2"
+      role="tablist"
+    >
+      {TAB_DEFINITIONS.map(({ icon: Icon, key, shortcut }) => {
+        const selected = activeTab === key;
+        return (
+          <Button
+            aria-selected={selected}
+            className={cn(
+              'h-9 shrink-0 gap-2 rounded-b-none border-transparent px-3 text-muted-foreground',
+              selected &&
+                'border-border border-b-background bg-background text-foreground shadow-xs'
+            )}
+            key={key}
+            onClick={() => onChange(key)}
+            role="tab"
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <Icon className="size-4" />
+            {labels[key]}
+            <span className="hidden font-mono text-[10px] opacity-50 sm:inline">
+              {shortcut}
+            </span>
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+export const COMMAND_LAUNCHER_TABS: readonly CommandLauncherTab[] = [
+  'tasks',
+  'all',
+  'navigation',
+  'apps',
+  'actions',
+];

--- a/packages/satellite/src/components/command-launcher/command-launcher-tabs.tsx
+++ b/packages/satellite/src/components/command-launcher/command-launcher-tabs.tsx
@@ -12,11 +12,11 @@ export type CommandLauncherTab =
   | 'actions';
 
 const TAB_DEFINITIONS = [
-  { icon: ListTodo, key: 'tasks', shortcut: '1' },
-  { icon: Search, key: 'all', shortcut: '2' },
-  { icon: Compass, key: 'navigation', shortcut: '3' },
-  { icon: Boxes, key: 'apps', shortcut: '4' },
-  { icon: Sparkles, key: 'actions', shortcut: '5' },
+  { icon: ListTodo, key: 'tasks' },
+  { icon: Search, key: 'all' },
+  { icon: Compass, key: 'navigation' },
+  { icon: Boxes, key: 'apps' },
+  { icon: Sparkles, key: 'actions' },
 ] as const;
 
 export function parseLauncherQuery(query: string): {
@@ -55,17 +55,16 @@ export function CommandLauncherTabs({
   onChange: (tab: CommandLauncherTab) => void;
 }) {
   return (
-    <div
+    <fieldset
       aria-label={ariaLabel}
-      className="flex gap-1 overflow-x-auto border-b bg-muted/20 px-3 pt-2"
-      role="tablist"
+      className="m-0 flex min-w-0 gap-1 overflow-x-auto border-0 border-b bg-muted/20 px-3 pt-2"
     >
       {TAB_DEFINITIONS.filter(({ key }) => availableTabs.includes(key)).map(
         ({ icon: Icon, key }, index) => {
           const selected = activeTab === key;
           return (
             <Button
-              aria-selected={selected}
+              aria-pressed={selected}
               className={cn(
                 'h-9 shrink-0 gap-2 rounded-b-none border-transparent px-3 text-muted-foreground',
                 selected &&
@@ -73,7 +72,6 @@ export function CommandLauncherTabs({
               )}
               key={key}
               onClick={() => onChange(key)}
-              role="tab"
               size="sm"
               type="button"
               variant="ghost"
@@ -87,17 +85,12 @@ export function CommandLauncherTabs({
           );
         }
       )}
-    </div>
+    </fieldset>
   );
 }
 
-export const COMMAND_LAUNCHER_TABS: readonly CommandLauncherTab[] = [
-  'tasks',
-  'all',
-  'navigation',
-  'apps',
-  'actions',
-];
+export const COMMAND_LAUNCHER_TABS: readonly CommandLauncherTab[] =
+  TAB_DEFINITIONS.map((definition) => definition.key);
 
 export const COMMAND_LAUNCHER_TABS_WITHOUT_TASKS: readonly CommandLauncherTab[] =
-  ['all', 'navigation', 'apps', 'actions'];
+  COMMAND_LAUNCHER_TABS.filter((tab) => tab !== 'tasks');

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
@@ -218,7 +218,7 @@ describe('GlobalCommandLauncher', () => {
 
   it('switches result categories with tabs, prefixes, and keyboard shortcuts', async () => {
     listWorkspaces.mockResolvedValue(workspaces);
-    renderLauncher();
+    renderLauncher({ enableTasks: true });
 
     openGlobalCommandLauncher();
     const input = await screen.findByPlaceholderText(
@@ -235,14 +235,24 @@ describe('GlobalCommandLauncher', () => {
       screen.getByRole('button', { name: /Apps/ }).getAttribute('aria-pressed')
     ).toBe('true');
 
-    expect(screen.queryByRole('button', { name: /Tasks/ })).toBeNull();
-
-    fireEvent.keyDown(input, { ctrlKey: true, key: '2' });
+    fireEvent.keyDown(input, { ctrlKey: true, key: '3' });
     expect(
       screen
         .getByRole('button', { name: /Navigation/ })
         .getAttribute('aria-pressed')
     ).toBe('true');
+  });
+
+  it('keeps capability-free satellite search unified without empty tabs', async () => {
+    listWorkspaces.mockResolvedValue(workspaces);
+    renderLauncher();
+
+    openGlobalCommandLauncher();
+    await screen.findByPlaceholderText('Search apps, workspaces, and pages...');
+
+    expect(screen.queryByRole('button', { name: /Tasks/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Actions/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /All/ })).toBeNull();
   });
 
   it('exposes task-first navigation only when the host enables tasks', async () => {

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
@@ -60,7 +60,9 @@ const workspaces = [
 function renderLauncher({
   currentApp = 'calendar',
   currentWorkspaceId = 'personal-id',
+  defaultTab = 'all',
   duplicateCount = 1,
+  enableTasks = false,
   onNavigate,
 }: Partial<Parameters<typeof GlobalCommandLauncher>[0]> & {
   duplicateCount?: number;
@@ -80,6 +82,8 @@ function renderLauncher({
         <GlobalCommandLauncher
           currentApp={currentApp}
           currentWorkspaceId={currentWorkspaceId}
+          defaultTab={defaultTab}
+          enableTasks={enableTasks}
           key={index}
           navItems={[
             {
@@ -216,12 +220,27 @@ describe('GlobalCommandLauncher', () => {
       screen.getByRole('tab', { name: /Apps/ }).getAttribute('aria-selected')
     ).toBe('true');
 
-    fireEvent.keyDown(input, { ctrlKey: true, key: '3' });
+    expect(screen.queryByRole('tab', { name: /Tasks/ })).toBeNull();
+
+    fireEvent.keyDown(input, { ctrlKey: true, key: '2' });
     expect(
       screen
         .getByRole('tab', { name: /Navigation/ })
         .getAttribute('aria-selected')
     ).toBe('true');
+  });
+
+  it('exposes task-first navigation only when the host enables tasks', async () => {
+    listWorkspaces.mockResolvedValue(workspaces);
+    renderLauncher({ defaultTab: 'tasks', enableTasks: true });
+
+    openGlobalCommandLauncher();
+    await screen.findByPlaceholderText('Search apps, workspaces, and pages...');
+
+    expect(
+      screen.getByRole('tab', { name: /Tasks/ }).getAttribute('aria-selected')
+    ).toBe('true');
+    expect(screen.getByRole('tab', { name: /All/ })).toBeTruthy();
   });
 
   it('queries workspace search results beyond the initially loaded workspaces', async () => {

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
@@ -197,6 +197,33 @@ describe('GlobalCommandLauncher', () => {
     expect(await screen.findByText('Task Boards')).toBeTruthy();
   });
 
+  it('switches result categories with tabs, prefixes, and keyboard shortcuts', async () => {
+    listWorkspaces.mockResolvedValue(workspaces);
+    renderLauncher();
+
+    openGlobalCommandLauncher();
+    const input = await screen.findByPlaceholderText(
+      'Search apps, workspaces, and pages...'
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Navigation/ }));
+    expect(screen.queryByText('Calendar')).toBeNull();
+    expect(screen.getByText('Task Boards')).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: '@finance' } });
+    expect(await screen.findByText('Finance')).toBeTruthy();
+    expect(
+      screen.getByRole('tab', { name: /Apps/ }).getAttribute('aria-selected')
+    ).toBe('true');
+
+    fireEvent.keyDown(input, { ctrlKey: true, key: '3' });
+    expect(
+      screen
+        .getByRole('tab', { name: /Navigation/ })
+        .getAttribute('aria-selected')
+    ).toBe('true');
+  });
+
   it('queries workspace search results beyond the initially loaded workspaces', async () => {
     const remoteWorkspace = {
       access_type: 'owner',
@@ -274,12 +301,12 @@ describe('GlobalCommandLauncher', () => {
     const commandList = document.querySelector('[data-slot="command-list"]');
 
     expect(dialogContent?.className).toContain(
-      'h-[min(760px,calc(100dvh-2rem))]'
+      'h-[min(820px,calc(100dvh-2rem))]'
     );
     expect(dialogContent?.className).toContain(
       'grid-rows-[auto_minmax(0,1fr)]'
     );
-    expect(dialogContent?.className).toContain('w-[min(760px,96vw)]');
+    expect(dialogContent?.className).toContain('w-[min(1040px,96vw)]');
     expect(dialogContent?.className).toContain('overflow-hidden');
     expect(commandList?.className).toContain('min-h-0');
     expect(commandList?.className).toContain('flex-1');

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
@@ -63,6 +63,13 @@ function renderLauncher({
   defaultTab = 'all',
   duplicateCount = 1,
   enableTasks = false,
+  navItems = [
+    {
+      href: '/personal/tasks',
+      keywords: ['Project boards'],
+      title: 'Task Boards',
+    },
+  ],
   onNavigate,
 }: Partial<Parameters<typeof GlobalCommandLauncher>[0]> & {
   duplicateCount?: number;
@@ -85,13 +92,7 @@ function renderLauncher({
           defaultTab={defaultTab}
           enableTasks={enableTasks}
           key={index}
-          navItems={[
-            {
-              href: '/personal/tasks',
-              keywords: ['Project boards'],
-              title: 'Task Boards',
-            },
-          ]}
+          navItems={navItems}
           onNavigate={onNavigate}
         />
       ))}
@@ -266,6 +267,23 @@ describe('GlobalCommandLauncher', () => {
       screen.getByRole('button', { name: /Tasks/ }).getAttribute('aria-pressed')
     ).toBe('true');
     expect(screen.getByRole('button', { name: /All/ })).toBeTruthy();
+  });
+
+  it('hides the navigation tab when a task-enabled host has no pages', async () => {
+    listWorkspaces.mockResolvedValue(workspaces);
+    renderLauncher({ enableTasks: true, navItems: [] });
+
+    openGlobalCommandLauncher();
+    const input = await screen.findByPlaceholderText(
+      'Search apps, workspaces, and pages...'
+    );
+
+    expect(screen.queryByRole('button', { name: /Navigation/ })).toBeNull();
+
+    fireEvent.keyDown(input, { ctrlKey: true, key: '3' });
+    expect(
+      screen.getByRole('button', { name: /Apps/ }).getAttribute('aria-pressed')
+    ).toBe('true');
   });
 
   it('queries workspace search results beyond the initially loaded workspaces', async () => {

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
@@ -271,7 +271,7 @@ describe('GlobalCommandLauncher', () => {
 
   it('hides the navigation tab when a task-enabled host has no pages', async () => {
     listWorkspaces.mockResolvedValue(workspaces);
-    renderLauncher({ enableTasks: true, navItems: [] });
+    renderLauncher({ defaultTab: 'tasks', enableTasks: true, navItems: [] });
 
     openGlobalCommandLauncher();
     const input = await screen.findByPlaceholderText(
@@ -284,6 +284,22 @@ describe('GlobalCommandLauncher', () => {
     expect(
       screen.getByRole('button', { name: /Apps/ }).getAttribute('aria-pressed')
     ).toBe('true');
+  });
+
+  it('does not search remote workspaces from a task-only category', async () => {
+    listWorkspaces.mockResolvedValue(workspaces);
+    renderLauncher({ defaultTab: 'tasks', enableTasks: true, navItems: [] });
+
+    openGlobalCommandLauncher();
+    const input = await screen.findByPlaceholderText(
+      'Search apps, workspaces, and pages...'
+    );
+
+    await waitFor(() => expect(listWorkspaces).toHaveBeenCalledTimes(1));
+    fireEvent.change(input, { target: { value: 'launch' } });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(listWorkspaces).toHaveBeenCalledTimes(1);
   });
 
   it('queries workspace search results beyond the initially loaded workspaces', async () => {

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.test.tsx
@@ -151,6 +151,21 @@ describe('GlobalCommandLauncher', () => {
     });
   });
 
+  it('ignores Cmd/Ctrl+K while an input method is composing', () => {
+    listWorkspaces.mockResolvedValue(workspaces);
+    renderLauncher();
+
+    fireEvent.keyDown(document, {
+      ctrlKey: true,
+      isComposing: true,
+      key: 'k',
+    });
+
+    expect(
+      screen.queryByPlaceholderText('Search apps, workspaces, and pages...')
+    ).toBeNull();
+  });
+
   it('opens only one same-app launcher from the global open event', async () => {
     listWorkspaces.mockResolvedValue(workspaces);
     renderLauncher({ duplicateCount: 2 });
@@ -210,23 +225,23 @@ describe('GlobalCommandLauncher', () => {
       'Search apps, workspaces, and pages...'
     );
 
-    fireEvent.click(screen.getByRole('tab', { name: /Navigation/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Navigation/ }));
     expect(screen.queryByText('Calendar')).toBeNull();
     expect(screen.getByText('Task Boards')).toBeTruthy();
 
     fireEvent.change(input, { target: { value: '@finance' } });
     expect(await screen.findByText('Finance')).toBeTruthy();
     expect(
-      screen.getByRole('tab', { name: /Apps/ }).getAttribute('aria-selected')
+      screen.getByRole('button', { name: /Apps/ }).getAttribute('aria-pressed')
     ).toBe('true');
 
-    expect(screen.queryByRole('tab', { name: /Tasks/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Tasks/ })).toBeNull();
 
     fireEvent.keyDown(input, { ctrlKey: true, key: '2' });
     expect(
       screen
-        .getByRole('tab', { name: /Navigation/ })
-        .getAttribute('aria-selected')
+        .getByRole('button', { name: /Navigation/ })
+        .getAttribute('aria-pressed')
     ).toBe('true');
   });
 
@@ -238,9 +253,9 @@ describe('GlobalCommandLauncher', () => {
     await screen.findByPlaceholderText('Search apps, workspaces, and pages...');
 
     expect(
-      screen.getByRole('tab', { name: /Tasks/ }).getAttribute('aria-selected')
+      screen.getByRole('button', { name: /Tasks/ }).getAttribute('aria-pressed')
     ).toBe('true');
-    expect(screen.getByRole('tab', { name: /All/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /All/ })).toBeTruthy();
   });
 
   it('queries workspace search results beyond the initially loaded workspaces', async () => {

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
@@ -310,6 +310,7 @@ export function GlobalCommandLauncher({
   const routedTab = prefixedTab ?? activeTab;
   const trimmedQuery = trimQuery(parsedQuery.query);
   const deferredWorkspaceQuery = useDeferredValue(trimmedQuery);
+  const showApps = routedTab === 'all' || routedTab === 'apps';
 
   const closeLauncher = useCallback(() => setOpen(false), []);
 
@@ -381,7 +382,7 @@ export function GlobalCommandLauncher({
   const launcherWorkspaces = workspaces as LauncherWorkspace[];
   const { data: remoteWorkspaces = [], isFetching: isSearchingWorkspaces } =
     useQuery({
-      enabled: open && deferredWorkspaceQuery.length > 0,
+      enabled: open && showApps && deferredWorkspaceQuery.length > 0,
       queryFn: () =>
         listWorkspaces({
           limit: REMOTE_WORKSPACE_SEARCH_LIMIT,
@@ -524,7 +525,6 @@ export function GlobalCommandLauncher({
         })
       : extraSections;
 
-  const showApps = routedTab === 'all' || routedTab === 'apps';
   const showNavigation = routedTab === 'all' || routedTab === 'navigation';
   const showExtraSections =
     routedTab === 'tasks' || routedTab === 'all' || routedTab === 'actions';

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
@@ -285,11 +285,14 @@ export function GlobalCommandLauncher({
   workspacePathResolver,
 }: GlobalCommandLauncherProps) {
   const labels = { ...DEFAULT_LABELS, ...labelOverrides };
-  const availableTabs = enableTasks
+  const hostTabs = enableTasks
     ? COMMAND_LAUNCHER_TABS
     : extraSections
       ? COMMAND_LAUNCHER_TABS_WITHOUT_TASKS
       : (['all'] as const);
+  const availableTabs = hostTabs.filter(
+    (tab) => tab !== 'navigation' || navItems.length > 0
+  );
   const resolvedDefaultTab = availableTabs.includes(defaultTab)
     ? defaultTab
     : 'all';

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
@@ -47,6 +47,7 @@ import {
 } from './command-launcher-items';
 import {
   COMMAND_LAUNCHER_TABS,
+  COMMAND_LAUNCHER_TABS_WITHOUT_TASKS,
   type CommandLauncherTab,
   CommandLauncherTabs,
   parseLauncherQuery,
@@ -109,6 +110,7 @@ export type GlobalCommandLauncherProps = {
   currentApp: CommandLauncherHostApp;
   currentWorkspaceId?: string | null;
   defaultTab?: CommandLauncherTab;
+  enableTasks?: boolean;
   extraSections?:
     | ReactNode
     | ((context: CommandLauncherExtraSectionContext) => ReactNode);
@@ -275,6 +277,7 @@ export function GlobalCommandLauncher({
   currentApp,
   currentWorkspaceId,
   defaultTab = 'all',
+  enableTasks = false,
   extraSections,
   labels: labelOverrides,
   navItems = [],
@@ -282,13 +285,24 @@ export function GlobalCommandLauncher({
   workspacePathResolver,
 }: GlobalCommandLauncherProps) {
   const labels = { ...DEFAULT_LABELS, ...labelOverrides };
+  const availableTabs = enableTasks
+    ? COMMAND_LAUNCHER_TABS
+    : COMMAND_LAUNCHER_TABS_WITHOUT_TASKS;
+  const resolvedDefaultTab = availableTabs.includes(defaultTab)
+    ? defaultTab
+    : 'all';
   const instanceId = useMemo(() => Symbol('GlobalCommandLauncher'), []);
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const [activeTab, setActiveTab] = useState<CommandLauncherTab>(defaultTab);
+  const [activeTab, setActiveTab] =
+    useState<CommandLauncherTab>(resolvedDefaultTab);
   const parsedQuery = useMemo(() => parseLauncherQuery(query), [query]);
-  const routedTab = parsedQuery.tab ?? activeTab;
+  const prefixedTab =
+    parsedQuery.tab && availableTabs.includes(parsedQuery.tab)
+      ? parsedQuery.tab
+      : null;
+  const routedTab = prefixedTab ?? activeTab;
   const trimmedQuery = trimQuery(parsedQuery.query);
   const deferredWorkspaceQuery = useDeferredValue(trimmedQuery);
 
@@ -342,9 +356,9 @@ export function GlobalCommandLauncher({
   useEffect(() => {
     if (!open) {
       setQuery('');
-      setActiveTab(defaultTab);
+      setActiveTab(resolvedDefaultTab);
     }
-  }, [defaultTab, open]);
+  }, [open, resolvedDefaultTab]);
 
   const {
     data: workspaces = [],
@@ -516,7 +530,7 @@ export function GlobalCommandLauncher({
 
   const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
     if (!(event.metaKey || event.ctrlKey)) return;
-    const nextTab = COMMAND_LAUNCHER_TABS[Number(event.key) - 1];
+    const nextTab = availableTabs[Number(event.key) - 1];
     if (!nextTab) return;
     event.preventDefault();
     setActiveTab(nextTab);
@@ -572,6 +586,7 @@ export function GlobalCommandLauncher({
             <CommandLauncherTabs
               activeTab={routedTab}
               ariaLabel={labels.categories}
+              availableTabs={availableTabs}
               labels={{
                 actions: labels.actions,
                 all: labels.all,

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
@@ -1,17 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import {
-  ArrowRight,
-  Building2,
-  Check,
-  ExternalLink,
-  Globe2,
-  Loader2,
-  PanelTop,
-  Search,
-  User,
-} from '@tuturuuu/icons';
+import { Loader2, Search } from '@tuturuuu/icons';
 import { listWorkspaces } from '@tuturuuu/internal-api';
 import type { InternalApiWorkspaceSummary } from '@tuturuuu/types';
 import { Badge } from '@tuturuuu/ui/badge';
@@ -30,7 +20,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@tuturuuu/ui/dialog';
-import { cn } from '@tuturuuu/utils/format';
 import {
   LAUNCHABLE_APPS,
   type LaunchableApp,
@@ -42,6 +31,7 @@ import {
 import { type IntentSearchResult, searchIntent } from '@tuturuuu/utils/search';
 import { usePathname } from 'next/navigation';
 import {
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
   useCallback,
   useDeferredValue,
@@ -49,6 +39,18 @@ import {
   useMemo,
   useState,
 } from 'react';
+import {
+  AppCommandItem,
+  EmptyState,
+  NavigationCommandItem,
+  WorkspaceCommandItem,
+} from './command-launcher-items';
+import {
+  COMMAND_LAUNCHER_TABS,
+  type CommandLauncherTab,
+  CommandLauncherTabs,
+  parseLauncherQuery,
+} from './command-launcher-tabs';
 import {
   GLOBAL_COMMAND_LAUNCHER_EVENT,
   type GlobalCommandLauncherEvent,
@@ -66,6 +68,7 @@ export type CommandLauncherNavItem = {
 };
 
 export type CommandLauncherExtraSectionContext = {
+  activeTab: CommandLauncherTab;
   onClose: () => void;
   query: string;
   setQuery: (query: string) => void;
@@ -73,6 +76,9 @@ export type CommandLauncherExtraSectionContext = {
 
 export type GlobalCommandLauncherLabels = {
   apps: string;
+  categories: string;
+  all: string;
+  actions: string;
   close: string;
   current: string;
   currentApp: string;
@@ -93,6 +99,7 @@ export type GlobalCommandLauncherLabels = {
   searchHint: string;
   select: string;
   title: string;
+  tasks: string;
   workspaces: string;
 };
 
@@ -101,6 +108,7 @@ type CommandLauncherHostApp = LaunchableAppSlug | 'external';
 export type GlobalCommandLauncherProps = {
   currentApp: CommandLauncherHostApp;
   currentWorkspaceId?: string | null;
+  defaultTab?: CommandLauncherTab;
   extraSections?:
     | ReactNode
     | ((context: CommandLauncherExtraSectionContext) => ReactNode);
@@ -110,31 +118,19 @@ export type GlobalCommandLauncherProps = {
   workspacePathResolver?: LaunchableAppWorkspacePathResolver;
 };
 
-type LauncherWorkspace = InternalApiWorkspaceSummary & LaunchableWorkspace;
+export type LauncherWorkspace = InternalApiWorkspaceSummary &
+  LaunchableWorkspace;
 type WorkspaceSearchItem = LauncherWorkspace & {
   aliases: string[];
   keywords: string[];
   title: string;
 };
 
-type LauncherItem =
-  | {
-      app: LaunchableApp;
-      result: IntentSearchResult<LaunchableApp>;
-      type: 'app';
-    }
-  | {
-      result: IntentSearchResult<CommandLauncherNavItem>;
-      type: 'nav';
-    }
-  | {
-      result: IntentSearchResult<WorkspaceSearchItem>;
-      type: 'workspace';
-      workspace: WorkspaceSearchItem;
-    };
-
 const DEFAULT_LABELS: GlobalCommandLauncherLabels = {
+  actions: 'Actions',
+  all: 'All',
   apps: 'Apps',
+  categories: 'Search category',
   close: 'close',
   current: 'Current',
   currentApp: 'Current app',
@@ -155,6 +151,7 @@ const DEFAULT_LABELS: GlobalCommandLauncherLabels = {
   searchHint: 'Type a workspace, app, page, acronym, or close spelling.',
   select: 'select',
   title: 'Command Launcher',
+  tasks: 'Tasks',
   workspaces: 'Workspaces',
 };
 
@@ -241,11 +238,10 @@ function isWorkspaceCurrent(
 
   const firstSegment = pathname.split('/').filter(Boolean)[0];
 
-  return firstSegment === workspace.id || firstSegment === 'personal';
-}
-
-function getWorkspaceAccessType(workspace: LauncherWorkspace) {
-  return 'access_type' in workspace ? workspace.access_type : null;
+  return (
+    firstSegment === workspace.id ||
+    (firstSegment === 'personal' && workspace.personal)
+  );
 }
 
 function getMatchContext<T extends { title: string }>(
@@ -278,6 +274,7 @@ function mergeWorkspaces(
 export function GlobalCommandLauncher({
   currentApp,
   currentWorkspaceId,
+  defaultTab = 'all',
   extraSections,
   labels: labelOverrides,
   navItems = [],
@@ -289,7 +286,10 @@ export function GlobalCommandLauncher({
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const trimmedQuery = trimQuery(query);
+  const [activeTab, setActiveTab] = useState<CommandLauncherTab>(defaultTab);
+  const parsedQuery = useMemo(() => parseLauncherQuery(query), [query]);
+  const routedTab = parsedQuery.tab ?? activeTab;
+  const trimmedQuery = trimQuery(parsedQuery.query);
   const deferredWorkspaceQuery = useDeferredValue(trimmedQuery);
 
   const closeLauncher = useCallback(() => setOpen(false), []);
@@ -301,6 +301,7 @@ export function GlobalCommandLauncher({
       if (!isActiveCommandLauncherInstance(currentApp, instanceId)) return;
 
       if (
+        !event.repeat &&
         event.key.toLowerCase() === 'k' &&
         (event.metaKey || event.ctrlKey) &&
         !event.altKey &&
@@ -308,7 +309,7 @@ export function GlobalCommandLauncher({
       ) {
         event.preventDefault();
         event.stopPropagation();
-        setOpen(true);
+        setOpen((current) => !current);
       }
     };
 
@@ -339,8 +340,11 @@ export function GlobalCommandLauncher({
   }, [currentApp, instanceId]);
 
   useEffect(() => {
-    if (!open) setQuery('');
-  }, [open]);
+    if (!open) {
+      setQuery('');
+      setActiveTab(defaultTab);
+    }
+  }, [defaultTab, open]);
 
   const {
     data: workspaces = [],
@@ -425,25 +429,6 @@ export function GlobalCommandLauncher({
     [navItems, trimmedQuery]
   );
 
-  const visibleItems: LauncherItem[] = [
-    ...appResults.map((result) => ({
-      app: result.item,
-      result,
-      type: 'app' as const,
-    })),
-    ...workspaceResults.map((result) => ({
-      result,
-      type: 'workspace' as const,
-      workspace: result.item,
-    })),
-    ...navigationResults.map((result) => ({
-      result,
-      type: 'nav' as const,
-    })),
-  ];
-
-  const hasResults = visibleItems.length > 0;
-
   const navigateTo = useCallback(
     (url: string, options: { newTab?: boolean } = {}) => {
       closeLauncher();
@@ -512,17 +497,37 @@ export function GlobalCommandLauncher({
   const renderedExtraSections =
     typeof extraSections === 'function'
       ? extraSections({
+          activeTab: routedTab,
           onClose: closeLauncher,
-          query,
+          query: parsedQuery.query,
           setQuery,
         })
       : extraSections;
+
+  const showApps = routedTab === 'all' || routedTab === 'apps';
+  const showNavigation = routedTab === 'all' || routedTab === 'navigation';
+  const showExtraSections =
+    routedTab === 'tasks' || routedTab === 'all' || routedTab === 'actions';
+  const currentAppTitle =
+    LAUNCHABLE_APPS.find((app) => app.slug === currentApp)?.title ??
+    labels.title;
+  const activeTabLabel =
+    routedTab === 'navigation' ? labels.navigation : labels[routedTab];
+
+  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (!(event.metaKey || event.ctrlKey)) return;
+    const nextTab = COMMAND_LAUNCHER_TABS[Number(event.key) - 1];
+    if (!nextTab) return;
+    event.preventDefault();
+    setActiveTab(nextTab);
+    if (parsedQuery.tab) setQuery(parsedQuery.query);
+  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
         aria-label={labels.title}
-        className="grid h-[min(760px,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] w-[min(760px,96vw)] grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden rounded-lg border bg-background p-0 shadow-2xl sm:max-w-[min(760px,96vw)]"
+        className="grid h-[min(820px,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] w-[min(1040px,96vw)] grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden rounded-xl border-border/70 bg-background/95 p-0 shadow-2xl backdrop-blur-xl sm:max-w-[min(1040px,96vw)]"
         showCloseButton={false}
       >
         <DialogHeader className="sr-only">
@@ -534,22 +539,60 @@ export function GlobalCommandLauncher({
           shouldFilter={false}
         >
           <div className="flex min-h-0 flex-col overflow-hidden">
+            <div className="flex items-center justify-between gap-4 border-b bg-muted/15 px-4 py-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <h2 className="truncate font-semibold text-sm">
+                    {labels.title}
+                  </h2>
+                  <Badge className="h-5 px-1.5 text-[10px]" variant="secondary">
+                    {activeTabLabel}
+                  </Badge>
+                </div>
+                <p className="truncate text-muted-foreground text-xs">
+                  {currentWorkspace?.name ?? currentAppTitle}
+                </p>
+              </div>
+              <kbd className="hidden rounded-md border bg-background px-2 py-1 font-mono text-[10px] text-muted-foreground shadow-xs sm:block">
+                ⌘/Ctrl K
+              </kbd>
+            </div>
             <div className="border-b">
               <CommandInput
                 aria-label={labels.title}
-                className="h-12"
+                autoFocus
+                className="h-14 text-base"
+                onKeyDown={handleInputKeyDown}
                 onValueChange={setQuery}
                 placeholder={labels.placeholder}
                 value={query}
               />
             </div>
 
+            <CommandLauncherTabs
+              activeTab={routedTab}
+              ariaLabel={labels.categories}
+              labels={{
+                actions: labels.actions,
+                all: labels.all,
+                apps: labels.apps,
+                navigation: labels.navigation,
+                tasks: labels.tasks,
+              }}
+              onChange={(tab) => {
+                setActiveTab(tab);
+                if (parsedQuery.tab) setQuery(parsedQuery.query);
+              }}
+            />
+
             <CommandList className="max-h-none min-h-0 flex-1 overflow-y-auto p-2">
               <CommandEmpty>
                 <EmptyState labels={labels} query={trimmedQuery} />
               </CommandEmpty>
 
-              {appResults.length > 0 && (
+              {showExtraSections ? renderedExtraSections : null}
+
+              {showApps && appResults.length > 0 && (
                 <CommandGroup heading={labels.apps}>
                   {appResults.map((result) => (
                     <AppCommandItem
@@ -564,41 +607,42 @@ export function GlobalCommandLauncher({
                 </CommandGroup>
               )}
 
-              {(isLoadingWorkspaces ||
-                isSearchingWorkspaces ||
-                workspaceError ||
-                workspaceResults.length > 0) && (
-                <CommandGroup heading={labels.workspaces}>
-                  {(isLoadingWorkspaces || isSearchingWorkspaces) && (
-                    <CommandItem disabled value="loading-workspaces">
-                      <Loader2 className="size-4 animate-spin" />
-                      <span>{labels.loadingWorkspaces}</span>
-                    </CommandItem>
-                  )}
-                  {workspaceError && (
-                    <CommandItem disabled value="workspace-error">
-                      <Search className="size-4" />
-                      <span>{labels.errorWorkspaces}</span>
-                    </CommandItem>
-                  )}
-                  {workspaceResults.map((result) => (
-                    <WorkspaceCommandItem
-                      isCurrent={isWorkspaceCurrent(
-                        result.item,
-                        currentWorkspaceId,
-                        pathname
-                      )}
-                      key={result.item.id}
-                      labels={labels}
-                      matchContext={getMatchContext(result, labels)}
-                      onSelect={() => openWorkspace(result.item)}
-                      workspace={result.item}
-                    />
-                  ))}
-                </CommandGroup>
-              )}
+              {showApps &&
+                (isLoadingWorkspaces ||
+                  isSearchingWorkspaces ||
+                  workspaceError ||
+                  workspaceResults.length > 0) && (
+                  <CommandGroup heading={labels.workspaces}>
+                    {(isLoadingWorkspaces || isSearchingWorkspaces) && (
+                      <CommandItem disabled value="loading-workspaces">
+                        <Loader2 className="size-4 animate-spin" />
+                        <span>{labels.loadingWorkspaces}</span>
+                      </CommandItem>
+                    )}
+                    {workspaceError && (
+                      <CommandItem disabled value="workspace-error">
+                        <Search className="size-4" />
+                        <span>{labels.errorWorkspaces}</span>
+                      </CommandItem>
+                    )}
+                    {workspaceResults.map((result) => (
+                      <WorkspaceCommandItem
+                        isCurrent={isWorkspaceCurrent(
+                          result.item,
+                          currentWorkspaceId,
+                          pathname
+                        )}
+                        key={result.item.id}
+                        labels={labels}
+                        matchContext={getMatchContext(result, labels)}
+                        onSelect={() => openWorkspace(result.item)}
+                        workspace={result.item}
+                      />
+                    ))}
+                  </CommandGroup>
+                )}
 
-              {navigationResults.length > 0 && (
+              {showNavigation && navigationResults.length > 0 && (
                 <CommandGroup heading={labels.navigation}>
                   {navigationResults.map((result) => (
                     <NavigationCommandItem
@@ -611,191 +655,10 @@ export function GlobalCommandLauncher({
                   ))}
                 </CommandGroup>
               )}
-
-              {renderedExtraSections}
-
-              {!hasResults &&
-                !isLoadingWorkspaces &&
-                !isSearchingWorkspaces && (
-                  <div className="py-8">
-                    <EmptyState labels={labels} query={trimmedQuery} />
-                  </div>
-                )}
             </CommandList>
           </div>
         </Command>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function AppCommandItem({
-  app,
-  isCurrent,
-  labels,
-  matchContext,
-  onSelect,
-}: {
-  app: LaunchableApp;
-  isCurrent: boolean;
-  labels: GlobalCommandLauncherLabels;
-  matchContext: string | null;
-  onSelect: () => void;
-}) {
-  return (
-    <CommandItem
-      className="min-h-13 rounded-md px-2"
-      onSelect={onSelect}
-      value={`app-${app.slug}-${app.title}`}
-    >
-      <div className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted/60">
-        <Globe2 className="size-4" />
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate font-medium">{app.title}</span>
-          {isCurrent && (
-            <Badge
-              className="h-5 rounded-md px-1.5 text-[10px]"
-              variant="secondary"
-            >
-              {labels.current}
-            </Badge>
-          )}
-        </div>
-        <div className="truncate text-muted-foreground text-xs">
-          {matchContext ?? app.productionUrl}
-        </div>
-      </div>
-      <span className="hidden text-muted-foreground text-xs sm:inline">
-        {labels.openApp}
-      </span>
-      <ArrowRight className="size-4" />
-    </CommandItem>
-  );
-}
-
-function WorkspaceCommandItem({
-  isCurrent,
-  labels,
-  matchContext,
-  onSelect,
-  workspace,
-}: {
-  isCurrent: boolean;
-  labels: GlobalCommandLauncherLabels;
-  matchContext: string | null;
-  onSelect: () => void;
-  workspace: LauncherWorkspace;
-}) {
-  const accessType = getWorkspaceAccessType(workspace);
-
-  return (
-    <CommandItem
-      className="min-h-13 rounded-md px-2"
-      onSelect={onSelect}
-      value={`workspace-${workspace.id}-${workspace.name}`}
-    >
-      <div className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted/60">
-        {workspace.personal ? (
-          <User className="size-4" />
-        ) : (
-          <Building2 className="size-4" />
-        )}
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate font-medium">
-            {workspace.name || workspace.id}
-          </span>
-          {isCurrent && <StatusBadge label={labels.current} />}
-          {workspace.personal && <StatusBadge label={labels.personal} />}
-          {accessType === 'guest' && <StatusBadge label={labels.guest} />}
-        </div>
-        <div className="truncate text-muted-foreground text-xs">
-          {matchContext ?? workspace.id}
-        </div>
-      </div>
-      <span className="hidden text-muted-foreground text-xs sm:inline">
-        {labels.openWorkspace}
-      </span>
-      {isCurrent ? (
-        <Check className="size-4" />
-      ) : (
-        <ArrowRight className="size-4" />
-      )}
-    </CommandItem>
-  );
-}
-
-function NavigationCommandItem({
-  item,
-  labels,
-  matchContext,
-  onSelect,
-}: {
-  item: CommandLauncherNavItem;
-  labels: GlobalCommandLauncherLabels;
-  matchContext: string | null;
-  onSelect: () => void;
-}) {
-  return (
-    <CommandItem
-      className="min-h-13 rounded-md px-2"
-      onSelect={onSelect}
-      value={`nav-${item.href}-${item.title}`}
-    >
-      <div className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted/60">
-        {item.icon ?? <PanelTop className="size-4" />}
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate font-medium">{item.title}</span>
-          {item.external && (
-            <ExternalLink className="size-3 text-muted-foreground" />
-          )}
-        </div>
-        <div className="truncate text-muted-foreground text-xs">
-          {matchContext ?? item.subtitle ?? item.href}
-        </div>
-      </div>
-      <span className="hidden text-muted-foreground text-xs sm:inline">
-        {labels.open}
-      </span>
-      <ArrowRight className="size-4" />
-    </CommandItem>
-  );
-}
-
-function EmptyState({
-  labels,
-  query,
-}: {
-  labels: GlobalCommandLauncherLabels;
-  query: string;
-}) {
-  return (
-    <div className="flex flex-col items-center gap-3 px-6 py-10 text-center">
-      <div className="flex size-12 items-center justify-center rounded-lg border bg-muted/60">
-        <Search className="size-5 text-muted-foreground" />
-      </div>
-      <div className="space-y-1">
-        <p className="font-medium">{labels.empty}</p>
-        <p className="text-muted-foreground text-sm">
-          {query ? `"${query}"` : labels.emptyDescription}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function StatusBadge({ label }: { label: string }) {
-  return (
-    <Badge
-      className={cn('h-5 rounded-md px-1.5 text-[10px]', 'uppercase')}
-      variant="outline"
-    >
-      {label}
-    </Badge>
   );
 }

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
@@ -313,6 +313,7 @@ export function GlobalCommandLauncher({
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (!isActiveCommandLauncherInstance(currentApp, instanceId)) return;
+      if (event.isComposing) return;
 
       if (
         !event.repeat &&

--- a/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
+++ b/packages/satellite/src/components/command-launcher/global-command-launcher.tsx
@@ -287,7 +287,9 @@ export function GlobalCommandLauncher({
   const labels = { ...DEFAULT_LABELS, ...labelOverrides };
   const availableTabs = enableTasks
     ? COMMAND_LAUNCHER_TABS
-    : COMMAND_LAUNCHER_TABS_WITHOUT_TASKS;
+    : extraSections
+      ? COMMAND_LAUNCHER_TABS_WITHOUT_TASKS
+      : (['all'] as const);
   const resolvedDefaultTab = availableTabs.includes(defaultTab)
     ? defaultTab
     : 'all';
@@ -560,9 +562,14 @@ export function GlobalCommandLauncher({
                   <h2 className="truncate font-semibold text-sm">
                     {labels.title}
                   </h2>
-                  <Badge className="h-5 px-1.5 text-[10px]" variant="secondary">
-                    {activeTabLabel}
-                  </Badge>
+                  {availableTabs.length > 1 ? (
+                    <Badge
+                      className="h-5 px-1.5 text-[10px]"
+                      variant="secondary"
+                    >
+                      {activeTabLabel}
+                    </Badge>
+                  ) : null}
                 </div>
                 <p className="truncate text-muted-foreground text-xs">
                   {currentWorkspace?.name ?? currentAppTitle}
@@ -584,22 +591,24 @@ export function GlobalCommandLauncher({
               />
             </div>
 
-            <CommandLauncherTabs
-              activeTab={routedTab}
-              ariaLabel={labels.categories}
-              availableTabs={availableTabs}
-              labels={{
-                actions: labels.actions,
-                all: labels.all,
-                apps: labels.apps,
-                navigation: labels.navigation,
-                tasks: labels.tasks,
-              }}
-              onChange={(tab) => {
-                setActiveTab(tab);
-                if (parsedQuery.tab) setQuery(parsedQuery.query);
-              }}
-            />
+            {availableTabs.length > 1 ? (
+              <CommandLauncherTabs
+                activeTab={routedTab}
+                ariaLabel={labels.categories}
+                availableTabs={availableTabs}
+                labels={{
+                  actions: labels.actions,
+                  all: labels.all,
+                  apps: labels.apps,
+                  navigation: labels.navigation,
+                  tasks: labels.tasks,
+                }}
+                onChange={(tab) => {
+                  setActiveTab(tab);
+                  if (parsedQuery.tab) setQuery(parsedQuery.query);
+                }}
+              />
+            ) : null}
 
             <CommandList className="max-h-none min-h-0 flex-1 overflow-y-auto p-2">
               <CommandEmpty>

--- a/packages/satellite/src/components/command-launcher/index.ts
+++ b/packages/satellite/src/components/command-launcher/index.ts
@@ -1,3 +1,4 @@
+export type { CommandLauncherTab } from './command-launcher-tabs';
 export {
   closeGlobalCommandLauncher,
   GLOBAL_COMMAND_LAUNCHER_EVENT,

--- a/packages/tasks-api/src/server/tasks/route.ts
+++ b/packages/tasks-api/src/server/tasks/route.ts
@@ -2167,7 +2167,6 @@ export async function handleTaskRouteGET(
         );
       }
     }
-
     const tasksWithRelationshipSummary = tasks.map((task) => {
       const summary = relationshipSummaryByTaskId.get(task.id);
       const taskList = task.task_lists as
@@ -2182,6 +2181,7 @@ export async function handleTaskRouteGET(
         | undefined;
       return {
         ...task,
+        is_assigned_to_current_user: task.assignee_ids?.includes(user.id),
         board_id: task.board_id ?? taskList?.board_id ?? null,
         board_name: task.board_name ?? taskList?.workspace_boards?.name ?? null,
         ticket_prefix:

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -34,12 +34,14 @@ function CommandDialog({
   children,
   showCloseButton = true,
   contentClassName,
+  commandProps,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string;
   description?: string;
   showCloseButton?: boolean;
   contentClassName?: string;
+  commandProps?: React.ComponentProps<typeof CommandPrimitive>;
 }) {
   return (
     <Dialog {...props}>
@@ -51,7 +53,13 @@ function CommandDialog({
         className={cn('overflow-hidden p-0', contentClassName)}
         showCloseButton={showCloseButton}
       >
-        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          {...commandProps}
+          className={cn(
+            '**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5',
+            commandProps?.className
+          )}
+        >
           {/* TODO: Fix Bun types issue with children prop */}
           {children as any}
         </Command>


### PR DESCRIPTION
## Summary
- redesign the live Cmd/Ctrl+K launcher as a task-first command center with Tasks, All, Pages, Apps, and Actions tabs
- add status and priority filters, relevance/due/priority/newest sorting, power prefixes, keyboard tab switching, quick completion/reopen, copy-link actions, and bilingual copy
- unify the command engine, move task retrieval to the internal API, and keep the shared cross-app launcher responsive and accessible
- restore inherited main validation parity for the email-policy route manifest, generated migration counters, and source-size gate

## Verification
- focused command/task tests: 21 passed
- web and dependent package type-check: passed
- full elevated bun check: all repository gates passed
- migration manifest JSON parse and script validators: passed