### PR TITLE
feat(forms): add landing page, per-form SEO, realtime collaboration, and embeds

### DIFF
--- a/apps/database/supabase/migrations/20260825045312_forms_seo_metadata.sql
+++ b/apps/database/supabase/migrations/20260825045312_forms_seo_metadata.sql
@@ -1,0 +1,35 @@
+-- Per-form SEO and social-sharing metadata.
+--
+-- Until now every public form at `/f/<shareCode>` derived its title, social
+-- description and Open Graph image from the form's own content. That is a fine
+-- default but not controllable: a form titled "Q3 intake — v2 (FINAL)" reads
+-- badly as a link preview, and there was no way to keep a public form out of
+-- search results short of leaving it unpublished.
+--
+-- Stored as a single jsonb column, matching the existing `settings` and `theme`
+-- columns on this table, so adding a field later does not need a migration.
+-- Shape (all keys optional, empty string/false means "fall back to derived"):
+--
+--   {
+--     "title":         text,     -- overrides the derived social/page title
+--     "description":   text,     -- overrides the derived description
+--     "image":         { "storagePath": text, "url": text, "alt": text },
+--     "keywords":      text[],   -- replaces the derived keyword list
+--     "canonicalUrl":  text,     -- points crawlers at a different canonical
+--     "noIndex":       boolean   -- emits robots noindex,nofollow
+--   }
+
+alter table if exists private.forms
+  add column if not exists seo jsonb not null default '{}'::jsonb;
+
+comment on column private.forms.seo is
+  'Optional per-form SEO/social overrides. Empty object means every field is derived from the form content. See the migration that introduced this column for the shape.';
+
+-- Guard against a non-object landing here (an array or scalar would silently
+-- break every read path, which merges this column into a Zod object schema).
+alter table if exists private.forms
+  drop constraint if exists forms_seo_is_object;
+
+alter table if exists private.forms
+  add constraint forms_seo_is_object
+  check (jsonb_typeof(seo) = 'object');

--- a/apps/database/supabase/migrations/20260825053118_forms_realtime_collaboration.sql
+++ b/apps/database/supabase/migrations/20260825053118_forms_realtime_collaboration.sql
@@ -1,0 +1,110 @@
+-- Realtime collaboration for the form studio.
+--
+-- Two people editing the same form had no way to see each other. The studio now
+-- joins a private Supabase Realtime channel per form, carrying presence (who is
+-- here, which block they are on) and broadcasts (someone saved, reload).
+--
+-- Broadcast and presence are used rather than `postgres_changes` because the
+-- forms tables live in the `private` schema with service-role-only access —
+-- they are deliberately off the public Data API, so a browser client cannot
+-- subscribe to row changes on them at all.
+--
+-- Topic shape: `form-studio-<formId>`.
+
+create schema if not exists private;
+
+create or replace function private.can_join_form_realtime_topic(
+  p_topic text,
+  p_user_id uuid
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public, private
+as $$
+declare
+  form_id_text text;
+  topic_form_id uuid;
+  topic_ws_id uuid;
+begin
+  if p_user_id is null or p_topic is null then
+    return false;
+  end if;
+
+  if p_topic not like 'form-studio-%' then
+    return false;
+  end if;
+
+  form_id_text := substring(p_topic from length('form-studio-') + 1);
+
+  -- A topic whose suffix is not a uuid can never match a form. Reject it
+  -- rather than letting the cast raise, which would surface as a channel error
+  -- instead of a clean denial.
+  begin
+    topic_form_id := form_id_text::uuid;
+  exception
+    when invalid_text_representation then
+      return false;
+  end;
+
+  select forms.ws_id
+  into topic_ws_id
+  from private.forms forms
+  where forms.id = topic_form_id;
+
+  if topic_ws_id is null then
+    return false;
+  end if;
+
+  -- Editing presence is gated on the same permission the studio itself
+  -- requires. Analysts who can only read responses have no reason to appear in
+  -- an editing session, and would leak their identity to editors if they did.
+  return public.has_workspace_permission(
+    topic_ws_id,
+    p_user_id,
+    'manage_forms'
+  );
+end;
+$$;
+
+revoke all on function private.can_join_form_realtime_topic(text, uuid)
+from public, anon;
+
+grant execute on function private.can_join_form_realtime_topic(text, uuid)
+to authenticated;
+
+-- Additive alongside the existing task-realtime policy. Multiple permissive
+-- policies on `realtime.messages` are OR-ed, so this grants form topics without
+-- touching board topics.
+drop policy if exists "form studio realtime channels are scoped"
+on realtime.messages;
+
+create policy "form studio realtime channels are scoped"
+on realtime.messages
+for select
+to authenticated
+using (
+  private = true
+  and realtime.topic() like 'form-studio-%'
+  and private.can_join_form_realtime_topic(realtime.topic(), auth.uid())
+  and extension in ('broadcast', 'presence')
+);
+
+-- Broadcasting requires insert on `realtime.messages`; the task policy only
+-- covers select because its broadcasts are all sent server-side with the
+-- service role. Studio editors broadcast from the browser, so they need insert
+-- on exactly the topics they may already read.
+drop policy if exists "form studio realtime broadcasts are scoped"
+on realtime.messages;
+
+create policy "form studio realtime broadcasts are scoped"
+on realtime.messages
+for insert
+to authenticated
+with check (
+  private = true
+  and realtime.topic() like 'form-studio-%'
+  and private.can_join_form_realtime_topic(realtime.topic(), auth.uid())
+  and extension in ('broadcast', 'presence')
+);

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -33,6 +33,7 @@
                   "platform/features/command-center-dashboard",
                   "platform/features/cms-site-contract-v1",
                   "platform/features/external-project-studio",
+                  "platform/features/forms-embedding-and-seo",
                   "platform/features/meet-calls",
                   "platform/features/meet-together",
                   "platform/features/mobile-workspace-tools",

--- a/apps/docs/platform/features/forms-embedding-and-seo.mdx
+++ b/apps/docs/platform/features/forms-embedding-and-seo.mdx
@@ -1,0 +1,155 @@
+---
+title: 'Forms: embedding, SEO, and studio collaboration'
+description: 'Embed a Tuturuuu form in a third-party page, control its search and social metadata, and understand how the studio shares editing presence.'
+updatedAt: '2026-08-26'
+---
+
+## TL;DR
+
+`apps/forms` (`forms.tuturuuu.com`, port `7828`) owns the whole forms product.
+Three surfaces are worth knowing about before you touch it:
+
+- **Embedding** — six modes driven by a dependency-free SDK at `/embed.js`,
+  rendered by the `/embed/<shareCode>` route.
+- **SEO** — per-form overrides stored in `private.forms.seo`, applied to
+  `/f/<shareCode>` metadata.
+- **Realtime collaboration** — presence and broadcast on a private
+  `form-studio-<formId>` channel, never `postgres_changes`.
+
+## Embedding
+
+The studio's embed panel generates the snippet; this is what it emits and why.
+
+### Script SDK (preferred)
+
+```html
+<script src="https://forms.tuturuuu.com/embed.js" async></script>
+<div data-tuturuuu-form="<shareCode>" data-mode="inline"></div>
+```
+
+The SDK scans for `data-tuturuuu-form` elements, mounts an iframe pointed at
+`/embed/<shareCode>`, and marks the container `data-tuturuuu-form-mounted` so a
+re-run cannot double-mount it.
+
+| Attribute | Applies to | Default | Meaning |
+| --- | --- | --- | --- |
+| `data-tuturuuu-form` | all | — | The form's share code. Required. |
+| `data-mode` | all | `inline` | `inline`, `fullpage`, `popup`, `slider`, `popover`, or `sidetab`. |
+| `data-height` | inline modes | `520` | Fixed pixel height. Omit to let the embed auto-size. |
+| `data-title` | all | — | `title` on the generated iframe, for screen readers. |
+| `data-launcher-text` | overlay modes | localized default | Launcher button label. |
+| `data-launcher-color` | overlay modes | `#6d28d9` | Launcher button background. |
+| `data-open` | overlay modes | `false` | `true` opens the overlay on load. |
+| `data-close-on-submit` | overlay modes | `true` | `false` keeps the overlay open after submit. |
+
+`inline` and `fullpage` render in place. `popup`, `slider`, `popover`, and
+`sidetab` are overlay modes: they render a launcher and only mount the form when
+it opens.
+
+### Iframe fallback
+
+Hosts that forbid third-party scripts (locked-down CMSes, most email-adjacent
+tools) can use a plain iframe. It loses auto-resize, so give it a height:
+
+```html
+<iframe src="https://forms.tuturuuu.com/embed/<shareCode>"
+  title="Form" width="100%" height="640" style="border:0"></iframe>
+```
+
+### The framing exception
+
+Framing is denied platform-wide by `createTuturuuuNextConfig`
+(`frame-ancestors 'none'` plus `X-Frame-Options: DENY`). `X-Frame-Options` has no
+"allow from any origin" value, so a later permissive header cannot override the
+deny — the header has to be **absent** instead.
+
+`createTuturuuuNextConfig` therefore accepts `framablePathPatterns`, and builds
+the anti-framing `source` as a negative lookahead over every framable path:
+
+```ts
+// apps/forms/next.config.ts
+createTuturuuuNextConfig({
+  framablePathPatterns: ['embed/[^/]+'],
+});
+```
+
+Opt in per route, never per app. Everything not listed stays denied.
+
+`apps/forms/src/proxy.ts` must also treat `/embed/` as public, or the embed
+redirects to login *inside the host's iframe*.
+
+### Host-page messages
+
+The embed posts `window.postMessage` events the SDK listens for. The contract
+lives in `apps/forms/src/features/forms/embed/protocol.ts` and is shared by the
+React page and `public/embed.js` so the two cannot drift.
+
+Every message carries `source: 'tuturuuu-forms'`; verify it before acting, since
+a host page may run other iframes.
+
+| `type` | Payload | Meaning |
+| --- | --- | --- |
+| `ready` | — | The embed mounted and can be shown. |
+| `resize` | `height` (CSS px) | Content height changed; resize the iframe. |
+| `submitted` | — | The respondent submitted; overlay modes may auto-dismiss. |
+
+## Per-form SEO
+
+`private.forms.seo` is a `jsonb` column (constrained to an object) holding
+optional overrides. Every key is optional, and an empty string or `false` means
+"fall back to the value derived from the form's content":
+
+- `title`, `description` — override the derived page and social title/description
+- `image` — `{ storagePath, url, alt }` for the social card
+- `keywords` — `text[]`, replaces the derived list
+- `canonicalUrl` — points crawlers at a different canonical
+- `noIndex` — emits `noindex,nofollow`
+
+It is a single `jsonb` column, matching the existing `settings` and `theme`
+columns on the same table, so adding a field later needs no migration.
+
+The studio's SEO panel renders a live search-result preview showing where Google
+truncates each field.
+
+## Studio collaboration
+
+The studio joins a **private** Supabase Realtime channel per form, topic
+`form-studio-<formId>`, carrying presence (who is here, which block they are on)
+and broadcasts (someone saved).
+
+It uses broadcast and presence rather than `postgres_changes` because the forms
+tables live in the Postgres `private` schema with service-role-only access. They
+are deliberately off the public Data API, so a browser client cannot subscribe to
+row changes on them at all.
+
+Access is authorized by `private.can_join_form_realtime_topic(topic, user_id)`,
+which resolves the form from the topic suffix and defers to
+`public.has_workspace_permission(ws_id, user_id, 'manage_forms')`. Presence is
+gated on the same permission the studio itself requires: analysts who can only
+read responses have no reason to appear in an editing session, and would leak
+their identity to editors if they did.
+
+<Warning>
+`apps/forms` is a registered satellite app, so the `internal-app-auth` guard
+forbids `supabase.auth.*` inside it. Resolve identity server-side with
+`getSatelliteAppSessionUser('forms')` and pass the id down as a prop, and take
+the realtime client from `@tuturuuu/supabase/next/realtime-browser`.
+</Warning>
+
+When a remote save arrives, the studio refetches immediately **only if your copy
+is clean**. If you have unsaved edits it raises a reload prompt instead —
+refetching blindly would discard your work.
+
+## Gotchas worth carrying elsewhere
+
+<Warning>
+`packages/satellite` is **not** in Tailwind's content scan set. Classes used only
+from that package emit no CSS at all, so the markup renders unstyled and
+invisible rather than failing loudly. Shared presentational code that needs
+Tailwind belongs in `packages/ui` — that is why the marketing kit lives at
+`@tuturuuu/ui/marketing`.
+</Warning>
+
+Calling `connection()` at the root of a marketing page forces the entire page
+dynamic. Scope it to the session-dependent subtree instead, so the static shell
+still prerenders.

--- a/apps/forms/AGENTS.md
+++ b/apps/forms/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/forms/CLAUDE.md
+++ b/apps/forms/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -2860,7 +2860,10 @@
       "validation_constraint_real_range": "Enter a number between {min} and {max}",
       "validation_constraint_regex": "Must match the required pattern",
       "validation_fix_errors": "Please fix the errors above before submitting.",
-      "view_image_fullscreen": "View image fullscreen"
+      "view_image_fullscreen": "View image fullscreen",
+      "welcome_start": "Start",
+      "welcome_question_count": "{count, plural, =1 {1 question} other {# questions}}",
+      "step_progress": "{current} of {total}"
     },
     "settings": {
       "active": "Active",
@@ -2981,7 +2984,24 @@
       "embed_launcher_placeholder": "Open form",
       "embed_snippet": "Script embed (recommended)",
       "embed_iframe_snippet": "Plain iframe (no scripts)",
-      "embed_requires_share_link": "Publish this form and create a share link first — an embed points at that link."
+      "embed_requires_share_link": "Publish this form and create a share link first — an embed points at that link.",
+      "display_mode": "How questions are shown",
+      "display_modes": {
+        "sections": "All at once",
+        "one_question": "One at a time"
+      },
+      "display_mode_hints": {
+        "sections": "A whole section on one screen. Good for short forms people scan before answering.",
+        "one_question": "One question per screen. Keeps long forms from looking daunting and lifts completion."
+      },
+      "welcome_screen": "Show a welcome screen",
+      "welcome_screen_hint": "A cover screen before the first question, so people know what they are starting.",
+      "welcome_title": "Welcome title",
+      "welcome_title_placeholder": "Leave empty to use the form title",
+      "welcome_body": "Welcome message",
+      "welcome_body_placeholder": "Leave empty to use the form description",
+      "welcome_button": "Button label",
+      "welcome_button_placeholder": "Start"
     },
     "shared": {
       "metadata_fallback_description": "Open this shared form to review the questions and submit a response.",
@@ -3397,7 +3417,8 @@
           "fonts": "Nineteen headline and body faces, paired independently",
           "density": "Airy, balanced or compact spacing",
           "typography": "Separate display, heading and body sizes",
-          "cover": "Cover image and headline, plus per-section art"
+          "cover": "Cover image and headline, plus per-section art",
+          "pacing": "One question at a time, or a whole section per screen"
         }
       },
       "embed": {

--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -3009,7 +3009,10 @@
       "metadata_protected_description": "This shared form is protected. Sign in or use the provided access path to continue.",
       "open_graph_alt": "Preview image for {title}",
       "unavailable_description": "This form may have been unpublished, closed, or removed.",
-      "unavailable_title": "Form unavailable"
+      "unavailable_title": "Form unavailable",
+      "sign_in_required_title": "Sign in to continue",
+      "sign_in_required_description": "This form asks who you are, which cannot be done inside an embedded frame.",
+      "open_in_new_tab": "Open the form in a new tab"
     },
     "status": {
       "closed": "Closed",

--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -3562,6 +3562,17 @@
           "contact": "Contact"
         }
       }
+    },
+    "collaboration": {
+      "away": "Away",
+      "viewing": "Viewing the form",
+      "editing_block": "Editing “{block}”",
+      "editing_now": "{name} is editing this",
+      "editing_now_multiple": "{count} people are editing this",
+      "editor_count": "{count, plural, =1 {1 other editor} other {# other editors}}",
+      "remote_save_title": "{name} saved changes",
+      "remote_save_description": "You have unsaved edits, so this copy was left alone. Reload to take their version — your changes will be lost.",
+      "remote_save_reload": "Reload"
     }
   },
   "guest-lead-data-table": {

--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -2933,7 +2933,27 @@
       "turnstile_always_on": "Turnstile is always on for live forms",
       "turnstile_always_on_hint": "Every public submission must pass the verification challenge. Creators cannot disable this protection.",
       "typography_scale": "Typography scale",
-      "unlimited": "Unlimited"
+      "unlimited": "Unlimited",
+      "seo": "Search & sharing",
+      "seo_description": "Control how this form looks in search results and link previews.",
+      "seo_preview": "Search result preview",
+      "seo_preview_unpublished_url": "forms.tuturuuu.com/f/… (publish to get a link)",
+      "seo_preview_truncated": "Search engines will cut this off — shorten it to control what shows.",
+      "seo_title": "Search title",
+      "seo_title_placeholder": "Leave empty to use the form title",
+      "seo_title_hint": "Around 60 characters shows in full. Empty falls back to the cover headline, then the form title.",
+      "seo_meta_description": "Search description",
+      "seo_meta_description_placeholder": "Leave empty to use the form description",
+      "seo_meta_description_hint": "Around 160 characters shows in full. Empty falls back to the form description, then the first section's.",
+      "seo_keywords": "Keywords",
+      "seo_keywords_placeholder": "hiring, application, engineering",
+      "seo_keywords_hint": "Comma separated, up to {max}. Empty uses keywords derived from the title.",
+      "seo_canonical": "Canonical URL",
+      "seo_canonical_hint": "Point crawlers at another page when this form is embedded somewhere else. Empty uses the form's own link.",
+      "seo_image": "Social card image",
+      "seo_image_hint": "1200×630 works best. Empty uses the card generated from your form's theme and cover.",
+      "seo_no_index": "Hide from search engines",
+      "seo_no_index_hint": "Emits noindex. The link keeps working for anyone you share it with — it just will not be indexed."
     },
     "shared": {
       "metadata_fallback_description": "Open this shared form to review the questions and submit a response.",
@@ -3148,6 +3168,400 @@
       "responses_cleared": "Responses cleared",
       "section_needs_question": "Section {section} must contain at least one question.",
       "share_link_copied": "Share link copied"
+    },
+    "landing": {
+      "app_name": "Tuturuuu Forms",
+      "meta": {
+        "title": "Forms that people actually finish",
+        "social_title": "Tuturuuu Forms — build, theme, embed, analyze",
+        "description": "Build beautiful forms and surveys in minutes. Conditional logic, live themes, six embed modes, realtime co-editing, and response analytics — all in one workspace."
+      },
+      "nav": {
+        "workflow": "How it works",
+        "build": "Blocks",
+        "design": "Design",
+        "embed": "Embed",
+        "insights": "Insights",
+        "get_started": "Start free",
+        "workspace": "Open workspace",
+        "sign_in": "Sign in"
+      },
+      "hero": {
+        "eyebrow": "Forms",
+        "title": "Forms that people actually finish",
+        "description": "Design a form in minutes, publish it anywhere, and watch the answers land in real time. No template lock-in, no per-response paywall, no data you cannot export.",
+        "primary": "Start free",
+        "primary_authed": "Open your workspace",
+        "secondary": "See how it works",
+        "reassurance": "Free to start · No credit card · Export everything, always"
+      },
+      "stats": {
+        "blocks": {
+          "value": "14",
+          "label": "Question & content blocks"
+        },
+        "themes": {
+          "value": "12",
+          "label": "Themes, fully editable"
+        },
+        "embeds": {
+          "value": "6",
+          "label": "Ways to embed"
+        },
+        "languages": {
+          "value": "2",
+          "label": "Interface languages"
+        }
+      },
+      "demo": {
+        "theme_label": "Try a theme",
+        "title": "Product feedback",
+        "description": "A real form, running the real renderer. Answer it — nothing is recorded.",
+        "confirmation_title": "That is the whole flow",
+        "confirmation_message": "This demo does not store anything. Your own forms collect responses, track drop-off, and export to CSV.",
+        "section_title": "Tell us about your team",
+        "section_description": "Four questions. About thirty seconds.",
+        "role_title": "What best describes your role?",
+        "role_option_1": "Founder",
+        "role_option_2": "Operations",
+        "role_option_3": "Product",
+        "role_option_4": "Something else",
+        "priority_title": "Which of these would you use first?",
+        "priority_description": "Pick as many as you like.",
+        "priority_option_1": "Customer feedback",
+        "priority_option_2": "Event registration",
+        "priority_option_3": "Job applications",
+        "priority_option_4": "Internal requests",
+        "satisfaction_title": "How happy are you with your current form tool?",
+        "satisfaction_min": "Not at all",
+        "satisfaction_max": "Very happy",
+        "notes_title": "Anything else we should know?",
+        "notes_placeholder": "Optional — write as much or as little as you like"
+      },
+      "workflow": {
+        "eyebrow": "End to end",
+        "title": "Blank page to first response, without leaving the tab",
+        "subtitle": "Building, styling, sharing and analyzing are four tabs of the same editor — not four tools you have to stitch together.",
+        "steps": {
+          "build": {
+            "title": "Build",
+            "description": "Drag blocks into sections, write questions in Markdown, and add branching that skips whatever is not relevant."
+          },
+          "design": {
+            "title": "Design",
+            "description": "Pick a theme, then tune the accent, fonts, density and cover image until it looks like it belongs to you."
+          },
+          "share": {
+            "title": "Share",
+            "description": "Publish a link or drop the form into your own site as an inline panel, popup, slider, side tab or full page."
+          },
+          "learn": {
+            "title": "Learn",
+            "description": "Watch responses arrive live, see where people give up, and export everything to CSV whenever you want."
+          }
+        }
+      },
+      "build": {
+        "eyebrow": "The builder",
+        "title": "Every block you need, and nothing you have to configure twice",
+        "subtitle": "Question types and content blocks share one editor. Set a placeholder, mark a field required, add validation, reorder by dragging.",
+        "footnote": "Sections, page breaks, dividers and rich text are blocks too — so a form can read like a document when it needs to.",
+        "blocks": {
+          "short_text": {
+            "title": "Short text",
+            "description": "One-line answers with placeholder and length rules."
+          },
+          "long_text": {
+            "title": "Long text",
+            "description": "Multi-line answers for context and detail."
+          },
+          "choice": {
+            "title": "Choice",
+            "description": "Single or multiple select, as a list or an image grid."
+          },
+          "dropdown": {
+            "title": "Dropdown",
+            "description": "Long option lists without eating the page."
+          },
+          "scale": {
+            "title": "Linear scale",
+            "description": "1–10 ranges with labelled endpoints."
+          },
+          "rating": {
+            "title": "Rating",
+            "description": "Star ratings from two to ten points."
+          },
+          "date": {
+            "title": "Date & time",
+            "description": "Calendar and clock inputs with validation."
+          },
+          "media": {
+            "title": "Image",
+            "description": "Illustrate a question, or make the options themselves images."
+          },
+          "video": {
+            "title": "Video",
+            "description": "Embed a YouTube clip inline, with a start offset."
+          },
+          "rich_text": {
+            "title": "Rich text",
+            "description": "Markdown blocks for instructions, consent and context."
+          }
+        }
+      },
+      "logic": {
+        "eyebrow": "Logic",
+        "title": "Ask only what is relevant",
+        "subtitle": "Rules route people to the right section based on what they answered — or end the form early when there is nothing left to ask.",
+        "diagram": {
+          "source_label": "When someone answers",
+          "source_question": "How big is your team?",
+          "if": "If",
+          "note": "Rules can fire on a single answer or at the end of a whole section, and can jump to any section or submit immediately.",
+          "rules": {
+            "enterprise": {
+              "answer": "More than 200 people",
+              "destination": "Procurement questions"
+            },
+            "startup": {
+              "answer": "10 to 200 people",
+              "destination": "Team setup"
+            },
+            "individual": {
+              "answer": "Just me",
+              "destination": "Submit"
+            }
+          }
+        },
+        "features": {
+          "branching": {
+            "title": "Answer branching",
+            "description": "Send people down a different path based on what they picked."
+          },
+          "section_end": {
+            "title": "Section rules",
+            "description": "Decide where to go once a whole section is finished."
+          },
+          "validation": {
+            "title": "Validation",
+            "description": "Numbers, email, URL, ranges and custom patterns, with your own error copy."
+          },
+          "scheduling": {
+            "title": "Open & close",
+            "description": "Schedule a window, cap total responses, or limit one per person."
+          }
+        }
+      },
+      "design": {
+        "eyebrow": "Design",
+        "title": "Themes you can actually edit",
+        "subtitle": "Start from a preset, then change anything. The preview is the form — what you see while editing is exactly what a respondent gets.",
+        "surface_heading": "Three surface styles",
+        "surface_description": "Paper is flat and printed. Glass floats over the background. Panel is bordered and dense. Every theme works in light and dark.",
+        "controls_heading": "Tune the details",
+        "controls_description": "Presets are a starting point, not a cage — each of these is an independent control.",
+        "surfaces": {
+          "paper": "Paper",
+          "glass": "Glass",
+          "panel": "Panel"
+        },
+        "controls": {
+          "fonts": "Nineteen headline and body faces, paired independently",
+          "density": "Airy, balanced or compact spacing",
+          "typography": "Separate display, heading and body sizes",
+          "cover": "Cover image and headline, plus per-section art"
+        }
+      },
+      "embed": {
+        "eyebrow": "Embed",
+        "title": "Six ways to put a form where people already are",
+        "subtitle": "One share code, one script tag. Change the mode with a data attribute — no rebuild, no redeploy.",
+        "snippet_heading": "One tag, any mode",
+        "snippet_description": "Drop the script once, then mark up as many forms as you like. Switch between inline, popup, slider, popover, side tab and full page by changing a single attribute.",
+        "modes": {
+          "inline": {
+            "title": "Inline",
+            "description": "The form sits in the flow of your page and grows with its content."
+          },
+          "fullpage": {
+            "title": "Full page",
+            "description": "A hosted page of its own — nothing else on screen but the form."
+          },
+          "popup": {
+            "title": "Popup",
+            "description": "Opens centered over the page, dimming everything behind it."
+          },
+          "slider": {
+            "title": "Slider",
+            "description": "Slides in from the edge, keeping the page visible alongside."
+          },
+          "popover": {
+            "title": "Popover",
+            "description": "A launcher bubble in the corner that expands into a compact card."
+          },
+          "sidetab": {
+            "title": "Side tab",
+            "description": "A persistent tab pinned to the edge that opens a panel on click."
+          }
+        }
+      },
+      "collaborate": {
+        "eyebrow": "Collaboration",
+        "title": "Edit together, without overwriting each other",
+        "subtitle": "Everyone in the workspace sees the same form as it changes. Presence, block-level editing indicators and autosave are on by default.",
+        "presence_label": "3 teammates editing right now",
+        "features": {
+          "presence": {
+            "title": "Live presence",
+            "description": "See who else has the form open and which block they are on."
+          },
+          "locks": {
+            "title": "Soft locks",
+            "description": "A block being edited is flagged before you type into it, not after."
+          },
+          "autosave": {
+            "title": "Autosave",
+            "description": "Changes save on their own, with an explicit save whenever you want one."
+          }
+        }
+      },
+      "insights": {
+        "eyebrow": "Insights",
+        "title": "Know what happened, not just how many",
+        "subtitle": "Every form tracks views, starts, completions and drop-off per question — so you can tell a quiet form from a broken one.",
+        "funnel": {
+          "label": "Response funnel",
+          "note": "Illustrative figures. Your own funnel is computed from real sessions, broken down by device, referrer and country.",
+          "steps": {
+            "views": {
+              "label": "Viewed",
+              "value": "1,000"
+            },
+            "starts": {
+              "label": "Started",
+              "value": "740"
+            },
+            "completed": {
+              "label": "Completed",
+              "value": "520"
+            }
+          }
+        },
+        "features": {
+          "live": {
+            "title": "Live responses",
+            "description": "Answers appear as they arrive, grouped by respondent."
+          },
+          "dropoff": {
+            "title": "Drop-off",
+            "description": "Find the exact question where people stop answering."
+          },
+          "export": {
+            "title": "Export",
+            "description": "Download responses as CSV, or the whole form as portable JSON."
+          },
+          "receipts": {
+            "title": "Response copies",
+            "description": "Let respondents email themselves a copy of what they submitted."
+          }
+        }
+      },
+      "trust": {
+        "eyebrow": "Trust",
+        "title": "Your responses stay yours",
+        "subtitle": "Forms and their answers are stored off the public data API and reached only through checked workspace permissions.",
+        "developer_heading": "Built to be integrated",
+        "developer_description": "Everything the studio can do is reachable from your own code, and nothing is a one-way door.",
+        "features": {
+          "private_schema": {
+            "title": "Private storage",
+            "description": "Definitions and answers live outside the public API surface."
+          },
+          "access": {
+            "title": "Access control",
+            "description": "Anonymous, signed-in, or signed-in with a verified email address."
+          },
+          "spam": {
+            "title": "Spam protection",
+            "description": "Turnstile plus rate limiting on every public submission."
+          },
+          "portable": {
+            "title": "No lock-in",
+            "description": "Export any form to JSON and import it into another workspace."
+          }
+        },
+        "developer": {
+          "sdk": {
+            "title": "Embed SDK",
+            "description": "A single script that mounts any embed mode from data attributes."
+          },
+          "share_link": {
+            "title": "Share links",
+            "description": "Rotate or revoke a public link without touching the form."
+          },
+          "portable": {
+            "title": "Portable format",
+            "description": "Versioned JSON export you can diff, review and check into git."
+          }
+        }
+      },
+      "faq": {
+        "eyebrow": "Questions",
+        "title": "Before you start",
+        "subtitle": "The things people ask most often.",
+        "items": {
+          "free": {
+            "question": "Is it free?",
+            "answer": "Yes — building forms, collecting responses and exporting your data are all free to start. There is no per-response charge and no cap that quietly hides answers you already collected."
+          },
+          "anonymous": {
+            "question": "Do respondents need an account?",
+            "answer": "No. A form can accept fully anonymous responses. You can also require a signed-in Tuturuuu account, or a signed-in account with a verified email, if you need to know who answered."
+          },
+          "embed": {
+            "question": "Can I put a form on my own site?",
+            "answer": "Yes, in six different ways: inline, full page, popup, slider, popover bubble and side tab. All of them come from one script tag and one share code, so switching between them is a single attribute change."
+          },
+          "realtime": {
+            "question": "Can my team edit a form at the same time?",
+            "answer": "Yes. Everyone with access to the workspace sees live presence, an indicator on whichever block a teammate is editing, and each other's changes as they are saved."
+          },
+          "export": {
+            "question": "Can I get my data out?",
+            "answer": "Always. Responses export to CSV, and the form itself exports to a versioned JSON file you can import into any other workspace."
+          },
+          "languages": {
+            "question": "What languages are supported?",
+            "answer": "The interface ships in English and Vietnamese, and your form content can be written in any language. Fonts cover Vietnamese diacritics properly rather than falling back mid-sentence."
+          }
+        }
+      },
+      "closing": {
+        "title": "Build your first form in the next five minutes",
+        "description": "Start with a blank page or import one you already have. Either way, you will have a shareable link before your coffee gets cold.",
+        "secondary": "Read the FAQ"
+      },
+      "footer": {
+        "tagline": "Build, theme, embed and analyze forms — part of the Tuturuuu workspace.",
+        "product": "Product",
+        "platform": "Platform",
+        "legal": "Legal",
+        "legal_line": "© {year} Tuturuuu. All rights reserved.",
+        "links": {
+          "workflow": "How it works",
+          "build": "Blocks",
+          "design": "Design",
+          "embed": "Embed",
+          "tuturuuu": "Tuturuuu",
+          "products": "All products",
+          "pricing": "Pricing",
+          "docs": "Docs",
+          "terms": "Terms",
+          "privacy": "Privacy",
+          "security": "Security",
+          "contact": "Contact"
+        }
+      }
     }
   },
   "guest-lead-data-table": {

--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -1595,7 +1595,8 @@
     "write_something": "Write something",
     "years_old": "years old",
     "yellow": "Yellow",
-    "yesterday": "Yesterday"
+    "yesterday": "Yesterday",
+    "copy": "Copy"
   },
   "course-data-table": {
     "modules": "Modules"
@@ -2953,7 +2954,34 @@
       "seo_image": "Social card image",
       "seo_image_hint": "1200×630 works best. Empty uses the card generated from your form's theme and cover.",
       "seo_no_index": "Hide from search engines",
-      "seo_no_index_hint": "Emits noindex. The link keeps working for anyone you share it with — it just will not be indexed."
+      "seo_no_index_hint": "Emits noindex. The link keeps working for anyone you share it with — it just will not be indexed.",
+      "embed": "Embed",
+      "embed_description": "Put this form on your own site — inline, as a popup, or behind a launcher.",
+      "embed_mode": "Embed style",
+      "embed_modes": {
+        "inline": "Inline",
+        "fullpage": "Full page",
+        "popup": "Popup",
+        "slider": "Slider",
+        "popover": "Popover",
+        "sidetab": "Side tab"
+      },
+      "embed_mode_hints": {
+        "inline": "Sits in the flow of your page and grows with the form.",
+        "fullpage": "Fills the viewport. Best on a page of its own.",
+        "popup": "Opens centered over the page, dimming everything behind it.",
+        "slider": "Slides in from the right edge, keeping the page visible.",
+        "popover": "A launcher bubble in the corner that opens a compact card.",
+        "sidetab": "A tab pinned to the edge that opens a panel on click."
+      },
+      "embed_height": "Height",
+      "embed_height_placeholder": "Leave empty to auto-size",
+      "embed_height_hint": "Auto-sizing needs the script embed. A plain iframe always needs a fixed height.",
+      "embed_launcher_text": "Launcher label",
+      "embed_launcher_placeholder": "Open form",
+      "embed_snippet": "Script embed (recommended)",
+      "embed_iframe_snippet": "Plain iframe (no scripts)",
+      "embed_requires_share_link": "Publish this form and create a share link first — an embed points at that link."
     },
     "shared": {
       "metadata_fallback_description": "Open this shared form to review the questions and submit a response.",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -3009,7 +3009,10 @@
       "metadata_protected_description": "Biểu mẫu chia sẻ này đang được bảo vệ. Hãy đăng nhập hoặc dùng đường truy cập phù hợp để tiếp tục.",
       "open_graph_alt": "Ảnh xem trước cho {title}",
       "unavailable_description": "Biểu mẫu này có thể đã bị gỡ xuất bản, đã đóng, hoặc đã bị xóa.",
-      "unavailable_title": "Không thể truy cập biểu mẫu"
+      "unavailable_title": "Không thể truy cập biểu mẫu",
+      "sign_in_required_title": "Đăng nhập để tiếp tục",
+      "sign_in_required_description": "Biểu mẫu này cần xác định danh tính của bạn, việc đó không thực hiện được bên trong khung nhúng.",
+      "open_in_new_tab": "Mở biểu mẫu trong tab mới"
     },
     "status": {
       "closed": "Đã đóng",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -2933,7 +2933,27 @@
       "turnstile_always_on": "Turnstile luôn bật cho biểu mẫu công khai",
       "turnstile_always_on_hint": "Mọi lượt gửi công khai đều phải vượt qua bước xác minh. Người tạo biểu mẫu không thể tắt lớp bảo vệ này.",
       "typography_scale": "Tỷ lệ typography",
-      "unlimited": "Không giới hạn"
+      "unlimited": "Không giới hạn",
+      "seo": "Tìm kiếm & chia sẻ",
+      "seo_description": "Kiểm soát cách biểu mẫu này hiển thị trong kết quả tìm kiếm và bản xem trước liên kết.",
+      "seo_preview": "Xem trước kết quả tìm kiếm",
+      "seo_preview_unpublished_url": "forms.tuturuuu.com/f/… (đăng biểu mẫu để có liên kết)",
+      "seo_preview_truncated": "Công cụ tìm kiếm sẽ cắt bớt phần này — rút ngắn lại để kiểm soát nội dung hiển thị.",
+      "seo_title": "Tiêu đề tìm kiếm",
+      "seo_title_placeholder": "Để trống để dùng tiêu đề biểu mẫu",
+      "seo_title_hint": "Khoảng 60 ký tự sẽ hiện đầy đủ. Để trống thì lấy dòng tiêu đề bìa, rồi tới tiêu đề biểu mẫu.",
+      "seo_meta_description": "Mô tả tìm kiếm",
+      "seo_meta_description_placeholder": "Để trống để dùng mô tả biểu mẫu",
+      "seo_meta_description_hint": "Khoảng 160 ký tự sẽ hiện đầy đủ. Để trống thì lấy mô tả biểu mẫu, rồi tới mô tả của phần đầu tiên.",
+      "seo_keywords": "Từ khoá",
+      "seo_keywords_placeholder": "tuyển dụng, ứng tuyển, kỹ thuật",
+      "seo_keywords_hint": "Ngăn cách bằng dấu phẩy, tối đa {max}. Để trống thì dùng từ khoá suy ra từ tiêu đề.",
+      "seo_canonical": "URL chuẩn (canonical)",
+      "seo_canonical_hint": "Trỏ trình thu thập dữ liệu tới trang khác khi biểu mẫu được nhúng ở nơi khác. Để trống thì dùng chính liên kết của biểu mẫu.",
+      "seo_image": "Ảnh thẻ chia sẻ",
+      "seo_image_hint": "Kích thước 1200×630 là hợp nhất. Để trống thì dùng thẻ được tạo từ giao diện và ảnh bìa của biểu mẫu.",
+      "seo_no_index": "Ẩn khỏi công cụ tìm kiếm",
+      "seo_no_index_hint": "Phát tín hiệu noindex. Liên kết vẫn dùng được với những người bạn chia sẻ — chỉ là không được lập chỉ mục."
     },
     "shared": {
       "metadata_fallback_description": "Mở biểu mẫu chia sẻ này để xem các câu hỏi và gửi phản hồi.",
@@ -3148,6 +3168,400 @@
       "responses_cleared": "Đã xóa phản hồi",
       "section_needs_question": "Phần {section} phải có ít nhất một câu hỏi.",
       "share_link_copied": "Đã sao chép liên kết chia sẻ"
+    },
+    "landing": {
+      "app_name": "Tuturuuu Forms",
+      "meta": {
+        "title": "Biểu mẫu mà người ta thật sự điền xong",
+        "social_title": "Tuturuuu Forms — tạo, phối màu, nhúng, phân tích",
+        "description": "Tạo biểu mẫu và khảo sát đẹp mắt trong vài phút. Logic điều kiện, giao diện chỉnh được, sáu kiểu nhúng, đồng chỉnh sửa thời gian thực và phân tích phản hồi — trong cùng một workspace."
+      },
+      "nav": {
+        "workflow": "Cách hoạt động",
+        "build": "Khối câu hỏi",
+        "design": "Giao diện",
+        "embed": "Nhúng",
+        "insights": "Phân tích",
+        "get_started": "Bắt đầu miễn phí",
+        "workspace": "Mở workspace",
+        "sign_in": "Đăng nhập"
+      },
+      "hero": {
+        "eyebrow": "Forms",
+        "title": "Biểu mẫu mà người ta thật sự điền xong",
+        "description": "Thiết kế biểu mẫu trong vài phút, đăng ở bất cứ đâu và xem câu trả lời về theo thời gian thực. Không bị khoá vào mẫu có sẵn, không tính tiền theo lượt phản hồi, không có dữ liệu nào bạn không xuất được.",
+        "primary": "Bắt đầu miễn phí",
+        "primary_authed": "Mở workspace của bạn",
+        "secondary": "Xem cách hoạt động",
+        "reassurance": "Miễn phí để bắt đầu · Không cần thẻ · Luôn xuất được toàn bộ dữ liệu"
+      },
+      "stats": {
+        "blocks": {
+          "value": "14",
+          "label": "Khối câu hỏi & nội dung"
+        },
+        "themes": {
+          "value": "12",
+          "label": "Giao diện, chỉnh được hết"
+        },
+        "embeds": {
+          "value": "6",
+          "label": "Cách nhúng"
+        },
+        "languages": {
+          "value": "2",
+          "label": "Ngôn ngữ giao diện"
+        }
+      },
+      "demo": {
+        "theme_label": "Thử một giao diện",
+        "title": "Góp ý sản phẩm",
+        "description": "Biểu mẫu thật, chạy bằng trình kết xuất thật. Cứ điền thử — không có gì được lưu lại.",
+        "confirmation_title": "Toàn bộ luồng là như vậy",
+        "confirmation_message": "Bản demo này không lưu gì cả. Biểu mẫu của bạn sẽ thu phản hồi, theo dõi tỉ lệ bỏ dở và xuất ra CSV.",
+        "section_title": "Kể cho chúng tôi về đội của bạn",
+        "section_description": "Bốn câu hỏi. Khoảng ba mươi giây.",
+        "role_title": "Vai trò nào mô tả đúng bạn nhất?",
+        "role_option_1": "Nhà sáng lập",
+        "role_option_2": "Vận hành",
+        "role_option_3": "Sản phẩm",
+        "role_option_4": "Khác",
+        "priority_title": "Bạn sẽ dùng cái nào trước?",
+        "priority_description": "Chọn bao nhiêu tuỳ bạn.",
+        "priority_option_1": "Góp ý khách hàng",
+        "priority_option_2": "Đăng ký sự kiện",
+        "priority_option_3": "Hồ sơ ứng tuyển",
+        "priority_option_4": "Yêu cầu nội bộ",
+        "satisfaction_title": "Bạn hài lòng đến đâu với công cụ biểu mẫu hiện tại?",
+        "satisfaction_min": "Không hài lòng",
+        "satisfaction_max": "Rất hài lòng",
+        "notes_title": "Còn điều gì chúng tôi nên biết không?",
+        "notes_placeholder": "Không bắt buộc — viết nhiều hay ít tuỳ bạn"
+      },
+      "workflow": {
+        "eyebrow": "Từ đầu đến cuối",
+        "title": "Từ trang trắng đến phản hồi đầu tiên, không cần rời tab",
+        "subtitle": "Dựng, phối màu, chia sẻ và phân tích là bốn thẻ của cùng một trình soạn thảo — không phải bốn công cụ bạn phải tự ghép lại.",
+        "steps": {
+          "build": {
+            "title": "Dựng",
+            "description": "Kéo khối vào từng phần, viết câu hỏi bằng Markdown và thêm nhánh để bỏ qua những gì không liên quan."
+          },
+          "design": {
+            "title": "Phối màu",
+            "description": "Chọn một giao diện, rồi chỉnh màu nhấn, phông chữ, độ thoáng và ảnh bìa cho tới khi nó ra chất của bạn."
+          },
+          "share": {
+            "title": "Chia sẻ",
+            "description": "Đăng một liên kết, hoặc đặt biểu mẫu vào trang của bạn dạng khung nội tuyến, popup, trượt, tab bên hoặc toàn trang."
+          },
+          "learn": {
+            "title": "Đo lường",
+            "description": "Xem phản hồi về theo thời gian thực, biết người ta bỏ dở ở đâu và xuất mọi thứ ra CSV bất cứ lúc nào."
+          }
+        }
+      },
+      "build": {
+        "eyebrow": "Trình dựng",
+        "title": "Đủ mọi khối bạn cần, và không phải cấu hình lại lần hai",
+        "subtitle": "Các loại câu hỏi và khối nội dung dùng chung một trình soạn thảo. Đặt gợi ý nhập, đánh dấu bắt buộc, thêm kiểm tra hợp lệ, kéo thả để sắp xếp lại.",
+        "footnote": "Phần, ngắt trang, đường phân cách và văn bản có định dạng cũng là khối — nên biểu mẫu có thể đọc như một tài liệu khi cần.",
+        "blocks": {
+          "short_text": {
+            "title": "Văn bản ngắn",
+            "description": "Câu trả lời một dòng, có gợi ý nhập và giới hạn độ dài."
+          },
+          "long_text": {
+            "title": "Văn bản dài",
+            "description": "Câu trả lời nhiều dòng cho bối cảnh và chi tiết."
+          },
+          "choice": {
+            "title": "Lựa chọn",
+            "description": "Chọn một hoặc nhiều, dạng danh sách hoặc lưới ảnh."
+          },
+          "dropdown": {
+            "title": "Danh sách thả xuống",
+            "description": "Danh sách lựa chọn dài mà không chiếm hết trang."
+          },
+          "scale": {
+            "title": "Thang tuyến tính",
+            "description": "Thang 1–10 với nhãn ở hai đầu."
+          },
+          "rating": {
+            "title": "Chấm sao",
+            "description": "Chấm điểm từ hai đến mười sao."
+          },
+          "date": {
+            "title": "Ngày & giờ",
+            "description": "Ô chọn lịch và giờ, có kiểm tra hợp lệ."
+          },
+          "media": {
+            "title": "Hình ảnh",
+            "description": "Minh hoạ cho câu hỏi, hoặc để chính các lựa chọn là ảnh."
+          },
+          "video": {
+            "title": "Video",
+            "description": "Nhúng video YouTube ngay trong biểu mẫu, có mốc bắt đầu."
+          },
+          "rich_text": {
+            "title": "Văn bản có định dạng",
+            "description": "Khối Markdown cho hướng dẫn, điều khoản đồng ý và bối cảnh."
+          }
+        }
+      },
+      "logic": {
+        "eyebrow": "Logic",
+        "title": "Chỉ hỏi những gì liên quan",
+        "subtitle": "Quy tắc đưa người trả lời tới đúng phần dựa trên câu họ đã chọn — hoặc kết thúc sớm khi không còn gì để hỏi.",
+        "diagram": {
+          "source_label": "Khi có người trả lời",
+          "source_question": "Đội của bạn lớn cỡ nào?",
+          "if": "Nếu",
+          "note": "Quy tắc có thể kích hoạt theo một câu trả lời hoặc ở cuối cả một phần, và có thể nhảy tới bất kỳ phần nào hoặc gửi luôn.",
+          "rules": {
+            "enterprise": {
+              "answer": "Hơn 200 người",
+              "destination": "Câu hỏi mua sắm"
+            },
+            "startup": {
+              "answer": "10 đến 200 người",
+              "destination": "Thiết lập đội"
+            },
+            "individual": {
+              "answer": "Chỉ mình tôi",
+              "destination": "Gửi"
+            }
+          }
+        },
+        "features": {
+          "branching": {
+            "title": "Rẽ nhánh theo câu trả lời",
+            "description": "Đưa người trả lời đi hướng khác tuỳ theo lựa chọn của họ."
+          },
+          "section_end": {
+            "title": "Quy tắc theo phần",
+            "description": "Quyết định đi đâu khi một phần đã hoàn tất."
+          },
+          "validation": {
+            "title": "Kiểm tra hợp lệ",
+            "description": "Số, email, URL, khoảng giá trị và mẫu tuỳ chỉnh, kèm thông báo lỗi của riêng bạn."
+          },
+          "scheduling": {
+            "title": "Mở & đóng",
+            "description": "Hẹn khung thời gian, giới hạn tổng phản hồi, hoặc mỗi người một lần."
+          }
+        }
+      },
+      "design": {
+        "eyebrow": "Giao diện",
+        "title": "Giao diện mà bạn chỉnh được thật",
+        "subtitle": "Bắt đầu từ một mẫu có sẵn, rồi đổi mọi thứ. Bản xem trước chính là biểu mẫu — thứ bạn thấy khi chỉnh đúng bằng thứ người trả lời nhận được.",
+        "surface_heading": "Ba kiểu bề mặt",
+        "surface_description": "Paper phẳng như in trên giấy. Glass nổi trên nền. Panel có viền và dày dặn. Mọi giao diện đều chạy được ở chế độ sáng và tối.",
+        "controls_heading": "Chỉnh tới từng chi tiết",
+        "controls_description": "Mẫu có sẵn chỉ là điểm bắt đầu, không phải cái lồng — mỗi mục dưới đây là một tuỳ chỉnh độc lập.",
+        "surfaces": {
+          "paper": "Paper",
+          "glass": "Glass",
+          "panel": "Panel"
+        },
+        "controls": {
+          "fonts": "Mười chín phông tiêu đề và nội dung, ghép cặp độc lập",
+          "density": "Khoảng cách thoáng, cân bằng hoặc gọn",
+          "typography": "Cỡ chữ riêng cho tiêu đề lớn, tiêu đề và nội dung",
+          "cover": "Ảnh bìa và dòng tiêu đề, kèm ảnh cho từng phần"
+        }
+      },
+      "embed": {
+        "eyebrow": "Nhúng",
+        "title": "Sáu cách đặt biểu mẫu ngay nơi người dùng đang ở",
+        "subtitle": "Một mã chia sẻ, một thẻ script. Đổi kiểu hiển thị bằng một thuộc tính dữ liệu — không cần build lại, không cần deploy lại.",
+        "snippet_heading": "Một thẻ, mọi kiểu",
+        "snippet_description": "Chèn script một lần, rồi khai báo bao nhiêu biểu mẫu tuỳ bạn. Chuyển giữa nội tuyến, popup, trượt, bong bóng, tab bên và toàn trang chỉ bằng một thuộc tính.",
+        "modes": {
+          "inline": {
+            "title": "Nội tuyến",
+            "description": "Biểu mẫu nằm trong mạch nội dung trang và giãn theo nội dung của nó."
+          },
+          "fullpage": {
+            "title": "Toàn trang",
+            "description": "Một trang riêng — trên màn hình không có gì ngoài biểu mẫu."
+          },
+          "popup": {
+            "title": "Popup",
+            "description": "Mở ra giữa màn hình, làm mờ mọi thứ phía sau."
+          },
+          "slider": {
+            "title": "Trượt",
+            "description": "Trượt vào từ mép màn hình, vẫn thấy trang ở bên cạnh."
+          },
+          "popover": {
+            "title": "Bong bóng",
+            "description": "Nút tròn ở góc màn hình, bấm vào là mở ra một thẻ gọn."
+          },
+          "sidetab": {
+            "title": "Tab bên",
+            "description": "Một tab cố định ở mép trang, bấm vào là mở bảng biểu mẫu."
+          }
+        }
+      },
+      "collaborate": {
+        "eyebrow": "Cộng tác",
+        "title": "Cùng chỉnh sửa mà không ghi đè lên nhau",
+        "subtitle": "Mọi người trong workspace thấy cùng một biểu mẫu khi nó thay đổi. Hiện diện trực tuyến, chỉ báo theo từng khối và tự động lưu đều bật sẵn.",
+        "presence_label": "3 đồng đội đang chỉnh sửa",
+        "features": {
+          "presence": {
+            "title": "Hiện diện trực tuyến",
+            "description": "Thấy ai đang mở biểu mẫu và họ đang ở khối nào."
+          },
+          "locks": {
+            "title": "Khoá mềm",
+            "description": "Khối đang được người khác chỉnh sẽ được báo trước khi bạn gõ vào, không phải sau."
+          },
+          "autosave": {
+            "title": "Tự động lưu",
+            "description": "Thay đổi tự lưu, và vẫn có nút lưu thủ công khi bạn muốn."
+          }
+        }
+      },
+      "insights": {
+        "eyebrow": "Phân tích",
+        "title": "Biết chuyện gì đã xảy ra, không chỉ biết bao nhiêu",
+        "subtitle": "Mỗi biểu mẫu đều theo dõi lượt xem, lượt bắt đầu, lượt hoàn tất và tỉ lệ bỏ dở theo từng câu — để bạn phân biệt được biểu mẫu ế và biểu mẫu hỏng.",
+        "funnel": {
+          "label": "Phễu phản hồi",
+          "note": "Số liệu minh hoạ. Phễu của bạn được tính từ phiên thật, chia theo thiết bị, nguồn giới thiệu và quốc gia.",
+          "steps": {
+            "views": {
+              "label": "Đã xem",
+              "value": "1.000"
+            },
+            "starts": {
+              "label": "Đã bắt đầu",
+              "value": "740"
+            },
+            "completed": {
+              "label": "Đã hoàn tất",
+              "value": "520"
+            }
+          }
+        },
+        "features": {
+          "live": {
+            "title": "Phản hồi trực tiếp",
+            "description": "Câu trả lời hiện lên ngay khi về, nhóm theo người trả lời."
+          },
+          "dropoff": {
+            "title": "Tỉ lệ bỏ dở",
+            "description": "Tìm đúng câu hỏi khiến người ta ngừng trả lời."
+          },
+          "export": {
+            "title": "Xuất dữ liệu",
+            "description": "Tải phản hồi dạng CSV, hoặc cả biểu mẫu dạng JSON di động."
+          },
+          "receipts": {
+            "title": "Bản sao phản hồi",
+            "description": "Cho phép người trả lời tự gửi email bản sao những gì họ đã gửi."
+          }
+        }
+      },
+      "trust": {
+        "eyebrow": "Tin cậy",
+        "title": "Phản hồi của bạn vẫn là của bạn",
+        "subtitle": "Biểu mẫu và câu trả lời được lưu ngoài Data API công khai, và chỉ truy cập được sau khi quyền workspace đã được kiểm tra.",
+        "developer_heading": "Sinh ra để tích hợp",
+        "developer_description": "Mọi thứ studio làm được đều gọi được từ mã của bạn, và không có cánh cửa nào một chiều.",
+        "features": {
+          "private_schema": {
+            "title": "Lưu trữ riêng tư",
+            "description": "Định nghĩa và câu trả lời nằm ngoài bề mặt API công khai."
+          },
+          "access": {
+            "title": "Kiểm soát truy cập",
+            "description": "Ẩn danh, đã đăng nhập, hoặc đã đăng nhập kèm email đã xác minh."
+          },
+          "spam": {
+            "title": "Chống spam",
+            "description": "Turnstile cùng giới hạn tần suất trên mọi lượt gửi công khai."
+          },
+          "portable": {
+            "title": "Không khoá dữ liệu",
+            "description": "Xuất bất kỳ biểu mẫu nào ra JSON và nhập vào workspace khác."
+          }
+        },
+        "developer": {
+          "sdk": {
+            "title": "SDK nhúng",
+            "description": "Một script duy nhất, dựng mọi kiểu nhúng từ thuộc tính dữ liệu."
+          },
+          "share_link": {
+            "title": "Liên kết chia sẻ",
+            "description": "Đổi hoặc thu hồi liên kết công khai mà không đụng vào biểu mẫu."
+          },
+          "portable": {
+            "title": "Định dạng di động",
+            "description": "JSON có đánh phiên bản, xem khác biệt, review và đưa vào git được."
+          }
+        }
+      },
+      "faq": {
+        "eyebrow": "Câu hỏi",
+        "title": "Trước khi bắt đầu",
+        "subtitle": "Những điều được hỏi nhiều nhất.",
+        "items": {
+          "free": {
+            "question": "Có miễn phí không?",
+            "answer": "Có — tạo biểu mẫu, thu phản hồi và xuất dữ liệu đều miễn phí để bắt đầu. Không tính tiền theo lượt phản hồi và không có giới hạn nào âm thầm giấu đi những câu trả lời bạn đã thu."
+          },
+          "anonymous": {
+            "question": "Người trả lời có cần tài khoản không?",
+            "answer": "Không. Biểu mẫu có thể nhận phản hồi hoàn toàn ẩn danh. Bạn cũng có thể yêu cầu tài khoản Tuturuuu đã đăng nhập, hoặc tài khoản đã đăng nhập kèm email đã xác minh, nếu cần biết ai đã trả lời."
+          },
+          "embed": {
+            "question": "Tôi đặt biểu mẫu lên trang của mình được không?",
+            "answer": "Được, theo sáu cách: nội tuyến, toàn trang, popup, trượt, bong bóng và tab bên. Tất cả đều dùng chung một thẻ script và một mã chia sẻ, nên đổi qua lại chỉ là đổi một thuộc tính."
+          },
+          "realtime": {
+            "question": "Đội của tôi có chỉnh cùng lúc được không?",
+            "answer": "Được. Mọi người có quyền vào workspace đều thấy hiện diện trực tuyến, chỉ báo trên khối mà đồng đội đang chỉnh, và thay đổi của nhau ngay khi được lưu."
+          },
+          "export": {
+            "question": "Tôi lấy dữ liệu ra được không?",
+            "answer": "Luôn luôn. Phản hồi xuất ra CSV, và bản thân biểu mẫu xuất ra tệp JSON có đánh phiên bản để nhập vào bất kỳ workspace nào khác."
+          },
+          "languages": {
+            "question": "Hỗ trợ những ngôn ngữ nào?",
+            "answer": "Giao diện có tiếng Anh và tiếng Việt, còn nội dung biểu mẫu viết bằng ngôn ngữ nào cũng được. Phông chữ hiển thị đúng dấu tiếng Việt thay vì rơi sang phông khác giữa câu."
+          }
+        }
+      },
+      "closing": {
+        "title": "Dựng biểu mẫu đầu tiên trong năm phút tới",
+        "description": "Bắt đầu từ trang trắng hoặc nhập một biểu mẫu bạn đã có. Kiểu gì bạn cũng sẽ có một liên kết chia sẻ được trước khi ly cà phê nguội.",
+        "secondary": "Đọc câu hỏi thường gặp"
+      },
+      "footer": {
+        "tagline": "Dựng, phối màu, nhúng và phân tích biểu mẫu — một phần của workspace Tuturuuu.",
+        "product": "Sản phẩm",
+        "platform": "Nền tảng",
+        "legal": "Pháp lý",
+        "legal_line": "© {year} Tuturuuu. Bảo lưu mọi quyền.",
+        "links": {
+          "workflow": "Cách hoạt động",
+          "build": "Khối câu hỏi",
+          "design": "Giao diện",
+          "embed": "Nhúng",
+          "tuturuuu": "Tuturuuu",
+          "products": "Tất cả sản phẩm",
+          "pricing": "Bảng giá",
+          "docs": "Tài liệu",
+          "terms": "Điều khoản",
+          "privacy": "Quyền riêng tư",
+          "security": "Bảo mật",
+          "contact": "Liên hệ"
+        }
+      }
     }
   },
   "guest-lead-data-table": {

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -1595,7 +1595,8 @@
     "write_something": "Hãy viết gì đó...",
     "years_old": "tuổi",
     "yellow": "Vàng",
-    "yesterday": "Hôm qua"
+    "yesterday": "Hôm qua",
+    "copy": "Sao chép"
   },
   "course-data-table": {
     "modules": "Mô-đun"
@@ -2953,7 +2954,34 @@
       "seo_image": "Ảnh thẻ chia sẻ",
       "seo_image_hint": "Kích thước 1200×630 là hợp nhất. Để trống thì dùng thẻ được tạo từ giao diện và ảnh bìa của biểu mẫu.",
       "seo_no_index": "Ẩn khỏi công cụ tìm kiếm",
-      "seo_no_index_hint": "Phát tín hiệu noindex. Liên kết vẫn dùng được với những người bạn chia sẻ — chỉ là không được lập chỉ mục."
+      "seo_no_index_hint": "Phát tín hiệu noindex. Liên kết vẫn dùng được với những người bạn chia sẻ — chỉ là không được lập chỉ mục.",
+      "embed": "Nhúng",
+      "embed_description": "Đặt biểu mẫu này lên trang của bạn — nội tuyến, dạng popup, hoặc sau một nút mở.",
+      "embed_mode": "Kiểu nhúng",
+      "embed_modes": {
+        "inline": "Nội tuyến",
+        "fullpage": "Toàn trang",
+        "popup": "Popup",
+        "slider": "Trượt",
+        "popover": "Bong bóng",
+        "sidetab": "Tab bên"
+      },
+      "embed_mode_hints": {
+        "inline": "Nằm trong mạch nội dung trang và giãn theo biểu mẫu.",
+        "fullpage": "Chiếm toàn màn hình. Hợp nhất khi để ở một trang riêng.",
+        "popup": "Mở ra giữa màn hình, làm mờ mọi thứ phía sau.",
+        "slider": "Trượt vào từ mép phải, vẫn thấy trang bên cạnh.",
+        "popover": "Nút tròn ở góc màn hình, bấm vào là mở một thẻ gọn.",
+        "sidetab": "Tab cố định ở mép trang, bấm vào là mở bảng biểu mẫu."
+      },
+      "embed_height": "Chiều cao",
+      "embed_height_placeholder": "Để trống để tự động điều chỉnh",
+      "embed_height_hint": "Tự động điều chỉnh cần bản nhúng bằng script. Iframe thuần luôn cần chiều cao cố định.",
+      "embed_launcher_text": "Nhãn nút mở",
+      "embed_launcher_placeholder": "Mở biểu mẫu",
+      "embed_snippet": "Nhúng bằng script (khuyên dùng)",
+      "embed_iframe_snippet": "Iframe thuần (không dùng script)",
+      "embed_requires_share_link": "Hãy đăng biểu mẫu và tạo liên kết chia sẻ trước — bản nhúng trỏ tới liên kết đó."
     },
     "shared": {
       "metadata_fallback_description": "Mở biểu mẫu chia sẻ này để xem các câu hỏi và gửi phản hồi.",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -2860,7 +2860,10 @@
       "validation_constraint_real_range": "Nhập số từ {min} đến {max}",
       "validation_constraint_regex": "Phải khớp với mẫu yêu cầu",
       "validation_fix_errors": "Vui lòng sửa các lỗi ở trên trước khi gửi.",
-      "view_image_fullscreen": "Xem ảnh toàn màn hình"
+      "view_image_fullscreen": "Xem ảnh toàn màn hình",
+      "welcome_start": "Bắt đầu",
+      "welcome_question_count": "{count, plural, other {# câu hỏi}}",
+      "step_progress": "{current} / {total}"
     },
     "settings": {
       "active": "Đang dùng",
@@ -2981,7 +2984,24 @@
       "embed_launcher_placeholder": "Mở biểu mẫu",
       "embed_snippet": "Nhúng bằng script (khuyên dùng)",
       "embed_iframe_snippet": "Iframe thuần (không dùng script)",
-      "embed_requires_share_link": "Hãy đăng biểu mẫu và tạo liên kết chia sẻ trước — bản nhúng trỏ tới liên kết đó."
+      "embed_requires_share_link": "Hãy đăng biểu mẫu và tạo liên kết chia sẻ trước — bản nhúng trỏ tới liên kết đó.",
+      "display_mode": "Cách hiển thị câu hỏi",
+      "display_modes": {
+        "sections": "Hiện tất cả",
+        "one_question": "Từng câu một"
+      },
+      "display_mode_hints": {
+        "sections": "Cả một phần trên một màn hình. Hợp với biểu mẫu ngắn mà người ta muốn xem lướt trước khi trả lời.",
+        "one_question": "Mỗi màn hình một câu hỏi. Giúp biểu mẫu dài bớt ngợp và tăng tỉ lệ hoàn tất."
+      },
+      "welcome_screen": "Hiện màn hình chào",
+      "welcome_screen_hint": "Một màn hình mở đầu trước câu hỏi đầu tiên, để người trả lời biết họ sắp bắt đầu việc gì.",
+      "welcome_title": "Tiêu đề màn hình chào",
+      "welcome_title_placeholder": "Để trống để dùng tiêu đề biểu mẫu",
+      "welcome_body": "Lời chào",
+      "welcome_body_placeholder": "Để trống để dùng mô tả biểu mẫu",
+      "welcome_button": "Nhãn nút",
+      "welcome_button_placeholder": "Bắt đầu"
     },
     "shared": {
       "metadata_fallback_description": "Mở biểu mẫu chia sẻ này để xem các câu hỏi và gửi phản hồi.",
@@ -3397,7 +3417,8 @@
           "fonts": "Mười chín phông tiêu đề và nội dung, ghép cặp độc lập",
           "density": "Khoảng cách thoáng, cân bằng hoặc gọn",
           "typography": "Cỡ chữ riêng cho tiêu đề lớn, tiêu đề và nội dung",
-          "cover": "Ảnh bìa và dòng tiêu đề, kèm ảnh cho từng phần"
+          "cover": "Ảnh bìa và dòng tiêu đề, kèm ảnh cho từng phần",
+          "pacing": "Từng câu một, hoặc cả một phần trên mỗi màn hình"
         }
       },
       "embed": {

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -3562,6 +3562,17 @@
           "contact": "Liên hệ"
         }
       }
+    },
+    "collaboration": {
+      "away": "Đang vắng",
+      "viewing": "Đang xem biểu mẫu",
+      "editing_block": "Đang sửa “{block}”",
+      "editing_now": "{name} đang sửa mục này",
+      "editing_now_multiple": "{count} người đang sửa mục này",
+      "editor_count": "{count, plural, other {# người khác đang sửa}}",
+      "remote_save_title": "{name} vừa lưu thay đổi",
+      "remote_save_description": "Bạn đang có chỉnh sửa chưa lưu nên bản này được giữ nguyên. Tải lại để lấy bản của họ — thay đổi của bạn sẽ mất.",
+      "remote_save_reload": "Tải lại"
     }
   },
   "guest-lead-data-table": {

--- a/apps/forms/next.config.ts
+++ b/apps/forms/next.config.ts
@@ -9,6 +9,11 @@ const withNextIntl = createNextIntlPlugin();
 const WEB_APP_URL = resolveTuturuuuWebAppUrl();
 
 const nextConfig = createTuturuuuNextConfig({
+  // `/embed/<shareCode>` is the only route in this app meant to be framed by a
+  // third-party site. Listing it here removes the platform-wide
+  // `frame-ancestors 'none'` / `X-Frame-Options: DENY` headers for that path
+  // and nothing else.
+  framablePathPatterns: ['embed/[^/]+'],
   async rewrites() {
     return {
       beforeFiles: createTuturuuuWebWorkspaceApiRewrites(WEB_APP_URL),

--- a/apps/forms/public/embed.js
+++ b/apps/forms/public/embed.js
@@ -118,12 +118,18 @@
     panel.style.zIndex = '2147483001';
     panel.style.display = 'none';
 
+    // Every panel needs a DEFINITE height, not just a maxHeight. The iframe
+    // inside is `height: 100%`, and a percentage height resolves against an
+    // auto-height containing block as `auto` — which collapses the form to the
+    // iframe's ~150px intrinsic height. The slider gets it from pinning both
+    // `top` and `bottom`; the centred and anchored panels have to say it.
     if (mode === 'popup') {
       styleSurface(panel, {
         top: '50%',
         left: '50%',
         transform: 'translate(-50%, -50%)',
         width: 'min(680px, calc(100vw - 32px))',
+        height: 'min(720px, calc(100vh - 64px))',
         maxHeight: 'calc(100vh - 64px)',
       });
     } else if (mode === 'slider' || mode === 'sidetab') {
@@ -140,6 +146,7 @@
         right: '20px',
         bottom: '92px',
         width: 'min(400px, calc(100vw - 32px))',
+        height: 'min(640px, calc(100vh - 140px))',
         maxHeight: 'min(640px, calc(100vh - 140px))',
       });
     }

--- a/apps/forms/public/embed.js
+++ b/apps/forms/public/embed.js
@@ -1,0 +1,337 @@
+/**
+ * Tuturuuu Forms embed SDK.
+ *
+ * Usage:
+ *   <script src="https://forms.tuturuuu.com/embed.js" async></script>
+ *   <div data-tuturuuu-form="SHARE_CODE" data-mode="inline"></div>
+ *
+ * Deliberately dependency-free and framework-free: it runs on whatever page a
+ * customer already has, which may be WordPress, Webflow, or hand-written HTML.
+ * Anything that needs a build step would not survive contact with those.
+ */
+(() => {
+  if (window.__tuturuuuFormsEmbedLoaded) return;
+  window.__tuturuuuFormsEmbedLoaded = true;
+
+  const MESSAGE_SOURCE = 'tuturuuu-forms';
+  const ATTRIBUTE = 'data-tuturuuu-form';
+  const MODES = ['inline', 'fullpage', 'popup', 'slider', 'popover', 'sidetab'];
+  const OVERLAY_MODES = ['popup', 'slider', 'popover', 'sidetab'];
+  const DEFAULT_HEIGHT = 520;
+
+  /**
+   * Resolve the origin from this script's own src, so a self-hosted or staging
+   * deployment serves its own forms rather than hard-coding production.
+   */
+  function resolveOrigin() {
+    const current = document.currentScript;
+    if (current?.src) {
+      try {
+        return new URL(current.src).origin;
+      } catch (_error) {
+        /* fall through */
+      }
+    }
+
+    const scripts = document.getElementsByTagName('script');
+    for (let index = scripts.length - 1; index >= 0; index -= 1) {
+      const src = scripts[index].src || '';
+      if (src.indexOf('/embed.js') !== -1) {
+        try {
+          return new URL(src).origin;
+        } catch (_error) {
+          /* keep looking */
+        }
+      }
+    }
+
+    return 'https://forms.tuturuuu.com';
+  }
+
+  const ORIGIN = resolveOrigin();
+  const registry = Object.create(null);
+  let counter = 0;
+
+  function readMode(element) {
+    const mode = (element.getAttribute('data-mode') || 'inline').toLowerCase();
+    return MODES.indexOf(mode) === -1 ? 'inline' : mode;
+  }
+
+  function buildUrl(shareCode) {
+    return `${ORIGIN}/embed/${encodeURIComponent(shareCode)}`;
+  }
+
+  function createIframe(shareCode, title) {
+    const iframe = document.createElement('iframe');
+    iframe.src = buildUrl(shareCode);
+    iframe.title = title || 'Form';
+    iframe.loading = 'lazy';
+    iframe.style.width = '100%';
+    iframe.style.height = `${DEFAULT_HEIGHT}px`;
+    iframe.style.border = '0';
+    iframe.style.display = 'block';
+    iframe.style.background = 'transparent';
+    iframe.setAttribute('allowtransparency', 'true');
+    // The embedded form posts only a height, a public share code and a
+    // submitted flag, and needs no access to the host page.
+    iframe.setAttribute(
+      'sandbox',
+      'allow-scripts allow-forms allow-same-origin allow-popups'
+    );
+    return iframe;
+  }
+
+  function styleSurface(node, extra) {
+    node.style.background = 'var(--tuturuuu-embed-bg, #fff)';
+    node.style.borderRadius = '12px';
+    node.style.overflow = 'hidden';
+    node.style.boxShadow = '0 24px 60px rgba(15, 23, 42, 0.22)';
+    for (const key in extra) {
+      if (Object.hasOwn(extra, key)) {
+        node.style[key] = extra[key];
+      }
+    }
+  }
+
+  function mountInline(element, entry) {
+    element.appendChild(entry.iframe);
+  }
+
+  function mountFullpage(element, entry) {
+    entry.iframe.style.height = '100vh';
+    element.style.display = 'block';
+    element.appendChild(entry.iframe);
+  }
+
+  /** Shared shell for popup / slider / popover / sidetab. */
+  function mountOverlay(element, entry, mode) {
+    const backdrop = document.createElement('div');
+    backdrop.setAttribute('data-tuturuuu-form-backdrop', '');
+    backdrop.style.position = 'fixed';
+    backdrop.style.inset = '0';
+    backdrop.style.zIndex = '2147483000';
+    backdrop.style.display = 'none';
+    backdrop.style.background = 'rgba(15, 23, 42, 0.55)';
+
+    const panel = document.createElement('div');
+    panel.style.position = 'fixed';
+    panel.style.zIndex = '2147483001';
+    panel.style.display = 'none';
+
+    if (mode === 'popup') {
+      styleSurface(panel, {
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: 'min(680px, calc(100vw - 32px))',
+        maxHeight: 'calc(100vh - 64px)',
+      });
+    } else if (mode === 'slider' || mode === 'sidetab') {
+      styleSurface(panel, {
+        top: '0',
+        right: '0',
+        bottom: '0',
+        width: 'min(520px, 100vw)',
+        borderRadius: '12px 0 0 12px',
+        maxHeight: '100vh',
+      });
+    } else {
+      styleSurface(panel, {
+        right: '20px',
+        bottom: '92px',
+        width: 'min(400px, calc(100vw - 32px))',
+        maxHeight: 'min(640px, calc(100vh - 140px))',
+      });
+    }
+
+    entry.iframe.style.height = '100%';
+    panel.appendChild(entry.iframe);
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.setAttribute('aria-label', 'Close form');
+    close.textContent = '×';
+    close.style.position = 'absolute';
+    close.style.top = '8px';
+    close.style.right = '10px';
+    close.style.zIndex = '1';
+    close.style.border = '0';
+    close.style.borderRadius = '999px';
+    close.style.width = '28px';
+    close.style.height = '28px';
+    close.style.cursor = 'pointer';
+    close.style.fontSize = '18px';
+    close.style.lineHeight = '1';
+    close.style.background = 'rgba(15, 23, 42, 0.08)';
+    close.style.color = 'inherit';
+    panel.appendChild(close);
+
+    const launcher = document.createElement('button');
+    launcher.type = 'button';
+    launcher.textContent =
+      element.getAttribute('data-launcher-text') ||
+      (mode === 'sidetab' ? 'Feedback' : 'Open form');
+    launcher.style.position = 'fixed';
+    launcher.style.zIndex = '2147483000';
+    launcher.style.cursor = 'pointer';
+    launcher.style.border = '0';
+    launcher.style.color = '#fff';
+    launcher.style.background =
+      element.getAttribute('data-launcher-color') || '#6d28d9';
+    launcher.style.font =
+      '500 14px/1 ui-sans-serif, system-ui, -apple-system, sans-serif';
+    launcher.style.boxShadow = '0 10px 30px rgba(15, 23, 42, 0.25)';
+
+    if (mode === 'sidetab') {
+      launcher.style.right = '0';
+      launcher.style.top = '50%';
+      launcher.style.transform = 'translateY(-50%) rotate(180deg)';
+      launcher.style.writingMode = 'vertical-rl';
+      launcher.style.padding = '18px 10px';
+      launcher.style.borderRadius = '8px 0 0 8px';
+    } else {
+      launcher.style.right = '20px';
+      launcher.style.bottom = '20px';
+      launcher.style.padding = '14px 20px';
+      launcher.style.borderRadius = '999px';
+    }
+
+    function open() {
+      backdrop.style.display = mode === 'popover' ? 'none' : 'block';
+      panel.style.display = 'block';
+      launcher.style.display = 'none';
+      entry.isOpen = true;
+    }
+
+    function closePanel() {
+      backdrop.style.display = 'none';
+      panel.style.display = 'none';
+      launcher.style.display = 'block';
+      entry.isOpen = false;
+    }
+
+    launcher.addEventListener('click', open);
+    close.addEventListener('click', closePanel);
+    backdrop.addEventListener('click', closePanel);
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && entry.isOpen) closePanel();
+    });
+
+    entry.open = open;
+    entry.close = closePanel;
+    // Overlay chrome is fixed-position, so it belongs on <body> rather than
+    // inside whatever container the customer happened to put the div in — a
+    // parent with `overflow: hidden` or its own stacking context would
+    // otherwise clip or bury it.
+    document.body.appendChild(backdrop);
+    document.body.appendChild(panel);
+    document.body.appendChild(launcher);
+
+    if (element.getAttribute('data-open') === 'true') open();
+  }
+
+  function mount(element) {
+    if (element.getAttribute('data-tuturuuu-form-mounted') === 'true') return;
+
+    const shareCode = element.getAttribute(ATTRIBUTE);
+    if (!shareCode) return;
+
+    element.setAttribute('data-tuturuuu-form-mounted', 'true');
+
+    counter += 1;
+    const mode = readMode(element);
+    const entry = {
+      id: `tuturuuu-form-${counter}`,
+      element: element,
+      iframe: createIframe(shareCode, element.getAttribute('data-title')),
+      isOpen: false,
+      mode: mode,
+      shareCode: shareCode,
+    };
+    registry[shareCode] = entry;
+
+    const height = parseInt(element.getAttribute('data-height') || '', 10);
+    if (!Number.isNaN(height) && height > 0) {
+      entry.fixedHeight = height;
+      entry.iframe.style.height = `${height}px`;
+    }
+
+    if (mode === 'inline') {
+      mountInline(element, entry);
+    } else if (mode === 'fullpage') {
+      mountFullpage(element, entry);
+    } else if (OVERLAY_MODES.indexOf(mode) !== -1) {
+      mountOverlay(element, entry, mode);
+    }
+  }
+
+  function scan() {
+    const nodes = document.querySelectorAll(`[${ATTRIBUTE}]`);
+    for (let index = 0; index < nodes.length; index += 1) {
+      mount(nodes[index]);
+    }
+  }
+
+  window.addEventListener('message', (event) => {
+    if (event.origin !== ORIGIN) return;
+
+    const data = event.data;
+    if (!data || data.source !== MESSAGE_SOURCE) return;
+
+    const entry = registry[data.shareCode];
+    if (!entry) return;
+
+    if (data.type === 'resize' && !entry.fixedHeight) {
+      // Overlay panels are sized by their own CSS; only flow-positioned
+      // embeds grow with their content.
+      if (entry.mode === 'inline') {
+        entry.iframe.style.height = `${Math.max(data.height || 0, 120)}px`;
+      }
+      return;
+    }
+
+    if (data.type === 'submitted') {
+      const element = entry.element;
+      if (
+        element.getAttribute('data-close-on-submit') !== 'false' &&
+        entry.close
+      ) {
+        window.setTimeout(entry.close, 2500);
+      }
+
+      if (typeof window.tuturuuuFormsOnSubmit === 'function') {
+        try {
+          window.tuturuuuFormsOnSubmit({ shareCode: data.shareCode });
+        } catch (_error) {
+          /* a host callback must never break the embed */
+        }
+      }
+    }
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', scan);
+  } else {
+    scan();
+  }
+
+  // Containers added after load (SPA route changes, CMS previews) still mount.
+  if (typeof MutationObserver === 'function') {
+    new MutationObserver(scan).observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  window.tuturuuuForms = {
+    mount: scan,
+    open: (shareCode) => {
+      const entry = registry[shareCode];
+      if (entry?.open) entry.open();
+    },
+    close: (shareCode) => {
+      const entry = registry[shareCode];
+      if (entry?.close) entry.close();
+    },
+  };
+})();

--- a/apps/forms/src/app/[locale]/[wsId]/forms/[formId]/page.tsx
+++ b/apps/forms/src/app/[locale]/[wsId]/forms/[formId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { connection } from 'next/server';
 import WorkspaceWrapper from '@/components/workspace-wrapper';
+import { resolveCollaboratorIdentity } from '@/features/forms/collaboration/identity';
 import { FormStudio } from '@/features/forms/form-studio';
 import {
   fetchFormDefinition,
@@ -38,6 +39,11 @@ export default async function FormDetailPage({
           notFound();
         }
 
+        const collaboratorIdentity = await resolveCollaboratorIdentity({
+          adminClient: context.adminClient,
+          user: context.user,
+        });
+
         const { adminClient, canManageForms, canViewAnalytics } = context;
 
         if (!canManageForms && !canViewAnalytics) {
@@ -73,6 +79,7 @@ export default async function FormDetailPage({
 
         return (
           <FormStudio
+            currentUser={collaboratorIdentity}
             wsId={wsId}
             workspaceSlug={resolvedParams.wsId}
             mode="edit"

--- a/apps/forms/src/app/[locale]/[wsId]/forms/[formId]/page.tsx
+++ b/apps/forms/src/app/[locale]/[wsId]/forms/[formId]/page.tsx
@@ -1,7 +1,10 @@
 import { notFound } from 'next/navigation';
 import { connection } from 'next/server';
 import WorkspaceWrapper from '@/components/workspace-wrapper';
-import { resolveCollaboratorIdentity } from '@/features/forms/collaboration/identity';
+import {
+  canJoinFormRealtime,
+  resolveCollaboratorIdentity,
+} from '@/features/forms/collaboration/identity';
 import { FormStudio } from '@/features/forms/form-studio';
 import {
   fetchFormDefinition,
@@ -39,6 +42,7 @@ export default async function FormDetailPage({
           notFound();
         }
 
+        const canRealtime = await canJoinFormRealtime();
         const collaboratorIdentity = await resolveCollaboratorIdentity({
           adminClient: context.adminClient,
           user: context.user,
@@ -80,6 +84,7 @@ export default async function FormDetailPage({
         return (
           <FormStudio
             currentUser={collaboratorIdentity}
+            canRealtime={canRealtime}
             wsId={wsId}
             workspaceSlug={resolvedParams.wsId}
             mode="edit"

--- a/apps/forms/src/app/[locale]/[wsId]/forms/new/page.tsx
+++ b/apps/forms/src/app/[locale]/[wsId]/forms/new/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { connection } from 'next/server';
 import WorkspaceWrapper from '@/components/workspace-wrapper';
+import { resolveCollaboratorIdentity } from '@/features/forms/collaboration/identity';
 import { FormStudio } from '@/features/forms/form-studio';
 import { getFormsPageContext } from '@/lib/forms-permissions';
 
@@ -22,8 +23,14 @@ export default async function NewFormPage({ params }: PageProps) {
           notFound();
         }
 
+        const collaboratorIdentity = await resolveCollaboratorIdentity({
+          adminClient: context.adminClient,
+          user: context.user,
+        });
+
         return (
           <FormStudio
+            currentUser={collaboratorIdentity}
             wsId={wsId}
             workspaceSlug={resolvedParams.wsId}
             mode="create"

--- a/apps/forms/src/app/[locale]/[wsId]/forms/new/page.tsx
+++ b/apps/forms/src/app/[locale]/[wsId]/forms/new/page.tsx
@@ -1,7 +1,10 @@
 import { notFound } from 'next/navigation';
 import { connection } from 'next/server';
 import WorkspaceWrapper from '@/components/workspace-wrapper';
-import { resolveCollaboratorIdentity } from '@/features/forms/collaboration/identity';
+import {
+  canJoinFormRealtime,
+  resolveCollaboratorIdentity,
+} from '@/features/forms/collaboration/identity';
 import { FormStudio } from '@/features/forms/form-studio';
 import { getFormsPageContext } from '@/lib/forms-permissions';
 
@@ -23,6 +26,7 @@ export default async function NewFormPage({ params }: PageProps) {
           notFound();
         }
 
+        const canRealtime = await canJoinFormRealtime();
         const collaboratorIdentity = await resolveCollaboratorIdentity({
           adminClient: context.adminClient,
           user: context.user,
@@ -31,6 +35,7 @@ export default async function NewFormPage({ params }: PageProps) {
         return (
           <FormStudio
             currentUser={collaboratorIdentity}
+            canRealtime={canRealtime}
             wsId={wsId}
             workspaceSlug={resolvedParams.wsId}
             mode="create"

--- a/apps/forms/src/app/[locale]/embed/[shareCode]/page.tsx
+++ b/apps/forms/src/app/[locale]/embed/[shareCode]/page.tsx
@@ -1,6 +1,5 @@
 import { NO_INDEX_ROBOTS } from '@tuturuuu/utils/common/metadata';
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
 import { connection } from 'next/server';
 import { getTranslations } from 'next-intl/server';
 import { EmbedContent } from '@/features/forms/embed/embed-content';
@@ -36,10 +35,35 @@ export default async function EmbeddedFormPage({ params }: PageProps) {
   const { status, data } = await loadSharedFormForPage(shareCode);
 
   // A form requiring sign-in cannot complete an auth round trip inside someone
-  // else's iframe, so send the respondent to the hosted page in a new context
-  // rather than trapping them in a frame that can never authenticate.
+  // else's iframe, so offer the hosted page in a new tab.
+  //
+  // Redirecting here does not work: `redirect()` navigates the iframe itself,
+  // and `/f/<shareCode>` is not in `framablePathPatterns`, so it still carries
+  // `frame-ancestors 'none'` and `X-Frame-Options: DENY`. The browser blocks
+  // the load and the respondent gets a blank frame with no way forward.
   if (status === 401) {
-    redirect(`/f/${shareCode}`);
+    return (
+      <EmbedFrame shareCode={shareCode}>
+        <div className="flex items-center justify-center px-4 py-10">
+          <div className="max-w-sm space-y-3 text-center">
+            <h1 className="font-semibold text-lg">
+              {t('shared.sign_in_required_title')}
+            </h1>
+            <p className="text-muted-foreground text-sm">
+              {t('shared.sign_in_required_description')}
+            </p>
+            <a
+              href={`/f/${shareCode}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center rounded-full bg-foreground px-4 py-2 font-medium text-background text-sm"
+            >
+              {t('shared.open_in_new_tab')}
+            </a>
+          </div>
+        </div>
+      </EmbedFrame>
+    );
   }
 
   // The unavailable state is wrapped too, not just the happy path: without a

--- a/apps/forms/src/app/[locale]/embed/[shareCode]/page.tsx
+++ b/apps/forms/src/app/[locale]/embed/[shareCode]/page.tsx
@@ -1,0 +1,66 @@
+import { NO_INDEX_ROBOTS } from '@tuturuuu/utils/common/metadata';
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { connection } from 'next/server';
+import { getTranslations } from 'next-intl/server';
+import { EmbedContent } from '@/features/forms/embed/embed-content';
+import { EmbedFrame } from '@/features/forms/embed/embed-frame';
+import { loadSharedFormForPage } from '@/features/forms/shared-form-loader';
+
+interface PageProps {
+  params: Promise<{ locale: string; shareCode: string }>;
+}
+
+/**
+ * An embed is a duplicate of the canonical `/f/<shareCode>` page, so it is
+ * always `noindex`: two indexable URLs for the same form would compete with
+ * each other, and the version without page chrome is the wrong one to rank.
+ */
+export function generateMetadata(): Metadata {
+  return { robots: NO_INDEX_ROBOTS };
+}
+
+/**
+ * Chrome-less form for embedding in a third-party page.
+ *
+ * Framing is denied platform-wide; this route is opted out through
+ * `framablePathPatterns` in `next.config.ts`, which removes the deny headers
+ * for `/embed/*` only. Everything else in the app stays unframable.
+ */
+export default async function EmbeddedFormPage({ params }: PageProps) {
+  // Reads the respondent's session cookie to restore in-progress answers.
+  await connection();
+
+  const { shareCode } = await params;
+  const t = await getTranslations('forms');
+  const { status, data } = await loadSharedFormForPage(shareCode);
+
+  // A form requiring sign-in cannot complete an auth round trip inside someone
+  // else's iframe, so send the respondent to the hosted page in a new context
+  // rather than trapping them in a frame that can never authenticate.
+  if (status === 401) {
+    redirect(`/f/${shareCode}`);
+  }
+
+  // The unavailable state is wrapped too, not just the happy path: without a
+  // resize message the host iframe keeps its default height and the visitor
+  // sees a short notice floating in a tall empty box.
+  if (!data) {
+    return (
+      <EmbedFrame shareCode={shareCode}>
+        <div className="flex items-center justify-center px-4 py-10">
+          <div className="max-w-sm space-y-2 text-center">
+            <h1 className="font-semibold text-lg">
+              {t('shared.unavailable_title')}
+            </h1>
+            <p className="text-muted-foreground text-sm">
+              {t('shared.unavailable_description')}
+            </p>
+          </div>
+        </div>
+      </EmbedFrame>
+    );
+  }
+
+  return <EmbedContent data={data} shareCode={shareCode} />;
+}

--- a/apps/forms/src/app/[locale]/f/[shareCode]/content.tsx
+++ b/apps/forms/src/app/[locale]/f/[shareCode]/content.tsx
@@ -24,6 +24,7 @@ export default function SharedFormContent({
   readOnlyResponseSessionId,
   canRequestResponseCopy,
   responseCopyAlreadySent,
+  onSubmitted,
 }: {
   form: FormDefinition;
   shareCode: string;
@@ -37,6 +38,8 @@ export default function SharedFormContent({
   readOnlyResponseSessionId?: string | null;
   canRequestResponseCopy?: boolean;
   responseCopyAlreadySent?: boolean;
+  /** Fired after a successful submission; used by the embed to notify the host. */
+  onSubmitted?: () => void;
 }) {
   const submitMutation = usePublicFormSubmit(shareCode);
   const responseCopyMutation = usePublicFormResponseCopy(shareCode);
@@ -56,12 +59,14 @@ export default function SharedFormContent({
       responseCopyAlreadySent={responseCopyAlreadySent}
       onSubmit={async ({ answers, turnstileToken, sendResponseCopy }) => {
         if (!sessionId) return;
-        return submitMutation.mutateAsync({
+        const result = await submitMutation.mutateAsync({
           sessionId,
           answers,
           turnstileToken,
           sendResponseCopy: sendResponseCopy ?? false,
         });
+        onSubmitted?.();
+        return result;
       }}
       onRequestResponseCopy={({
         responseId,

--- a/apps/forms/src/app/[locale]/page.tsx
+++ b/apps/forms/src/app/[locale]/page.tsx
@@ -1,10 +1,71 @@
-import { redirect } from '@/i18n/navigation';
+import { marketingFontVariables } from '@tuturuuu/ui/marketing';
+import { generatePageMetadata } from '@tuturuuu/utils/common/nextjs';
+import { cn } from '@tuturuuu/utils/format';
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { BASE_URL } from '@/constants/common';
+import { FormsLandingPage } from '@/features/landing/landing-page';
+import { LandingStructuredData } from '@/features/landing/structured-data';
 
-export default async function FormsPage({
-  params,
-}: {
+interface PageProps {
   params: Promise<{ locale: string }>;
-}) {
+}
+
+/**
+ * The landing page is the one indexable surface in this app — everything else
+ * sits behind a workspace session, and the root layout marks the app
+ * `indexable: false`. Overriding robots here rather than app-wide keeps the
+ * studio and every `/f/<shareCode>` page out of search results by default while
+ * still letting the marketing page rank.
+ */
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
   const { locale } = await params;
-  redirect({ href: '/dashboard', locale });
+  const t = await getTranslations({ locale, namespace: 'forms.landing' });
+
+  return generatePageMetadata({
+    config: {
+      baseUrl: BASE_URL,
+      description: t('meta.description'),
+      indexable: true,
+      keywords: [
+        'form builder',
+        'online forms',
+        'survey builder',
+        'typeform alternative',
+        'google forms alternative',
+        'form analytics',
+        'embeddable forms',
+      ],
+      localePrefix: 'never',
+      pathname: '/',
+      siteName: t('app_name'),
+      socialTitle: t('meta.social_title'),
+      title: t('meta.title'),
+    },
+    params,
+  });
+}
+
+/**
+ * The page itself is fully prerenderable. The only request-dependent detail is
+ * whether the visitor is signed in, and that is isolated inside the CTA slots'
+ * own `<Suspense>` boundaries — so the marketing HTML is static and the buttons
+ * stream in.
+ */
+export default async function FormsLandingRoute({ params }: PageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'forms.landing' });
+
+  return (
+    <div className={cn('bg-background', marketingFontVariables)}>
+      <LandingStructuredData
+        description={t('meta.description')}
+        name={t('app_name')}
+        url={BASE_URL}
+      />
+      <FormsLandingPage />
+    </div>
+  );
 }

--- a/apps/forms/src/app/api/v1/workspaces/[wsId]/forms/media/route.ts
+++ b/apps/forms/src/app/api/v1/workspaces/[wsId]/forms/media/route.ts
@@ -7,7 +7,7 @@ import { getWorkspaceRouteContext } from '@/features/forms/route-utils';
 
 const requestSchema = z.object({
   filename: z.string().min(1).max(255),
-  scope: z.enum(['cover', 'section', 'option']).default('section'),
+  scope: z.enum(['cover', 'section', 'option', 'social']).default('section'),
 });
 
 export async function POST(

--- a/apps/forms/src/features/forms/answer-utils.test.ts
+++ b/apps/forms/src/features/forms/answer-utils.test.ts
@@ -2,46 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { deriveOptionValue, findMatchingOption } from './answer-utils';
 import { getNextSectionTarget } from './branching';
+import { createTestFormDefinition } from './test-support/form-fixtures';
 import type { FormDefinition } from './types';
 
-const baseForm: FormDefinition = {
-  id: 'form-1',
-  wsId: 'ws-1',
-  creatorId: 'user-1',
+const baseForm: FormDefinition = createTestFormDefinition({
   title: 'Form',
-  description: '',
-  status: 'draft',
-  accessMode: 'anonymous',
-  openAt: null,
-  closeAt: null,
-  maxResponses: null,
-  createdAt: '2026-03-09T00:00:00.000Z',
-  updatedAt: '2026-03-09T00:00:00.000Z',
-  shareCode: null,
-  theme: {
-    presetId: 'editorial-moss',
-    density: 'balanced',
-    accentColor: 'dynamic-green',
-    headlineFontId: 'noto-serif',
-    bodyFontId: 'be-vietnam-pro',
-    surfaceStyle: 'paper',
-    coverHeadline: '',
-    coverImage: { storagePath: '', url: '', alt: '' },
-    sectionImages: {},
-    typography: {
-      displaySize: 'md',
-      headingSize: 'md',
-      bodySize: 'md',
-    },
-  },
-  settings: {
-    showProgressBar: true,
-    allowMultipleSubmissions: true,
-    oneResponsePerUser: false,
-    requireTurnstile: true,
-    confirmationTitle: 'Thanks',
-    confirmationMessage: 'Done',
-  },
   sections: [
     {
       id: 'section-1',
@@ -88,7 +53,7 @@ const baseForm: FormDefinition = {
       targetSectionId: 'section-2',
     },
   ],
-};
+});
 
 describe('form markdown option helpers', () => {
   it('derives stable option values from markdown labels', () => {

--- a/apps/forms/src/features/forms/branching.test.ts
+++ b/apps/forms/src/features/forms/branching.test.ts
@@ -4,49 +4,11 @@ import {
   getReachableSectionIds,
   matchesRule,
 } from './branching';
+import { createTestFormDefinition } from './test-support/form-fixtures';
 import type { FormDefinition } from './types';
 
-const baseForm: FormDefinition = {
-  id: 'a0bba3b1-8861-4f5f-b174-746f75949001',
-  wsId: 'a0bba3b1-8861-4f5f-b174-746f75949002',
-  creatorId: 'a0bba3b1-8861-4f5f-b174-746f75949003',
+const baseForm: FormDefinition = createTestFormDefinition({
   title: 'Branching test',
-  description: '',
-  status: 'draft',
-  accessMode: 'anonymous',
-  openAt: null,
-  closeAt: null,
-  maxResponses: null,
-  theme: {
-    presetId: 'editorial-moss',
-    density: 'balanced',
-    accentColor: 'dynamic-green',
-    headlineFontId: 'noto-serif',
-    bodyFontId: 'be-vietnam-pro',
-    surfaceStyle: 'paper',
-    coverHeadline: '',
-    coverImage: {
-      storagePath: '',
-      url: '',
-      alt: '',
-    },
-    sectionImages: {},
-    typography: {
-      displaySize: 'md',
-      headingSize: 'md',
-      bodySize: 'md',
-    },
-  },
-  settings: {
-    showProgressBar: true,
-    allowMultipleSubmissions: true,
-    oneResponsePerUser: false,
-    requireTurnstile: true,
-    confirmationTitle: 'Thanks',
-    confirmationMessage: 'Done',
-  },
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
   sections: [
     {
       id: 'a0bba3b1-8861-4f5f-b174-746f75949010',
@@ -118,7 +80,7 @@ const baseForm: FormDefinition = {
       targetSectionId: 'a0bba3b1-8861-4f5f-b174-746f75949030',
     },
   ],
-};
+});
 
 describe('forms branching', () => {
   it('matches contains rules against array answers', () => {

--- a/apps/forms/src/features/forms/collaboration/block-editing-badge.tsx
+++ b/apps/forms/src/features/forms/collaboration/block-editing-badge.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import type { FormCollaboratorPresence } from './channel';
+import { getCollaboratorTone } from './collaborator-avatars';
+
+/**
+ * "Mai is editing" marker on a block another editor currently has focused.
+ *
+ * A soft signal, not a lock. The studio saves whole documents, so a hard lock
+ * would have to be released reliably across crashes and lost connections to
+ * avoid stranding a block — a visible warning before you start typing gets most
+ * of the benefit with none of that failure mode.
+ */
+export function BlockEditingBadge({
+  className,
+  editors,
+}: {
+  className?: string;
+  editors: FormCollaboratorPresence[];
+}) {
+  const t = useTranslations('forms');
+
+  const first = editors[0];
+  if (!first) {
+    return null;
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border border-dynamic-orange/30 bg-dynamic-orange/10 py-0.5 pr-2.5 pl-1.5 font-medium text-[0.7rem] text-dynamic-orange',
+        className
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'h-1.5 w-1.5 rounded-full',
+          getCollaboratorTone(first.user.id)
+        )}
+      />
+      {editors.length === 1
+        ? t('collaboration.editing_now', { name: first.user.displayName })
+        : t('collaboration.editing_now_multiple', { count: editors.length })}
+    </span>
+  );
+}

--- a/apps/forms/src/features/forms/collaboration/channel.test.ts
+++ b/apps/forms/src/features/forms/collaboration/channel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FORM_STUDIO_CHANNEL_PREFIX,
+  getFormStudioChannelName,
+} from './channel';
+
+describe('getFormStudioChannelName', () => {
+  it('produces the topic shape the RLS policy parses', () => {
+    // `private.can_join_form_realtime_topic` strips this exact prefix and casts
+    // the remainder to uuid. If the two ever disagree, every channel join is
+    // denied with no clue why — so the contract is asserted here.
+    const formId = '9f1c0a52-1f4c-4a3f-9a4e-0d3b4c5d6e7f';
+
+    expect(getFormStudioChannelName(formId)).toBe(`form-studio-${formId}`);
+    expect(
+      getFormStudioChannelName(formId).slice(FORM_STUDIO_CHANNEL_PREFIX.length)
+    ).toBe(formId);
+  });
+});

--- a/apps/forms/src/features/forms/collaboration/channel.ts
+++ b/apps/forms/src/features/forms/collaboration/channel.ts
@@ -1,0 +1,53 @@
+/**
+ * Realtime channel naming and payload shapes for form studio collaboration.
+ *
+ * Kept free of React and of the Supabase client so both the hook and any
+ * server-side broadcaster can share one definition of the wire format — a
+ * mismatch here is invisible until two clients disagree at runtime.
+ */
+
+export const FORM_STUDIO_CHANNEL_PREFIX = 'form-studio-';
+
+/**
+ * Must stay in step with `private.can_join_form_realtime_topic`, which parses
+ * the form id out of this exact prefix.
+ */
+export function getFormStudioChannelName(formId: string) {
+  return `${FORM_STUDIO_CHANNEL_PREFIX}${formId}`;
+}
+
+export interface FormCollaboratorIdentity {
+  id: string;
+  displayName: string;
+  email: string | null;
+  avatarUrl: string | null;
+}
+
+export interface FormCollaboratorPresence {
+  user: FormCollaboratorIdentity;
+  /**
+   * Distinguishes two tabs belonging to the same person. Presence is keyed by
+   * user id so one person shows as one avatar, but the block they are editing
+   * is per-tab.
+   */
+  sessionId: string;
+  /** Block currently focused, or null when the editor is idle. */
+  blockId: string | null;
+  /** Human-readable label for the focused block, for the tooltip. */
+  blockLabel: string | null;
+  /** True while the tab is hidden, so the avatar can dim instead of vanishing. */
+  away: boolean;
+  onlineAt: string;
+}
+
+export const FORM_STUDIO_EVENTS = {
+  /** A collaborator persisted the form; other editors should refetch. */
+  saved: 'form:saved',
+} as const;
+
+export interface FormSavedBroadcast {
+  formId: string;
+  actorId: string;
+  actorName: string;
+  savedAt: string;
+}

--- a/apps/forms/src/features/forms/collaboration/collaborator-avatars.tsx
+++ b/apps/forms/src/features/forms/collaboration/collaborator-avatars.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@tuturuuu/ui/avatar';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@tuturuuu/ui/tooltip';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import type { FormCollaboratorPresence } from './channel';
+
+/**
+ * Deterministic per-user tint.
+ *
+ * Colour has to survive a reload and agree across every client, so it is
+ * derived from the user id rather than assigned by arrival order — otherwise
+ * two people would see the same collaborator in different colours.
+ */
+const AVATAR_TONES = [
+  'bg-dynamic-purple',
+  'bg-dynamic-blue',
+  'bg-dynamic-green',
+  'bg-dynamic-orange',
+  'bg-dynamic-pink',
+  'bg-dynamic-cyan',
+] as const;
+
+export function getCollaboratorTone(userId: string) {
+  let hash = 0;
+  for (let index = 0; index < userId.length; index += 1) {
+    hash = (hash * 31 + userId.charCodeAt(index)) >>> 0;
+  }
+
+  return AVATAR_TONES[hash % AVATAR_TONES.length] as string;
+}
+
+function getInitials(displayName: string) {
+  const parts = displayName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return `${parts[0]![0]}${parts.at(-1)![0]}`.toUpperCase();
+}
+
+const MAX_VISIBLE = 4;
+
+/** Stacked avatars for everyone else currently in the studio. */
+export function CollaboratorAvatars({
+  className,
+  collaborators,
+  isConnected,
+}: {
+  className?: string;
+  collaborators: FormCollaboratorPresence[];
+  isConnected: boolean;
+}) {
+  const t = useTranslations('forms');
+
+  if (!isConnected || collaborators.length === 0) {
+    return null;
+  }
+
+  const visible = collaborators.slice(0, MAX_VISIBLE);
+  const overflow = collaborators.length - visible.length;
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div
+        className={cn(
+          'flex items-center gap-2 rounded-full border border-border/60 bg-background/70 py-1 pr-3 pl-1.5',
+          className
+        )}
+      >
+        <div className="flex -space-x-2">
+          {visible.map((collaborator) => (
+            <Tooltip key={`${collaborator.user.id}:${collaborator.sessionId}`}>
+              <TooltipTrigger asChild>
+                <span
+                  className={cn(
+                    'inline-flex transition-opacity',
+                    collaborator.away && 'opacity-40'
+                  )}
+                >
+                  <Avatar className="h-7 w-7 border-2 border-background">
+                    {collaborator.user.avatarUrl ? (
+                      <AvatarImage
+                        alt={collaborator.user.displayName}
+                        src={collaborator.user.avatarUrl}
+                      />
+                    ) : null}
+                    <AvatarFallback
+                      className={cn(
+                        'font-medium text-[0.6rem] text-white',
+                        getCollaboratorTone(collaborator.user.id)
+                      )}
+                    >
+                      {getInitials(collaborator.user.displayName)}
+                    </AvatarFallback>
+                  </Avatar>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="font-medium">{collaborator.user.displayName}</p>
+                <p className="text-muted-foreground text-xs">
+                  {collaborator.away
+                    ? t('collaboration.away')
+                    : collaborator.blockLabel
+                      ? t('collaboration.editing_block', {
+                          block: collaborator.blockLabel,
+                        })
+                      : t('collaboration.viewing')}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+
+          {overflow > 0 ? (
+            <span className="inline-flex h-7 w-7 items-center justify-center rounded-full border-2 border-background bg-muted font-medium text-[0.6rem] text-muted-foreground">
+              +{overflow}
+            </span>
+          ) : null}
+        </div>
+
+        <span className="text-muted-foreground text-xs">
+          {t('collaboration.editor_count', { count: collaborators.length })}
+        </span>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/apps/forms/src/features/forms/collaboration/identity.ts
+++ b/apps/forms/src/features/forms/collaboration/identity.ts
@@ -1,7 +1,28 @@
 import 'server-only';
 
+import { getSatelliteSupabaseSessionUser } from '@tuturuuu/satellite/auth';
 import type { TypedSupabaseClient } from '@tuturuuu/supabase/next/client';
 import type { FormCollaboratorIdentity } from './channel';
+
+/**
+ * Whether this request's browser will be able to join a private Realtime
+ * channel.
+ *
+ * `getSatelliteAppSessionUser` resolves an actor from either an app-session
+ * token or a Supabase session. Only the second leaves the browser with Supabase
+ * auth cookies, and the browser Realtime client authenticates from those — so
+ * on the app-session path the client connects as `anon` and both
+ * `realtime.messages` policies, which are `to authenticated`, refuse the topic.
+ *
+ * Resolved on the server because a registered satellite must not call
+ * `supabase.auth.*` in the browser, so the client cannot check for itself.
+ * Without this the studio subscribes, is silently refused, and shows an empty
+ * collaborator list that looks exactly like "nobody else is here".
+ */
+export async function canJoinFormRealtime(): Promise<boolean> {
+  const supabaseUser = await getSatelliteSupabaseSessionUser();
+  return Boolean(supabaseUser?.id);
+}
 
 /**
  * Resolves the collaborator identity handed to the studio.

--- a/apps/forms/src/features/forms/collaboration/identity.ts
+++ b/apps/forms/src/features/forms/collaboration/identity.ts
@@ -1,0 +1,46 @@
+import 'server-only';
+
+import type { TypedSupabaseClient } from '@tuturuuu/supabase/next/client';
+import type { FormCollaboratorIdentity } from './channel';
+
+/**
+ * Resolves the collaborator identity handed to the studio.
+ *
+ * Done on the server from the app session, because registered satellites must
+ * not read Supabase auth in the browser — the `internal-app-auth` guard
+ * enforces that, and `NotificationPopover` already takes a server-resolved
+ * `userId` the same way.
+ *
+ * The app-session user carries only an id and email, so the display name and
+ * avatar are read from `public.users` through the admin client the caller
+ * already holds. A missing profile row is not an error: presence falls back to
+ * the email local part, which is still recognisable to teammates.
+ */
+export async function resolveCollaboratorIdentity({
+  adminClient,
+  user,
+}: {
+  adminClient: TypedSupabaseClient;
+  user: { id: string; email?: string | null } | null | undefined;
+}): Promise<FormCollaboratorIdentity | null> {
+  if (!user?.id) {
+    return null;
+  }
+
+  const { data: profile } = await adminClient
+    .from('users')
+    .select('display_name, avatar_url')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  const email = user.email ?? null;
+  const displayName =
+    profile?.display_name?.trim() || email?.split('@')[0] || 'Teammate';
+
+  return {
+    id: user.id,
+    displayName,
+    email,
+    avatarUrl: profile?.avatar_url ?? null,
+  };
+}

--- a/apps/forms/src/features/forms/collaboration/index.ts
+++ b/apps/forms/src/features/forms/collaboration/index.ts
@@ -1,0 +1,18 @@
+export { BlockEditingBadge } from './block-editing-badge';
+export {
+  FORM_STUDIO_CHANNEL_PREFIX,
+  FORM_STUDIO_EVENTS,
+  type FormCollaboratorIdentity,
+  type FormCollaboratorPresence,
+  type FormSavedBroadcast,
+  getFormStudioChannelName,
+} from './channel';
+export {
+  CollaboratorAvatars,
+  getCollaboratorTone,
+} from './collaborator-avatars';
+export {
+  type UseFormCollaborationResult,
+  useFormCollaboration,
+} from './use-form-collaboration';
+export { useRemoteSaveNotice } from './use-remote-save-notice';

--- a/apps/forms/src/features/forms/collaboration/use-form-collaboration.ts
+++ b/apps/forms/src/features/forms/collaboration/use-form-collaboration.ts
@@ -1,0 +1,300 @@
+'use client';
+
+import {
+  createRealtimeClient,
+  type RealtimePresenceState,
+} from '@tuturuuu/supabase/next/realtime-browser';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DEV_MODE } from '@/constants/common';
+import {
+  FORM_STUDIO_EVENTS,
+  type FormCollaboratorIdentity,
+  type FormCollaboratorPresence,
+  type FormSavedBroadcast,
+  getFormStudioChannelName,
+} from './channel';
+
+type StudioChannel = ReturnType<
+  ReturnType<typeof createRealtimeClient>['channel']
+>;
+
+const SESSION_STORAGE_KEY = 'tuturuuu:form-studio:session-id';
+
+export interface UseFormCollaborationOptions {
+  /** Omitted while creating a form — there is no id to scope a channel to. */
+  formId?: string;
+  /**
+   * The local editor, resolved on the server from the app session.
+   *
+   * Registered satellites must not read Supabase auth in the browser (the
+   * `internal-app-auth` guard enforces this), so identity is passed in rather
+   * than looked up here — the same shape `NotificationPopover` already uses.
+   */
+  currentUser: FormCollaboratorIdentity | null;
+  enabled?: boolean;
+  /** Fired when another editor saves, so the caller can refetch. */
+  onRemoteSave?: (payload: FormSavedBroadcast) => void;
+}
+
+export interface UseFormCollaborationResult {
+  /** Everyone in the session except the local user, most recent first. */
+  collaborators: FormCollaboratorPresence[];
+  currentUserId: string | null;
+  isConnected: boolean;
+  /** Reports which block the local user is editing. `null` clears it. */
+  setActiveBlock: (blockId: string | null, blockLabel?: string | null) => void;
+  /** Tells other editors the form was just persisted. */
+  broadcastSaved: () => void;
+  /** Collaborators currently focused on a given block. */
+  getBlockEditors: (blockId: string) => FormCollaboratorPresence[];
+}
+
+function createSessionId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `fallback-${Date.now().toString(36)}-${Math.round(Math.random() * 1e9)}`;
+}
+
+/**
+ * One tab keeps one session id for its lifetime, so a re-render or a
+ * reconnection does not present the same person as two collaborators.
+ */
+function getOrCreateSessionId() {
+  if (typeof sessionStorage === 'undefined') {
+    return createSessionId();
+  }
+
+  try {
+    const existing = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (existing) return existing;
+
+    const next = createSessionId();
+    sessionStorage.setItem(SESSION_STORAGE_KEY, next);
+    return next;
+  } catch {
+    return createSessionId();
+  }
+}
+
+/**
+ * Live presence and save notifications for the form studio.
+ *
+ * The forms tables sit in the `private` schema with service-role-only access,
+ * so `postgres_changes` is not available here — this uses a private Broadcast +
+ * Presence channel instead, authorized by `realtime.messages` policies that
+ * check `manage_forms` on the form's workspace.
+ *
+ * Deliberately not an operational-transform layer: the studio autosaves whole
+ * documents, so the useful signals are "who else is here", "which block are
+ * they in" and "the server copy just changed" — enough to stop two people
+ * silently overwriting each other, without pretending edits merge.
+ */
+export function useFormCollaboration({
+  formId,
+  currentUser,
+  enabled = true,
+  onRemoteSave,
+}: UseFormCollaborationOptions): UseFormCollaborationResult {
+  const [presenceState, setPresenceState] = useState<
+    RealtimePresenceState<FormCollaboratorPresence>
+  >({});
+  const [isConnected, setIsConnected] = useState(false);
+  const currentUserId = currentUser?.id ?? null;
+
+  const channelRef = useRef<StudioChannel | null>(null);
+  const identityRef = useRef<FormCollaboratorIdentity | null>(currentUser);
+  identityRef.current = currentUser;
+  const sessionIdRef = useRef<string>('');
+  const blockRef = useRef<{ id: string | null; label: string | null }>({
+    id: null,
+    label: null,
+  });
+  const awayRef = useRef(false);
+  const disposedRef = useRef(false);
+  // `onRemoteSave` is usually an inline closure; keeping it in a ref stops the
+  // channel from being torn down and rebuilt on every parent render.
+  const onRemoteSaveRef = useRef(onRemoteSave);
+  onRemoteSaveRef.current = onRemoteSave;
+
+  const channelName = enabled && formId ? getFormStudioChannelName(formId) : '';
+
+  const track = useCallback(async () => {
+    const channel = channelRef.current;
+    if (!channel || !identityRef.current || disposedRef.current) return;
+
+    try {
+      await channel.track({
+        user: identityRef.current,
+        sessionId: sessionIdRef.current,
+        blockId: blockRef.current.id,
+        blockLabel: blockRef.current.label,
+        away: awayRef.current,
+        onlineAt: new Date().toISOString(),
+      } satisfies FormCollaboratorPresence);
+    } catch (error) {
+      if (DEV_MODE) {
+        console.error('Form studio presence track failed:', error);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!(channelName && currentUserId)) {
+      setIsConnected(false);
+      return;
+    }
+
+    disposedRef.current = false;
+    sessionIdRef.current = getOrCreateSessionId();
+    const supabase = createRealtimeClient();
+
+    const channel = supabase.channel(channelName, {
+      config: {
+        broadcast: { self: false },
+        presence: { enabled: true, key: currentUserId },
+        private: true,
+      },
+    });
+    channelRef.current = channel;
+
+    channel
+      .on('presence', { event: 'sync' }, () => {
+        if (disposedRef.current) return;
+        setPresenceState({
+          ...(channel.presenceState() as RealtimePresenceState<FormCollaboratorPresence>),
+        });
+      })
+      .on(
+        'broadcast',
+        { event: FORM_STUDIO_EVENTS.saved },
+        ({ payload }: { payload: FormSavedBroadcast }) => {
+          if (disposedRef.current) return;
+          onRemoteSaveRef.current?.(payload);
+        }
+      )
+      .subscribe((status) => {
+        if (disposedRef.current) return;
+
+        if (status === 'SUBSCRIBED') {
+          setIsConnected(true);
+          void track();
+          return;
+        }
+
+        // CHANNEL_ERROR here usually means the `realtime.messages` policy
+        // denied the topic. Collaboration is additive, so the studio keeps
+        // working with presence simply switched off rather than surfacing an
+        // error the editor cannot act on.
+        setIsConnected(false);
+        if (DEV_MODE && status === 'CHANNEL_ERROR') {
+          console.warn('Form studio channel rejected:', channelName);
+        }
+      });
+
+    return () => {
+      disposedRef.current = true;
+      setIsConnected(false);
+      setPresenceState({});
+
+      channelRef.current = null;
+      channel.untrack?.().catch(() => {});
+      supabase.removeChannel(channel).catch(() => {});
+    };
+  }, [channelName, currentUserId, track]);
+
+  // A tab left open in the background should dim rather than disappear:
+  // vanishing and reappearing reads as a connection problem.
+  useEffect(() => {
+    if (!channelName) return;
+
+    const onVisibilityChange = () => {
+      const away = document.visibilityState === 'hidden';
+      if (awayRef.current === away) return;
+
+      awayRef.current = away;
+      void track();
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () =>
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, [channelName, track]);
+
+  const setActiveBlock = useCallback(
+    (blockId: string | null, blockLabel: string | null = null) => {
+      if (
+        blockRef.current.id === blockId &&
+        blockRef.current.label === blockLabel
+      ) {
+        return;
+      }
+
+      blockRef.current = { id: blockId, label: blockLabel };
+      void track();
+    },
+    [track]
+  );
+
+  const broadcastSaved = useCallback(() => {
+    const channel = channelRef.current;
+    const identity = identityRef.current;
+    if (!(channel && identity && formId)) return;
+
+    channel
+      .send({
+        type: 'broadcast',
+        event: FORM_STUDIO_EVENTS.saved,
+        payload: {
+          formId,
+          actorId: identity.id,
+          actorName: identity.displayName,
+          savedAt: new Date().toISOString(),
+        } satisfies FormSavedBroadcast,
+      })
+      .catch((error) => {
+        if (DEV_MODE) {
+          console.error('Form studio save broadcast failed:', error);
+        }
+      });
+  }, [formId]);
+
+  const collaborators = useMemo(() => {
+    const bySession = new Map<string, FormCollaboratorPresence>();
+
+    for (const entries of Object.values(presenceState)) {
+      for (const entry of entries) {
+        if (!entry?.user?.id || entry.user.id === currentUserId) continue;
+
+        // Presence is keyed by user id, so a person with two tabs open arrives
+        // as two entries under one key. Keep the most recent per tab.
+        const key = `${entry.user.id}:${entry.sessionId}`;
+        const existing = bySession.get(key);
+        if (!existing || existing.onlineAt <= entry.onlineAt) {
+          bySession.set(key, entry);
+        }
+      }
+    }
+
+    return [...bySession.values()].sort((left, right) =>
+      right.onlineAt.localeCompare(left.onlineAt)
+    );
+  }, [currentUserId, presenceState]);
+
+  const getBlockEditors = useCallback(
+    (blockId: string) =>
+      collaborators.filter(
+        (collaborator) => !collaborator.away && collaborator.blockId === blockId
+      ),
+    [collaborators]
+  );
+
+  return {
+    broadcastSaved,
+    collaborators,
+    currentUserId,
+    getBlockEditors,
+    isConnected,
+    setActiveBlock,
+  };
+}

--- a/apps/forms/src/features/forms/collaboration/use-remote-save-notice.ts
+++ b/apps/forms/src/features/forms/collaboration/use-remote-save-notice.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { toast } from '@tuturuuu/ui/sonner';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useCallback, useRef } from 'react';
+import type { FormSavedBroadcast } from './channel';
+
+/**
+ * Reacts to another editor saving the form.
+ *
+ * The studio holds the whole document in a react-hook-form instance, so
+ * refetching on every remote save would silently discard whatever the local
+ * editor has typed since their last save. The rule is therefore:
+ *
+ * - local form clean → refresh straight away; there is nothing to lose and the
+ *   editor should not keep working against a stale copy
+ * - local form dirty → surface a toast and let them decide when to reload,
+ *   because only they know whether their in-progress edit or the incoming one
+ *   should win
+ *
+ * Notices are throttled per actor: autosave fires every couple of seconds while
+ * someone types, and a toast per keystroke-batch would be unusable.
+ */
+const NOTICE_THROTTLE_MS = 15_000;
+
+export function useRemoteSaveNotice({
+  isDirty,
+  onReload,
+}: {
+  isDirty: boolean;
+  /** Refetch hook; falls back to a router refresh when omitted. */
+  onReload?: () => void;
+}) {
+  const t = useTranslations('forms');
+  const router = useRouter();
+  const lastNoticeRef = useRef<Map<string, number>>(new Map());
+  // Read through refs so the callback identity stays stable — it is handed to
+  // a realtime subscription that should not resubscribe on every render.
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+  const onReloadRef = useRef(onReload);
+  onReloadRef.current = onReload;
+
+  const reload = useCallback(() => {
+    if (onReloadRef.current) {
+      onReloadRef.current();
+      return;
+    }
+    router.refresh();
+  }, [router]);
+
+  return useCallback(
+    (payload: FormSavedBroadcast) => {
+      if (!isDirtyRef.current) {
+        reload();
+        return;
+      }
+
+      const now = Date.now();
+      const last = lastNoticeRef.current.get(payload.actorId) ?? 0;
+      if (now - last < NOTICE_THROTTLE_MS) {
+        return;
+      }
+      lastNoticeRef.current.set(payload.actorId, now);
+
+      toast.warning(
+        t('collaboration.remote_save_title', { name: payload.actorName }),
+        {
+          description: t('collaboration.remote_save_description'),
+          duration: 12_000,
+          action: {
+            label: t('collaboration.remote_save_reload'),
+            onClick: reload,
+          },
+        }
+      );
+    },
+    [reload, t]
+  );
+}

--- a/apps/forms/src/features/forms/embed/embed-content.tsx
+++ b/apps/forms/src/features/forms/embed/embed-content.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import SharedFormContent from '@/app/[locale]/f/[shareCode]/content';
+import type { SharedFormPayload } from '@/features/forms/shared-form-data';
+import { EmbedFrame } from './embed-frame';
+
+/**
+ * The embedded form.
+ *
+ * Reuses the public form component verbatim rather than a stripped-down copy:
+ * an embedded form must behave identically to the hosted one — same branching,
+ * same validation, same Turnstile, same submission endpoint — and a parallel
+ * implementation would inevitably fall behind.
+ */
+export function EmbedContent({
+  data,
+  shareCode,
+}: {
+  data: SharedFormPayload;
+  shareCode: string;
+}) {
+  const [submitted, setSubmitted] = useState(Boolean(data.submittedAt));
+
+  return (
+    <EmbedFrame shareCode={shareCode} submitted={submitted}>
+      <SharedFormContent
+        answerIssues={data.answerIssues}
+        canRequestResponseCopy={data.canRequestResponseCopy}
+        form={data.form}
+        initialAnswers={data.initialAnswers}
+        onSubmitted={() => setSubmitted(true)}
+        readOnly={data.readOnly}
+        readOnlyResponseId={data.readOnlyResponseId}
+        readOnlyResponseSessionId={data.readOnlyResponseSessionId}
+        responseCopyAlreadySent={data.responseCopyAlreadySent}
+        responseCopyEmail={data.responseCopyEmail}
+        sessionId={data.sessionId}
+        shareCode={shareCode}
+        submittedAt={data.submittedAt}
+      />
+    </EmbedFrame>
+  );
+}

--- a/apps/forms/src/features/forms/embed/embed-frame.tsx
+++ b/apps/forms/src/features/forms/embed/embed-frame.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  EMBED_MESSAGE_SOURCE,
+  EMBED_MESSAGE_TYPES,
+  type EmbedMessage,
+} from './protocol';
+
+/**
+ * Reports the embedded form's height to the host page.
+ *
+ * An iframe cannot size itself, so an inline embed would otherwise either
+ * scroll inside a fixed box or reserve far too much space. A `ResizeObserver`
+ * on the content posts the real height whenever it changes — which it does a
+ * lot in a form, as sections open, validation messages appear and branching
+ * swaps the visible questions.
+ *
+ * Messages are posted to `*` because the host origin is unknown by design: any
+ * site may embed a public form. Nothing sensitive is sent — a height, a share
+ * code that is already public, and a submitted flag.
+ */
+export function EmbedFrame({
+  children,
+  shareCode,
+  submitted,
+}: {
+  children: React.ReactNode;
+  shareCode: string;
+  /** Flips to true once the respondent submits, so overlays can dismiss. */
+  submitted?: boolean;
+}) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const lastHeightRef = useRef(0);
+
+  useEffect(() => {
+    const node = contentRef.current;
+    if (!node || window.parent === window) return;
+
+    const post = (message: Omit<EmbedMessage, 'source'>) => {
+      window.parent.postMessage(
+        { ...message, source: EMBED_MESSAGE_SOURCE } satisfies EmbedMessage,
+        '*'
+      );
+    };
+
+    const postHeight = () => {
+      const height = Math.ceil(node.getBoundingClientRect().height);
+      // Sub-pixel churn during animation would otherwise post on every frame
+      // and make the host iframe visibly jitter.
+      if (Math.abs(height - lastHeightRef.current) < 2) return;
+
+      lastHeightRef.current = height;
+      post({ height, shareCode, type: EMBED_MESSAGE_TYPES.resize });
+    };
+
+    post({ shareCode, type: EMBED_MESSAGE_TYPES.ready });
+    postHeight();
+
+    const observer = new ResizeObserver(postHeight);
+    observer.observe(node);
+
+    return () => observer.disconnect();
+  }, [shareCode]);
+
+  useEffect(() => {
+    if (!submitted || window.parent === window) return;
+
+    window.parent.postMessage(
+      {
+        shareCode,
+        source: EMBED_MESSAGE_SOURCE,
+        type: EMBED_MESSAGE_TYPES.submitted,
+      } satisfies EmbedMessage,
+      '*'
+    );
+  }, [shareCode, submitted]);
+
+  return (
+    <div className="min-h-0 bg-transparent" ref={contentRef}>
+      {children}
+    </div>
+  );
+}

--- a/apps/forms/src/features/forms/embed/embed-snippet.test.ts
+++ b/apps/forms/src/features/forms/embed/embed-snippet.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildEmbedSnippet,
+  buildIframeSnippet,
+  buildShareUrl,
+  isOverlayEmbedMode,
+} from './embed-snippet';
+
+const base = { baseUrl: 'https://forms.tuturuuu.com', shareCode: 'AbC123' };
+
+describe('buildEmbedSnippet', () => {
+  it('emits the script tag and container the SDK looks for', () => {
+    const snippet = buildEmbedSnippet({ ...base, mode: 'inline' });
+
+    expect(snippet).toContain(
+      '<script src="https://forms.tuturuuu.com/embed.js" async></script>'
+    );
+    expect(snippet).toContain('data-tuturuuu-form="AbC123"');
+    expect(snippet).toContain('data-mode="inline"');
+  });
+
+  it('omits height on overlay modes, which size themselves', () => {
+    expect(
+      buildEmbedSnippet({ ...base, mode: 'popup', height: 800 })
+    ).not.toContain('data-height');
+    expect(
+      buildEmbedSnippet({ ...base, mode: 'inline', height: 800 })
+    ).toContain('data-height="800"');
+  });
+
+  it('omits launcher text on modes with no launcher', () => {
+    expect(
+      buildEmbedSnippet({
+        ...base,
+        mode: 'popup',
+        launcherText: 'Give feedback',
+      })
+    ).toContain('data-launcher-text="Give feedback"');
+    expect(
+      buildEmbedSnippet({
+        ...base,
+        mode: 'inline',
+        launcherText: 'Give feedback',
+      })
+    ).not.toContain('data-launcher-text');
+  });
+
+  it('escapes values so a crafted label cannot break out of the attribute', () => {
+    const snippet = buildEmbedSnippet({
+      ...base,
+      mode: 'popup',
+      launcherText: '"><script>alert(1)</script>',
+    });
+
+    expect(snippet).not.toContain('"><script>alert(1)');
+    expect(snippet).toContain('&quot;&gt;&lt;script&gt;');
+  });
+
+  it('escapes the share code too', () => {
+    const snippet = buildEmbedSnippet({
+      baseUrl: base.baseUrl,
+      shareCode: 'a"b',
+      mode: 'inline',
+    });
+
+    expect(snippet).toContain('data-tuturuuu-form="a&quot;b"');
+  });
+});
+
+describe('buildIframeSnippet', () => {
+  it('falls back to a fixed height, since a bare iframe cannot auto-resize', () => {
+    expect(buildIframeSnippet(base)).toContain('height="640"');
+    expect(buildIframeSnippet({ ...base, height: 900 })).toContain(
+      'height="900"'
+    );
+  });
+
+  it('url-encodes the share code', () => {
+    expect(buildIframeSnippet({ ...base, shareCode: 'a b/c' })).toContain(
+      '/embed/a%20b%2Fc'
+    );
+  });
+});
+
+describe('buildShareUrl', () => {
+  it('points at the canonical hosted page', () => {
+    expect(buildShareUrl(base.baseUrl, base.shareCode)).toBe(
+      'https://forms.tuturuuu.com/f/AbC123'
+    );
+  });
+});
+
+describe('isOverlayEmbedMode', () => {
+  it.each(['popup', 'slider', 'popover', 'sidetab'] as const)(
+    '%s is an overlay',
+    (mode) => expect(isOverlayEmbedMode(mode)).toBe(true)
+  );
+
+  it.each(['inline', 'fullpage'] as const)('%s is not an overlay', (mode) =>
+    expect(isOverlayEmbedMode(mode)).toBe(false)
+  );
+});

--- a/apps/forms/src/features/forms/embed/embed-snippet.ts
+++ b/apps/forms/src/features/forms/embed/embed-snippet.ts
@@ -1,0 +1,86 @@
+import type { EmbedMode } from './protocol';
+
+export interface EmbedSnippetOptions {
+  baseUrl: string;
+  shareCode: string;
+  mode: EmbedMode;
+  /** Fixed pixel height; omit to let inline embeds auto-size. */
+  height?: number | null;
+  /** Launcher label for the overlay modes. */
+  launcherText?: string | null;
+}
+
+const OVERLAY_MODES: EmbedMode[] = ['popup', 'slider', 'popover', 'sidetab'];
+
+export function isOverlayEmbedMode(mode: EmbedMode) {
+  return OVERLAY_MODES.includes(mode);
+}
+
+/** Escapes a value for use inside a double-quoted HTML attribute. */
+function escapeAttribute(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Builds the copy-paste snippet for one embed mode.
+ *
+ * Emits only the attributes that differ from the SDK's defaults, so the snippet
+ * stays short enough to read — a wall of redundant `data-*` attributes invites
+ * people to edit the wrong one.
+ */
+export function buildEmbedSnippet({
+  baseUrl,
+  shareCode,
+  mode,
+  height,
+  launcherText,
+}: EmbedSnippetOptions) {
+  const attributes = [
+    `data-tuturuuu-form="${escapeAttribute(shareCode)}"`,
+    `data-mode="${mode}"`,
+  ];
+
+  if (height && height > 0 && !isOverlayEmbedMode(mode)) {
+    attributes.push(`data-height="${Math.round(height)}"`);
+  }
+
+  if (launcherText?.trim() && isOverlayEmbedMode(mode)) {
+    attributes.push(
+      `data-launcher-text="${escapeAttribute(launcherText.trim())}"`
+    );
+  }
+
+  const container = `<div\n  ${attributes.join('\n  ')}\n></div>`;
+
+  return `<script src="${baseUrl}/embed.js" async></script>\n${container}`;
+}
+
+/**
+ * Plain iframe fallback for hosts that forbid third-party scripts — common in
+ * locked-down CMSes. Loses auto-resize, so it takes an explicit height.
+ */
+export function buildIframeSnippet({
+  baseUrl,
+  shareCode,
+  height,
+}: Pick<EmbedSnippetOptions, 'baseUrl' | 'shareCode' | 'height'>) {
+  const resolvedHeight = height && height > 0 ? Math.round(height) : 640;
+
+  return [
+    `<iframe src="${baseUrl}/embed/${encodeURIComponent(shareCode)}"`,
+    `  title="Form"`,
+    `  width="100%"`,
+    `  height="${resolvedHeight}"`,
+    `  style="border:0"`,
+    `></iframe>`,
+  ].join('\n');
+}
+
+/** Direct link to the hosted form — the simplest way to share it. */
+export function buildShareUrl(baseUrl: string, shareCode: string) {
+  return `${baseUrl}/f/${encodeURIComponent(shareCode)}`;
+}

--- a/apps/forms/src/features/forms/embed/protocol.ts
+++ b/apps/forms/src/features/forms/embed/protocol.ts
@@ -1,0 +1,44 @@
+/**
+ * Message contract between an embedded form and the host page.
+ *
+ * Shared by the React embed page and the plain-JS SDK in `public/embed.js`, so
+ * the two cannot drift. Every message carries `source` so a host page running
+ * other iframes can tell ours apart, and the SDK verifies it before acting.
+ */
+
+export const EMBED_MESSAGE_SOURCE = 'tuturuuu-forms';
+
+export const EMBED_MESSAGE_TYPES = {
+  /** Content height changed; the host should resize the iframe. */
+  resize: 'resize',
+  /** The respondent submitted; overlay modes may auto-dismiss. */
+  submitted: 'submitted',
+  /** The embed mounted and is ready to be shown. */
+  ready: 'ready',
+} as const;
+
+export type EmbedMessageType =
+  (typeof EMBED_MESSAGE_TYPES)[keyof typeof EMBED_MESSAGE_TYPES];
+
+export interface EmbedMessage {
+  source: typeof EMBED_MESSAGE_SOURCE;
+  type: EmbedMessageType;
+  shareCode: string;
+  /** Present on `resize`. Content height in CSS pixels. */
+  height?: number;
+}
+
+export const EMBED_MODES = [
+  'inline',
+  'fullpage',
+  'popup',
+  'slider',
+  'popover',
+  'sidetab',
+] as const;
+
+export type EmbedMode = (typeof EMBED_MODES)[number];
+
+export function isEmbedMode(value: string): value is EmbedMode {
+  return (EMBED_MODES as readonly string[]).includes(value);
+}

--- a/apps/forms/src/features/forms/hooks.ts
+++ b/apps/forms/src/features/forms/hooks.ts
@@ -167,6 +167,12 @@ export function usePublicFormResponseCopy(shareCode: string) {
   });
 }
 
+/**
+ * Upload scopes double as the storage folder under `<wsId>/forms/`, so a new
+ * scope has to be added to the route's enum as well as here.
+ */
+export type FormMediaScope = 'cover' | 'section' | 'option' | 'social';
+
 export function useFormMediaUploadMutation({ wsId }: { wsId: string }) {
   const t = useTranslations('forms');
 
@@ -176,7 +182,7 @@ export function useFormMediaUploadMutation({ wsId }: { wsId: string }) {
       scope,
     }: {
       file: File;
-      scope: 'cover' | 'section' | 'option';
+      scope: FormMediaScope;
     }) => {
       const upload = await apiFetch<{
         signedUrl: string;

--- a/apps/forms/src/features/forms/response-analytics.test.ts
+++ b/apps/forms/src/features/forms/response-analytics.test.ts
@@ -3,53 +3,15 @@ import {
   buildQuestionAnalytics,
   buildResponseSummary,
 } from './response-analytics';
+import { createTestFormDefinition } from './test-support/form-fixtures';
 import type {
   FormDefinition,
   FormResponseAnswerRow,
   FormResponseRow,
 } from './types';
 
-const form: FormDefinition = {
-  id: '50000000-0000-0000-0000-000000000001',
-  wsId: '50000000-0000-0000-0000-000000000002',
-  creatorId: '50000000-0000-0000-0000-000000000003',
+const form: FormDefinition = createTestFormDefinition({
   title: 'Feedback form',
-  description: '',
-  status: 'published',
-  accessMode: 'anonymous',
-  openAt: null,
-  closeAt: null,
-  maxResponses: null,
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
-  theme: {
-    presetId: 'editorial-moss',
-    density: 'balanced',
-    accentColor: 'dynamic-green',
-    headlineFontId: 'noto-serif',
-    bodyFontId: 'be-vietnam-pro',
-    surfaceStyle: 'paper',
-    coverHeadline: '',
-    coverImage: {
-      storagePath: '',
-      url: '',
-      alt: '',
-    },
-    sectionImages: {},
-    typography: {
-      displaySize: 'md',
-      headingSize: 'md',
-      bodySize: 'md',
-    },
-  },
-  settings: {
-    showProgressBar: true,
-    allowMultipleSubmissions: true,
-    oneResponsePerUser: false,
-    requireTurnstile: false,
-    confirmationTitle: 'Thanks',
-    confirmationMessage: 'Done',
-  },
   sections: [
     {
       id: '50000000-0000-0000-0000-000000000010',
@@ -89,7 +51,7 @@ const form: FormDefinition = {
     },
   ],
   logicRules: [],
-};
+});
 
 describe('buildQuestionAnalytics', () => {
   it('keeps unmatched stored answers out of the current choice breakdown without dropping them', () => {

--- a/apps/forms/src/features/forms/runtime-progress.test.ts
+++ b/apps/forms/src/features/forms/runtime-progress.test.ts
@@ -1,48 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { getRuntimeProgressStats } from './runtime-progress';
+import { createTestFormDefinition } from './test-support/form-fixtures';
 import type { FormDefinition } from './types';
 
-const form: FormDefinition = {
-  id: '50000000-0000-0000-0000-000000000001',
-  wsId: '50000000-0000-0000-0000-000000000002',
-  creatorId: '50000000-0000-0000-0000-000000000003',
+const form: FormDefinition = createTestFormDefinition({
   title: 'Progress form',
-  description: '',
-  status: 'published',
-  accessMode: 'anonymous',
-  openAt: null,
-  closeAt: null,
-  maxResponses: null,
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
-  theme: {
-    presetId: 'editorial-moss',
-    density: 'balanced',
-    accentColor: 'dynamic-green',
-    headlineFontId: 'noto-serif',
-    bodyFontId: 'be-vietnam-pro',
-    surfaceStyle: 'paper',
-    coverHeadline: '',
-    coverImage: {
-      storagePath: '',
-      url: '',
-      alt: '',
-    },
-    sectionImages: {},
-    typography: {
-      displaySize: 'md',
-      headingSize: 'md',
-      bodySize: 'md',
-    },
-  },
-  settings: {
-    showProgressBar: true,
-    allowMultipleSubmissions: true,
-    oneResponsePerUser: false,
-    requireTurnstile: false,
-    confirmationTitle: 'Thanks',
-    confirmationMessage: 'Done',
-  },
   sections: [
     {
       id: '50000000-0000-0000-0000-000000000010',
@@ -160,7 +122,7 @@ const form: FormDefinition = {
       targetSectionId: '50000000-0000-0000-0000-000000000030',
     },
   ],
-};
+});
 
 describe('getRuntimeProgressStats', () => {
   it('counts answered and skipped questions instead of section position', () => {

--- a/apps/forms/src/features/forms/runtime/form-runtime.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.tsx
@@ -28,6 +28,9 @@ import { renderFormSectionCard } from './section-card';
 import { renderSubmittedScreen } from './submitted-screen';
 import type { FormRuntimeProps } from './types';
 import { useFormDraft } from './use-form-draft';
+import { useFormSteps } from './use-form-steps';
+import { useResponseCopy } from './use-response-copy';
+import { WelcomeScreen } from './welcome-screen';
 
 export function FormRuntime({
   form,
@@ -63,6 +66,12 @@ export function FormRuntime({
   const [validationErrorsByQuestionId, setValidationErrorsByQuestionId] =
     useState<Record<string, string>>({});
   const [submitted, setSubmitted] = useState(false);
+  // The welcome screen is skipped entirely when disabled, and also when the
+  // respondent is reviewing an already-submitted response — there is nothing
+  // left to introduce.
+  const [hasStarted, setHasStarted] = useState(
+    () => !form.settings.welcomeEnabled || readOnly || Boolean(submittedAt)
+  );
   const [sendResponseCopy, setSendResponseCopy] = useState(false);
   const [submittedResponseCopyEmail, setSubmittedResponseCopyEmail] = useState<
     string | null
@@ -71,11 +80,6 @@ export function FormRuntime({
     useState<'sent' | 'rate_limited' | 'failed' | null>(null);
   const [submittedResponseCopyRequested, setSubmittedResponseCopyRequested] =
     useState(false);
-  const [isRequestingResponseCopy, setIsRequestingResponseCopy] =
-    useState(false);
-  const [readOnlyResponseCopySentTo, setReadOnlyResponseCopySentTo] = useState<
-    string | null
-  >(responseCopyAlreadySent ? (responseCopyEmail ?? null) : null);
   const [captchaToken, setCaptchaToken] = useState<string>();
   const [captchaError, setCaptchaError] = useState<string>();
   const [previewImage, setPreviewImage] = useState<{
@@ -106,6 +110,25 @@ export function FormRuntime({
   const turnstileSiteKey = turnstileClientState.siteKey;
   const requiresTurnstile =
     mode === 'public' && turnstileClientState.isRequired;
+  const {
+    isRequestingResponseCopy,
+    requestResponseCopy: handleReadOnlyResponseCopy,
+    responseCopySentTo: readOnlyResponseCopySentTo,
+  } = useResponseCopy({
+    captchaRef,
+    captchaToken,
+    isBusy: isSubmitting,
+    onRequestResponseCopy,
+    readOnlyResponseId,
+    readOnlyResponseSessionId,
+    requiresTurnstile,
+    initialSentTo: responseCopyAlreadySent ? responseCopyEmail : null,
+    responseCopyEmail,
+    setCaptchaToken,
+    setError,
+    t,
+    turnstileSiteKey,
+  });
   const currentSectionIndex = form.sections.findIndex(
     (section) => section.id === currentSectionId
   );
@@ -113,6 +136,22 @@ export function FormRuntime({
   const visibleSectionTitle =
     currentSection?.title ||
     t('studio.section_number', { count: currentSectionIndex + 1 });
+  const {
+    currentStep,
+    goToNextStep,
+    goToPreviousStep,
+    isFirstStep,
+    isLastStep,
+    resetSteps,
+    stepIndex,
+    steps,
+  } = useFormSteps({
+    displayMode: form.settings.displayMode,
+    section: currentSection,
+  });
+  // In `sections` mode this is the whole section, so every downstream consumer
+  // can treat the step as the unit of work without branching on the mode.
+  const currentStepQuestions = currentStep?.questions ?? [];
   const activeAnswers = answersRef.current;
   const progressStats = useMemo(
     () =>
@@ -125,17 +164,19 @@ export function FormRuntime({
     [answers, currentSection?.id, form, sectionTrail]
   );
 
+  // Scoped to the visible step: in one-question mode, blocking on a required
+  // answer the respondent has not been shown yet would strand them.
   const requiredQuestionIds = useMemo(
     () =>
       new Set(
-        currentSection?.questions
+        currentStepQuestions
           .filter(
             (question) =>
               question.required && isAnswerableQuestionType(question.type)
           )
           .map((question) => question.id)
       ),
-    [currentSection]
+    [currentStepQuestions]
   );
   const advanceTarget = currentSection
     ? readOnly
@@ -249,12 +290,6 @@ export function FormRuntime({
   }, [responseCopyEmail]);
 
   useEffect(() => {
-    setReadOnlyResponseCopySentTo(
-      responseCopyAlreadySent ? (responseCopyEmail ?? null) : null
-    );
-  }, [responseCopyAlreadySent, responseCopyEmail]);
-
-  useEffect(() => {
     if (shouldShowTurnstile) {
       return;
     }
@@ -302,19 +337,18 @@ export function FormRuntime({
   const validateCurrentSection = (
     currentAnswers: Record<string, FormAnswerValue>
   ) => {
-    const missingRequiredQuestions =
-      currentSection?.questions.filter((question) => {
-        if (!requiredQuestionIds.has(question.id)) {
-          return false;
-        }
+    const missingRequiredQuestions = currentStepQuestions.filter((question) => {
+      if (!requiredQuestionIds.has(question.id)) {
+        return false;
+      }
 
-        const value = currentAnswers[question.id];
-        if (Array.isArray(value)) {
-          return value.length === 0;
-        }
+      const value = currentAnswers[question.id];
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      }
 
-        return value == null || value === '';
-      }) ?? [];
+      return value == null || value === '';
+    });
 
     if (missingRequiredQuestions.length > 0) {
       const firstMissing = missingRequiredQuestions[0]!;
@@ -348,6 +382,32 @@ export function FormRuntime({
     return true;
   };
 
+  /**
+   * Back walks screens before sections, so a respondent in one-question mode
+   * returns to the previous question rather than jumping over the whole
+   * section they are partway through.
+   */
+  const canGoBack = !isFirstStep || sectionTrail.length > 1;
+
+  const handleBack = () => {
+    if (isBusy) return;
+
+    if (goToPreviousStep()) {
+      setError(null);
+      return;
+    }
+
+    const previousSectionId = sectionTrail[sectionTrail.length - 2];
+    if (!previousSectionId) return;
+
+    // Entering the previous section from the end, so its last screen is what
+    // the respondent last saw.
+    resetSteps('last');
+    setSectionTrail((currentTrail) => currentTrail.slice(0, -1));
+    setCurrentSectionId(previousSectionId);
+    setError(null);
+  };
+
   const handleAdvance = async () => {
     if (isBusy) {
       return;
@@ -359,12 +419,25 @@ export function FormRuntime({
       return;
     }
 
+    // One-question mode splits a section into screens. Walk those first;
+    // branching only applies once the section is exhausted, which keeps rule
+    // evaluation defined per section exactly as it was.
+    if (!isLastStep && goToNextStep()) {
+      setError(null);
+      sectionCardRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+      return;
+    }
+
     const target = readOnly
       ? advanceTarget
       : getNextSectionTarget(form, currentSection.id, currentAnswers);
 
     if (readOnly) {
       if (target.targetSectionId) {
+        resetSteps('first');
         setCurrentSectionId(target.targetSectionId);
         setSectionTrail((currentTrail) =>
           currentTrail.at(-1) === target.targetSectionId
@@ -451,6 +524,7 @@ export function FormRuntime({
     }
 
     if (target.targetSectionId) {
+      resetSteps('first');
       setCurrentSectionId(target.targetSectionId);
       setSectionTrail((currentTrail) =>
         currentTrail.at(-1) === target.targetSectionId
@@ -459,46 +533,6 @@ export function FormRuntime({
       );
       setError(null);
       setValidationErrorsByQuestionId({});
-    }
-  };
-
-  const handleReadOnlyResponseCopy = async () => {
-    if (
-      isBusy ||
-      !onRequestResponseCopy ||
-      !readOnlyResponseId ||
-      !readOnlyResponseSessionId
-    ) {
-      return;
-    }
-
-    if (requiresTurnstile && !turnstileSiteKey) {
-      setError(t('runtime.turnstile_not_configured'));
-      return;
-    }
-
-    if (requiresTurnstile && !captchaToken) {
-      setError(t('runtime.turnstile_required'));
-      return;
-    }
-
-    setIsRequestingResponseCopy(true);
-    setError(null);
-
-    try {
-      const result = await onRequestResponseCopy({
-        responseId: readOnlyResponseId,
-        sessionId: readOnlyResponseSessionId,
-        turnstileToken: captchaToken,
-      });
-
-      setReadOnlyResponseCopySentTo(
-        result?.responseCopySentTo ?? responseCopyEmail ?? null
-      );
-      captchaRef.current?.reset();
-      setCaptchaToken(undefined);
-    } finally {
-      setIsRequestingResponseCopy(false);
     }
   };
 
@@ -516,6 +550,33 @@ export function FormRuntime({
       submittedResponseCopyRequested,
       submittedResponseCopyStatus,
     });
+  }
+
+  if (!hasStarted) {
+    return (
+      <div
+        className={cn(
+          'min-h-screen py-10',
+          FORM_FONT_VARIABLES,
+          toneClasses.pageClassName,
+          className
+        )}
+        style={bodyFontStyle}
+      >
+        <div className="mx-auto flex max-w-3xl flex-col gap-8 px-4">
+          <WelcomeScreen
+            bodyTypographyClassName={bodyTypographyClassName}
+            displayTypographyClassName={displayTypographyClassName}
+            form={form}
+            headlineFontStyle={headlineFontStyle}
+            onStart={() => setHasStarted(true)}
+            t={t}
+            toneClasses={toneClasses}
+          />
+          <FormBrandFooter />
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -578,12 +639,15 @@ export function FormRuntime({
           advanceSectionTitle,
           hasReadOnlyNextSection,
           shouldShowSectionNavigation,
+          canGoBack,
+          handleBack,
+          visibleQuestions: currentStepQuestions,
+          stepIndex,
+          stepCount: steps.length,
+          isLastStep,
           shouldShowTurnstile,
           isSubmitBlockedByTurnstile,
           isBusy,
-          sectionTrail,
-          setSectionTrail,
-          setCurrentSectionId,
           setError,
           responseCopyEmail,
           sendResponseCopy,

--- a/apps/forms/src/features/forms/runtime/section-card.tsx
+++ b/apps/forms/src/features/forms/runtime/section-card.tsx
@@ -22,6 +22,7 @@ import type { getRuntimeProgressStats } from '../runtime-progress';
 import type {
   FormAnswerValue,
   FormDefinition,
+  FormDefinitionQuestion,
   FormReadOnlyAnswerIssue,
 } from '../types';
 import type { FormDensityClasses } from './constants';
@@ -53,12 +54,15 @@ export function renderFormSectionCard({
   advanceSectionTitle,
   hasReadOnlyNextSection,
   shouldShowSectionNavigation,
+  canGoBack,
+  handleBack,
+  visibleQuestions,
+  stepIndex,
+  stepCount,
+  isLastStep,
   shouldShowTurnstile,
   isSubmitBlockedByTurnstile,
   isBusy,
-  sectionTrail,
-  setSectionTrail,
-  setCurrentSectionId,
   setError,
   responseCopyEmail,
   sendResponseCopy,
@@ -70,6 +74,25 @@ export function renderFormSectionCard({
   setCaptchaError,
   handleAdvance,
 }: {
+  /** True when there is a previous screen or section to return to. */
+  canGoBack: boolean;
+  /** Steps back a screen, or a section once the first screen is reached. */
+  handleBack: () => void;
+  /**
+   * Questions for the current screen. In `sections` mode this is the whole
+   * section; in `one_question` mode it is the current step.
+   */
+  visibleQuestions: FormDefinitionQuestion[];
+  /** Zero-based screen index within the section. */
+  stepIndex: number;
+  /** Number of screens the section is split into; 1 in `sections` mode. */
+  stepCount: number;
+  /**
+   * True on the section's final screen. Submit, the response-copy opt-in and
+   * the next-section hint all describe what happens after the *section*, so
+   * they must not appear while the respondent is still mid-section.
+   */
+  isLastStep: boolean;
   form: FormDefinition;
   t: FormsTranslator;
   mode: 'preview' | 'public';
@@ -100,9 +123,6 @@ export function renderFormSectionCard({
   shouldShowTurnstile: boolean;
   isSubmitBlockedByTurnstile: boolean;
   isBusy: boolean;
-  sectionTrail: string[];
-  setSectionTrail: Dispatch<SetStateAction<string[]>>;
-  setCurrentSectionId: Dispatch<SetStateAction<string>>;
   setError: Dispatch<SetStateAction<string | null>>;
   responseCopyEmail?: string | null;
   sendResponseCopy: boolean;
@@ -134,11 +154,24 @@ export function renderFormSectionCard({
               />
             </div>
           </div>
-          <Badge variant="outline" className="rounded-full px-3 py-1">
-            <Flag className="mr-1 h-3.5 w-3.5" />
-            {progressStats.currentSectionNumber} /{' '}
-            {progressStats.routeSectionCount}
-          </Badge>
+          <div className="flex flex-wrap items-center gap-2">
+            {/* Only meaningful once a section is split into screens; in
+                `sections` mode there is exactly one and the counter would
+                always read "1 / 1". */}
+            {stepCount > 1 ? (
+              <Badge className="rounded-full px-3 py-1" variant="secondary">
+                {t('runtime.step_progress', {
+                  current: stepIndex + 1,
+                  total: stepCount,
+                })}
+              </Badge>
+            ) : null}
+            <Badge variant="outline" className="rounded-full px-3 py-1">
+              <Flag className="mr-1 h-3.5 w-3.5" />
+              {progressStats.currentSectionNumber} /{' '}
+              {progressStats.routeSectionCount}
+            </Badge>
+          </div>
         </div>
         {currentSection.image.url ? (
           <div className="relative mt-4 aspect-16/6 overflow-hidden rounded-[1.4rem] border border-border/60 bg-background/70">
@@ -186,7 +219,7 @@ export function renderFormSectionCard({
           </div>
         ) : null}
         <div className={density.questionGap}>
-          {currentSection.questions.map((question) => (
+          {visibleQuestions.map((question) => (
             <QuestionBlock
               key={question.id}
               question={question}
@@ -200,10 +233,10 @@ export function renderFormSectionCard({
             />
           ))}
           {readOnly &&
-          currentSection.questions.some(
+          visibleQuestions.some(
             (question) => (answerIssueMap.get(question.id) ?? []).length > 0
           )
-            ? currentSection.questions.map((question) => {
+            ? visibleQuestions.map((question) => {
                 const issues = answerIssueMap.get(question.id) ?? [];
                 if (issues.length === 0) {
                   return null;
@@ -241,7 +274,10 @@ export function renderFormSectionCard({
           </div>
         ) : null}
 
-        {mode === 'public' && !readOnly && advanceTarget.type === 'submit' ? (
+        {mode === 'public' &&
+        !readOnly &&
+        isLastStep &&
+        advanceTarget.type === 'submit' ? (
           <div className="rounded-3xl border border-border/60 bg-linear-to-br from-background/90 via-background/70 to-background/45 p-5 shadow-sm">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
               <div className="space-y-2">
@@ -354,22 +390,14 @@ export function renderFormSectionCard({
               type="button"
               variant="outline"
               className={toneClasses.secondaryButtonClassName}
-              onClick={() => {
-                const previousSectionId = sectionTrail[sectionTrail.length - 2];
-                if (!previousSectionId) {
-                  return;
-                }
-
-                setSectionTrail((currentTrail) => currentTrail.slice(0, -1));
-                setCurrentSectionId(previousSectionId);
-              }}
-              disabled={sectionTrail.length <= 1 || isBusy}
+              onClick={handleBack}
+              disabled={!canGoBack || isBusy}
             >
               <ArrowLeft className="mr-2 h-4 w-4" />
               {t('runtime.back')}
             </Button>
             <div className="flex flex-col items-stretch gap-2 sm:items-end">
-              {advanceSectionTitle ? (
+              {isLastStep && advanceSectionTitle ? (
                 <div className="rounded-full border border-border/60 bg-background/60 px-3 py-1 text-[11px] text-muted-foreground uppercase tracking-[0.2em]">
                   {t('studio.target_section')}: {advanceSectionTitle}
                 </div>
@@ -381,7 +409,7 @@ export function renderFormSectionCard({
                   onClick={handleAdvance}
                   disabled={isBusy || isSubmitBlockedByTurnstile}
                 >
-                  {advanceTarget.type === 'submit' ? (
+                  {isLastStep && advanceTarget.type === 'submit' ? (
                     <>
                       <Check className="mr-2 h-4 w-4" />
                       {mode === 'preview'

--- a/apps/forms/src/features/forms/runtime/step-plan.test.ts
+++ b/apps/forms/src/features/forms/runtime/step-plan.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { FormDefinitionQuestion, FormDefinitionSection } from '../types';
+import { buildSectionSteps, clampStepIndex } from './step-plan';
+
+const media = { storagePath: '', url: '', alt: '' };
+
+function question(
+  id: string,
+  type: FormDefinitionQuestion['type']
+): FormDefinitionQuestion {
+  return {
+    id,
+    sectionId: 'section-1',
+    type,
+    title: id,
+    description: '',
+    required: false,
+    image: { ...media },
+    settings: {},
+    options: [],
+  };
+}
+
+function section(questions: FormDefinitionQuestion[]): FormDefinitionSection {
+  return {
+    id: 'section-1',
+    title: 'Section',
+    description: '',
+    image: { ...media },
+    questions,
+  };
+}
+
+describe('buildSectionSteps', () => {
+  it('keeps a whole section on one screen in sections mode', () => {
+    const steps = buildSectionSteps(
+      section([question('a', 'short_text'), question('b', 'long_text')]),
+      'sections'
+    );
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.answerableQuestionIds).toEqual(['a', 'b']);
+  });
+
+  it('gives each answerable question its own screen in one_question mode', () => {
+    const steps = buildSectionSteps(
+      section([
+        question('a', 'short_text'),
+        question('b', 'long_text'),
+        question('c', 'rating'),
+      ]),
+      'one_question'
+    );
+
+    expect(steps.map((step) => step.answerableQuestionIds)).toEqual([
+      ['a'],
+      ['b'],
+      ['c'],
+    ]);
+  });
+
+  it('attaches leading content blocks to the question they introduce', () => {
+    const steps = buildSectionSteps(
+      section([
+        question('intro', 'rich_text'),
+        question('image', 'image'),
+        question('a', 'short_text'),
+        question('b', 'long_text'),
+      ]),
+      'one_question'
+    );
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0]?.questions.map((q) => q.id)).toEqual([
+      'intro',
+      'image',
+      'a',
+    ]);
+    expect(steps[0]?.answerableQuestionIds).toEqual(['a']);
+    expect(steps[1]?.questions.map((q) => q.id)).toEqual(['b']);
+  });
+
+  it('keeps trailing content on the last screen rather than stranding it', () => {
+    const steps = buildSectionSteps(
+      section([
+        question('a', 'short_text'),
+        question('outro', 'rich_text'),
+        question('divider', 'divider'),
+      ]),
+      'one_question'
+    );
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.questions.map((q) => q.id)).toEqual([
+      'a',
+      'outro',
+      'divider',
+    ]);
+  });
+
+  it('still renders a section that has no answerable question at all', () => {
+    const steps = buildSectionSteps(
+      section([question('intro', 'rich_text'), question('img', 'image')]),
+      'one_question'
+    );
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.questions).toHaveLength(2);
+    expect(steps[0]?.answerableQuestionIds).toEqual([]);
+  });
+
+  it('returns nothing for a missing section', () => {
+    expect(buildSectionSteps(undefined, 'one_question')).toEqual([]);
+  });
+});
+
+describe('clampStepIndex', () => {
+  it('keeps an index inside the available steps', () => {
+    expect(clampStepIndex(5, 3)).toBe(2);
+    expect(clampStepIndex(-1, 3)).toBe(0);
+    expect(clampStepIndex(1, 3)).toBe(1);
+  });
+
+  it('collapses to zero when a branch lands on an empty section', () => {
+    expect(clampStepIndex(4, 0)).toBe(0);
+  });
+});

--- a/apps/forms/src/features/forms/runtime/step-plan.ts
+++ b/apps/forms/src/features/forms/runtime/step-plan.ts
@@ -1,0 +1,78 @@
+import { isAnswerableQuestionType } from '../block-utils';
+import type { FormDefinitionQuestion, FormDefinitionSection } from '../types';
+
+/**
+ * Splitting a section into screens.
+ *
+ * In `sections` mode a section is one screen, which is what the runtime has
+ * always done. In `one_question` mode each answerable question gets its own
+ * screen — the Typeform shape — and branching still happens at section
+ * boundaries, so all the existing rule evaluation is untouched.
+ *
+ * Content blocks (rich text, images, video, dividers) are not screens of their
+ * own: they exist to introduce or illustrate the question they sit above, and
+ * stranding them alone would strip that context. Each one is attached to the
+ * next answerable question instead, and any trailing content after the last
+ * question stays with it.
+ */
+
+export type FormDisplayMode = 'sections' | 'one_question';
+
+export interface FormStep {
+  /** Questions and content blocks shown together on this screen. */
+  questions: FormDefinitionQuestion[];
+  /** Ids of the answerable questions on this screen, for validation. */
+  answerableQuestionIds: string[];
+}
+
+export function buildSectionSteps(
+  section: FormDefinitionSection | undefined,
+  displayMode: FormDisplayMode
+): FormStep[] {
+  if (!section) {
+    return [];
+  }
+
+  const toStep = (questions: FormDefinitionQuestion[]): FormStep => ({
+    questions,
+    answerableQuestionIds: questions
+      .filter((question) => isAnswerableQuestionType(question.type))
+      .map((question) => question.id),
+  });
+
+  if (displayMode === 'sections') {
+    return [toStep(section.questions)];
+  }
+
+  const steps: FormStep[] = [];
+  let pending: FormDefinitionQuestion[] = [];
+
+  for (const question of section.questions) {
+    pending.push(question);
+
+    if (isAnswerableQuestionType(question.type)) {
+      steps.push(toStep(pending));
+      pending = [];
+    }
+  }
+
+  // Trailing content with no question after it — a closing note, an image —
+  // belongs on the last screen rather than on a screen of its own.
+  if (pending.length > 0) {
+    const last = steps.at(-1);
+    if (last) {
+      last.questions.push(...pending);
+    } else {
+      steps.push(toStep(pending));
+    }
+  }
+
+  // A section of nothing but content blocks still has to render something.
+  return steps.length > 0 ? steps : [toStep(section.questions)];
+}
+
+/** Clamps a step index that a branching jump or an edit may have invalidated. */
+export function clampStepIndex(stepIndex: number, stepCount: number) {
+  if (stepCount <= 0) return 0;
+  return Math.min(Math.max(stepIndex, 0), stepCount - 1);
+}

--- a/apps/forms/src/features/forms/runtime/use-form-steps.ts
+++ b/apps/forms/src/features/forms/runtime/use-form-steps.ts
@@ -1,0 +1,109 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { FormDefinitionSection } from '../types';
+import {
+  buildSectionSteps,
+  clampStepIndex,
+  type FormDisplayMode,
+  type FormStep,
+} from './step-plan';
+
+export interface UseFormStepsResult {
+  /** Screens the current section is split into. */
+  steps: FormStep[];
+  stepIndex: number;
+  currentStep: FormStep | undefined;
+  isFirstStep: boolean;
+  isLastStep: boolean;
+  /** Advances within the section. False when the section is exhausted, in
+   *  which case the caller should apply branching and move sections. */
+  goToNextStep: () => boolean;
+  /** Steps back within the section. False at the first step. */
+  goToPreviousStep: () => boolean;
+  /** Called by the caller after a section change, to restart the plan. */
+  resetSteps: (position?: 'first' | 'last') => void;
+}
+
+/**
+ * Screen-by-screen navigation inside the current section.
+ *
+ * Deliberately layered on top of the existing section navigation instead of
+ * replacing it: branching rules, validation and progress are all defined per
+ * section, so keeping sections as the unit of navigation means one-question
+ * mode is a presentational split rather than a second engine to keep in sync.
+ */
+export function useFormSteps({
+  displayMode,
+  section,
+}: {
+  displayMode: FormDisplayMode;
+  section: FormDefinitionSection | undefined;
+}): UseFormStepsResult {
+  // Position is stored with the section it belongs to, and adjusted during
+  // render when the section changes. An effect would paint one frame of the
+  // wrong screen first, and would also have to lie to the dependency linter:
+  // the plan is rebuilt from `section`, but resetting on the `steps` array
+  // identity would throw the reader's place away whenever an answer changed a
+  // label.
+  const [position, setPosition] = useState({ index: 0, sectionId: '' });
+  // Tracks whether the next section should open at its first or last screen,
+  // so stepping backwards out of a section lands on its final question rather
+  // than restarting it.
+  const pendingPositionRef = useRef<'first' | 'last'>('first');
+
+  const steps = useMemo(
+    () => buildSectionSteps(section, displayMode),
+    [displayMode, section]
+  );
+
+  const sectionId = section?.id ?? '';
+
+  if (position.sectionId !== sectionId) {
+    const entryPosition = pendingPositionRef.current;
+    pendingPositionRef.current = 'first';
+    setPosition({
+      index: entryPosition === 'last' ? Math.max(steps.length - 1, 0) : 0,
+      sectionId,
+    });
+  }
+
+  const stepIndex = position.sectionId === sectionId ? position.index : 0;
+  const setStepIndex = useCallback(
+    (index: number) => setPosition({ index, sectionId }),
+    [sectionId]
+  );
+
+  const safeIndex = clampStepIndex(stepIndex, steps.length);
+
+  const goToNextStep = useCallback(() => {
+    if (safeIndex >= steps.length - 1) {
+      return false;
+    }
+    setStepIndex(safeIndex + 1);
+    return true;
+  }, [safeIndex, setStepIndex, steps.length]);
+
+  const goToPreviousStep = useCallback(() => {
+    if (safeIndex <= 0) {
+      return false;
+    }
+    setStepIndex(safeIndex - 1);
+    return true;
+  }, [safeIndex, setStepIndex]);
+
+  const resetSteps = useCallback((position: 'first' | 'last' = 'first') => {
+    pendingPositionRef.current = position;
+  }, []);
+
+  return {
+    currentStep: steps[safeIndex],
+    goToNextStep,
+    goToPreviousStep,
+    isFirstStep: safeIndex <= 0,
+    isLastStep: safeIndex >= steps.length - 1,
+    resetSteps,
+    stepIndex: safeIndex,
+    steps,
+  };
+}

--- a/apps/forms/src/features/forms/runtime/use-response-copy.ts
+++ b/apps/forms/src/features/forms/runtime/use-response-copy.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import type { TurnstileInstance } from '@marsidev/react-turnstile';
+import { type RefObject, useCallback, useState } from 'react';
+import type { FormsTranslator } from './types';
+
+/**
+ * Emailing a respondent a copy of what they already submitted.
+ *
+ * Only reachable from the read-only view of an existing response, and gated on
+ * Turnstile for the same reason submission is: the endpoint sends mail to an
+ * address the caller supplies, so an ungated one is a spam relay.
+ */
+export function useResponseCopy({
+  captchaRef,
+  captchaToken,
+  isBusy,
+  onRequestResponseCopy,
+  readOnlyResponseId,
+  readOnlyResponseSessionId,
+  initialSentTo,
+  requiresTurnstile,
+  responseCopyEmail,
+  setCaptchaToken,
+  setError,
+  t,
+  turnstileSiteKey,
+}: {
+  captchaRef: RefObject<TurnstileInstance | null>;
+  captchaToken: string | undefined;
+  isBusy: boolean;
+  onRequestResponseCopy?: (payload: {
+    responseId: string;
+    sessionId: string;
+    turnstileToken?: string;
+  }) => Promise<{ responseCopySentTo?: string | null } | undefined>;
+  readOnlyResponseId?: string | null;
+  readOnlyResponseSessionId?: string | null;
+  /**
+   * Address a copy was already sent to before this render, from the server.
+   * Kept separate from local state so a prop change is reflected without an
+   * effect that would clobber an address just sent in this session.
+   */
+  initialSentTo?: string | null;
+  requiresTurnstile: boolean;
+  responseCopyEmail?: string | null;
+  setCaptchaToken: (token: string | undefined) => void;
+  setError: (message: string | null) => void;
+  t: FormsTranslator;
+  turnstileSiteKey?: string;
+}) {
+  const [isRequesting, setIsRequesting] = useState(false);
+  const [sentTo, setSentTo] = useState<string | null>(null);
+  const resolvedSentTo = sentTo ?? initialSentTo ?? null;
+
+  const requestResponseCopy = useCallback(async () => {
+    if (
+      isBusy ||
+      !onRequestResponseCopy ||
+      !readOnlyResponseId ||
+      !readOnlyResponseSessionId
+    ) {
+      return;
+    }
+
+    if (requiresTurnstile && !turnstileSiteKey) {
+      setError(t('runtime.turnstile_not_configured'));
+      return;
+    }
+
+    if (requiresTurnstile && !captchaToken) {
+      setError(t('runtime.turnstile_required'));
+      return;
+    }
+
+    setIsRequesting(true);
+    setError(null);
+
+    try {
+      const result = await onRequestResponseCopy({
+        responseId: readOnlyResponseId,
+        sessionId: readOnlyResponseSessionId,
+        turnstileToken: captchaToken,
+      });
+
+      setSentTo(result?.responseCopySentTo ?? responseCopyEmail ?? null);
+      // A Turnstile token is single-use, so the widget has to be reset or a
+      // second request would fail verification.
+      captchaRef.current?.reset();
+      setCaptchaToken(undefined);
+    } finally {
+      setIsRequesting(false);
+    }
+  }, [
+    captchaRef,
+    captchaToken,
+    isBusy,
+    onRequestResponseCopy,
+    readOnlyResponseId,
+    readOnlyResponseSessionId,
+    requiresTurnstile,
+    responseCopyEmail,
+    setCaptchaToken,
+    setError,
+    t,
+    turnstileSiteKey,
+  ]);
+
+  return {
+    isRequestingResponseCopy: isRequesting,
+    requestResponseCopy,
+    responseCopySentTo: resolvedSentTo,
+  };
+}

--- a/apps/forms/src/features/forms/runtime/welcome-screen.tsx
+++ b/apps/forms/src/features/forms/runtime/welcome-screen.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { ArrowRight } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { Card, CardContent } from '@tuturuuu/ui/card';
+import { cn } from '@tuturuuu/utils/format';
+import type { CSSProperties } from 'react';
+import { FormsMarkdown } from '../forms-markdown';
+import type { FormDefinition } from '../types';
+import type { FormsTranslator, FormToneClasses } from './types';
+
+/**
+ * Optional cover screen shown before the first question.
+ *
+ * Its job is to set expectations — what this is, how long it takes — before
+ * someone commits to answering. Falls back to the form's own title and
+ * description so enabling it is useful without writing anything new.
+ */
+export function WelcomeScreen({
+  bodyTypographyClassName,
+  displayTypographyClassName,
+  form,
+  headlineFontStyle,
+  onStart,
+  t,
+  toneClasses,
+}: {
+  bodyTypographyClassName: string;
+  displayTypographyClassName: string;
+  form: FormDefinition;
+  headlineFontStyle: CSSProperties;
+  onStart: () => void;
+  t: FormsTranslator;
+  toneClasses: FormToneClasses;
+}) {
+  const title =
+    form.settings.welcomeTitle.trim() ||
+    form.theme.coverHeadline.trim() ||
+    form.title;
+  const description =
+    form.settings.welcomeDescription.trim() || form.description;
+  const buttonLabel =
+    form.settings.welcomeButtonLabel.trim() || t('runtime.welcome_start');
+
+  const questionCount = form.sections.reduce(
+    (count, section) =>
+      count +
+      section.questions.filter((question) => question.type !== 'divider')
+        .length,
+    0
+  );
+
+  return (
+    <Card className={cn('overflow-hidden border-0', toneClasses.heroClassName)}>
+      <CardContent className="flex flex-col items-start gap-6 p-8 sm:p-12">
+        <div className="space-y-4">
+          <h1
+            className={cn('font-semibold', displayTypographyClassName)}
+            style={headlineFontStyle}
+          >
+            <FormsMarkdown
+              className="[&_p]:m-0"
+              content={title}
+              variant="inline"
+            />
+          </h1>
+
+          {description ? (
+            <div
+              className={cn('text-muted-foreground', bodyTypographyClassName)}
+            >
+              <FormsMarkdown content={description} />
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <Button
+            className={cn(
+              'rounded-2xl px-6',
+              toneClasses.primaryButtonClassName
+            )}
+            onClick={onStart}
+            size="lg"
+            type="button"
+          >
+            {buttonLabel}
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+
+          <p className="text-muted-foreground text-sm">
+            {t('runtime.welcome_question_count', { count: questionCount })}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/forms/src/features/forms/schema.ts
+++ b/apps/forms/src/features/forms/schema.ts
@@ -27,6 +27,12 @@ export const FORM_ACCESS_MODE_VALUES = [
   'authenticated_email',
 ] as const;
 export const FORM_DENSITY_VALUES = ['airy', 'balanced', 'compact'] as const;
+/**
+ * `sections` shows a whole section per screen (the original behaviour);
+ * `one_question` gives each answerable question its own screen. Branching still
+ * runs at section boundaries in both.
+ */
+export const FORM_DISPLAY_MODE_VALUES = ['sections', 'one_question'] as const;
 export const FORM_SURFACE_STYLE_VALUES = ['paper', 'glass', 'panel'] as const;
 export const FORM_OPTION_LAYOUT_VALUES = ['list', 'grid'] as const;
 export const FORM_THEME_ACCENT_VALUES = [
@@ -275,7 +281,23 @@ export const formSeoSchema = z.object({
   noIndex: z.boolean().default(false),
 });
 
+export const FORM_WELCOME_TITLE_MAX_LENGTH = 120;
+export const FORM_WELCOME_DESCRIPTION_MAX_LENGTH = 600;
+export const FORM_WELCOME_BUTTON_MAX_LENGTH = 40;
+
 export const formSettingsSchema = z.object({
+  displayMode: z.enum(FORM_DISPLAY_MODE_VALUES).default('sections'),
+  /** Optional cover screen shown before the first question. */
+  welcomeEnabled: z.boolean().default(false),
+  welcomeTitle: z.string().max(FORM_WELCOME_TITLE_MAX_LENGTH).default(''),
+  welcomeDescription: z
+    .string()
+    .max(FORM_WELCOME_DESCRIPTION_MAX_LENGTH)
+    .default(''),
+  welcomeButtonLabel: z
+    .string()
+    .max(FORM_WELCOME_BUTTON_MAX_LENGTH)
+    .default(''),
   showProgressBar: z.boolean().default(true),
   allowMultipleSubmissions: z.boolean().default(true),
   oneResponsePerUser: z.boolean().default(false),
@@ -434,6 +456,11 @@ export function createDefaultFormStudioInput(): FormStudioInput {
       },
     },
     settings: {
+      displayMode: 'sections',
+      welcomeEnabled: false,
+      welcomeTitle: '',
+      welcomeDescription: '',
+      welcomeButtonLabel: '',
       showProgressBar: true,
       allowMultipleSubmissions: true,
       oneResponsePerUser: false,

--- a/apps/forms/src/features/forms/schema.ts
+++ b/apps/forms/src/features/forms/schema.ts
@@ -9,6 +9,16 @@ export const FORM_QUESTION_DESCRIPTION_MAX_LENGTH = 16000;
 export const FORM_RESPONSE_ANSWER_MAX_LENGTH = 16000;
 export const FORM_CONFIRMATION_TITLE_MAX_LENGTH = 120;
 export const FORM_CONFIRMATION_MESSAGE_MAX_LENGTH = 1000;
+/**
+ * SEO limits track what search engines and social cards actually render, not
+ * what the column can hold: titles are truncated around 60 characters in a
+ * result listing and descriptions around 160, so allowing more would only let
+ * someone write copy that silently gets cut.
+ */
+export const FORM_SEO_TITLE_MAX_LENGTH = 120;
+export const FORM_SEO_DESCRIPTION_MAX_LENGTH = 320;
+export const FORM_SEO_KEYWORD_MAX_LENGTH = 60;
+export const FORM_SEO_KEYWORDS_MAX_COUNT = 12;
 
 export const FORM_STATUS_VALUES = ['draft', 'published', 'closed'] as const;
 export const FORM_ACCESS_MODE_VALUES = [
@@ -243,6 +253,28 @@ export const formThemeSchema = z.object({
     }),
 });
 
+export const formSeoSchema = z.object({
+  /** Overrides the title derived from the form's cover headline or title. */
+  title: z.string().trim().max(FORM_SEO_TITLE_MAX_LENGTH).default(''),
+  /** Overrides the description derived from the form or its first section. */
+  description: z
+    .string()
+    .trim()
+    .max(FORM_SEO_DESCRIPTION_MAX_LENGTH)
+    .default(''),
+  /** Replaces the generated Open Graph card with an uploaded image. */
+  image: formMediaSchema.default(defaultFormMediaValue),
+  /** Replaces the derived keyword list. Empty means "derive". */
+  keywords: z
+    .array(z.string().trim().min(1).max(FORM_SEO_KEYWORD_MAX_LENGTH))
+    .max(FORM_SEO_KEYWORDS_MAX_COUNT)
+    .default([]),
+  /** Points crawlers at a different canonical URL for this form. */
+  canonicalUrl: z.union([z.literal(''), z.url().max(2000)]).default(''),
+  /** Emits `noindex, nofollow` for the public page. */
+  noIndex: z.boolean().default(false),
+});
+
 export const formSettingsSchema = z.object({
   showProgressBar: z.boolean().default(true),
   allowMultipleSubmissions: z.boolean().default(true),
@@ -320,6 +352,14 @@ export const formStudioSchema = z.object({
   maxResponses: z.number().int().positive().nullable().optional(),
   theme: formThemeSchema,
   settings: formSettingsSchema,
+  seo: formSeoSchema.default({
+    title: '',
+    description: '',
+    image: defaultFormMediaValue,
+    keywords: [],
+    canonicalUrl: '',
+    noIndex: false,
+  }),
   sections: z.array(formSectionSchema).min(1),
   logicRules: z.array(formLogicRuleSchema).default([]),
 });
@@ -361,6 +401,7 @@ export type FormQuestionInput = z.infer<typeof formQuestionSchema>;
 export type FormLogicRuleInput = z.infer<typeof formLogicRuleSchema>;
 export type FormThemeInput = z.infer<typeof formThemeSchema>;
 export type FormSettingsInput = z.infer<typeof formSettingsSchema>;
+export type FormSeoInput = z.infer<typeof formSeoSchema>;
 export type FormSubmitInput = z.infer<typeof formSubmitSchema>;
 
 export function createDefaultFormStudioInput(): FormStudioInput {
@@ -399,6 +440,18 @@ export function createDefaultFormStudioInput(): FormStudioInput {
       requireTurnstile: true,
       confirmationTitle: 'Response received',
       confirmationMessage: 'Thanks for taking the time to respond.',
+    },
+    seo: {
+      title: '',
+      description: '',
+      image: {
+        storagePath: '',
+        url: '',
+        alt: '',
+      },
+      keywords: [],
+      canonicalUrl: '',
+      noIndex: false,
     },
     sections: [
       {

--- a/apps/forms/src/features/forms/server/definition.ts
+++ b/apps/forms/src/features/forms/server/definition.ts
@@ -16,6 +16,7 @@ import {
   sanitizeFormMediaForStorage,
 } from './media';
 import {
+  parseFormSeo,
   parseFormSettings,
   parseFormTheme,
   parseQuestionSettings,
@@ -69,6 +70,7 @@ export function buildFormDefinition({
     shareCode: shareLink?.code ?? null,
     theme: parsedTheme,
     settings: parseFormSettings(form.settings),
+    seo: parseFormSeo(form.seo),
     sections: sections
       .sort((left, right) => left.position - right.position)
       .map((section) => ({

--- a/apps/forms/src/features/forms/server/media.ts
+++ b/apps/forms/src/features/forms/server/media.ts
@@ -75,10 +75,10 @@ export async function resolveFormDefinitionMedia(
   supabase: SupabaseClient<Database>,
   definition: FormDefinition
 ) {
-  const coverImage = await resolveFormMedia(
-    supabase,
-    definition.theme.coverImage
-  );
+  const [coverImage, seoImage] = await Promise.all([
+    resolveFormMedia(supabase, definition.theme.coverImage),
+    resolveFormMedia(supabase, definition.seo.image),
+  ]);
   const sectionMediaEntries = await Promise.all(
     definition.sections.map(async (section) => [
       section.id,
@@ -117,6 +117,10 @@ export async function resolveFormDefinitionMedia(
       ...definition.theme,
       coverImage,
       sectionImages: resolvedSectionImages,
+    },
+    seo: {
+      ...definition.seo,
+      image: seoImage,
     },
     sections: definition.sections.map((section) => ({
       ...section,

--- a/apps/forms/src/features/forms/server/mutations.ts
+++ b/apps/forms/src/features/forms/server/mutations.ts
@@ -72,6 +72,12 @@ export async function saveFormDefinition({
       ...input.settings,
       requireTurnstile: true,
     },
+    seo: {
+      ...input.seo,
+      // The signed URL on an uploaded card expires; only the storage path is
+      // durable, so it is re-signed on read the same way cover art is.
+      image: sanitizeFormMediaForStorage(input.seo.image),
+    },
     published_at: timestamps.publishedAt,
     closed_at: timestamps.closedAt,
   };

--- a/apps/forms/src/features/forms/server/parsers.ts
+++ b/apps/forms/src/features/forms/server/parsers.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import {
   createDefaultFormStudioInput,
   formQuestionSettingsSchema,
+  formSeoSchema,
   formSettingsSchema,
   formThemeSchema,
 } from '../schema';
@@ -38,6 +39,19 @@ export function parseFormSettings(settings: FormRow['settings']) {
   });
 
   return result.success ? result.data : createDefaultFormStudioInput().settings;
+}
+
+/**
+ * Rows written before the `seo` column existed default to `{}`, and every key
+ * inside it is optional, so an empty object parses cleanly into "derive
+ * everything from the form content".
+ */
+export function parseFormSeo(seo: FormRow['seo']) {
+  const result = formSeoSchema.safeParse(
+    seo && typeof seo === 'object' && !Array.isArray(seo) ? seo : {}
+  );
+
+  return result.success ? result.data : createDefaultFormStudioInput().seo;
 }
 
 export function parseQuestionSettings(settings: FormQuestionRow['settings']) {

--- a/apps/forms/src/features/forms/shared-form-data.test.ts
+++ b/apps/forms/src/features/forms/shared-form-data.test.ts
@@ -3,6 +3,7 @@ import {
   buildSharedFormMetadata,
   getSharedFormPresentation,
 } from './shared-form-data';
+import { createTestFormDefinition } from './test-support/form-fixtures';
 
 const strings = {
   brand: 'Tuturuuu Forms',
@@ -54,47 +55,17 @@ describe('shared-form-data', () => {
 
   it('builds form-based presentation using plain-text title and description', () => {
     const presentation = getSharedFormPresentation(
-      {
-        id: 'form-1',
-        wsId: 'ws-1',
-        creatorId: 'user-1',
+      createTestFormDefinition({
         title: '<p><strong>Quarterly feedback</strong></p>',
         description: '<p>Help us improve the next release.</p>',
-        status: 'published',
-        accessMode: 'anonymous',
-        openAt: null,
-        closeAt: null,
-        maxResponses: null,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
         shareCode: 'abc123',
         theme: {
-          presetId: 'editorial-moss',
-          density: 'balanced',
-          accentColor: 'dynamic-green',
-          headlineFontId: 'noto-serif',
-          bodyFontId: 'be-vietnam-pro',
-          surfaceStyle: 'paper',
-          coverHeadline: '',
+          ...createTestFormDefinition().theme,
           coverImage: {
             storagePath: '',
             url: 'https://example.com/cover.png',
             alt: 'Cover',
           },
-          sectionImages: {},
-          typography: {
-            displaySize: 'md',
-            headingSize: 'md',
-            bodySize: 'md',
-          },
-        },
-        settings: {
-          showProgressBar: true,
-          allowMultipleSubmissions: true,
-          oneResponsePerUser: false,
-          requireTurnstile: true,
-          confirmationTitle: 'Thanks',
-          confirmationMessage: 'Done',
         },
         sections: [
           {
@@ -117,8 +88,7 @@ describe('shared-form-data', () => {
             ],
           },
         ],
-        logicRules: [],
-      },
+      }),
       strings
     );
 
@@ -133,51 +103,11 @@ describe('shared-form-data', () => {
       shareCode: 'share-1',
       status: 200,
       strings,
-      form: {
-        id: 'form-2',
-        wsId: 'ws-1',
-        creatorId: 'user-1',
+      form: createTestFormDefinition({
         title: '<p><strong>Employee Pulse Survey</strong></p>',
         description: '<p>Share your feedback for this sprint.</p>',
-        status: 'published',
-        accessMode: 'anonymous',
-        openAt: null,
-        closeAt: null,
-        maxResponses: null,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
         shareCode: 'share-1',
-        theme: {
-          presetId: 'editorial-moss',
-          density: 'balanced',
-          accentColor: 'dynamic-green',
-          headlineFontId: 'noto-serif',
-          bodyFontId: 'be-vietnam-pro',
-          surfaceStyle: 'paper',
-          coverHeadline: '',
-          coverImage: {
-            storagePath: '',
-            url: '',
-            alt: '',
-          },
-          sectionImages: {},
-          typography: {
-            displaySize: 'md',
-            headingSize: 'md',
-            bodySize: 'md',
-          },
-        },
-        settings: {
-          showProgressBar: true,
-          allowMultipleSubmissions: true,
-          oneResponsePerUser: false,
-          requireTurnstile: true,
-          confirmationTitle: 'Thanks',
-          confirmationMessage: 'Done',
-        },
-        sections: [],
-        logicRules: [],
-      },
+      }),
     });
 
     expect(metadata.title).toBe('Employee Pulse Survey | Tuturuuu Forms');
@@ -194,5 +124,81 @@ describe('shared-form-data', () => {
     expect(metadata.twitter?.description).toBe(
       'Share your feedback for this sprint.'
     );
+  });
+
+  it('marks unavailable forms as noindex', () => {
+    // The page a crawler reaches for a missing or closed form is an error
+    // state, not the form, so it must never be indexed regardless of what the
+    // form itself configured.
+    const metadata = buildSharedFormMetadata({
+      shareCode: 'share-1',
+      status: 404,
+      strings,
+      form: null,
+    });
+
+    expect(metadata.robots).toMatchObject({ index: false, follow: false });
+  });
+
+  it('honours per-form SEO overrides', () => {
+    const metadata = buildSharedFormMetadata({
+      shareCode: 'share-1',
+      status: 200,
+      strings,
+      form: createTestFormDefinition({
+        title: 'Internal only',
+        shareCode: 'share-1',
+        seo: {
+          title: 'Apply to the 2027 cohort',
+          description: 'Applications close on 30 September.',
+          image: {
+            storagePath: 'ws/forms/social/card.png',
+            url: 'https://cdn.example.com/card.png',
+            alt: 'Cohort banner',
+          },
+          keywords: ['cohort', 'applications'],
+          canonicalUrl: 'https://example.com/apply',
+          noIndex: true,
+        },
+      }),
+    });
+
+    // An author-supplied title is used verbatim: no item count, no brand
+    // suffix eating the characters a social card has room for.
+    expect(metadata.title).toBe('Apply to the 2027 cohort');
+    expect(metadata.description).toBe('Applications close on 30 September.');
+    expect(metadata.keywords).toEqual(['cohort', 'applications']);
+    expect(metadata.alternates?.canonical).toBe('https://example.com/apply');
+    expect(metadata.robots).toMatchObject({ index: false, follow: false });
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: 'https://cdn.example.com/card.png',
+        width: 1200,
+        height: 630,
+        alt: 'Cohort banner',
+      },
+    ]);
+    expect(metadata.twitter?.images).toEqual([
+      'https://cdn.example.com/card.png',
+    ]);
+  });
+
+  it('keeps the derived title and generated card when no overrides are set', () => {
+    const metadata = buildSharedFormMetadata({
+      shareCode: 'share-1',
+      status: 200,
+      strings,
+      form: createTestFormDefinition({
+        title: 'Employee Pulse Survey',
+        shareCode: 'share-1',
+      }),
+    });
+
+    expect(metadata.title).toBe('Employee Pulse Survey | Tuturuuu Forms');
+    expect(metadata.alternates?.canonical).toContain('/f/share-1');
+    expect(metadata.robots).toBeUndefined();
+    expect(metadata.twitter?.images).toEqual([
+      expect.stringContaining('/f/share-1/twitter-image'),
+    ]);
   });
 });

--- a/apps/forms/src/features/forms/shared-form-data.ts
+++ b/apps/forms/src/features/forms/shared-form-data.ts
@@ -1,6 +1,8 @@
+import { NO_INDEX_ROBOTS } from '@tuturuuu/utils/common/metadata';
 import type { Metadata } from 'next';
 import { siteConfig } from '@/constants/configs';
 import { normalizeMarkdownToText } from '@/features/forms/content';
+import { resolveFormSeo } from '@/features/forms/shared-form-seo';
 import type {
   FormAnswerValue,
   FormDefinition,
@@ -78,6 +80,15 @@ export function getSharedFormPresentation(
       accentColor: 'dynamic-green' as const,
       sectionCount: 0,
       itemCount: 0,
+      // A form that could not be loaded must never be indexed: the page the
+      // crawler sees is an error state, not the form.
+      seo: {
+        canonicalUrl: null,
+        imageAlt: strings.openGraphAlt,
+        imageUrl: null,
+        keywords: [],
+        noIndex: true,
+      },
     };
   }
 
@@ -103,14 +114,31 @@ export function getSharedFormPresentation(
     0
   );
 
+  const resolved = resolveFormSeo({
+    derived: {
+      description,
+      keywords: [title, strings.brand, 'form', 'survey', 'shared form'],
+      title,
+    },
+    fallbackImageAlt: strings.openGraphAlt,
+    seo: form.seo,
+  });
+
   return {
-    title: clampSocialText(title, 90),
-    description: clampSocialText(description, 160),
+    title: clampSocialText(resolved.title, 90),
+    description: clampSocialText(resolved.description, 160),
     coverImageUrl: form.theme.coverImage.url || '',
     coverImagePath: form.theme.coverImage.storagePath || '',
     accentColor: form.theme.accentColor,
     sectionCount: form.sections.length,
     itemCount,
+    seo: {
+      canonicalUrl: resolved.canonicalUrl,
+      imageAlt: resolved.imageAlt,
+      imageUrl: resolved.imageUrl,
+      keywords: resolved.keywords,
+      noIndex: resolved.noIndex,
+    },
   };
 }
 
@@ -126,12 +154,19 @@ export function buildSharedFormMetadata({
   status?: number;
 }): Metadata {
   const pageUrl = buildSharedFormUrl(shareCode);
-  const imageUrl = `${pageUrl}/opengraph-image`;
-  const twitterImageUrl = `${pageUrl}/twitter-image`;
   const presentation = getSharedFormPresentation(form, strings, status);
+  // An uploaded card replaces both the Open Graph and Twitter images. Falling
+  // back per-network would show two different previews for the same link.
+  const imageUrl = presentation.seo.imageUrl ?? `${pageUrl}/opengraph-image`;
+  const twitterImageUrl =
+    presentation.seo.imageUrl ?? `${pageUrl}/twitter-image`;
 
-  const title =
-    presentation.itemCount > 0
+  // An author-supplied title is used verbatim. The item count and brand suffix
+  // exist to make a derived title informative; appending them to deliberate
+  // copy would just eat the characters a social card has room for.
+  const title = form?.seo?.title?.trim()
+    ? presentation.title
+    : presentation.itemCount > 0
       ? `${presentation.title} (${presentation.itemCount} items) | ${strings.brand}`
       : `${presentation.title} | ${strings.brand}`;
 
@@ -139,15 +174,10 @@ export function buildSharedFormMetadata({
     title,
     description: presentation.description,
     alternates: {
-      canonical: pageUrl,
+      canonical: presentation.seo.canonicalUrl ?? pageUrl,
     },
-    keywords: [
-      presentation.title,
-      strings.brand,
-      'form',
-      'survey',
-      'shared form',
-    ],
+    keywords: presentation.seo.keywords,
+    ...(presentation.seo.noIndex ? { robots: NO_INDEX_ROBOTS } : {}),
     openGraph: {
       type: 'website',
       url: pageUrl,
@@ -159,7 +189,7 @@ export function buildSharedFormMetadata({
           url: imageUrl,
           width: 1200,
           height: 630,
-          alt: strings.openGraphAlt,
+          alt: presentation.seo.imageAlt || strings.openGraphAlt,
         },
       ],
     },

--- a/apps/forms/src/features/forms/shared-form-loader.test.ts
+++ b/apps/forms/src/features/forms/shared-form-loader.test.ts
@@ -35,51 +35,23 @@ import {
   loadSharedFormForPage,
   loadSharedFormSnapshot,
 } from './shared-form-loader';
+import { createTestFormDefinition } from './test-support/form-fixtures';
+import type { FormDefinition } from './types';
 
 function createFormDefinition(
   accessMode: 'anonymous' | 'authenticated' = 'anonymous'
-) {
-  return {
+): FormDefinition {
+  return createTestFormDefinition({
     id: 'form-1',
     wsId: 'ws-1',
     creatorId: 'user-1',
     title: '<p>Shared form</p>',
     description: '<p>Fill this out</p>',
-    status: 'published' as const,
     accessMode,
-    openAt: null,
-    closeAt: null,
-    maxResponses: null,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
     shareCode: 'share-1',
-    theme: {
-      presetId: 'editorial-moss',
-      density: 'balanced' as const,
-      accentColor: 'dynamic-green' as const,
-      headlineFontId: 'noto-serif' as const,
-      bodyFontId: 'be-vietnam-pro' as const,
-      surfaceStyle: 'paper' as const,
-      coverHeadline: '',
-      coverImage: {
-        storagePath: '',
-        url: '',
-        alt: '',
-      },
-      sectionImages: {},
-      typography: {
-        displaySize: 'md' as const,
-        headingSize: 'md' as const,
-        bodySize: 'md' as const,
-      },
-    },
     settings: {
-      showProgressBar: true,
-      allowMultipleSubmissions: true,
-      oneResponsePerUser: false,
+      ...createTestFormDefinition().settings,
       requireTurnstile: true,
-      confirmationTitle: 'Thanks',
-      confirmationMessage: 'Done',
     },
     sections: [
       {
@@ -91,7 +63,7 @@ function createFormDefinition(
           {
             id: 'question-1',
             sectionId: 'section-1',
-            type: 'short_text' as const,
+            type: 'short_text',
             title: 'Question',
             description: '',
             required: false,
@@ -102,8 +74,7 @@ function createFormDefinition(
         ],
       },
     ],
-    logicRules: [],
-  };
+  });
 }
 
 function createLoadedRecord(

--- a/apps/forms/src/features/forms/shared-form-seo.test.ts
+++ b/apps/forms/src/features/forms/shared-form-seo.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { FormSeoInput } from './schema';
+import { hasFormSeoOverrides, resolveFormSeo } from './shared-form-seo';
+
+const derived = {
+  description: 'Derived description',
+  keywords: ['derived'],
+  title: 'Derived title',
+};
+
+function seo(overrides: Partial<FormSeoInput> = {}): FormSeoInput {
+  return {
+    title: '',
+    description: '',
+    image: { storagePath: '', url: '', alt: '' },
+    keywords: [],
+    canonicalUrl: '',
+    noIndex: false,
+    ...overrides,
+  };
+}
+
+describe('resolveFormSeo', () => {
+  it('falls back to derived values when no overrides are set', () => {
+    const result = resolveFormSeo({
+      derived,
+      fallbackImageAlt: 'Fallback alt',
+      seo: seo(),
+    });
+
+    expect(result).toEqual({
+      canonicalUrl: null,
+      description: 'Derived description',
+      imageAlt: 'Fallback alt',
+      imageUrl: null,
+      keywords: ['derived'],
+      noIndex: false,
+      title: 'Derived title',
+    });
+  });
+
+  it('treats a missing seo object the same as an empty one', () => {
+    const result = resolveFormSeo({
+      derived,
+      fallbackImageAlt: 'Fallback alt',
+      seo: null,
+    });
+
+    expect(result.title).toBe('Derived title');
+    expect(result.noIndex).toBe(false);
+  });
+
+  it('prefers overrides when they are set', () => {
+    const result = resolveFormSeo({
+      derived,
+      fallbackImageAlt: 'Fallback alt',
+      seo: seo({
+        canonicalUrl: 'https://example.com/apply',
+        description: 'Custom description',
+        image: {
+          alt: 'Custom alt',
+          storagePath: 'ws/forms/social/card.png',
+          url: 'https://cdn.example.com/card.png',
+        },
+        keywords: ['hiring', 'engineering'],
+        noIndex: true,
+        title: 'Custom title',
+      }),
+    });
+
+    expect(result).toEqual({
+      canonicalUrl: 'https://example.com/apply',
+      description: 'Custom description',
+      imageAlt: 'Custom alt',
+      imageUrl: 'https://cdn.example.com/card.png',
+      keywords: ['hiring', 'engineering'],
+      noIndex: true,
+      title: 'Custom title',
+    });
+  });
+
+  it('treats whitespace-only overrides as unset', () => {
+    const result = resolveFormSeo({
+      derived,
+      fallbackImageAlt: 'Fallback alt',
+      seo: seo({ canonicalUrl: '   ', description: '   ', title: '   ' }),
+    });
+
+    expect(result.title).toBe('Derived title');
+    expect(result.description).toBe('Derived description');
+    expect(result.canonicalUrl).toBeNull();
+  });
+
+  it('ignores an unsigned storage path so the generated card is used', () => {
+    // The media resolver signs `storagePath` into `url` on read. When signing
+    // fails there is no usable URL, and emitting the raw path would produce a
+    // broken social card instead of falling back to the generated one.
+    const result = resolveFormSeo({
+      derived,
+      fallbackImageAlt: 'Fallback alt',
+      seo: seo({
+        image: { alt: '', storagePath: 'ws/forms/social/card.png', url: '' },
+      }),
+    });
+
+    expect(result.imageUrl).toBeNull();
+  });
+});
+
+describe('hasFormSeoOverrides', () => {
+  it('is false for an empty or missing configuration', () => {
+    expect(hasFormSeoOverrides(seo())).toBe(false);
+    expect(hasFormSeoOverrides(null)).toBe(false);
+  });
+
+  it.each([
+    ['title', seo({ title: 'x' })],
+    ['description', seo({ description: 'x' })],
+    ['keywords', seo({ keywords: ['x'] })],
+    ['canonicalUrl', seo({ canonicalUrl: 'https://example.com' })],
+    ['noIndex', seo({ noIndex: true })],
+    ['image', seo({ image: { alt: '', storagePath: 'p', url: '' } })],
+  ])('is true when %s is set', (_field, value) => {
+    expect(hasFormSeoOverrides(value)).toBe(true);
+  });
+});

--- a/apps/forms/src/features/forms/shared-form-seo.ts
+++ b/apps/forms/src/features/forms/shared-form-seo.ts
@@ -1,0 +1,101 @@
+import type { FormSeoInput } from './schema';
+
+/**
+ * Resolution of a form's SEO overrides against the values derived from its
+ * content.
+ *
+ * Every override is optional and an empty value means "keep the derived one",
+ * so a form that was created before the SEO panel existed — or one whose author
+ * never opened it — behaves exactly as it did before.
+ */
+
+export interface DerivedFormSeo {
+  /** Title derived from the cover headline or the form title. */
+  title: string;
+  /** Description derived from the form or its first non-empty section. */
+  description: string;
+  /** Keywords derived from the title and brand. */
+  keywords: string[];
+}
+
+export interface ResolvedFormSeo {
+  title: string;
+  description: string;
+  /**
+   * An uploaded social card, or `null` to fall back to the card this app
+   * renders at `/f/<shareCode>/opengraph-image`.
+   */
+  imageUrl: string | null;
+  imageAlt: string;
+  keywords: string[];
+  /** Overrides the canonical URL; `null` keeps the form's own public URL. */
+  canonicalUrl: string | null;
+  noIndex: boolean;
+}
+
+const EMPTY_SEO: FormSeoInput = {
+  title: '',
+  description: '',
+  image: { storagePath: '', url: '', alt: '' },
+  keywords: [],
+  canonicalUrl: '',
+  noIndex: false,
+};
+
+function firstNonEmpty(...values: (string | null | undefined)[]) {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return '';
+}
+
+export function resolveFormSeo({
+  seo,
+  derived,
+  fallbackImageAlt,
+}: {
+  seo: FormSeoInput | null | undefined;
+  derived: DerivedFormSeo;
+  /** Used when an uploaded card carries no alt text of its own. */
+  fallbackImageAlt: string;
+}): ResolvedFormSeo {
+  const overrides = seo ?? EMPTY_SEO;
+
+  return {
+    title: firstNonEmpty(overrides.title, derived.title),
+    description: firstNonEmpty(overrides.description, derived.description),
+    // Only a resolved URL is usable here. A storage path with no signed URL
+    // means the media resolver could not sign it, and emitting the raw path
+    // would produce a broken social card rather than falling back to the
+    // generated one.
+    imageUrl: overrides.image.url.trim() || null,
+    imageAlt: firstNonEmpty(overrides.image.alt, fallbackImageAlt),
+    keywords: overrides.keywords.length ? overrides.keywords : derived.keywords,
+    canonicalUrl: overrides.canonicalUrl.trim() || null,
+    noIndex: overrides.noIndex,
+  };
+}
+
+/**
+ * True when the author has customised anything at all — used by the studio to
+ * show an "in use" badge without re-deriving each field.
+ */
+export function hasFormSeoOverrides(seo: FormSeoInput | null | undefined) {
+  if (!seo) {
+    return false;
+  }
+
+  return Boolean(
+    seo.title.trim() ||
+      seo.description.trim() ||
+      seo.image.url.trim() ||
+      seo.image.storagePath.trim() ||
+      seo.keywords.length ||
+      seo.canonicalUrl.trim() ||
+      seo.noIndex
+  );
+}

--- a/apps/forms/src/features/forms/studio/form-media-field.tsx
+++ b/apps/forms/src/features/forms/studio/form-media-field.tsx
@@ -22,7 +22,7 @@ import { useTranslations } from 'next-intl';
 import { useRef, useState } from 'react';
 
 import { FormsImageDialog } from '../forms-image-dialog';
-import { useFormMediaUploadMutation } from '../hooks';
+import { type FormMediaScope, useFormMediaUploadMutation } from '../hooks';
 import type { FormStudioInput } from '../schema';
 import type { getFormToneClasses } from '../theme';
 
@@ -38,7 +38,7 @@ export function FormMediaField({
   hint,
 }: {
   wsId: string;
-  scope: 'cover' | 'section' | 'option';
+  scope: FormMediaScope;
   value: FormMediaValue;
   onChange: (value: FormMediaValue) => void;
   toneClasses: ReturnType<typeof getFormToneClasses>;
@@ -47,7 +47,7 @@ export function FormMediaField({
 }) {
   const t = useTranslations('forms');
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [open, setOpen] = useState(scope === 'cover');
+  const [open, setOpen] = useState(scope === 'cover' || scope === 'social');
   const [previewOpen, setPreviewOpen] = useState(false);
   const uploadMutation = useFormMediaUploadMutation({ wsId });
   const hasImage = Boolean(value.url || value.storagePath);

--- a/apps/forms/src/features/forms/studio/form-studio-build-tab.tsx
+++ b/apps/forms/src/features/forms/studio/form-studio-build-tab.tsx
@@ -18,7 +18,8 @@ import { Label } from '@tuturuuu/ui/label';
 import { TabsContent } from '@tuturuuu/ui/tabs';
 import { cn } from '@tuturuuu/utils/format';
 import type { ComponentType } from 'react';
-
+import type { FormCollaboratorPresence } from '../collaboration';
+import { BlockEditingBadge } from '../collaboration';
 import { FormsMarkdown } from '../forms-markdown';
 import { FormsRichTextEditor } from '../forms-rich-text-editor';
 import { FloatingBlockToolbar } from './floating-block-toolbar';
@@ -48,6 +49,7 @@ export function renderBuildTab({
   addBlockToActiveSection,
   handleSectionDragEnd,
   SectionDivider,
+  getBlockEditors,
 }: {
   wsId: string;
   t: FormStudioState['t'];
@@ -68,6 +70,8 @@ export function renderBuildTab({
   addBlockToActiveSection: FormStudioState['addBlockToActiveSection'];
   handleSectionDragEnd: (event: DragEndEvent) => void;
   SectionDivider: ComponentType<{ onClick: () => void }>;
+  /** Collaborators currently focused on a given block id. */
+  getBlockEditors: (blockId: string) => FormCollaboratorPresence[];
 }) {
   return (
     <TabsContent value="build" className="mt-0 min-w-0">
@@ -202,8 +206,15 @@ export function renderBuildTab({
                     const sectionFormId =
                       values.sections[sectionIndex]?.id ?? field.id;
 
+                    const sectionEditors = getBlockEditors(sectionFormId);
+
                     return (
                       <div key={field.id} className="space-y-4">
+                        {sectionEditors.length > 0 ? (
+                          <div className="flex justify-end">
+                            <BlockEditingBadge editors={sectionEditors} />
+                          </div>
+                        ) : null}
                         <SectionEditor
                           index={sectionIndex}
                           wsId={wsId}

--- a/apps/forms/src/features/forms/studio/form-studio-save.ts
+++ b/apps/forms/src/features/forms/studio/form-studio-save.ts
@@ -32,6 +32,7 @@ export function useFormStudioSave({
   setSecondsUntilAutosave,
   primarySaveButtonRef,
   setShowFloatingSave,
+  onSaved,
 }: {
   t: FormStudioState['t'];
   form: FormStudioState['form'];
@@ -51,6 +52,8 @@ export function useFormStudioSave({
   setSecondsUntilAutosave: FormStudioState['setSecondsUntilAutosave'];
   primarySaveButtonRef: FormStudioState['primarySaveButtonRef'];
   setShowFloatingSave: FormStudioState['setShowFloatingSave'];
+  /** Notifies collaborators that the stored document changed. */
+  onSaved?: () => void;
 }) {
   const getSaveValidationMessage = (
     error: ReturnType<typeof findFirstValidationError>
@@ -135,9 +138,15 @@ export function useFormStudioSave({
       if (!isAutosave) {
         form.reset(normalizedPayload, { keepValues: true });
       }
+
+      // Tell other editors in this form's realtime channel that the server copy
+      // moved. Fired for autosaves too — an autosave changes the stored
+      // document just as much as an explicit save does.
+      onSaved?.();
+
       return result;
     },
-    [form, mode, pathname, router, saveMutation, workspaceSlug]
+    [form, mode, onSaved, pathname, router, saveMutation, workspaceSlug]
   );
 
   const handleSave = form.handleSubmit(

--- a/apps/forms/src/features/forms/studio/form-studio-state.ts
+++ b/apps/forms/src/features/forms/studio/form-studio-state.ts
@@ -116,6 +116,33 @@ export function useFormStudioState({
 
   const values = useWatch({ control: form.control }) as FormStudioInput;
   const isDirty = form.formState.isDirty;
+
+  // `router.refresh()` re-renders the server tree and hands this client
+  // component a new `initialForm`, but it does NOT remount it — and
+  // `defaultValues` is only read once, at mount. Without this the studio keeps
+  // editing the document it loaded with, and the next autosave writes that
+  // stale copy back over whatever the other editor just saved.
+  //
+  // Keyed on `updatedAt` rather than the object: `toStudioInput` builds a new
+  // object every render, so comparing identity would reset on every render and
+  // fight the user's typing.
+  const lastAppliedUpdatedAtRef = useRef(initialForm?.updatedAt ?? null);
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+
+  useEffect(() => {
+    const incomingUpdatedAt = initialForm?.updatedAt ?? null;
+    if (!initialForm || incomingUpdatedAt === null) return;
+    if (incomingUpdatedAt === lastAppliedUpdatedAtRef.current) return;
+
+    // A dirty form is never overwritten. `useRemoteSaveNotice` has already
+    // shown the editor a reload prompt in that case; taking their unsaved work
+    // away here would be the exact loss the prompt exists to prevent.
+    if (isDirtyRef.current) return;
+
+    lastAppliedUpdatedAtRef.current = incomingUpdatedAt;
+    form.reset(toStudioInput(initialForm));
+  }, [form, initialForm]);
   const questionCount = values.sections.reduce(
     (total, section) => total + section.questions.length,
     0

--- a/apps/forms/src/features/forms/studio/form-studio.tsx
+++ b/apps/forms/src/features/forms/studio/form-studio.tsx
@@ -23,7 +23,15 @@ import {
 } from '@tuturuuu/ui/dropdown-menu';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@tuturuuu/ui/tabs';
 import { cn } from '@tuturuuu/utils/format';
+import { useEffect } from 'react';
 
+import {
+  CollaboratorAvatars,
+  type FormCollaboratorIdentity,
+  useFormCollaboration,
+  useRemoteSaveNotice,
+} from '../collaboration';
+import { normalizeMarkdownToText } from '../content';
 import { FORM_FONT_VARIABLES } from '../fonts';
 import { FormRuntime } from '../form-runtime';
 import { FormsMarkdown } from '../forms-markdown';
@@ -41,6 +49,7 @@ import { useFormStudioSave } from './form-studio-save';
 import { useFormStudioState } from './form-studio-state';
 import { ResponsesPanel } from './responses-panel';
 import { SettingsPanel } from './settings-panel';
+import { StudioSaveButton, type StudioSaveState } from './studio-save-button';
 import { ThemePickerPanel } from './theme-picker-panel';
 
 export function FormStudio({
@@ -48,6 +57,7 @@ export function FormStudio({
   workspaceSlug,
   mode,
   canManageForms = true,
+  currentUser,
   initialForm,
   initialResponses,
   initialResponsesTotal,
@@ -61,6 +71,11 @@ export function FormStudio({
   workspaceSlug: string;
   mode: 'create' | 'edit';
   canManageForms?: boolean;
+  /**
+   * Resolved server-side from the app session. Registered satellites must not
+   * read Supabase auth in the browser, so collaboration identity is passed in.
+   */
+  currentUser: FormCollaboratorIdentity | null;
   initialForm?: FormDefinition;
   initialResponses?: FormResponseRecord[];
   initialResponsesTotal?: number;
@@ -142,8 +157,68 @@ export function FormStudio({
     initialAnalytics,
   });
 
+  // Live collaboration is scoped to a saved form: a draft being created has no
+  // id yet, so there is no channel for anyone else to join.
+  const handleRemoteSave = useRemoteSaveNotice({
+    isDirty,
+    onReload: () => router.refresh(),
+  });
+  const {
+    broadcastSaved,
+    collaborators,
+    getBlockEditors,
+    isConnected: isCollaborationConnected,
+    setActiveBlock,
+  } = useFormCollaboration({
+    currentUser,
+    formId: initialForm?.id,
+    onRemoteSave: handleRemoteSave,
+  });
+
+  // Report which block this editor is on so collaborators see it on their copy.
+  // The question id is the finer signal; the section is the fallback while the
+  // editor is between questions.
+  useEffect(() => {
+    const activeQuestionId = resolvedActiveSectionId
+      ? activeQuestionIdsBySection[resolvedActiveSectionId]
+      : undefined;
+    const blockId = activeQuestionId ?? resolvedActiveSectionId ?? null;
+
+    if (!blockId) {
+      setActiveBlock(null);
+      return;
+    }
+
+    const section = values.sections.find(
+      (candidate) => candidate.id === resolvedActiveSectionId
+    );
+    const question = section?.questions.find(
+      (candidate) => candidate.id === activeQuestionId
+    );
+
+    setActiveBlock(
+      blockId,
+      normalizeMarkdownToText(question?.title ?? section?.title ?? '') || null
+    );
+  }, [
+    activeQuestionIdsBySection,
+    resolvedActiveSectionId,
+    setActiveBlock,
+    values.sections,
+  ]);
+
+  const saveState: StudioSaveState = {
+    autosaveEnabled,
+    autosaveStatus,
+    isDirty,
+    isPending: saveMutation.isPending,
+    mode,
+    secondsUntilAutosave,
+  };
+
   const { handleSave, saveButtonDisabled, handleSectionDragEnd } =
     useFormStudioSave({
+      onSaved: broadcastSaved,
       t,
       form,
       mode,
@@ -292,6 +367,10 @@ export function FormStudio({
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+              <CollaboratorAvatars
+                collaborators={collaborators}
+                isConnected={isCollaborationConnected}
+              />
               {(mode === 'edit' && canManageForms) ||
               (mode === 'edit' && shareQuery?.shareLink?.code) ? (
                 <DropdownMenu>
@@ -331,58 +410,28 @@ export function FormStudio({
                   </DropdownMenuContent>
                 </DropdownMenu>
               ) : null}
-              <Button
-                ref={primarySaveButtonRef}
-                className={cn(
-                  'rounded-2xl px-5',
-                  studioToneClasses.primaryButtonClassName
-                )}
-                onClick={handleSave}
+              <StudioSaveButton
+                buttonRef={primarySaveButtonRef}
+                className={studioToneClasses.primaryButtonClassName}
                 disabled={saveButtonDisabled}
-              >
-                {saveMutation.isPending
-                  ? t('studio.saving')
-                  : autosaveStatus === 'error'
-                    ? t('studio.autosave_failed')
-                    : autosaveEnabled && isDirty && secondsUntilAutosave > 0
-                      ? t('studio.autosave_in_seconds', {
-                          seconds: secondsUntilAutosave,
-                        })
-                      : autosaveStatus === 'saved'
-                        ? t('studio.autosave_saved')
-                        : mode === 'create'
-                          ? t('studio.create_form')
-                          : t('studio.save_changes')}
-              </Button>
+                onClick={handleSave}
+                state={saveState}
+              />
             </div>
           </CardContent>
         </Card>
 
         {showFloatingSave && (mode === 'create' || isDirty) ? (
           <div className="pointer-events-none fixed right-6 bottom-6 z-50">
-            <Button
-              type="button"
-              onClick={handleSave}
-              disabled={saveButtonDisabled}
+            <StudioSaveButton
               className={cn(
-                'pointer-events-auto rounded-2xl px-5 shadow-black/15 shadow-lg',
+                'pointer-events-auto shadow-black/15 shadow-lg',
                 studioToneClasses.primaryButtonClassName
               )}
-            >
-              {saveMutation.isPending
-                ? t('studio.saving')
-                : autosaveStatus === 'error'
-                  ? t('studio.autosave_failed')
-                  : autosaveEnabled && isDirty && secondsUntilAutosave > 0
-                    ? t('studio.autosave_in_seconds', {
-                        seconds: secondsUntilAutosave,
-                      })
-                    : autosaveStatus === 'saved'
-                      ? t('studio.autosave_saved')
-                      : mode === 'create'
-                        ? t('studio.create_form')
-                        : t('studio.save_changes')}
-            </Button>
+              disabled={saveButtonDisabled}
+              onClick={handleSave}
+              state={saveState}
+            />
           </div>
         ) : null}
 
@@ -479,6 +528,7 @@ export function FormStudio({
             addBlockToActiveSection,
             handleSectionDragEnd,
             SectionDivider,
+            getBlockEditors,
           })}
 
           <TabsContent value="preview" className="mt-0 min-w-0">

--- a/apps/forms/src/features/forms/studio/form-studio.tsx
+++ b/apps/forms/src/features/forms/studio/form-studio.tsx
@@ -58,6 +58,7 @@ export function FormStudio({
   mode,
   canManageForms = true,
   currentUser,
+  canRealtime = false,
   initialForm,
   initialResponses,
   initialResponsesTotal,
@@ -76,6 +77,12 @@ export function FormStudio({
    * read Supabase auth in the browser, so collaboration identity is passed in.
    */
   currentUser: FormCollaboratorIdentity | null;
+  /**
+   * Whether this browser holds a Supabase session. Realtime authenticates from
+   * Supabase cookies, and an app-session-only login has none — see
+   * `canJoinFormRealtime`.
+   */
+  canRealtime?: boolean;
   initialForm?: FormDefinition;
   initialResponses?: FormResponseRecord[];
   initialResponsesTotal?: number;
@@ -171,6 +178,11 @@ export function FormStudio({
     setActiveBlock,
   } = useFormCollaboration({
     currentUser,
+    // Subscribing without a Supabase session is not a degraded experience, it
+    // is a guaranteed refusal: the `realtime.messages` policies are
+    // `to authenticated`, and this browser would connect as `anon`. Skipping it
+    // avoids a channel error on every studio load for app-session logins.
+    enabled: canRealtime,
     formId: initialForm?.id,
     onRemoteSave: handleRemoteSave,
   });

--- a/apps/forms/src/features/forms/studio/form-studio.tsx
+++ b/apps/forms/src/features/forms/studio/form-studio.tsx
@@ -544,6 +544,7 @@ export function FormStudio({
             />
 
             <SettingsPanel
+              wsId={wsId}
               form={form}
               shareCode={shareQuery?.shareLink?.code}
               toneClasses={studioToneClasses}

--- a/apps/forms/src/features/forms/studio/seo-preview.tsx
+++ b/apps/forms/src/features/forms/studio/seo-preview.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Globe2 } from '@tuturuuu/icons';
+import { useTranslations } from 'next-intl';
+import { normalizeMarkdownToText } from '../content';
+
+/** Roughly where Google truncates a result title and snippet. */
+const TITLE_DISPLAY_LIMIT = 60;
+const DESCRIPTION_DISPLAY_LIMIT = 160;
+
+function clampForDisplay(value: string, limit: number) {
+  const normalized = normalizeMarkdownToText(value).replace(/\s+/g, ' ').trim();
+
+  if (normalized.length <= limit) {
+    return { text: normalized, truncated: false };
+  }
+
+  return {
+    text: `${normalized.slice(0, limit - 1).trimEnd()}…`,
+    truncated: true,
+  };
+}
+
+/**
+ * Approximate search-result preview for the public form page.
+ *
+ * Deliberately shows the *resolved* values — an empty SEO override falls back
+ * to the form's own title and description — so an author who has customised
+ * nothing still sees what a crawler would, rather than an empty box. The
+ * truncation marks are the point of the component: they make an over-long
+ * title visibly get cut before it is published rather than after.
+ */
+export function SearchResultPreview({
+  description,
+  fallbackDescription,
+  fallbackTitle,
+  shareCode,
+  title,
+}: {
+  description: string;
+  fallbackDescription: string;
+  fallbackTitle: string;
+  shareCode?: string | null;
+  title: string;
+}) {
+  const t = useTranslations('forms');
+
+  const origin =
+    typeof window === 'undefined'
+      ? ''
+      : window.location.origin.replace(/^https?:\/\//, '');
+  const displayUrl = shareCode
+    ? `${origin}/f/${shareCode}`
+    : t('settings.seo_preview_unpublished_url');
+
+  const resolvedTitle = clampForDisplay(
+    title || fallbackTitle,
+    TITLE_DISPLAY_LIMIT
+  );
+  const resolvedDescription = clampForDisplay(
+    description || fallbackDescription,
+    DESCRIPTION_DISPLAY_LIMIT
+  );
+
+  return (
+    <div className="space-y-2 rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
+      <p className="text-[11px] text-muted-foreground uppercase tracking-[0.24em]">
+        {t('settings.seo_preview')}
+      </p>
+
+      <div className="space-y-1">
+        <p className="flex items-center gap-1.5 text-muted-foreground text-xs">
+          <Globe2 className="h-3 w-3 shrink-0" />
+          <span className="truncate">{displayUrl}</span>
+        </p>
+        <p className="font-medium text-base text-dynamic-blue leading-snug">
+          {resolvedTitle.text}
+        </p>
+        <p className="text-muted-foreground text-sm leading-relaxed">
+          {resolvedDescription.text}
+        </p>
+      </div>
+
+      {resolvedTitle.truncated || resolvedDescription.truncated ? (
+        <p className="text-dynamic-orange text-xs">
+          {t('settings.seo_preview_truncated')}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/forms/src/features/forms/studio/settings-embed-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-embed-section.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { Check, Code2, Copy } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { Input } from '@tuturuuu/ui/input';
+import { Label } from '@tuturuuu/ui/label';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
+import { BASE_URL } from '@/constants/common';
+import {
+  buildEmbedSnippet,
+  buildIframeSnippet,
+  isOverlayEmbedMode,
+} from '../embed/embed-snippet';
+import { EMBED_MODES, type EmbedMode } from '../embed/protocol';
+import type { getFormToneClasses } from '../theme';
+import { SettingsSection } from './settings-section';
+
+function SnippetBlock({
+  label,
+  snippet,
+  toneClasses,
+}: {
+  label: string;
+  snippet: string;
+  toneClasses: ReturnType<typeof getFormToneClasses>;
+}) {
+  const tCommon = useTranslations('common');
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard access can be denied (insecure origin, permissions). The
+      // snippet is on screen and selectable, so there is nothing to recover.
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label>{label}</Label>
+        <Button
+          className={cn('h-8', toneClasses.secondaryButtonClassName)}
+          onClick={copy}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          {copied ? (
+            <Check className="mr-1.5 h-3.5 w-3.5 text-dynamic-green" />
+          ) : (
+            <Copy className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          {copied ? tCommon('copied') : tCommon('copy')}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto rounded-2xl border border-border/60 bg-muted/30 p-4 font-mono text-[0.72rem] leading-relaxed">
+        <code>{snippet}</code>
+      </pre>
+    </div>
+  );
+}
+
+/**
+ * Embed builder.
+ *
+ * Requires a share link: an embed is just a framed `/embed/<shareCode>`, so
+ * without a published link there is nothing to point at — better to say so than
+ * to hand over a snippet that renders an error on someone's site.
+ */
+export function EmbedSettingsSection({
+  shareCode,
+  toneClasses,
+}: {
+  shareCode?: string | null;
+  toneClasses: ReturnType<typeof getFormToneClasses>;
+}) {
+  const t = useTranslations('forms');
+  const [mode, setMode] = useState<EmbedMode>('inline');
+  const [height, setHeight] = useState('');
+  const [launcherText, setLauncherText] = useState('');
+
+  const snippets = useMemo(() => {
+    if (!shareCode) return null;
+
+    const parsedHeight = Number.parseInt(height, 10);
+
+    return {
+      embed: buildEmbedSnippet({
+        baseUrl: BASE_URL,
+        height: Number.isNaN(parsedHeight) ? null : parsedHeight,
+        launcherText,
+        mode,
+        shareCode,
+      }),
+      iframe: buildIframeSnippet({
+        baseUrl: BASE_URL,
+        height: Number.isNaN(parsedHeight) ? null : parsedHeight,
+        shareCode,
+      }),
+    };
+  }, [height, launcherText, mode, shareCode]);
+
+  return (
+    <SettingsSection
+      description={t('settings.embed_description')}
+      icon={Code2}
+      title={t('settings.embed')}
+      value="embed"
+    >
+      {snippets ? (
+        <>
+          <div className="space-y-2">
+            <Label>{t('settings.embed_mode')}</Label>
+            <div className="flex flex-wrap gap-2">
+              {EMBED_MODES.map((candidate) => (
+                <Button
+                  className={cn(
+                    'h-9',
+                    candidate === mode
+                      ? toneClasses.primaryButtonClassName
+                      : toneClasses.secondaryButtonClassName
+                  )}
+                  key={candidate}
+                  onClick={() => setMode(candidate)}
+                  size="sm"
+                  type="button"
+                  variant={candidate === mode ? 'default' : 'outline'}
+                >
+                  {t(`settings.embed_modes.${candidate}`)}
+                </Button>
+              ))}
+            </div>
+            <p className="text-muted-foreground text-xs">
+              {t(`settings.embed_mode_hints.${mode}`)}
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {isOverlayEmbedMode(mode) ? (
+              <div className="space-y-2">
+                <Label htmlFor="embed-launcher">
+                  {t('settings.embed_launcher_text')}
+                </Label>
+                <Input
+                  id="embed-launcher"
+                  maxLength={40}
+                  onChange={(event) => setLauncherText(event.target.value)}
+                  placeholder={t('settings.embed_launcher_placeholder')}
+                  value={launcherText}
+                />
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <Label htmlFor="embed-height">
+                  {t('settings.embed_height')}
+                </Label>
+                <Input
+                  id="embed-height"
+                  inputMode="numeric"
+                  onChange={(event) => setHeight(event.target.value)}
+                  placeholder={t('settings.embed_height_placeholder')}
+                  value={height}
+                />
+                <p className="text-muted-foreground text-xs">
+                  {t('settings.embed_height_hint')}
+                </p>
+              </div>
+            )}
+          </div>
+
+          <SnippetBlock
+            label={t('settings.embed_snippet')}
+            snippet={snippets.embed}
+            toneClasses={toneClasses}
+          />
+          <SnippetBlock
+            label={t('settings.embed_iframe_snippet')}
+            snippet={snippets.iframe}
+            toneClasses={toneClasses}
+          />
+        </>
+      ) : (
+        <p className="rounded-2xl border border-dynamic-orange/35 bg-dynamic-orange/8 px-4 py-3 text-sm">
+          {t('settings.embed_requires_share_link')}
+        </p>
+      )}
+    </SettingsSection>
+  );
+}

--- a/apps/forms/src/features/forms/studio/settings-experience-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-experience-section.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquare,
 } from '@tuturuuu/icons';
 import { Checkbox } from '@tuturuuu/ui/checkbox';
+import { useWatch } from '@tuturuuu/ui/hooks/use-form';
 import { Input } from '@tuturuuu/ui/input';
 import { Label } from '@tuturuuu/ui/label';
 import { Textarea } from '@tuturuuu/ui/textarea';
@@ -48,6 +49,15 @@ export function ExperienceSettingsSection({
 }) {
   const t = useTranslations('forms');
 
+  const displayMode = useWatch({
+    control: form.control,
+    name: 'settings.displayMode',
+  });
+  const welcomeEnabled = useWatch({
+    control: form.control,
+    name: 'settings.welcomeEnabled',
+  });
+
   return (
     <SettingsSection
       description={t('settings.responses_recorded')}
@@ -55,6 +65,98 @@ export function ExperienceSettingsSection({
       title={t('settings.experience_controls')}
       value="experience-controls"
     >
+      <div className="space-y-2">
+        <Label>{t('settings.display_mode')}</Label>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {(['sections', 'one_question'] as const).map((candidate) => (
+            <button
+              className={cn(
+                'rounded-2xl border px-4 py-3 text-left transition-colors',
+                candidate === displayMode
+                  ? 'border-foreground/25 bg-foreground/[0.04]'
+                  : 'border-border/60 bg-background/55 hover:border-foreground/20'
+              )}
+              key={candidate}
+              onClick={() =>
+                form.setValue('settings.displayMode', candidate, {
+                  shouldDirty: true,
+                })
+              }
+              type="button"
+            >
+              <span className="block font-medium text-sm">
+                {t(`settings.display_modes.${candidate}`)}
+              </span>
+              <span className="mt-1 block text-muted-foreground text-xs">
+                {t(`settings.display_mode_hints.${candidate}`)}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3 rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
+        <button
+          className="flex w-full items-start gap-3 text-left"
+          onClick={() =>
+            form.setValue('settings.welcomeEnabled', !welcomeEnabled, {
+              shouldDirty: true,
+            })
+          }
+          type="button"
+        >
+          <Checkbox
+            checked={welcomeEnabled}
+            className="pointer-events-none mt-0.5"
+            tabIndex={-1}
+          />
+          <span className="space-y-1">
+            <span className="block font-medium text-sm">
+              {t('settings.welcome_screen')}
+            </span>
+            <span className="block text-muted-foreground text-xs">
+              {t('settings.welcome_screen_hint')}
+            </span>
+          </span>
+        </button>
+
+        {welcomeEnabled ? (
+          <div className="space-y-3 border-border/50 border-t pt-3">
+            <div className="space-y-2">
+              <Label htmlFor="welcome-title">
+                {t('settings.welcome_title')}
+              </Label>
+              <Input
+                id="welcome-title"
+                placeholder={t('settings.welcome_title_placeholder')}
+                {...form.register('settings.welcomeTitle')}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="welcome-description">
+                {t('settings.welcome_body')}
+              </Label>
+              <Textarea
+                id="welcome-description"
+                placeholder={t('settings.welcome_body_placeholder')}
+                rows={3}
+                {...form.register('settings.welcomeDescription')}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="welcome-button">
+                {t('settings.welcome_button')}
+              </Label>
+              <Input
+                id="welcome-button"
+                placeholder={t('settings.welcome_button_placeholder')}
+                {...form.register('settings.welcomeButtonLabel')}
+              />
+            </div>
+          </div>
+        ) : null}
+      </div>
+
       <div className="rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
         <div className="grid gap-2 sm:grid-cols-3">
           <div className="rounded-2xl border border-border/60 bg-background/60 px-4 py-3">

--- a/apps/forms/src/features/forms/studio/settings-experience-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-experience-section.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import {
+  AlertTriangle,
+  CircleCheckBig,
+  FileText,
+  MessageSquare,
+} from '@tuturuuu/icons';
+import { Checkbox } from '@tuturuuu/ui/checkbox';
+import { Input } from '@tuturuuu/ui/input';
+import { Label } from '@tuturuuu/ui/label';
+import { Textarea } from '@tuturuuu/ui/textarea';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import { getFormFontLabel } from '../fonts';
+import { FieldLabel } from '../form-icons';
+import type { FormStudioInput } from '../schema';
+import { FORM_THEME_PRESETS, type getFormToneClasses } from '../theme';
+import type { FormResponseSummary } from '../types';
+import { SettingsSection } from './settings-section';
+import type { StudioForm } from './studio-utils';
+
+/** Progress bar, submission limits, confirmation copy, and the theme summary. */
+export function ExperienceSettingsSection({
+  accessMode,
+  allowMultipleSubmissions,
+  bodyFontId,
+  form,
+  headlineFontId,
+  oneResponseLimitLocked,
+  oneResponsePerUser,
+  responseSummary,
+  showProgressBar,
+  themePreset,
+  toneClasses,
+}: {
+  accessMode: FormStudioInput['accessMode'];
+  allowMultipleSubmissions: boolean;
+  bodyFontId: FormStudioInput['theme']['bodyFontId'];
+  form: StudioForm;
+  headlineFontId: FormStudioInput['theme']['headlineFontId'];
+  oneResponseLimitLocked: boolean;
+  oneResponsePerUser: boolean;
+  responseSummary: FormResponseSummary;
+  showProgressBar: boolean;
+  themePreset: string;
+  toneClasses: ReturnType<typeof getFormToneClasses>;
+}) {
+  const t = useTranslations('forms');
+
+  return (
+    <SettingsSection
+      description={t('settings.responses_recorded')}
+      icon={CircleCheckBig}
+      title={t('settings.experience_controls')}
+      value="experience-controls"
+    >
+      <div className="rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
+        <div className="grid gap-2 sm:grid-cols-3">
+          <div className="rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
+            <p className="text-[11px] text-muted-foreground uppercase tracking-[0.24em]">
+              {t('settings.responses_recorded')}
+            </p>
+            <p className="mt-1 font-semibold text-lg">
+              {responseSummary.totalSubmissions}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
+            <p className="text-[11px] text-muted-foreground uppercase tracking-[0.24em]">
+              {t('settings.responders')}
+            </p>
+            <p className="mt-1 font-semibold text-lg">
+              {responseSummary.totalResponders}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
+            <p className="text-[11px] text-muted-foreground uppercase tracking-[0.24em]">
+              {t('settings.repeat_users')}
+            </p>
+            <p className="mt-1 font-semibold text-lg">
+              {responseSummary.duplicateAuthenticatedResponders}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3 rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
+        <label
+          className={cn(
+            'flex items-center gap-3 rounded-2xl border px-4 py-3',
+            toneClasses.optionCardClassName
+          )}
+        >
+          <Checkbox
+            className={toneClasses.checkboxClassName}
+            checked={!!showProgressBar}
+            onCheckedChange={(checked) =>
+              form.setValue('settings.showProgressBar', checked === true, {
+                shouldDirty: true,
+              })
+            }
+          />
+          <span className="text-sm">{t('settings.show_progress_bar')}</span>
+        </label>
+
+        <label
+          className={cn(
+            'flex items-center gap-3 rounded-2xl border px-4 py-3',
+            toneClasses.optionCardClassName
+          )}
+        >
+          <Checkbox
+            className={toneClasses.checkboxClassName}
+            checked={!!allowMultipleSubmissions}
+            onCheckedChange={(checked) =>
+              form.setValue(
+                'settings.allowMultipleSubmissions',
+                checked === true,
+                {
+                  shouldDirty: true,
+                }
+              )
+            }
+          />
+          <span className="text-sm">
+            {t('settings.allow_multiple_submissions')}
+          </span>
+        </label>
+
+        <label
+          className={cn(
+            'flex items-start gap-3 rounded-2xl border px-4 py-3',
+            oneResponseLimitLocked && 'cursor-not-allowed opacity-70',
+            toneClasses.optionCardClassName
+          )}
+        >
+          <Checkbox
+            className={toneClasses.checkboxClassName}
+            checked={!!oneResponsePerUser}
+            disabled={oneResponseLimitLocked}
+            onCheckedChange={(checked) =>
+              form.setValue('settings.oneResponsePerUser', checked === true, {
+                shouldDirty: true,
+              })
+            }
+          />
+          <div className="space-y-1">
+            <span className="block text-sm">
+              {t('settings.one_response_per_user')}
+            </span>
+            <span className="block text-muted-foreground text-xs">
+              {t('settings.one_response_per_user_hint')}
+            </span>
+          </div>
+        </label>
+        {oneResponsePerUser && accessMode === 'anonymous' ? (
+          <div className="rounded-2xl border border-dynamic-orange/35 bg-dynamic-orange/8 px-4 py-3">
+            <div className="flex items-start gap-3">
+              <div className="rounded-full border border-dynamic-orange/35 bg-dynamic-orange/12 p-2 text-dynamic-orange">
+                <AlertTriangle className="h-4 w-4" />
+              </div>
+              <div className="space-y-1">
+                <p className="font-medium text-dynamic-orange text-sm">
+                  {t('settings.anonymous_one_response_warning_title')}
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  {t('settings.anonymous_one_response_warning_description')}
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="rounded-2xl border border-dynamic-blue/25 bg-dynamic-blue/8 px-4 py-3">
+          <p className="font-medium text-dynamic-blue text-sm">
+            {t('settings.turnstile_always_on')}
+          </p>
+          <p className="mt-1 text-muted-foreground text-xs">
+            {t('settings.turnstile_always_on_hint')}
+          </p>
+        </div>
+      </div>
+
+      {responseSummary.hasMultipleSubmissionsByUser ? (
+        <div className="rounded-2xl border border-dynamic-orange/35 bg-dynamic-orange/8 px-4 py-3">
+          <div className="flex items-start gap-3">
+            <div className="rounded-full border border-dynamic-orange/35 bg-dynamic-orange/12 p-2 text-dynamic-orange">
+              <AlertTriangle className="h-4 w-4" />
+            </div>
+            <div className="space-y-1">
+              <p className="font-medium text-dynamic-orange text-sm">
+                {t('settings.one_response_warning_title')}
+              </p>
+              <p className="text-muted-foreground text-sm">
+                {t('settings.one_response_warning_description', {
+                  responders: responseSummary.duplicateAuthenticatedResponders,
+                  submissions:
+                    responseSummary.duplicateAuthenticatedSubmissions,
+                })}
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="space-y-4 rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
+        <div className="space-y-2">
+          <Label>
+            <FieldLabel icon={FileText}>
+              {t('settings.confirmation_title')}
+            </FieldLabel>
+          </Label>
+          <Input
+            {...form.register('settings.confirmationTitle')}
+            className={toneClasses.fieldClassName}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>
+            <FieldLabel icon={MessageSquare}>
+              {t('settings.confirmation_message')}
+            </FieldLabel>
+          </Label>
+          <Textarea
+            {...form.register('settings.confirmationMessage')}
+            className={toneClasses.fieldClassName}
+          />
+        </div>
+        <div className="space-y-1">
+          <p className="text-muted-foreground text-xs">
+            {t('settings.current_theme', {
+              theme:
+                FORM_THEME_PRESETS.find((preset) => preset.id === themePreset)
+                  ?.name ?? '',
+            })}
+          </p>
+          <p className="text-muted-foreground text-xs">
+            {t('settings.current_fonts', {
+              headline: getFormFontLabel(headlineFontId),
+              body: getFormFontLabel(bodyFontId),
+            })}
+          </p>
+        </div>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/forms/src/features/forms/studio/settings-import-export-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-import-export-section.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Download, Upload } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { useTranslations } from 'next-intl';
+import type { getFormToneClasses } from '../theme';
+import { SettingsSection } from './settings-section';
+
+/** Portable JSON export and import. */
+export function ImportExportSettingsSection({
+  onExport,
+  toneClasses,
+  triggerImportFileInput,
+}: {
+  onExport: () => void;
+  toneClasses: ReturnType<typeof getFormToneClasses>;
+  triggerImportFileInput: () => void;
+}) {
+  const t = useTranslations('forms');
+
+  return (
+    <SettingsSection
+      description={t('settings.import_export_description')}
+      icon={Download}
+      title={t('settings.import_export')}
+      value="import-export"
+    >
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          className={toneClasses.secondaryButtonClassName}
+          onClick={onExport}
+        >
+          <Download className="mr-2 h-4 w-4" />
+          {t('settings.export_form')}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className={toneClasses.secondaryButtonClassName}
+          onClick={triggerImportFileInput}
+        >
+          <Upload className="mr-2 h-4 w-4" />
+          {t('settings.import_form')}
+        </Button>
+      </div>
+      <p className="text-muted-foreground text-xs">
+        {t('settings.import_export_hint')}
+      </p>
+    </SettingsSection>
+  );
+}

--- a/apps/forms/src/features/forms/studio/settings-panel.tsx
+++ b/apps/forms/src/features/forms/studio/settings-panel.tsx
@@ -19,6 +19,7 @@ import { useRef, useState } from 'react';
 import type { FormStudioInput } from '../schema';
 import type { getFormToneClasses } from '../theme';
 import type { FormResponseSummary } from '../types';
+import { EmbedSettingsSection } from './settings-embed-section';
 import { ExperienceSettingsSection } from './settings-experience-section';
 import { ImportExportSettingsSection } from './settings-import-export-section';
 import { PublishingSettingsSection } from './settings-publishing-section';
@@ -223,6 +224,8 @@ export function SettingsPanel({
           themePreset={themePreset}
           toneClasses={toneClasses}
         />
+
+        <EmbedSettingsSection shareCode={shareCode} toneClasses={toneClasses} />
 
         <SeoSettingsSection
           form={form}

--- a/apps/forms/src/features/forms/studio/settings-panel.tsx
+++ b/apps/forms/src/features/forms/studio/settings-panel.tsx
@@ -1,23 +1,6 @@
 'use client';
 
-import {
-  AlertTriangle,
-  CircleCheckBig,
-  ClipboardList,
-  Copy,
-  Download,
-  ExternalLink,
-  Eye,
-  FileText,
-  MessageSquare,
-  Upload,
-} from '@tuturuuu/icons';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@tuturuuu/ui/accordion';
+import { Accordion } from '@tuturuuu/ui/accordion';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -28,33 +11,30 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@tuturuuu/ui/alert-dialog';
-import { Button } from '@tuturuuu/ui/button';
-import { Checkbox } from '@tuturuuu/ui/checkbox';
-import { DateTimePicker } from '@tuturuuu/ui/date-time-picker';
 import { useWatch } from '@tuturuuu/ui/hooks/use-form';
-import { Input } from '@tuturuuu/ui/input';
-import { Label } from '@tuturuuu/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@tuturuuu/ui/select';
 import { toast } from '@tuturuuu/ui/sonner';
-import { Textarea } from '@tuturuuu/ui/textarea';
-import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
 import { useRef, useState } from 'react';
 
-import { getFormFontLabel } from '../fonts';
-import { FieldLabel } from '../form-icons';
-import type { FORM_ACCESS_MODE_VALUES, FormStudioInput } from '../schema';
-import { FORM_THEME_PRESETS, type getFormToneClasses } from '../theme';
+import type { FormStudioInput } from '../schema';
+import type { getFormToneClasses } from '../theme';
 import type { FormResponseSummary } from '../types';
+import { ExperienceSettingsSection } from './settings-experience-section';
+import { ImportExportSettingsSection } from './settings-import-export-section';
+import { PublishingSettingsSection } from './settings-publishing-section';
+import { SeoSettingsSection } from './settings-seo-section';
 import type { StudioForm } from './studio-utils';
 import { importFormStudioPayload } from './studio-utils';
 
+/**
+ * The settings tab.
+ *
+ * Orchestration only: it owns the import file input and its confirmation
+ * dialog, subscribes to the form values the sections need, and lays the
+ * sections out. Each section owns its own fields — the panel used to hold all
+ * of them inline and had grown to the repo's 700-line ceiling, which left no
+ * room to add one.
+ */
 export function SettingsPanel({
   form,
   shareCode,
@@ -64,6 +44,7 @@ export function SettingsPanel({
   onImport,
   isDirty,
   responseSummary,
+  wsId,
 }: {
   form: StudioForm;
   shareCode?: string | null;
@@ -73,6 +54,7 @@ export function SettingsPanel({
   onImport: (data: FormStudioInput) => void;
   isDirty: boolean;
   responseSummary: FormResponseSummary;
+  wsId: string;
 }) {
   const t = useTranslations('forms');
   const tCommon = useTranslations('common');
@@ -213,486 +195,47 @@ export function SettingsPanel({
         defaultValue={['publishing-and-access', 'experience-controls']}
         className="space-y-4"
       >
-        <AccordionItem
-          value="publishing-and-access"
-          className="overflow-hidden rounded-[1.75rem] border border-border/60 bg-card/80 px-6 shadow-sm"
-        >
-          <AccordionTrigger className="py-5 hover:no-underline">
-            <div className="flex items-start gap-3 text-left">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-background/70 text-muted-foreground">
-                <ExternalLink className="h-4 w-4" />
-              </span>
-              <div className="space-y-1">
-                <p className="font-semibold text-base">
-                  {t('settings.publishing_and_access')}
-                </p>
-                <p className="text-muted-foreground text-sm">
-                  {t('settings.share_link')}
-                </p>
-              </div>
-            </div>
-          </AccordionTrigger>
-          <AccordionContent className="overflow-hidden pb-0">
-            <div className="space-y-4 border-border/60 border-t pt-5 pb-5">
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <Label>
-                    <FieldLabel icon={ClipboardList}>
-                      {t('settings.status')}
-                    </FieldLabel>
-                  </Label>
-                  <Select
-                    value={status}
-                    onValueChange={(value) =>
-                      form.setValue(
-                        'status',
-                        value as FormStudioInput['status'],
-                        {
-                          shouldDirty: true,
-                        }
-                      )
-                    }
-                  >
-                    <SelectTrigger className={toneClasses.fieldClassName}>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="draft">{t('status.draft')}</SelectItem>
-                      <SelectItem value="published">
-                        {t('status.published')}
-                      </SelectItem>
-                      <SelectItem value="closed">
-                        {t('status.closed')}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label>
-                    <FieldLabel icon={CircleCheckBig}>
-                      {t('settings.responder_access')}
-                    </FieldLabel>
-                  </Label>
-                  <Select
-                    value={accessMode}
-                    onValueChange={(value) =>
-                      form.setValue(
-                        'accessMode',
-                        value as (typeof FORM_ACCESS_MODE_VALUES)[number],
-                        {
-                          shouldDirty: true,
-                        }
-                      )
-                    }
-                  >
-                    <SelectTrigger className={toneClasses.fieldClassName}>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="anonymous">
-                        {t('access_mode.anonymous')}
-                      </SelectItem>
-                      <SelectItem value="authenticated">
-                        {t('access_mode.authenticated')}
-                      </SelectItem>
-                      <SelectItem value="authenticated_email">
-                        {t('access_mode.authenticated_email')}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label>{t('settings.open_at')}</Label>
-                  <DateTimePicker
-                    date={openAt ? new Date(openAt) : undefined}
-                    setDate={(date) =>
-                      form.setValue('openAt', date?.toISOString() ?? null, {
-                        shouldDirty: true,
-                      })
-                    }
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label>{t('settings.close_at')}</Label>
-                  <DateTimePicker
-                    date={closeAt ? new Date(closeAt) : undefined}
-                    setDate={(date) =>
-                      form.setValue('closeAt', date?.toISOString() ?? null, {
-                        shouldDirty: true,
-                      })
-                    }
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label>
-                    <FieldLabel icon={ClipboardList}>
-                      {t('settings.maximum_responses')}
-                    </FieldLabel>
-                  </Label>
-                  <Input
-                    type="number"
-                    className={toneClasses.fieldClassName}
-                    placeholder={t('settings.unlimited')}
-                    value={maxResponses ?? ''}
-                    onChange={(event) =>
-                      form.setValue(
-                        'maxResponses',
-                        event.target.value ? Number(event.target.value) : null,
-                        {
-                          shouldDirty: true,
-                        }
-                      )
-                    }
-                  />
-                </div>
-                <div className="space-y-2 md:col-span-2">
-                  <Label>
-                    <FieldLabel icon={ExternalLink}>
-                      {t('settings.share_link')}
-                    </FieldLabel>
-                  </Label>
-                  <div className="rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
-                    <div className="flex items-center gap-2">
-                      <Input
-                        value={
-                          shareCode
-                            ? shareUrl
-                            : t('settings.publish_to_create_share_link')
-                        }
-                        className={toneClasses.fieldClassName}
-                        readOnly
-                      />
-                    </div>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className={toneClasses.secondaryButtonClassName}
-                        onClick={onOpenPreview}
-                      >
-                        <Eye className="mr-2 h-4 w-4" />
-                        {t('settings.open_preview_tab')}
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className={toneClasses.secondaryButtonClassName}
-                        disabled={!canOpenLiveForm}
-                        onClick={() => {
-                          if (canOpenLiveForm) {
-                            window.open(
-                              shareUrl,
-                              '_blank',
-                              'noopener,noreferrer'
-                            );
-                          }
-                        }}
-                      >
-                        <ExternalLink className="mr-2 h-4 w-4" />
-                        {t('settings.open_live_form')}
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className={toneClasses.secondaryButtonClassName}
-                        disabled={!shareCode}
-                        onClick={async () => {
-                          if (!shareCode) return;
-                          await navigator.clipboard.writeText(shareUrl);
-                          toast.success(t('toast.share_link_copied'));
-                        }}
-                      >
-                        <Copy className="mr-2 h-4 w-4" />
-                        {t('settings.copy_share_link')}
-                      </Button>
-                    </div>
-                    <p className="mt-3 text-muted-foreground text-xs">
-                      {isDirty
-                        ? t('settings.live_form_save_hint')
-                        : canOpenLiveForm
-                          ? t('settings.live_form_hint')
-                          : t('settings.live_form_publish_hint')}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
+        <PublishingSettingsSection
+          accessMode={accessMode}
+          canOpenLiveForm={canOpenLiveForm}
+          closeAt={closeAt}
+          form={form}
+          isDirty={isDirty}
+          maxResponses={maxResponses}
+          onOpenPreview={onOpenPreview}
+          openAt={openAt}
+          shareCode={shareCode}
+          shareUrl={shareUrl}
+          status={status}
+          toneClasses={toneClasses}
+        />
 
-        <AccordionItem
-          value="experience-controls"
-          className="overflow-hidden rounded-[1.75rem] border border-border/60 bg-card/80 px-6 shadow-sm"
-        >
-          <AccordionTrigger className="py-5 hover:no-underline">
-            <div className="flex items-start gap-3 text-left">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-background/70 text-muted-foreground">
-                <CircleCheckBig className="h-4 w-4" />
-              </span>
-              <div className="space-y-1">
-                <p className="font-semibold text-base">
-                  {t('settings.experience_controls')}
-                </p>
-                <p className="text-muted-foreground text-sm">
-                  {t('settings.responses_recorded')}
-                </p>
-              </div>
-            </div>
-          </AccordionTrigger>
-          <AccordionContent className="overflow-hidden pb-0">
-            <div className="space-y-4 border-border/60 border-t pt-5 pb-5">
-              <div className="rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
-                <div className="grid gap-2 sm:grid-cols-3">
-                  <div className="rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
-                    <p className="text-[11px] text-muted-foreground uppercase tracking-[0.24em]">
-                      {t('settings.responses_recorded')}
-                    </p>
-                    <p className="mt-1 font-semibold text-lg">
-                      {responseSummary.totalSubmissions}
-                    </p>
-                  </div>
-                  <div className="rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
-                    <p className="text-[11px] text-muted-foreground uppercase tracking-[0.24em]">
-                      {t('settings.responders')}
-                    </p>
-                    <p className="mt-1 font-semibold text-lg">
-                      {responseSummary.totalResponders}
-                    </p>
-                  </div>
-                  <div className="rounded-2xl border border-border/60 bg-background/60 px-4 py-3">
-                    <p className="text-[11px] text-muted-foreground uppercase tracking-[0.24em]">
-                      {t('settings.repeat_users')}
-                    </p>
-                    <p className="mt-1 font-semibold text-lg">
-                      {responseSummary.duplicateAuthenticatedResponders}
-                    </p>
-                  </div>
-                </div>
-              </div>
+        <ExperienceSettingsSection
+          accessMode={accessMode}
+          allowMultipleSubmissions={allowMultipleSubmissions}
+          bodyFontId={bodyFontId}
+          form={form}
+          headlineFontId={headlineFontId}
+          oneResponseLimitLocked={oneResponseLimitLocked}
+          oneResponsePerUser={oneResponsePerUser}
+          responseSummary={responseSummary}
+          showProgressBar={showProgressBar}
+          themePreset={themePreset}
+          toneClasses={toneClasses}
+        />
 
-              <div className="space-y-3 rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
-                <label
-                  className={cn(
-                    'flex items-center gap-3 rounded-2xl border px-4 py-3',
-                    toneClasses.optionCardClassName
-                  )}
-                >
-                  <Checkbox
-                    className={toneClasses.checkboxClassName}
-                    checked={!!showProgressBar}
-                    onCheckedChange={(checked) =>
-                      form.setValue(
-                        'settings.showProgressBar',
-                        checked === true,
-                        {
-                          shouldDirty: true,
-                        }
-                      )
-                    }
-                  />
-                  <span className="text-sm">
-                    {t('settings.show_progress_bar')}
-                  </span>
-                </label>
+        <SeoSettingsSection
+          form={form}
+          shareCode={shareCode}
+          toneClasses={toneClasses}
+          wsId={wsId}
+        />
 
-                <label
-                  className={cn(
-                    'flex items-center gap-3 rounded-2xl border px-4 py-3',
-                    toneClasses.optionCardClassName
-                  )}
-                >
-                  <Checkbox
-                    className={toneClasses.checkboxClassName}
-                    checked={!!allowMultipleSubmissions}
-                    onCheckedChange={(checked) =>
-                      form.setValue(
-                        'settings.allowMultipleSubmissions',
-                        checked === true,
-                        {
-                          shouldDirty: true,
-                        }
-                      )
-                    }
-                  />
-                  <span className="text-sm">
-                    {t('settings.allow_multiple_submissions')}
-                  </span>
-                </label>
-
-                <label
-                  className={cn(
-                    'flex items-start gap-3 rounded-2xl border px-4 py-3',
-                    oneResponseLimitLocked && 'cursor-not-allowed opacity-70',
-                    toneClasses.optionCardClassName
-                  )}
-                >
-                  <Checkbox
-                    className={toneClasses.checkboxClassName}
-                    checked={!!oneResponsePerUser}
-                    disabled={oneResponseLimitLocked}
-                    onCheckedChange={(checked) =>
-                      form.setValue(
-                        'settings.oneResponsePerUser',
-                        checked === true,
-                        {
-                          shouldDirty: true,
-                        }
-                      )
-                    }
-                  />
-                  <div className="space-y-1">
-                    <span className="block text-sm">
-                      {t('settings.one_response_per_user')}
-                    </span>
-                    <span className="block text-muted-foreground text-xs">
-                      {t('settings.one_response_per_user_hint')}
-                    </span>
-                  </div>
-                </label>
-                {oneResponsePerUser && accessMode === 'anonymous' ? (
-                  <div className="rounded-2xl border border-dynamic-orange/35 bg-dynamic-orange/8 px-4 py-3">
-                    <div className="flex items-start gap-3">
-                      <div className="rounded-full border border-dynamic-orange/35 bg-dynamic-orange/12 p-2 text-dynamic-orange">
-                        <AlertTriangle className="h-4 w-4" />
-                      </div>
-                      <div className="space-y-1">
-                        <p className="font-medium text-dynamic-orange text-sm">
-                          {t('settings.anonymous_one_response_warning_title')}
-                        </p>
-                        <p className="text-muted-foreground text-sm">
-                          {t(
-                            'settings.anonymous_one_response_warning_description'
-                          )}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                ) : null}
-
-                <div className="rounded-2xl border border-dynamic-blue/25 bg-dynamic-blue/8 px-4 py-3">
-                  <p className="font-medium text-dynamic-blue text-sm">
-                    {t('settings.turnstile_always_on')}
-                  </p>
-                  <p className="mt-1 text-muted-foreground text-xs">
-                    {t('settings.turnstile_always_on_hint')}
-                  </p>
-                </div>
-              </div>
-
-              {responseSummary.hasMultipleSubmissionsByUser ? (
-                <div className="rounded-2xl border border-dynamic-orange/35 bg-dynamic-orange/8 px-4 py-3">
-                  <div className="flex items-start gap-3">
-                    <div className="rounded-full border border-dynamic-orange/35 bg-dynamic-orange/12 p-2 text-dynamic-orange">
-                      <AlertTriangle className="h-4 w-4" />
-                    </div>
-                    <div className="space-y-1">
-                      <p className="font-medium text-dynamic-orange text-sm">
-                        {t('settings.one_response_warning_title')}
-                      </p>
-                      <p className="text-muted-foreground text-sm">
-                        {t('settings.one_response_warning_description', {
-                          responders:
-                            responseSummary.duplicateAuthenticatedResponders,
-                          submissions:
-                            responseSummary.duplicateAuthenticatedSubmissions,
-                        })}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-
-              <div className="space-y-4 rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
-                <div className="space-y-2">
-                  <Label>
-                    <FieldLabel icon={FileText}>
-                      {t('settings.confirmation_title')}
-                    </FieldLabel>
-                  </Label>
-                  <Input
-                    {...form.register('settings.confirmationTitle')}
-                    className={toneClasses.fieldClassName}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label>
-                    <FieldLabel icon={MessageSquare}>
-                      {t('settings.confirmation_message')}
-                    </FieldLabel>
-                  </Label>
-                  <Textarea
-                    {...form.register('settings.confirmationMessage')}
-                    className={toneClasses.fieldClassName}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <p className="text-muted-foreground text-xs">
-                    {t('settings.current_theme', {
-                      theme:
-                        FORM_THEME_PRESETS.find(
-                          (preset) => preset.id === themePreset
-                        )?.name ?? '',
-                    })}
-                  </p>
-                  <p className="text-muted-foreground text-xs">
-                    {t('settings.current_fonts', {
-                      headline: getFormFontLabel(headlineFontId),
-                      body: getFormFontLabel(bodyFontId),
-                    })}
-                  </p>
-                </div>
-              </div>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-
-        <AccordionItem
-          value="import-export"
-          className="overflow-hidden rounded-[1.75rem] border border-border/60 bg-card/80 px-6 shadow-sm"
-        >
-          <AccordionTrigger className="py-5 hover:no-underline">
-            <div className="flex items-start gap-3 text-left">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-background/70 text-muted-foreground">
-                <Download className="h-4 w-4" />
-              </span>
-              <div className="space-y-1">
-                <p className="font-semibold text-base">
-                  {t('settings.import_export')}
-                </p>
-                <p className="text-muted-foreground text-sm">
-                  {t('settings.import_export_description')}
-                </p>
-              </div>
-            </div>
-          </AccordionTrigger>
-          <AccordionContent className="overflow-hidden pb-0">
-            <div className="space-y-4 border-border/60 border-t pt-5 pb-5">
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className={toneClasses.secondaryButtonClassName}
-                  onClick={onExport}
-                >
-                  <Download className="mr-2 h-4 w-4" />
-                  {t('settings.export_form')}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  className={toneClasses.secondaryButtonClassName}
-                  onClick={triggerImportFileInput}
-                >
-                  <Upload className="mr-2 h-4 w-4" />
-                  {t('settings.import_form')}
-                </Button>
-              </div>
-              <p className="text-muted-foreground text-xs">
-                {t('settings.import_export_hint')}
-              </p>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
+        <ImportExportSettingsSection
+          onExport={onExport}
+          toneClasses={toneClasses}
+          triggerImportFileInput={triggerImportFileInput}
+        />
       </Accordion>
     </>
   );

--- a/apps/forms/src/features/forms/studio/settings-publishing-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-publishing-section.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import {
+  CircleCheckBig,
+  ClipboardList,
+  Copy,
+  ExternalLink,
+  Eye,
+} from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { DateTimePicker } from '@tuturuuu/ui/date-time-picker';
+import { Input } from '@tuturuuu/ui/input';
+import { Label } from '@tuturuuu/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@tuturuuu/ui/select';
+import { toast } from '@tuturuuu/ui/sonner';
+import { useTranslations } from 'next-intl';
+import { FieldLabel } from '../form-icons';
+import type { FORM_ACCESS_MODE_VALUES, FormStudioInput } from '../schema';
+import type { getFormToneClasses } from '../theme';
+import { SettingsSection } from './settings-section';
+import type { StudioForm } from './studio-utils';
+
+/** Status, access mode, scheduling, response cap, and the public share link. */
+export function PublishingSettingsSection({
+  accessMode,
+  canOpenLiveForm,
+  closeAt,
+  form,
+  isDirty,
+  maxResponses,
+  onOpenPreview,
+  openAt,
+  shareCode,
+  shareUrl,
+  status,
+  toneClasses,
+}: {
+  accessMode: FormStudioInput['accessMode'];
+  canOpenLiveForm: boolean;
+  closeAt: FormStudioInput['closeAt'];
+  form: StudioForm;
+  isDirty: boolean;
+  maxResponses: FormStudioInput['maxResponses'];
+  onOpenPreview: () => void;
+  openAt: FormStudioInput['openAt'];
+  shareCode?: string | null;
+  shareUrl: string;
+  status: FormStudioInput['status'];
+  toneClasses: ReturnType<typeof getFormToneClasses>;
+}) {
+  const t = useTranslations('forms');
+
+  return (
+    <SettingsSection
+      description={t('settings.share_link')}
+      icon={ExternalLink}
+      title={t('settings.publishing_and_access')}
+      value="publishing-and-access"
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label>
+            <FieldLabel icon={ClipboardList}>{t('settings.status')}</FieldLabel>
+          </Label>
+          <Select
+            value={status}
+            onValueChange={(value) =>
+              form.setValue('status', value as FormStudioInput['status'], {
+                shouldDirty: true,
+              })
+            }
+          >
+            <SelectTrigger className={toneClasses.fieldClassName}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="draft">{t('status.draft')}</SelectItem>
+              <SelectItem value="published">{t('status.published')}</SelectItem>
+              <SelectItem value="closed">{t('status.closed')}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label>
+            <FieldLabel icon={CircleCheckBig}>
+              {t('settings.responder_access')}
+            </FieldLabel>
+          </Label>
+          <Select
+            value={accessMode}
+            onValueChange={(value) =>
+              form.setValue(
+                'accessMode',
+                value as (typeof FORM_ACCESS_MODE_VALUES)[number],
+                {
+                  shouldDirty: true,
+                }
+              )
+            }
+          >
+            <SelectTrigger className={toneClasses.fieldClassName}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="anonymous">
+                {t('access_mode.anonymous')}
+              </SelectItem>
+              <SelectItem value="authenticated">
+                {t('access_mode.authenticated')}
+              </SelectItem>
+              <SelectItem value="authenticated_email">
+                {t('access_mode.authenticated_email')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label>{t('settings.open_at')}</Label>
+          <DateTimePicker
+            date={openAt ? new Date(openAt) : undefined}
+            setDate={(date) =>
+              form.setValue('openAt', date?.toISOString() ?? null, {
+                shouldDirty: true,
+              })
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>{t('settings.close_at')}</Label>
+          <DateTimePicker
+            date={closeAt ? new Date(closeAt) : undefined}
+            setDate={(date) =>
+              form.setValue('closeAt', date?.toISOString() ?? null, {
+                shouldDirty: true,
+              })
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>
+            <FieldLabel icon={ClipboardList}>
+              {t('settings.maximum_responses')}
+            </FieldLabel>
+          </Label>
+          <Input
+            type="number"
+            className={toneClasses.fieldClassName}
+            placeholder={t('settings.unlimited')}
+            value={maxResponses ?? ''}
+            onChange={(event) =>
+              form.setValue(
+                'maxResponses',
+                event.target.value ? Number(event.target.value) : null,
+                {
+                  shouldDirty: true,
+                }
+              )
+            }
+          />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <Label>
+            <FieldLabel icon={ExternalLink}>
+              {t('settings.share_link')}
+            </FieldLabel>
+          </Label>
+          <div className="rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
+            <div className="flex items-center gap-2">
+              <Input
+                value={
+                  shareCode
+                    ? shareUrl
+                    : t('settings.publish_to_create_share_link')
+                }
+                className={toneClasses.fieldClassName}
+                readOnly
+              />
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                className={toneClasses.secondaryButtonClassName}
+                onClick={onOpenPreview}
+              >
+                <Eye className="mr-2 h-4 w-4" />
+                {t('settings.open_preview_tab')}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className={toneClasses.secondaryButtonClassName}
+                disabled={!canOpenLiveForm}
+                onClick={() => {
+                  if (canOpenLiveForm) {
+                    window.open(shareUrl, '_blank', 'noopener,noreferrer');
+                  }
+                }}
+              >
+                <ExternalLink className="mr-2 h-4 w-4" />
+                {t('settings.open_live_form')}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className={toneClasses.secondaryButtonClassName}
+                disabled={!shareCode}
+                onClick={async () => {
+                  if (!shareCode) return;
+                  await navigator.clipboard.writeText(shareUrl);
+                  toast.success(t('toast.share_link_copied'));
+                }}
+              >
+                <Copy className="mr-2 h-4 w-4" />
+                {t('settings.copy_share_link')}
+              </Button>
+            </div>
+            <p className="mt-3 text-muted-foreground text-xs">
+              {isDirty
+                ? t('settings.live_form_save_hint')
+                : canOpenLiveForm
+                  ? t('settings.live_form_hint')
+                  : t('settings.live_form_publish_hint')}
+            </p>
+          </div>
+        </div>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/forms/src/features/forms/studio/settings-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-section.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@tuturuuu/ui/accordion';
+import type { ComponentType, ReactNode } from 'react';
+
+/**
+ * One collapsible block in the studio's settings tab.
+ *
+ * Every section used to repeat the same twenty lines of trigger markup — icon
+ * chip, title, subtitle, the same paddings and border treatment. Extracting it
+ * means a change to the settings language lands on all of them at once, and a
+ * new section is a title plus its fields.
+ */
+export function SettingsSection({
+  value,
+  icon: Icon,
+  title,
+  description,
+  children,
+}: {
+  /** Accordion item id; also what `defaultValue` on the parent refers to. */
+  value: string;
+  icon: ComponentType<{ className?: string }>;
+  title: ReactNode;
+  description: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <AccordionItem
+      className="overflow-hidden rounded-[1.75rem] border border-border/60 bg-card/80 px-6 shadow-sm"
+      value={value}
+    >
+      <AccordionTrigger className="py-5 hover:no-underline">
+        <div className="flex items-start gap-3 text-left">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-background/70 text-muted-foreground">
+            <Icon className="h-4 w-4" />
+          </span>
+          <div className="space-y-1">
+            <p className="font-semibold text-base">{title}</p>
+            <p className="text-muted-foreground text-sm">{description}</p>
+          </div>
+        </div>
+      </AccordionTrigger>
+      <AccordionContent className="overflow-hidden pb-0">
+        <div className="space-y-4 border-border/60 border-t pt-5 pb-5">
+          {children}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  );
+}

--- a/apps/forms/src/features/forms/studio/settings-seo-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-seo-section.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { Globe2, Search } from '@tuturuuu/icons';
+import { Checkbox } from '@tuturuuu/ui/checkbox';
+import { useWatch } from '@tuturuuu/ui/hooks/use-form';
+import { Input } from '@tuturuuu/ui/input';
+import { Label } from '@tuturuuu/ui/label';
+import { Textarea } from '@tuturuuu/ui/textarea';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import { FieldLabel } from '../form-icons';
+import {
+  FORM_SEO_DESCRIPTION_MAX_LENGTH,
+  FORM_SEO_KEYWORDS_MAX_COUNT,
+  FORM_SEO_TITLE_MAX_LENGTH,
+} from '../schema';
+import type { getFormToneClasses } from '../theme';
+import { FormMediaField } from './form-media-field';
+import { SearchResultPreview } from './seo-preview';
+import { SettingsSection } from './settings-section';
+import type { StudioForm } from './studio-utils';
+
+/**
+ * Keywords are stored as an array but edited as one comma-separated line: a
+ * repeatable row editor is a lot of interface for a field most authors leave
+ * empty, and the array is what the metadata layer wants.
+ */
+function parseKeywords(value: string) {
+  return [
+    ...new Set(
+      value
+        .split(',')
+        .map((keyword) => keyword.trim())
+        .filter(Boolean)
+    ),
+  ].slice(0, FORM_SEO_KEYWORDS_MAX_COUNT);
+}
+
+/**
+ * Search and social metadata for the public form page.
+ *
+ * Every field is an override: left empty, the value is derived from the form's
+ * own title, description and generated social card, which is what happened
+ * before this panel existed. The preview shows the resolved result rather than
+ * the raw override, so an empty field visibly falls back instead of looking
+ * broken.
+ */
+export function SeoSettingsSection({
+  form,
+  shareCode,
+  toneClasses,
+  wsId,
+}: {
+  form: StudioForm;
+  shareCode?: string | null;
+  toneClasses: ReturnType<typeof getFormToneClasses>;
+  wsId: string;
+}) {
+  const t = useTranslations('forms');
+
+  const formTitle = useWatch({ control: form.control, name: 'title' });
+  const formDescription = useWatch({
+    control: form.control,
+    name: 'description',
+  });
+  const coverHeadline = useWatch({
+    control: form.control,
+    name: 'theme.coverHeadline',
+  });
+  const seoTitle = useWatch({ control: form.control, name: 'seo.title' });
+  const seoDescription = useWatch({
+    control: form.control,
+    name: 'seo.description',
+  });
+  const keywords = useWatch({ control: form.control, name: 'seo.keywords' });
+  const noIndex = useWatch({ control: form.control, name: 'seo.noIndex' });
+  const seoImage = useWatch({ control: form.control, name: 'seo.image' });
+
+  return (
+    <SettingsSection
+      description={t('settings.seo_description')}
+      icon={Search}
+      title={t('settings.seo')}
+      value="seo"
+    >
+      <SearchResultPreview
+        description={seoDescription || formDescription}
+        fallbackDescription={t('shared.metadata_fallback_description')}
+        fallbackTitle={t('shared.metadata_fallback_title')}
+        shareCode={shareCode}
+        title={seoTitle || coverHeadline || formTitle}
+      />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="seo-title">
+            <FieldLabel icon={Search}>{t('settings.seo_title')}</FieldLabel>
+          </Label>
+          <Input
+            id="seo-title"
+            maxLength={FORM_SEO_TITLE_MAX_LENGTH}
+            placeholder={t('settings.seo_title_placeholder')}
+            {...form.register('seo.title')}
+          />
+          <p className="text-muted-foreground text-xs">
+            {t('settings.seo_title_hint')}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="seo-canonical">
+            <FieldLabel icon={Globe2}>{t('settings.seo_canonical')}</FieldLabel>
+          </Label>
+          <Input
+            id="seo-canonical"
+            inputMode="url"
+            placeholder="https://example.com/apply"
+            {...form.register('seo.canonicalUrl')}
+          />
+          <p className="text-muted-foreground text-xs">
+            {t('settings.seo_canonical_hint')}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="seo-description">
+          <FieldLabel icon={Search}>
+            {t('settings.seo_meta_description')}
+          </FieldLabel>
+        </Label>
+        <Textarea
+          id="seo-description"
+          maxLength={FORM_SEO_DESCRIPTION_MAX_LENGTH}
+          placeholder={t('settings.seo_meta_description_placeholder')}
+          rows={3}
+          {...form.register('seo.description')}
+        />
+        <p className="text-muted-foreground text-xs">
+          {t('settings.seo_meta_description_hint')}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="seo-keywords">
+          <FieldLabel icon={Search}>{t('settings.seo_keywords')}</FieldLabel>
+        </Label>
+        <Input
+          id="seo-keywords"
+          onChange={(event) =>
+            form.setValue('seo.keywords', parseKeywords(event.target.value), {
+              shouldDirty: true,
+            })
+          }
+          placeholder={t('settings.seo_keywords_placeholder')}
+          value={(keywords ?? []).join(', ')}
+        />
+        <p className="text-muted-foreground text-xs">
+          {t('settings.seo_keywords_hint', {
+            max: FORM_SEO_KEYWORDS_MAX_COUNT,
+          })}
+        </p>
+      </div>
+
+      <FormMediaField
+        hint={t('settings.seo_image_hint')}
+        label={t('settings.seo_image')}
+        onChange={(value) =>
+          form.setValue('seo.image', value, { shouldDirty: true })
+        }
+        scope="social"
+        toneClasses={toneClasses}
+        value={seoImage}
+        wsId={wsId}
+      />
+
+      <button
+        className={cn(
+          'flex w-full items-start gap-3 rounded-2xl border px-4 py-3 text-left transition-colors',
+          noIndex
+            ? 'border-dynamic-orange/35 bg-dynamic-orange/8'
+            : 'border-border/60 bg-background/55'
+        )}
+        onClick={() =>
+          form.setValue('seo.noIndex', !noIndex, { shouldDirty: true })
+        }
+        type="button"
+      >
+        <Checkbox
+          checked={noIndex}
+          className="pointer-events-none mt-0.5"
+          tabIndex={-1}
+        />
+        <span className="space-y-1">
+          <span className="block font-medium text-sm">
+            {t('settings.seo_no_index')}
+          </span>
+          <span className="block text-muted-foreground text-xs">
+            {t('settings.seo_no_index_hint')}
+          </span>
+        </span>
+      </button>
+    </SettingsSection>
+  );
+}

--- a/apps/forms/src/features/forms/studio/studio-save-button.tsx
+++ b/apps/forms/src/features/forms/studio/studio-save-button.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Button } from '@tuturuuu/ui/button';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import type { Ref } from 'react';
+import type { FormsTranslator } from '../runtime/types';
+
+export interface StudioSaveState {
+  autosaveEnabled: boolean;
+  autosaveStatus: 'idle' | 'saving' | 'saved' | 'error';
+  isDirty: boolean;
+  isPending: boolean;
+  mode: 'create' | 'edit';
+  secondsUntilAutosave: number;
+}
+
+/**
+ * The save button's label carries the whole autosave state machine — pending,
+ * failed, counting down, just-saved, create-vs-update. It is rendered in two
+ * places (the header and the floating action), and the two copies had drifted
+ * out of a single edit more than once, so the label lives here on its own.
+ */
+export function getStudioSaveLabel(state: StudioSaveState, t: FormsTranslator) {
+  if (state.isPending) {
+    return t('studio.saving');
+  }
+
+  if (state.autosaveStatus === 'error') {
+    return t('studio.autosave_failed');
+  }
+
+  if (
+    state.autosaveEnabled &&
+    state.isDirty &&
+    state.secondsUntilAutosave > 0
+  ) {
+    return t('studio.autosave_in_seconds', {
+      seconds: state.secondsUntilAutosave,
+    });
+  }
+
+  if (state.autosaveStatus === 'saved') {
+    return t('studio.autosave_saved');
+  }
+
+  return state.mode === 'create'
+    ? t('studio.create_form')
+    : t('studio.save_changes');
+}
+
+export function StudioSaveButton({
+  buttonRef,
+  className,
+  disabled,
+  onClick,
+  state,
+}: {
+  buttonRef?: Ref<HTMLButtonElement>;
+  className?: string;
+  disabled: boolean;
+  onClick: () => void;
+  state: StudioSaveState;
+}) {
+  const t = useTranslations('forms');
+
+  return (
+    <Button
+      className={cn('rounded-2xl px-5', className)}
+      disabled={disabled}
+      onClick={onClick}
+      ref={buttonRef}
+      type="button"
+    >
+      {getStudioSaveLabel(state, t)}
+    </Button>
+  );
+}

--- a/apps/forms/src/features/forms/studio/studio-utils.ts
+++ b/apps/forms/src/features/forms/studio/studio-utils.ts
@@ -375,6 +375,7 @@ export function toStudioInput(form?: FormDefinition): FormStudioInput {
     maxResponses: form.maxResponses,
     theme: form.theme,
     settings: form.settings,
+    seo: form.seo,
     sections: form.sections.map((section) => ({
       id: section.id,
       title: section.title,
@@ -439,6 +440,7 @@ export function toPreviewDefinition(
       sectionImages: resolvedSectionImages,
     },
     settings: values.settings,
+    seo: values.seo,
     sections: values.sections.map((section) => ({
       ...section,
       id: section.id ?? createClientId(),

--- a/apps/forms/src/features/forms/test-support/form-fixtures.ts
+++ b/apps/forms/src/features/forms/test-support/form-fixtures.ts
@@ -1,0 +1,55 @@
+import { createDefaultFormStudioInput } from '../schema';
+import type { FormDefinition, FormDefinitionSection } from '../types';
+
+/**
+ * Shared `FormDefinition` factory for tests.
+ *
+ * Every suite that needs a form used to inline the whole literal — theme,
+ * typography, settings, the lot — which meant adding one field to the type
+ * broke six files at once and each fixture drifted from the real defaults.
+ * Building from `createDefaultFormStudioInput()` keeps them honest: a new field
+ * with a default is picked up here automatically.
+ */
+export function createTestFormDefinition(
+  overrides: Partial<FormDefinition> = {}
+): FormDefinition {
+  const defaults = createDefaultFormStudioInput();
+  const timestamp = new Date(0).toISOString();
+
+  return {
+    id: '50000000-0000-0000-0000-000000000001',
+    wsId: '50000000-0000-0000-0000-000000000002',
+    creatorId: '50000000-0000-0000-0000-000000000003',
+    title: 'Test form',
+    description: '',
+    status: 'published',
+    accessMode: 'anonymous',
+    openAt: null,
+    closeAt: null,
+    maxResponses: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    shareCode: null,
+    theme: defaults.theme,
+    // Turnstile is on by default in production but would need a live widget in
+    // a test, so fixtures opt out unless a suite asks for it.
+    settings: { ...defaults.settings, requireTurnstile: false },
+    seo: defaults.seo,
+    sections: [],
+    logicRules: [],
+    ...overrides,
+  };
+}
+
+/** Convenience for the common "one section of N questions" shape. */
+export function createTestFormSection(
+  overrides: Partial<FormDefinitionSection> & { id: string }
+): FormDefinitionSection {
+  return {
+    title: '',
+    description: '',
+    image: { storagePath: '', url: '', alt: '' },
+    questions: [],
+    ...overrides,
+  };
+}

--- a/apps/forms/src/features/landing/cta-slots.tsx
+++ b/apps/forms/src/features/landing/cta-slots.tsx
@@ -1,0 +1,33 @@
+import { Suspense } from 'react';
+import { NavCta, PrimaryLandingCta, SessionAwareCta } from './session-cta';
+
+/**
+ * Suspense-wrapped CTA slots.
+ *
+ * Each slot prerenders its signed-out variant and swaps to the signed-in one
+ * once the session resolves. Kept in one file so every call site on the page
+ * uses the same boundary shape — a mismatched fallback would flash different
+ * copy on hydration.
+ */
+
+export function NavCtaSlot() {
+  return (
+    <Suspense fallback={<NavCta authed={false} />}>
+      <SessionAwareCta
+        signedIn={<NavCta authed />}
+        signedOut={<NavCta authed={false} />}
+      />
+    </Suspense>
+  );
+}
+
+export function PrimaryCtaSlot() {
+  return (
+    <Suspense fallback={<PrimaryLandingCta authed={false} />}>
+      <SessionAwareCta
+        signedIn={<PrimaryLandingCta authed />}
+        signedOut={<PrimaryLandingCta authed={false} />}
+      />
+    </Suspense>
+  );
+}

--- a/apps/forms/src/features/landing/demo/demo-form.ts
+++ b/apps/forms/src/features/landing/demo/demo-form.ts
@@ -96,6 +96,13 @@ export function buildDemoForm(
     shareCode: null,
     theme,
     settings: {
+      // Sections mode on the landing: a visitor skimming the page should see
+      // what the form asks, not have to click through four screens to find out.
+      displayMode: 'sections',
+      welcomeEnabled: false,
+      welcomeTitle: '',
+      welcomeDescription: '',
+      welcomeButtonLabel: '',
       showProgressBar: true,
       allowMultipleSubmissions: true,
       oneResponsePerUser: false,

--- a/apps/forms/src/features/landing/demo/demo-form.ts
+++ b/apps/forms/src/features/landing/demo/demo-form.ts
@@ -1,0 +1,172 @@
+import type { FormThemeInput } from '@/features/forms/schema';
+import type {
+  FormDefinition,
+  FormDefinitionQuestion,
+} from '@/features/forms/types';
+
+/**
+ * The landing page's demo form is a real `FormDefinition` rendered through the
+ * real `FormRuntime`, not a screenshot or a bespoke mock. Visitors interact with
+ * the same component that serves live responses, so the demo cannot drift away
+ * from the product, and theme switching on the landing exercises exactly the
+ * code path the studio's theme picker drives.
+ */
+
+const EMPTY_MEDIA = { storagePath: '', url: '', alt: '' } as const;
+
+/** Stable ids — the runtime keys answers by question id. */
+const DEMO_IDS = {
+  form: '00000000-0000-4000-8000-000000000001',
+  section: '00000000-0000-4000-8000-000000000010',
+  role: '00000000-0000-4000-8000-000000000011',
+  priority: '00000000-0000-4000-8000-000000000012',
+  satisfaction: '00000000-0000-4000-8000-000000000013',
+  notes: '00000000-0000-4000-8000-000000000014',
+} as const;
+
+export interface DemoFormCopy {
+  title: string;
+  description: string;
+  confirmationTitle: string;
+  confirmationMessage: string;
+  sectionTitle: string;
+  sectionDescription: string;
+  roleTitle: string;
+  roleOptions: string[];
+  priorityTitle: string;
+  priorityDescription: string;
+  priorityOptions: string[];
+  satisfactionTitle: string;
+  satisfactionMinLabel: string;
+  satisfactionMaxLabel: string;
+  notesTitle: string;
+  notesPlaceholder: string;
+}
+
+function choiceQuestion(
+  id: string,
+  type: 'single_choice' | 'multiple_choice',
+  title: string,
+  labels: string[],
+  extras: Partial<FormDefinitionQuestion> = {}
+): FormDefinitionQuestion {
+  return {
+    id,
+    sectionId: DEMO_IDS.section,
+    type,
+    title,
+    description: '',
+    required: false,
+    image: { ...EMPTY_MEDIA },
+    settings: { optionLayout: 'grid' },
+    options: labels.map((label, index) => ({
+      id: `${id}-opt-${index}`,
+      label,
+      value: `option-${index + 1}`,
+      image: { ...EMPTY_MEDIA },
+    })),
+    ...extras,
+  };
+}
+
+/**
+ * Builds the demo definition for a given theme. `theme` is passed in rather
+ * than baked in so the landing's theme switcher can rebuild the form without
+ * duplicating the question tree.
+ */
+export function buildDemoForm(
+  copy: DemoFormCopy,
+  theme: FormThemeInput
+): FormDefinition {
+  const now = new Date(0).toISOString();
+
+  return {
+    id: DEMO_IDS.form,
+    wsId: 'demo',
+    creatorId: 'demo',
+    createdAt: now,
+    updatedAt: now,
+    title: copy.title,
+    description: copy.description,
+    status: 'published',
+    accessMode: 'anonymous',
+    openAt: null,
+    closeAt: null,
+    maxResponses: null,
+    shareCode: null,
+    theme,
+    settings: {
+      showProgressBar: true,
+      allowMultipleSubmissions: true,
+      oneResponsePerUser: false,
+      // Turnstile only mounts in `public` mode; the demo runs in `preview`.
+      requireTurnstile: false,
+      confirmationTitle: copy.confirmationTitle,
+      confirmationMessage: copy.confirmationMessage,
+    },
+    // The demo is never crawled as a form page of its own, so it carries no
+    // SEO overrides — the landing route supplies the page's metadata.
+    seo: {
+      title: '',
+      description: '',
+      image: { ...EMPTY_MEDIA },
+      keywords: [],
+      canonicalUrl: '',
+      noIndex: false,
+    },
+    logicRules: [],
+    sections: [
+      {
+        id: DEMO_IDS.section,
+        title: copy.sectionTitle,
+        description: copy.sectionDescription,
+        image: { ...EMPTY_MEDIA },
+        questions: [
+          choiceQuestion(
+            DEMO_IDS.role,
+            'single_choice',
+            copy.roleTitle,
+            copy.roleOptions,
+            { required: true }
+          ),
+          choiceQuestion(
+            DEMO_IDS.priority,
+            'multiple_choice',
+            copy.priorityTitle,
+            copy.priorityOptions,
+            { description: copy.priorityDescription }
+          ),
+          {
+            id: DEMO_IDS.satisfaction,
+            sectionId: DEMO_IDS.section,
+            type: 'linear_scale',
+            title: copy.satisfactionTitle,
+            description: '',
+            required: false,
+            image: { ...EMPTY_MEDIA },
+            settings: {
+              scaleMin: 1,
+              scaleMax: 5,
+              minLabel: copy.satisfactionMinLabel,
+              maxLabel: copy.satisfactionMaxLabel,
+            },
+            options: [],
+          },
+          {
+            id: DEMO_IDS.notes,
+            sectionId: DEMO_IDS.section,
+            type: 'long_text',
+            title: copy.notesTitle,
+            description: '',
+            required: false,
+            image: { ...EMPTY_MEDIA },
+            settings: { placeholder: copy.notesPlaceholder },
+            options: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export { DEMO_IDS };

--- a/apps/forms/src/features/landing/demo/live-demo.tsx
+++ b/apps/forms/src/features/landing/demo/live-demo.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { Check, Palette } from '@tuturuuu/icons';
+import { cn } from '@tuturuuu/utils/format';
+import { useMemo, useState } from 'react';
+import { FormRuntime } from '@/features/forms/form-runtime';
+import type { FormThemeInput } from '@/features/forms/schema';
+import {
+  FORM_ACCENT_BADGE_CLASSES,
+  getThemePreset,
+} from '@/features/forms/theme';
+import { buildDemoForm, type DemoFormCopy } from './demo-form';
+
+/** Presets offered on the landing, in the order they read best left to right. */
+const SHOWCASE_PRESET_IDS = [
+  'editorial-moss',
+  'velvet-signal',
+  'coastal-notes',
+  'signal-coral',
+  'night-ledger',
+  'rose-ritual',
+] as const;
+
+const BASE_THEME = {
+  density: 'balanced',
+  coverHeadline: '',
+  coverImage: { storagePath: '', url: '', alt: '' },
+  sectionImages: {},
+  typography: { displaySize: 'md', headingSize: 'md', bodySize: 'md' },
+} satisfies Omit<
+  FormThemeInput,
+  'presetId' | 'accentColor' | 'headlineFontId' | 'bodyFontId' | 'surfaceStyle'
+>;
+
+function themeForPreset(presetId: string): FormThemeInput {
+  const preset = getThemePreset(presetId);
+
+  return {
+    ...BASE_THEME,
+    presetId: preset.id,
+    accentColor: preset.accentColor,
+    headlineFontId: preset.headlineFontId,
+    bodyFontId: preset.bodyFontId,
+    surfaceStyle: preset.surfaceStyle,
+  };
+}
+
+interface LiveDemoProps {
+  copy: DemoFormCopy;
+  /** Label for the theme switcher rail, e.g. "Try a theme". */
+  themeLabel: string;
+  className?: string;
+}
+
+/**
+ * Interactive product demo.
+ *
+ * Switching a preset rebuilds the definition and remounts the runtime through
+ * a keyed subtree. Remounting is deliberate: a theme change also changes the
+ * confirmation screen and font metrics, and a visitor who already submitted the
+ * demo should be dropped back at the top of a freshly themed form rather than
+ * left staring at a "thanks" card in a new colour.
+ */
+export function LiveDemo({ copy, themeLabel, className }: LiveDemoProps) {
+  const [presetId, setPresetId] = useState<string>(SHOWCASE_PRESET_IDS[0]);
+
+  const presets = useMemo(
+    () => SHOWCASE_PRESET_IDS.map((id) => getThemePreset(id)),
+    []
+  );
+  const form = useMemo(
+    () => buildDemoForm(copy, themeForPreset(presetId)),
+    [copy, presetId]
+  );
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 font-mono-ui text-[0.65rem] text-foreground/45 uppercase tracking-[0.18em]">
+          <Palette className="h-3.5 w-3.5" />
+          {themeLabel}
+        </span>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {presets.map((preset) => {
+            const active = preset.id === presetId;
+
+            return (
+              <button
+                aria-pressed={active}
+                className={cn(
+                  'group inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  active
+                    ? 'border-foreground/25 bg-foreground/[0.06] text-foreground'
+                    : 'border-foreground/10 text-foreground/55 hover:border-foreground/20 hover:text-foreground'
+                )}
+                key={preset.id}
+                onClick={() => setPresetId(preset.id)}
+                type="button"
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    'h-2.5 w-2.5 rounded-full',
+                    FORM_ACCENT_BADGE_CLASSES[preset.accentColor]
+                  )}
+                />
+                {preset.name}
+                {active ? <Check className="h-3 w-3" /> : null}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="relative overflow-hidden rounded-3xl border border-foreground/[0.08] bg-background/60 shadow-2xl shadow-foreground/[0.06] backdrop-blur-sm">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-10 top-0 h-px bg-[linear-gradient(90deg,transparent,color-mix(in_oklab,var(--foreground)_22%,transparent),transparent)]"
+        />
+        <div className="max-h-[34rem] overflow-y-auto overscroll-contain p-3 sm:p-5">
+          <FormRuntime form={form} key={presetId} mode="preview" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/forms/src/features/landing/feature-grid.tsx
+++ b/apps/forms/src/features/landing/feature-grid.tsx
@@ -1,0 +1,63 @@
+import { SurfaceCard } from '@tuturuuu/ui/marketing';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import type { LandingItem } from './landing-config';
+
+const columnClasses = {
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-2 lg:grid-cols-3',
+  4: 'sm:grid-cols-2 lg:grid-cols-4',
+  5: 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-5',
+} as const;
+
+interface FeatureGridProps {
+  items: LandingItem[];
+  /**
+   * Namespace holding `<key>.title` / `<key>.description` for every item, e.g.
+   * `forms.landing.build.blocks`.
+   */
+  namespace: string;
+  columns?: keyof typeof columnClasses;
+  layout?: 'stack' | 'inline';
+  size?: 'md' | 'lg';
+  className?: string;
+}
+
+/**
+ * Renders a `LandingItem[]` as a grid of `SurfaceCard`s.
+ *
+ * Every feature block on the landing page is the same shape — icon, accent,
+ * title, description — so they all route through here instead of each section
+ * re-typing the same `.map()` over a card.
+ */
+export function FeatureGrid({
+  items,
+  namespace,
+  columns = 3,
+  layout = 'stack',
+  size = 'md',
+  className,
+}: FeatureGridProps) {
+  // The namespace is chosen by the caller, so neither it nor the keys beneath
+  // it can be checked against the message tree statically. Parity between `en`
+  // and `vi` is enforced by the repo's i18n gates instead.
+  const t = useTranslations(namespace as never) as unknown as (
+    key: string
+  ) => string;
+
+  return (
+    <div className={cn('grid gap-3', columnClasses[columns], className)}>
+      {items.map((item) => (
+        <SurfaceCard
+          accent={item.accent}
+          description={t(`${item.key}.description`)}
+          icon={item.icon}
+          key={item.key}
+          layout={layout}
+          size={size}
+          title={t(`${item.key}.title`)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/forms/src/features/landing/landing-config.ts
+++ b/apps/forms/src/features/landing/landing-config.ts
@@ -1,0 +1,147 @@
+import {
+  BarChart3,
+  Braces,
+  CalendarClock,
+  ChartColumn,
+  CheckCircle2,
+  ClipboardList,
+  Code2,
+  Download,
+  FileSpreadsheet,
+  Globe2,
+  Image as ImageIcon,
+  LayoutTemplate,
+  Link2,
+  ListChecks,
+  Lock,
+  Mail,
+  MessageSquare,
+  MousePointerClick,
+  Palette,
+  PanelRightOpen,
+  Play,
+  Rows3,
+  Share2,
+  Shield,
+  SlidersHorizontal,
+  Sparkles,
+  Split,
+  Star,
+  Type,
+  Users,
+  Workflow,
+} from '@tuturuuu/icons';
+import type { MarketingAccent } from '@tuturuuu/ui/marketing';
+import type { ComponentType } from 'react';
+
+/**
+ * Landing page content, expressed as data.
+ *
+ * Sections render from these lists so adding a feature card or an embed mode is
+ * a one-line change here plus two message keys, rather than new JSX. Copy lives
+ * in `messages/*.json` under `forms.landing.*`; only the icon, accent and
+ * message key live in code.
+ */
+
+export interface LandingItem {
+  /** Message key segment under its section's namespace. */
+  key: string;
+  icon: ComponentType<{ className?: string }>;
+  accent: MarketingAccent;
+}
+
+/** The end-to-end path a new form takes, rendered as a numbered rail. */
+export const LANDING_WORKFLOW_STEPS: LandingItem[] = [
+  { key: 'build', icon: LayoutTemplate, accent: 'purple' },
+  { key: 'design', icon: Palette, accent: 'pink' },
+  { key: 'share', icon: Share2, accent: 'blue' },
+  { key: 'learn', icon: ChartColumn, accent: 'cyan' },
+];
+
+/** Question and content blocks available in the builder. */
+export const LANDING_BLOCKS: LandingItem[] = [
+  { key: 'short_text', icon: Type, accent: 'blue' },
+  { key: 'long_text', icon: MessageSquare, accent: 'blue' },
+  { key: 'choice', icon: ListChecks, accent: 'purple' },
+  { key: 'dropdown', icon: Rows3, accent: 'purple' },
+  { key: 'scale', icon: SlidersHorizontal, accent: 'cyan' },
+  { key: 'rating', icon: Star, accent: 'yellow' },
+  { key: 'date', icon: CalendarClock, accent: 'green' },
+  { key: 'media', icon: ImageIcon, accent: 'orange' },
+  { key: 'video', icon: Play, accent: 'red' },
+  { key: 'rich_text', icon: Braces, accent: 'indigo' },
+];
+
+/** Logic and validation capabilities. */
+export const LANDING_LOGIC_FEATURES: LandingItem[] = [
+  { key: 'branching', icon: Split, accent: 'purple' },
+  { key: 'section_end', icon: Workflow, accent: 'indigo' },
+  { key: 'validation', icon: CheckCircle2, accent: 'green' },
+  { key: 'scheduling', icon: CalendarClock, accent: 'orange' },
+];
+
+/** Embed modes offered by the embed builder. */
+export const LANDING_EMBED_MODES: LandingItem[] = [
+  { key: 'inline', icon: LayoutTemplate, accent: 'blue' },
+  { key: 'fullpage', icon: Globe2, accent: 'cyan' },
+  { key: 'popup', icon: MousePointerClick, accent: 'purple' },
+  { key: 'slider', icon: PanelRightOpen, accent: 'pink' },
+  { key: 'popover', icon: MessageSquare, accent: 'orange' },
+  { key: 'sidetab', icon: Rows3, accent: 'green' },
+];
+
+/** Response handling and analysis. */
+export const LANDING_INSIGHT_FEATURES: LandingItem[] = [
+  { key: 'live', icon: BarChart3, accent: 'cyan' },
+  { key: 'dropoff', icon: Split, accent: 'orange' },
+  { key: 'export', icon: FileSpreadsheet, accent: 'green' },
+  { key: 'receipts', icon: Mail, accent: 'blue' },
+];
+
+/** Trust and governance. */
+export const LANDING_SECURITY_FEATURES: LandingItem[] = [
+  { key: 'private_schema', icon: Lock, accent: 'green' },
+  { key: 'access', icon: Shield, accent: 'blue' },
+  { key: 'spam', icon: CheckCircle2, accent: 'purple' },
+  { key: 'portable', icon: Download, accent: 'cyan' },
+];
+
+/** Collaboration highlights. */
+export const LANDING_COLLABORATION_FEATURES: LandingItem[] = [
+  { key: 'presence', icon: Users, accent: 'purple' },
+  { key: 'locks', icon: Lock, accent: 'pink' },
+  { key: 'autosave', icon: Sparkles, accent: 'blue' },
+];
+
+/** Developer surface. */
+export const LANDING_DEVELOPER_FEATURES: LandingItem[] = [
+  { key: 'sdk', icon: Code2, accent: 'indigo' },
+  { key: 'share_link', icon: Link2, accent: 'blue' },
+  { key: 'portable', icon: ClipboardList, accent: 'green' },
+];
+
+/** FAQ entries — answers live under `forms.landing.faq.items.<id>`. */
+export const LANDING_FAQ_IDS = [
+  'free',
+  'anonymous',
+  'embed',
+  'realtime',
+  'export',
+  'languages',
+] as const;
+
+/** In-page nav anchors. */
+export const LANDING_NAV_SECTIONS = [
+  'workflow',
+  'build',
+  'design',
+  'embed',
+  'insights',
+] as const;
+
+/** Footer link columns — `href` values are resolved by the section. */
+export const LANDING_FOOTER_COLUMNS = [
+  { id: 'product', links: ['workflow', 'build', 'design', 'embed'] },
+  { id: 'platform', links: ['tuturuuu', 'tasks', 'calendar', 'docs'] },
+  { id: 'legal', links: ['terms', 'privacy', 'security', 'contact'] },
+] as const;

--- a/apps/forms/src/features/landing/landing-page.tsx
+++ b/apps/forms/src/features/landing/landing-page.tsx
@@ -1,0 +1,36 @@
+import { LandingShell } from './landing-shell';
+import { BlocksSection } from './sections/blocks-section';
+import { ClosingSection } from './sections/closing-section';
+import { CollaborationSection } from './sections/collaboration-section';
+import { DesignSection } from './sections/design-section';
+import { EmbedSection } from './sections/embed-section';
+import { FaqSection } from './sections/faq-section';
+import { HeroSection } from './sections/hero-section';
+import { InsightsSection } from './sections/insights-section';
+import { LogicSection } from './sections/logic-section';
+import { SecuritySection } from './sections/security-section';
+import { WorkflowSection } from './sections/workflow-section';
+
+/**
+ * forms.tuturuuu.com landing page.
+ *
+ * Composition only — every section owns its own markup and copy so this file
+ * stays a readable table of contents for the page.
+ */
+export function FormsLandingPage() {
+  return (
+    <LandingShell>
+      <HeroSection secondaryHref="#workflow" />
+      <WorkflowSection />
+      <BlocksSection />
+      <LogicSection />
+      <DesignSection />
+      <EmbedSection />
+      <CollaborationSection />
+      <InsightsSection />
+      <SecuritySection />
+      <FaqSection />
+      <ClosingSection secondaryHref="#faq" />
+    </LandingShell>
+  );
+}

--- a/apps/forms/src/features/landing/landing-shell.tsx
+++ b/apps/forms/src/features/landing/landing-shell.tsx
@@ -1,0 +1,113 @@
+import {
+  MarketingFooter,
+  type MarketingFooterColumn,
+  MarketingNav,
+  type MarketingNavLink,
+} from '@tuturuuu/ui/marketing';
+import { cacheLife } from 'next/cache';
+import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
+import { WEB_APP_URL } from '@/constants/common';
+import { NavCtaSlot } from './cta-slots';
+import { LANDING_NAV_SECTIONS } from './landing-config';
+import { LANDING_LOGIN_HREF } from './session-cta';
+
+type Translator = (key: string) => string;
+
+/**
+ * Current year for the copyright line.
+ *
+ * `cacheComponents` rejects reading the clock during render — the value would
+ * be frozen into the prerender with no way to tell it had gone stale. Behind
+ * `'use cache'` it becomes an explicitly cached value on a daily refresh, which
+ * is ample for a number that changes once a year.
+ */
+async function getCopyrightYear() {
+  'use cache';
+  cacheLife('days');
+
+  return new Date().getFullYear();
+}
+
+/** Footer link targets, built in one place so nav and footer cannot drift. */
+function buildFooterColumns(tFooter: Translator): MarketingFooterColumn[] {
+  const platformLink = (path: string, key: string) => ({
+    external: true,
+    href: `${WEB_APP_URL}${path}`,
+    label: tFooter(`links.${key}`),
+  });
+
+  return [
+    {
+      id: 'product',
+      title: tFooter('product'),
+      links: (['workflow', 'build', 'design', 'embed'] as const).map((key) => ({
+        href: `#${key}`,
+        label: tFooter(`links.${key}`),
+      })),
+    },
+    {
+      id: 'platform',
+      title: tFooter('platform'),
+      links: [
+        { external: true, href: WEB_APP_URL, label: tFooter('links.tuturuuu') },
+        platformLink('/products', 'products'),
+        platformLink('/pricing', 'pricing'),
+        platformLink('/docs', 'docs'),
+      ],
+    },
+    {
+      id: 'legal',
+      title: tFooter('legal'),
+      links: [
+        platformLink('/terms', 'terms'),
+        platformLink('/privacy', 'privacy'),
+        platformLink('/security', 'security'),
+        platformLink('/contact', 'contact'),
+      ],
+    },
+  ];
+}
+
+/**
+ * Chrome around the landing sections: sticky nav, page, footer.
+ *
+ * Kept separate from the section composition so the page file stays a readable
+ * table of contents, and so a second marketing route can reuse the same frame.
+ */
+export async function LandingShell({ children }: { children: ReactNode }) {
+  const [t, tNav, tFooter, year] = await Promise.all([
+    getTranslations('forms.landing'),
+    getTranslations('forms.landing.nav'),
+    getTranslations('forms.landing.footer'),
+    getCopyrightYear(),
+  ]);
+
+  const links: MarketingNavLink[] = LANDING_NAV_SECTIONS.map((section) => ({
+    href: `#${section}`,
+    label: tNav(section),
+  }));
+
+  return (
+    <div className="relative w-full overflow-x-hidden">
+      <MarketingNav
+        action={<NavCtaSlot />}
+        appName={t('app_name')}
+        links={links}
+        secondaryAction={{
+          href: LANDING_LOGIN_HREF,
+          label: tNav('sign_in'),
+        }}
+      />
+
+      <main className="relative">{children}</main>
+
+      <MarketingFooter
+        appName={t('app_name')}
+        columns={buildFooterColumns(tFooter as unknown as Translator)}
+        legal={tFooter('legal_line', { year })}
+        tagline={tFooter('tagline')}
+      />
+    </div>
+  );
+}

--- a/apps/forms/src/features/landing/sections/blocks-section.tsx
+++ b/apps/forms/src/features/landing/sections/blocks-section.tsx
@@ -1,0 +1,31 @@
+import { SectionShell } from '@tuturuuu/ui/marketing';
+import { useTranslations } from 'next-intl';
+import { FeatureGrid } from '../feature-grid';
+import { LANDING_BLOCKS } from '../landing-config';
+
+/** Question and content block gallery. */
+export function BlocksSection() {
+  const t = useTranslations('forms.landing.build');
+
+  return (
+    <SectionShell
+      bloom="blue"
+      eyebrow={t('eyebrow')}
+      id="build"
+      index="02"
+      subtitle={t('subtitle')}
+      title={t('title')}
+      width="wide"
+    >
+      <FeatureGrid
+        columns={5}
+        items={LANDING_BLOCKS}
+        layout="inline"
+        namespace="forms.landing.build.blocks"
+      />
+      <p className="mt-8 text-center text-foreground/40 text-sm">
+        {t('footnote')}
+      </p>
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/sections/closing-section.tsx
+++ b/apps/forms/src/features/landing/sections/closing-section.tsx
@@ -1,0 +1,36 @@
+import { SecondaryCta } from '@tuturuuu/ui/marketing';
+import { useTranslations } from 'next-intl';
+import { PrimaryCtaSlot } from '../cta-slots';
+
+interface ClosingSectionProps {
+  /** In-page anchor for the quiet secondary action. */
+  secondaryHref: string;
+}
+
+/** Final call to action. */
+export function ClosingSection({ secondaryHref }: ClosingSectionProps) {
+  const t = useTranslations('forms.landing.closing');
+
+  return (
+    <section className="relative px-4 pt-8 pb-28 sm:px-6 lg:px-8 lg:pb-36">
+      <div className="mx-auto max-w-4xl">
+        <div className="relative overflow-hidden rounded-3xl border border-foreground/10 bg-foreground/[0.02] px-6 py-14 text-center sm:px-14">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-20 top-0 h-px bg-gradient-to-r from-transparent via-dynamic-purple/50 to-transparent"
+          />
+          <h2 className="text-balance font-display font-semibold text-3xl tracking-[-0.03em] sm:text-4xl">
+            {t('title')}
+          </h2>
+          <p className="mx-auto mt-4 max-w-lg text-balance text-foreground/55">
+            {t('description')}
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <PrimaryCtaSlot />
+            <SecondaryCta href={secondaryHref}>{t('secondary')}</SecondaryCta>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/forms/src/features/landing/sections/collaboration-section.tsx
+++ b/apps/forms/src/features/landing/sections/collaboration-section.tsx
@@ -1,0 +1,63 @@
+import { SectionShell } from '@tuturuuu/ui/marketing';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import { FeatureGrid } from '../feature-grid';
+import { LANDING_COLLABORATION_FEATURES } from '../landing-config';
+
+/** Stand-in initials for the presence rail — never real user data. */
+const DEMO_EDITORS = [
+  { id: 'a', initials: 'MK', tone: 'bg-dynamic-purple' },
+  { id: 'b', initials: 'TL', tone: 'bg-dynamic-blue' },
+  { id: 'c', initials: 'NP', tone: 'bg-dynamic-orange' },
+] as const;
+
+/** Live avatar rail exactly as the studio header renders it. */
+function PresenceRail({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-3 rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] px-4 py-3">
+      <div className="flex -space-x-2">
+        {DEMO_EDITORS.map((editor) => (
+          <span
+            className={cn(
+              'flex h-8 w-8 items-center justify-center rounded-full border-2 border-background font-medium text-[0.65rem] text-white',
+              editor.tone
+            )}
+            key={editor.id}
+          >
+            {editor.initials}
+          </span>
+        ))}
+      </div>
+      <span className="relative flex h-2 w-2">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-dynamic-green opacity-60 motion-reduce:animate-none" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-dynamic-green" />
+      </span>
+      <span className="text-foreground/55 text-sm">{label}</span>
+    </div>
+  );
+}
+
+/** Realtime multiplayer editing. */
+export function CollaborationSection() {
+  const t = useTranslations('forms.landing.collaborate');
+
+  return (
+    <SectionShell
+      align="start"
+      bloom="purple"
+      eyebrow={t('eyebrow')}
+      id="collaborate"
+      index="06"
+      subtitle={t('subtitle')}
+      title={t('title')}
+    >
+      <PresenceRail label={t('presence_label')} />
+      <FeatureGrid
+        className="mt-4"
+        columns={3}
+        items={LANDING_COLLABORATION_FEATURES}
+        namespace="forms.landing.collaborate.features"
+      />
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/sections/design-section.tsx
+++ b/apps/forms/src/features/landing/sections/design-section.tsx
@@ -10,7 +10,13 @@ import {
 const SHOWCASE_PRESETS = FORM_THEME_PRESETS.slice(0, 10);
 
 const SURFACE_KEYS = ['paper', 'glass', 'panel'] as const;
-const CONTROL_KEYS = ['fonts', 'density', 'typography', 'cover'] as const;
+const CONTROL_KEYS = [
+  'fonts',
+  'density',
+  'typography',
+  'pacing',
+  'cover',
+] as const;
 
 /**
  * Theming.

--- a/apps/forms/src/features/landing/sections/design-section.tsx
+++ b/apps/forms/src/features/landing/sections/design-section.tsx
@@ -1,0 +1,121 @@
+import { SectionShell } from '@tuturuuu/ui/marketing';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import {
+  FORM_ACCENT_BADGE_CLASSES,
+  FORM_THEME_PRESETS,
+} from '@/features/forms/theme';
+
+/** Presets shown as swatch cards — the same ones the studio ships. */
+const SHOWCASE_PRESETS = FORM_THEME_PRESETS.slice(0, 10);
+
+const SURFACE_KEYS = ['paper', 'glass', 'panel'] as const;
+const CONTROL_KEYS = ['fonts', 'density', 'typography', 'cover'] as const;
+
+/**
+ * Theming.
+ *
+ * The swatch grid is generated from `FORM_THEME_PRESETS`, so the landing page
+ * can never advertise a palette the studio no longer ships — adding a preset
+ * adds it here automatically.
+ */
+export function DesignSection() {
+  const t = useTranslations('forms.landing.design');
+
+  return (
+    <SectionShell
+      bloom="pink"
+      eyebrow={t('eyebrow')}
+      id="design"
+      index="04"
+      subtitle={t('subtitle')}
+      title={t('title')}
+      width="wide"
+    >
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {SHOWCASE_PRESETS.map((preset) => (
+          <div
+            className="group relative overflow-hidden rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] p-4 transition-all duration-500 hover:-translate-y-1 hover:border-foreground/15"
+            key={preset.id}
+          >
+            <div className="flex items-center gap-1.5">
+              <span
+                aria-hidden
+                className={cn(
+                  'h-6 w-6 rounded-full',
+                  FORM_ACCENT_BADGE_CLASSES[preset.accentColor]
+                )}
+              />
+              <span
+                aria-hidden
+                className={cn(
+                  'h-3 w-3 rounded-full opacity-60',
+                  FORM_ACCENT_BADGE_CLASSES[preset.accentColor]
+                )}
+              />
+              <span
+                aria-hidden
+                className={cn(
+                  'h-2 w-2 rounded-full opacity-30',
+                  FORM_ACCENT_BADGE_CLASSES[preset.accentColor]
+                )}
+              />
+            </div>
+            <p className="mt-4 truncate font-display font-medium text-sm tracking-[-0.01em]">
+              {preset.name}
+            </p>
+            <p className="mt-1 truncate font-mono-ui text-[0.6rem] text-foreground/35 uppercase tracking-[0.14em]">
+              {t(`surfaces.${preset.surfaceStyle}`)}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-10 grid gap-4 lg:grid-cols-2">
+        <div className="rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] p-6">
+          <h3 className="font-display font-semibold text-lg tracking-[-0.01em]">
+            {t('surface_heading')}
+          </h3>
+          <p className="mt-2 text-foreground/50 text-sm leading-relaxed">
+            {t('surface_description')}
+          </p>
+          <div className="mt-5 grid grid-cols-3 gap-2">
+            {SURFACE_KEYS.map((key) => (
+              <div
+                className="rounded-xl border border-foreground/[0.07] bg-background/50 px-3 py-4 text-center"
+                key={key}
+              >
+                <p className="font-mono-ui text-[0.6rem] text-foreground/40 uppercase tracking-[0.14em]">
+                  {t(`surfaces.${key}`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] p-6">
+          <h3 className="font-display font-semibold text-lg tracking-[-0.01em]">
+            {t('controls_heading')}
+          </h3>
+          <p className="mt-2 text-foreground/50 text-sm leading-relaxed">
+            {t('controls_description')}
+          </p>
+          <ul className="mt-5 grid gap-2.5 sm:grid-cols-2">
+            {CONTROL_KEYS.map((key) => (
+              <li
+                className="flex items-start gap-2.5 text-foreground/60 text-sm"
+                key={key}
+              >
+                <span
+                  aria-hidden
+                  className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-dynamic-pink"
+                />
+                {t(`controls.${key}`)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/sections/embed-preview.tsx
+++ b/apps/forms/src/features/landing/sections/embed-preview.tsx
@@ -1,0 +1,153 @@
+import { cn } from '@tuturuuu/utils/format';
+
+export type EmbedPreviewMode =
+  | 'inline'
+  | 'fullpage'
+  | 'popup'
+  | 'slider'
+  | 'popover'
+  | 'sidetab';
+
+interface ModeSpec {
+  /** Absolute placement of the embedded form inside the host frame. */
+  frame: string;
+  /** Dim the host page behind the form. */
+  dims?: boolean;
+  /** Host page copy is visible around the form. */
+  showsHost: boolean;
+  /** A launcher affordance sits on the host page. */
+  launcher?: 'bubble' | 'tab';
+}
+
+/**
+ * Placement per mode, kept as data so the shapes stay comparable when read side
+ * by side and a new mode is a single entry rather than another branch.
+ */
+const MODE_SPECS: Record<EmbedPreviewMode, ModeSpec> = {
+  inline: { frame: 'inset-x-6 top-[42%] bottom-4 rounded-md', showsHost: true },
+  fullpage: {
+    frame: 'inset-x-0 top-5 bottom-0 rounded-none',
+    showsHost: false,
+  },
+  popup: {
+    dims: true,
+    frame: 'inset-x-[18%] top-[26%] bottom-[14%] rounded-md shadow-xl',
+    showsHost: true,
+  },
+  slider: {
+    dims: true,
+    frame: 'top-5 right-0 bottom-0 w-[46%] rounded-l-md shadow-xl',
+    showsHost: true,
+  },
+  popover: {
+    frame: 'right-3 bottom-8 h-[52%] w-[46%] rounded-md shadow-xl',
+    launcher: 'bubble',
+    showsHost: true,
+  },
+  sidetab: {
+    frame: 'top-5 right-0 bottom-0 w-[40%] rounded-l-md shadow-xl',
+    launcher: 'tab',
+    showsHost: true,
+  },
+};
+
+/** The skeleton of the embedded form: two label lines and a submit button. */
+function FormSkeleton({ tint }: { tint: string }) {
+  return (
+    <div className="flex h-full flex-col gap-1.5 p-2.5">
+      <span className={cn('block h-1.5 w-2/3 rounded-full', tint)} />
+      <span className={cn('block h-1 w-1/2 rounded-full opacity-60', tint)} />
+      <span className={cn('mt-auto block h-3 w-12 rounded-sm', tint)} />
+    </div>
+  );
+}
+
+/**
+ * Miniature diagram of one embed mode.
+ *
+ * A drawn abstraction of the host page — chrome bar, body copy, form panel —
+ * rather than a screenshot, so all six read at one scale, restyle with the
+ * theme and cost nothing to load. The form panel is a tinted surface rather
+ * than a solid fill: the point of the diagram is the *relationship* between
+ * form and host page, which a solid block would cover up.
+ */
+export function EmbedPreview({
+  mode,
+  surfaceClassName,
+  tintClassName,
+  borderClassName,
+  className,
+}: {
+  mode: EmbedPreviewMode;
+  /** Tinted background for the form panel, e.g. `bg-dynamic-blue/15`. */
+  surfaceClassName: string;
+  /** Solid accent for the skeleton lines, e.g. `bg-dynamic-blue`. */
+  tintClassName: string;
+  /** Border for the form panel, e.g. `border-dynamic-blue/40`. */
+  borderClassName: string;
+  className?: string;
+}) {
+  const spec = MODE_SPECS[mode];
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'relative aspect-[16/9] w-full overflow-hidden rounded-xl border border-foreground/10 bg-background',
+        className
+      )}
+    >
+      {/* Host page chrome */}
+      <div className="absolute inset-x-0 top-0 flex h-5 items-center gap-1 border-foreground/[0.07] border-b bg-foreground/[0.03] px-2">
+        <span className="h-1.5 w-1.5 rounded-full bg-foreground/15" />
+        <span className="h-1.5 w-1.5 rounded-full bg-foreground/15" />
+        <span className="h-1.5 w-1.5 rounded-full bg-foreground/15" />
+      </div>
+
+      {/* Host page body copy */}
+      {spec.showsHost ? (
+        <div className="absolute inset-x-6 top-8 space-y-1.5">
+          <span className="block h-1.5 w-2/5 rounded-full bg-foreground/20" />
+          <span className="block h-1 w-4/5 rounded-full bg-foreground/10" />
+          <span className="block h-1 w-3/5 rounded-full bg-foreground/10" />
+        </div>
+      ) : null}
+
+      {spec.dims ? (
+        <div className="absolute inset-x-0 top-5 bottom-0 bg-background/70" />
+      ) : null}
+
+      {spec.launcher === 'bubble' ? (
+        <span
+          className={cn(
+            'absolute right-3 bottom-2.5 h-4 w-4 rounded-full',
+            tintClassName
+          )}
+        />
+      ) : null}
+      {/* The tab sits flush against the panel's leading edge so it reads as
+          the handle that opened it, rather than a stray mark on the far side
+          of the page. */}
+      {spec.launcher === 'tab' ? (
+        <span
+          className={cn(
+            'absolute top-1/2 right-[40%] h-10 w-1.5 -translate-y-1/2 rounded-l-sm',
+            tintClassName
+          )}
+        />
+      ) : null}
+
+      {/* The embedded form */}
+      <div
+        className={cn(
+          'absolute overflow-hidden border backdrop-blur-sm',
+          surfaceClassName,
+          borderClassName,
+          spec.frame
+        )}
+      >
+        <FormSkeleton tint={tintClassName} />
+      </div>
+    </div>
+  );
+}

--- a/apps/forms/src/features/landing/sections/embed-section.tsx
+++ b/apps/forms/src/features/landing/sections/embed-section.tsx
@@ -1,0 +1,87 @@
+import { getMarketingAccent, SectionShell } from '@tuturuuu/ui/marketing';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import { LANDING_EMBED_MODES } from '../landing-config';
+import { EmbedPreview, type EmbedPreviewMode } from './embed-preview';
+
+const SNIPPET = `<script src="https://forms.tuturuuu.com/embed.js" async></script>
+<div
+  data-tuturuuu-form="YOUR_SHARE_CODE"
+  data-mode="popup"
+></div>`;
+
+/**
+ * Embed modes.
+ *
+ * Each card pairs a drawn preview with its copy, so the difference between a
+ * slider and a side tab is visible rather than described. The snippet below is
+ * the real embed contract — one script tag plus data attributes.
+ */
+export function EmbedSection() {
+  const t = useTranslations('forms.landing.embed');
+
+  return (
+    <SectionShell
+      bloom="cyan"
+      eyebrow={t('eyebrow')}
+      id="embed"
+      index="05"
+      subtitle={t('subtitle')}
+      title={t('title')}
+      width="wide"
+    >
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {LANDING_EMBED_MODES.map((mode) => {
+          const tokens = getMarketingAccent(mode.accent);
+          const Icon = mode.icon;
+
+          return (
+            <div
+              className="group relative overflow-hidden rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] p-5 transition-all duration-500 hover:-translate-y-1 hover:border-foreground/15"
+              key={mode.key}
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  'pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent to-transparent opacity-40 transition-opacity duration-500 group-hover:opacity-100',
+                  tokens.rule
+                )}
+              />
+
+              <EmbedPreview
+                borderClassName={tokens.border}
+                mode={mode.key as EmbedPreviewMode}
+                surfaceClassName={tokens.soft}
+                tintClassName={tokens.solid}
+              />
+
+              <div className="mt-4 flex items-center gap-2">
+                <Icon className={cn('h-4 w-4 shrink-0', tokens.text)} />
+                <h3 className="font-display font-semibold text-[0.95rem] tracking-[-0.01em]">
+                  {t(`modes.${mode.key}.title`)}
+                </h3>
+              </div>
+              <p className="mt-2 text-foreground/50 text-xs leading-relaxed">
+                {t(`modes.${mode.key}.description`)}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-10 grid gap-4 lg:grid-cols-[1fr_1.2fr] lg:items-center">
+        <div>
+          <h3 className="font-display font-semibold text-xl tracking-[-0.02em]">
+            {t('snippet_heading')}
+          </h3>
+          <p className="mt-3 text-foreground/50 text-sm leading-relaxed">
+            {t('snippet_description')}
+          </p>
+        </div>
+        <pre className="overflow-x-auto rounded-2xl border border-foreground/[0.08] bg-foreground/[0.03] p-5 font-mono-ui text-[0.75rem] text-foreground/70 leading-relaxed">
+          <code>{SNIPPET}</code>
+        </pre>
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/sections/faq-section.tsx
+++ b/apps/forms/src/features/landing/sections/faq-section.tsx
@@ -1,0 +1,28 @@
+import { MarketingFaqList, SectionShell } from '@tuturuuu/ui/marketing';
+import { useTranslations } from 'next-intl';
+import { LANDING_FAQ_IDS } from '../landing-config';
+
+/** Frequently asked questions. */
+export function FaqSection() {
+  const t = useTranslations('forms.landing.faq');
+
+  return (
+    <SectionShell
+      bloom="blue"
+      eyebrow={t('eyebrow')}
+      id="faq"
+      index="09"
+      subtitle={t('subtitle')}
+      title={t('title')}
+      width="narrow"
+    >
+      <MarketingFaqList
+        items={LANDING_FAQ_IDS.map((id) => ({
+          id,
+          answer: t(`items.${id}.answer`),
+          question: t(`items.${id}.question`),
+        }))}
+      />
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/sections/hero-section.tsx
+++ b/apps/forms/src/features/landing/sections/hero-section.tsx
@@ -1,0 +1,105 @@
+import { ClipboardList } from '@tuturuuu/icons';
+import {
+  HeroAtmosphere,
+  MarketingPill,
+  MarketingStatBand,
+  SecondaryCta,
+} from '@tuturuuu/ui/marketing';
+import { useTranslations } from 'next-intl';
+import { PrimaryCtaSlot } from '../cta-slots';
+import type { DemoFormCopy } from '../demo/demo-form';
+import { LiveDemo } from '../demo/live-demo';
+
+const STAT_KEYS = ['blocks', 'themes', 'embeds', 'languages'] as const;
+
+interface HeroSectionProps {
+  /** In-page anchor for the quiet secondary action. */
+  secondaryHref: string;
+}
+
+/**
+ * Hero: positioning copy, both calls to action, then a full-width frame holding
+ * the interactive demo. The demo sits below the copy rather than beside it —
+ * side by side, the runtime is squeezed to a column narrower than any real form
+ * would ever render at, which undersells it.
+ */
+export function HeroSection({ secondaryHref }: HeroSectionProps) {
+  const t = useTranslations('forms.landing');
+  const tHero = useTranslations('forms.landing.hero');
+  const tDemo = useTranslations('forms.landing.demo');
+
+  const demoCopy: DemoFormCopy = {
+    title: tDemo('title'),
+    description: tDemo('description'),
+    confirmationTitle: tDemo('confirmation_title'),
+    confirmationMessage: tDemo('confirmation_message'),
+    sectionTitle: tDemo('section_title'),
+    sectionDescription: tDemo('section_description'),
+    roleTitle: tDemo('role_title'),
+    roleOptions: [
+      tDemo('role_option_1'),
+      tDemo('role_option_2'),
+      tDemo('role_option_3'),
+      tDemo('role_option_4'),
+    ],
+    priorityTitle: tDemo('priority_title'),
+    priorityDescription: tDemo('priority_description'),
+    priorityOptions: [
+      tDemo('priority_option_1'),
+      tDemo('priority_option_2'),
+      tDemo('priority_option_3'),
+      tDemo('priority_option_4'),
+    ],
+    satisfactionTitle: tDemo('satisfaction_title'),
+    satisfactionMinLabel: tDemo('satisfaction_min'),
+    satisfactionMaxLabel: tDemo('satisfaction_max'),
+    notesTitle: tDemo('notes_title'),
+    notesPlaceholder: tDemo('notes_placeholder'),
+  };
+
+  return (
+    // `isolate` matters: the atmosphere paints at `-z-10`, and without a local
+    // stacking context it would slide behind the page wrapper's background and
+    // disappear entirely.
+    <section className="relative isolate overflow-hidden px-4 pt-28 pb-16 sm:px-6 sm:pt-32 lg:px-8 lg:pt-36">
+      <HeroAtmosphere primary="purple" secondary="blue" tertiary="cyan" />
+
+      <div className="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
+        <MarketingPill accent="purple" icon={ClipboardList}>
+          {tHero('eyebrow')}
+        </MarketingPill>
+
+        <h1 className="mt-8 text-balance font-display font-extrabold text-4xl leading-[1.02] tracking-[-0.04em] sm:text-5xl lg:text-6xl">
+          {tHero('title')}
+        </h1>
+
+        <p className="mt-6 max-w-2xl text-balance text-base text-foreground/55 leading-relaxed sm:text-lg">
+          {tHero('description')}
+        </p>
+
+        <div className="mt-9 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
+          <PrimaryCtaSlot />
+          <SecondaryCta href={secondaryHref}>{tHero('secondary')}</SecondaryCta>
+        </div>
+
+        <p className="mt-5 text-foreground/40 text-xs">
+          {tHero('reassurance')}
+        </p>
+      </div>
+
+      <div className="relative mx-auto mt-16 w-full max-w-5xl">
+        <LiveDemo copy={demoCopy} themeLabel={tDemo('theme_label')} />
+      </div>
+
+      <div className="mx-auto mt-14 w-full max-w-4xl">
+        <MarketingStatBand
+          stats={STAT_KEYS.map((key) => ({
+            id: key,
+            label: t(`stats.${key}.label`),
+            value: t(`stats.${key}.value`),
+          }))}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/forms/src/features/landing/sections/insights-section.tsx
+++ b/apps/forms/src/features/landing/sections/insights-section.tsx
@@ -1,0 +1,78 @@
+import { SectionShell } from '@tuturuuu/ui/marketing';
+import { useTranslations } from 'next-intl';
+import { FeatureGrid } from '../feature-grid';
+import { LANDING_INSIGHT_FEATURES } from '../landing-config';
+
+/** Funnel steps, widest first. Percentages are illustrative, not live data. */
+const FUNNEL_STEPS = [
+  { key: 'views', width: 'w-full', tone: 'bg-dynamic-blue/70' },
+  { key: 'starts', width: 'w-[74%]', tone: 'bg-dynamic-cyan/70' },
+  { key: 'completed', width: 'w-[52%]', tone: 'bg-dynamic-green/70' },
+] as const;
+
+/**
+ * Response funnel.
+ *
+ * Views → starts → completions is the shape the analytics tab actually reports,
+ * so showing it here sets the right expectation about what gets measured.
+ */
+function FunnelPreview() {
+  const t = useTranslations('forms.landing.insights.funnel');
+
+  return (
+    <div className="rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] p-6 sm:p-8">
+      <p className="font-mono-ui text-[0.65rem] text-foreground/40 uppercase tracking-[0.18em]">
+        {t('label')}
+      </p>
+      <ul className="mt-6 space-y-4">
+        {FUNNEL_STEPS.map((step) => (
+          <li key={step.key}>
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="text-foreground/65 text-sm">
+                {t(`steps.${step.key}.label`)}
+              </span>
+              <span className="font-display font-semibold text-base tabular-nums">
+                {t(`steps.${step.key}.value`)}
+              </span>
+            </div>
+            <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-foreground/[0.06]">
+              <div
+                className={`h-full rounded-full ${step.width} ${step.tone}`}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-6 text-foreground/40 text-xs leading-relaxed">
+        {t('note')}
+      </p>
+    </div>
+  );
+}
+
+/** Responses, analytics and export. */
+export function InsightsSection() {
+  const t = useTranslations('forms.landing.insights');
+
+  return (
+    <SectionShell
+      align="start"
+      bloom="cyan"
+      eyebrow={t('eyebrow')}
+      id="insights"
+      index="07"
+      subtitle={t('subtitle')}
+      title={t('title')}
+      width="wide"
+    >
+      <div className="grid gap-4 lg:grid-cols-[1fr_1.1fr] lg:gap-6">
+        <FunnelPreview />
+        <FeatureGrid
+          columns={2}
+          items={LANDING_INSIGHT_FEATURES}
+          namespace="forms.landing.insights.features"
+        />
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/sections/logic-section.tsx
+++ b/apps/forms/src/features/landing/sections/logic-section.tsx
@@ -1,0 +1,95 @@
+import { CornerDownRight } from '@tuturuuu/icons';
+import { SectionShell } from '@tuturuuu/ui/marketing';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import { FeatureGrid } from '../feature-grid';
+import { LANDING_LOGIC_FEATURES } from '../landing-config';
+
+/** The three branches drawn in the diagram, keyed to `rules.<key>`. */
+const RULE_KEYS = ['enterprise', 'startup', 'individual'] as const;
+
+/**
+ * Branching diagram.
+ *
+ * A literal rendering of one rule set — question, condition, destination —
+ * rather than an abstract flowchart, so the mechanic is legible without a
+ * legend. Static markup, not a screenshot, so it restyles with the theme and
+ * translates with the page.
+ */
+function BranchingDiagram() {
+  const t = useTranslations('forms.landing.logic.diagram');
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] p-6 sm:p-8">
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-x-8 top-0 h-px bg-[linear-gradient(90deg,transparent,color-mix(in_oklab,var(--purple)_45%,transparent),transparent)]"
+      />
+
+      <p className="font-mono-ui text-[0.65rem] text-foreground/40 uppercase tracking-[0.18em]">
+        {t('source_label')}
+      </p>
+      <p className="mt-2 font-display font-semibold text-lg tracking-[-0.01em]">
+        {t('source_question')}
+      </p>
+
+      <ul className="mt-6 space-y-2.5">
+        {RULE_KEYS.map((key) => (
+          <li
+            className="flex flex-col gap-2 rounded-xl border border-foreground/[0.07] bg-background/50 p-3 sm:flex-row sm:items-center sm:gap-3"
+            key={key}
+          >
+            <span className="inline-flex shrink-0 items-center gap-2 rounded-lg bg-foreground/[0.04] px-2.5 py-1 font-mono-ui text-[0.65rem] text-foreground/50 uppercase tracking-[0.14em]">
+              {t('if')}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-foreground/75 text-sm">
+              {t(`rules.${key}.answer`)}
+            </span>
+            <CornerDownRight
+              aria-hidden
+              className="hidden h-3.5 w-3.5 shrink-0 text-foreground/25 sm:block"
+            />
+            <span
+              className={cn(
+                'inline-flex shrink-0 items-center rounded-lg border border-dynamic-purple/25 bg-dynamic-purple/10 px-2.5 py-1 text-dynamic-purple text-xs'
+              )}
+            >
+              {t(`rules.${key}.destination`)}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-5 text-foreground/40 text-xs leading-relaxed">
+        {t('note')}
+      </p>
+    </div>
+  );
+}
+
+/** Logic, validation and scheduling. */
+export function LogicSection() {
+  const t = useTranslations('forms.landing.logic');
+
+  return (
+    <SectionShell
+      align="start"
+      bloom="indigo"
+      eyebrow={t('eyebrow')}
+      id="logic"
+      index="03"
+      subtitle={t('subtitle')}
+      title={t('title')}
+      width="wide"
+    >
+      <div className="grid gap-4 lg:grid-cols-[1.1fr_1fr] lg:gap-6">
+        <BranchingDiagram />
+        <FeatureGrid
+          columns={2}
+          items={LANDING_LOGIC_FEATURES}
+          namespace="forms.landing.logic.features"
+        />
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/sections/security-section.tsx
+++ b/apps/forms/src/features/landing/sections/security-section.tsx
@@ -1,0 +1,43 @@
+import { SectionShell } from '@tuturuuu/ui/marketing';
+import { useTranslations } from 'next-intl';
+import { FeatureGrid } from '../feature-grid';
+import {
+  LANDING_DEVELOPER_FEATURES,
+  LANDING_SECURITY_FEATURES,
+} from '../landing-config';
+
+/** Trust, governance and the developer surface. */
+export function SecuritySection() {
+  const t = useTranslations('forms.landing.trust');
+
+  return (
+    <SectionShell
+      bloom="green"
+      eyebrow={t('eyebrow')}
+      id="trust"
+      index="08"
+      subtitle={t('subtitle')}
+      title={t('title')}
+      width="wide"
+    >
+      <FeatureGrid
+        columns={4}
+        items={LANDING_SECURITY_FEATURES}
+        namespace="forms.landing.trust.features"
+      />
+
+      <h3 className="mt-14 text-center font-display font-semibold text-2xl tracking-[-0.02em]">
+        {t('developer_heading')}
+      </h3>
+      <p className="mx-auto mt-3 max-w-xl text-balance text-center text-foreground/50 text-sm leading-relaxed">
+        {t('developer_description')}
+      </p>
+      <FeatureGrid
+        className="mt-8"
+        columns={3}
+        items={LANDING_DEVELOPER_FEATURES}
+        namespace="forms.landing.trust.developer"
+      />
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/sections/workflow-section.tsx
+++ b/apps/forms/src/features/landing/sections/workflow-section.tsx
@@ -1,0 +1,72 @@
+import { getMarketingAccent, SectionShell } from '@tuturuuu/ui/marketing';
+import { cn } from '@tuturuuu/utils/format';
+import { useTranslations } from 'next-intl';
+import { LANDING_WORKFLOW_STEPS } from '../landing-config';
+
+/**
+ * The end-to-end path, as a connected rail.
+ *
+ * Rendered as four numbered stops joined by a hairline so the page states the
+ * whole journey — build, design, share, learn — before drilling into any one
+ * stage. The connector is drawn per-card rather than as one absolute line so it
+ * wraps correctly when the grid collapses to two columns and then one.
+ */
+export function WorkflowSection() {
+  const t = useTranslations('forms.landing.workflow');
+
+  return (
+    <SectionShell
+      bloom="purple"
+      eyebrow={t('eyebrow')}
+      id="workflow"
+      index="01"
+      subtitle={t('subtitle')}
+      title={t('title')}
+    >
+      <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {LANDING_WORKFLOW_STEPS.map((step, index) => {
+          const tokens = getMarketingAccent(step.accent);
+          const Icon = step.icon;
+          const isLast = index === LANDING_WORKFLOW_STEPS.length - 1;
+
+          return (
+            <li
+              className="group relative flex flex-col rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] p-6 transition-colors duration-500 hover:border-foreground/15"
+              key={step.key}
+            >
+              {/* Connector to the next stop; hidden on the last card and
+                  whenever the grid has wrapped to a single column. */}
+              {isLast ? null : (
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute top-11 -right-2 hidden h-px w-4 bg-foreground/15 lg:block"
+                />
+              )}
+
+              <div className="flex items-center justify-between">
+                <span
+                  className={cn(
+                    'flex h-9 w-9 items-center justify-center rounded-xl border border-foreground/10 bg-foreground/[0.03] transition-transform duration-500 group-hover:scale-105',
+                    tokens.text
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                </span>
+                <span className="font-mono-ui text-[0.7rem] text-foreground/25 tabular-nums">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+              </div>
+
+              <h3 className="mt-5 font-display font-semibold text-lg tracking-[-0.01em]">
+                {t(`steps.${step.key}.title`)}
+              </h3>
+              <p className="mt-2 text-foreground/50 text-sm leading-relaxed">
+                {t(`steps.${step.key}.description`)}
+              </p>
+            </li>
+          );
+        })}
+      </ol>
+    </SectionShell>
+  );
+}

--- a/apps/forms/src/features/landing/session-cta.tsx
+++ b/apps/forms/src/features/landing/session-cta.tsx
@@ -1,0 +1,68 @@
+import { ArrowRight } from '@tuturuuu/icons';
+import { getSatelliteAppSession } from '@tuturuuu/satellite/auth';
+import { MarketingNavAction, PrimaryCta } from '@tuturuuu/ui/marketing';
+import { connection } from 'next/server';
+import { useTranslations } from 'next-intl';
+import type { ReactNode } from 'react';
+
+/**
+ * Session-aware calls to action.
+ *
+ * Only the CTA copy and target depend on whether the visitor is signed in — the
+ * rest of the landing page is identical either way. Reading the session at the
+ * page root would force the whole marketing page to render per request, so the
+ * check is isolated here: the page prerenders as static HTML and each CTA
+ * streams in behind its own `<Suspense>` boundary.
+ *
+ * Both variants are built synchronously by the caller and handed in as nodes.
+ * A `<Suspense>` fallback must not itself suspend, so the signed-out button
+ * cannot be an async component — and it is the right fallback anyway, being
+ * both the common case and what a crawler should see in the prerendered HTML.
+ */
+export async function SessionAwareCta({
+  signedIn,
+  signedOut,
+}: {
+  signedIn: ReactNode;
+  signedOut: ReactNode;
+}) {
+  // Scoped to this boundary on purpose. The Supabase session helper reads the
+  // clock internally, which `cacheComponents` refuses to prerender; opting just
+  // the CTA into request-time rendering keeps the surrounding marketing page
+  // static instead of dragging the whole route dynamic.
+  await connection();
+
+  const appSession = await getSatelliteAppSession('forms');
+
+  return appSession ? signedIn : signedOut;
+}
+
+export const LANDING_WORKSPACE_HREF = '/dashboard';
+export const LANDING_LOGIN_HREF = '/login?next=/dashboard';
+
+/** The nav's action button, in either session state. */
+export function NavCta({ authed }: { authed: boolean }) {
+  const t = useTranslations('forms.landing.nav');
+
+  return (
+    <MarketingNavAction
+      href={authed ? LANDING_WORKSPACE_HREF : LANDING_LOGIN_HREF}
+      label={authed ? t('workspace') : t('get_started')}
+    />
+  );
+}
+
+/** The hero and closing sections' primary button, in either session state. */
+export function PrimaryLandingCta({ authed }: { authed: boolean }) {
+  const t = useTranslations('forms.landing.hero');
+
+  return (
+    <PrimaryCta
+      accent="purple"
+      href={authed ? LANDING_WORKSPACE_HREF : LANDING_LOGIN_HREF}
+    >
+      {authed ? t('primary_authed') : t('primary')}
+      <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+    </PrimaryCta>
+  );
+}

--- a/apps/forms/src/features/landing/structured-data.tsx
+++ b/apps/forms/src/features/landing/structured-data.tsx
@@ -1,0 +1,45 @@
+/**
+ * JSON-LD for the landing page.
+ *
+ * `SoftwareApplication` is the schema search engines use to render an app
+ * result — name, category, price. Emitted as a plain script tag because
+ * `next/script` defers execution, and structured data has to be in the HTML the
+ * crawler receives, not injected after hydration.
+ */
+export function LandingStructuredData({
+  description,
+  name,
+  url,
+}: {
+  description: string;
+  name: string;
+  url: string;
+}) {
+  const payload = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    applicationCategory: 'BusinessApplication',
+    description,
+    name,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+    operatingSystem: 'Web',
+    publisher: {
+      '@type': 'Organization',
+      name: 'Tuturuuu',
+      url: 'https://tuturuuu.com',
+    },
+    url,
+  };
+
+  return (
+    <script
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD has to be serialized into the document, and the payload is built entirely from trusted strings.
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }}
+      type="application/ld+json"
+    />
+  );
+}

--- a/apps/forms/src/proxy.ts
+++ b/apps/forms/src/proxy.ts
@@ -121,8 +121,13 @@ function getNextValue(request: NextRequest) {
 }
 
 /**
- * `/f/<shareCode>` is the public form-filling surface. It must stay reachable
- * without any session, including for social/OG crawlers.
+ * Surfaces that must stay reachable with no session at all.
+ *
+ * `/f/<shareCode>` is the public form-filling page, and `/embed/<shareCode>` is
+ * the same form rendered chrome-less for a third-party iframe. Both are used by
+ * anonymous respondents and by social/OG crawlers, so requiring a session would
+ * redirect them to a login screen they have no way to complete — inside an
+ * iframe, silently.
  */
 function isPublicFormsPath(unlocalizedPath: string) {
   if (unlocalizedPath === '/') return true;
@@ -133,7 +138,12 @@ function isPublicFormsPath(unlocalizedPath: string) {
     return true;
   }
 
-  return unlocalizedPath === '/f' || unlocalizedPath.startsWith('/f/');
+  return (
+    unlocalizedPath === '/f' ||
+    unlocalizedPath.startsWith('/f/') ||
+    unlocalizedPath === '/embed' ||
+    unlocalizedPath.startsWith('/embed/')
+  );
 }
 
 function isPublicSharedFormApiRequest(request: NextRequest) {

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -4673,6 +4673,7 @@ export type Database = {
           max_responses: number | null;
           open_at: string | null;
           published_at: string | null;
+          seo: Json;
           settings: Json;
           status: string;
           theme: Json;
@@ -4691,6 +4692,7 @@ export type Database = {
           max_responses?: number | null;
           open_at?: string | null;
           published_at?: string | null;
+          seo?: Json;
           settings?: Json;
           status?: string;
           theme?: Json;
@@ -4709,6 +4711,7 @@ export type Database = {
           max_responses?: number | null;
           open_at?: string | null;
           published_at?: string | null;
+          seo?: Json;
           settings?: Json;
           status?: string;
           theme?: Json;
@@ -11835,6 +11838,48 @@ export type Database = {
           },
         ];
       };
+      pending_invitation_seat_revocations: {
+        Row: {
+          created_at: string;
+          last_error: string | null;
+          seat_id: string;
+          updated_at: string;
+          user_id: string;
+          ws_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          last_error?: string | null;
+          seat_id: string;
+          updated_at?: string;
+          user_id: string;
+          ws_id: string;
+        };
+        Update: {
+          created_at?: string;
+          last_error?: string | null;
+          seat_id?: string;
+          updated_at?: string;
+          user_id?: string;
+          ws_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'pending_invitation_seat_revocations_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'nova_user_challenge_leaderboard';
+            referencedColumns: ['user_id'];
+          },
+          {
+            foreignKeyName: 'pending_invitation_seat_revocations_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'nova_user_leaderboard';
+            referencedColumns: ['user_id'];
+          },
+        ];
+      };
       personal_notes: {
         Row: {
           content: string | null;
@@ -16153,6 +16198,16 @@ export type Database = {
           wallet_id: string;
         }[];
       };
+      create_workspace_email_invitation_with_roles: {
+        Args: {
+          p_email: string;
+          p_invited_by: string;
+          p_member_type: Database['public']['Enums']['workspace_member_type'];
+          p_role_ids?: string[];
+          p_ws_id: string;
+        };
+        Returns: undefined;
+      };
       create_workspace_wallet_checkpoints_batch: {
         Args: {
           _actor_id: string;
@@ -16483,6 +16538,24 @@ export type Database = {
       external_project_set_cms_site_template: {
         Args: { p_actor_user_id: string; p_template: Json; p_ws_id: string };
         Returns: Json;
+      };
+      finalize_workspace_invitation_membership: {
+        Args: {
+          p_member_type: Database['public']['Enums']['workspace_member_type'];
+          p_role_id?: string;
+          p_user_id: string;
+          p_ws_id: string;
+        };
+        Returns: boolean;
+      };
+      finalize_workspace_invitation_membership_v2: {
+        Args: {
+          p_member_type: Database['public']['Enums']['workspace_member_type'];
+          p_role_ids?: string[];
+          p_user_id: string;
+          p_ws_id: string;
+        };
+        Returns: boolean;
       };
       finance_credit_cycle_date: {
         Args: { p_anchor_year: number; p_day: number; p_month_offset: number };
@@ -16973,6 +17046,15 @@ export type Database = {
           trust_multiplier: number;
         }[];
       };
+      get_report_user_status_summary: {
+        Args: { p_group_id: string; p_user_ids: string[]; p_ws_id: string };
+        Returns: {
+          approved_count: number;
+          pending_count: number;
+          rejected_count: number;
+          user_id: string;
+        }[];
+      };
       get_report_workspace_id: {
         Args: { p_report_id: string };
         Returns: string;
@@ -17152,6 +17234,10 @@ export type Database = {
       get_wallet_ledger_balance_at: {
         Args: { _checked_at: string; _wallet_id: string };
         Returns: number;
+      };
+      get_workspace_invitation_role_ids: {
+        Args: { p_email?: string; p_user_id?: string; p_ws_id: string };
+        Returns: string[];
       };
       get_workspace_post_email_rows: {
         Args: {
@@ -17717,6 +17803,14 @@ export type Database = {
           transaction_count: number;
         }[];
       };
+      list_workspace_invitation_role_ids: {
+        Args: { p_ws_id: string };
+        Returns: {
+          email: string;
+          role_ids: string[];
+          user_id: string;
+        }[];
+      };
       list_workspace_user_groups_for_table: {
         Args: {
           p_accessible_group_ids?: string[];
@@ -18033,6 +18127,92 @@ export type Database = {
           workspace_name: string;
           ws_id: string;
         }[];
+      };
+      search_periodic_reports: {
+        Args: {
+          p_cadence: string;
+          p_group_ids?: string[];
+          p_search: string;
+          p_ws_id: string;
+        };
+        Returns: {
+          approved_at: string | null;
+          approved_by: string | null;
+          cadence: string | null;
+          content: string | null;
+          created_at: string | null;
+          creator_display_name: string | null;
+          creator_email: string | null;
+          creator_full_name: string | null;
+          creator_id: string | null;
+          delivered_at: string | null;
+          delivery_requested_at: string | null;
+          delivery_status: string | null;
+          feedback: string | null;
+          generation_mode: string | null;
+          generation_status: string | null;
+          group_id: string | null;
+          group_name: string | null;
+          group_ws_id: string | null;
+          id: string | null;
+          last_delivery_error: string | null;
+          manager_instruction: string | null;
+          modifier_display_name: string | null;
+          modifier_email: string | null;
+          modifier_full_name: string | null;
+          period_end: string | null;
+          period_start: string | null;
+          rejected_at: string | null;
+          rejected_by: string | null;
+          rejection_reason: string | null;
+          report_approval_status:
+            | Database['public']['Enums']['approval_status']
+            | null;
+          score: number | null;
+          scores: number[] | null;
+          source_context: Json | null;
+          title: string | null;
+          updated_at: string | null;
+          updated_by: string | null;
+          user_archived: boolean | null;
+          user_archived_until: string | null;
+          user_display_name: string | null;
+          user_email: string | null;
+          user_full_name: string | null;
+          user_id: string | null;
+          user_note: string | null;
+          user_ws_id: string | null;
+        }[];
+        SetofOptions: {
+          from: '*';
+          to: 'external_user_monthly_reports_workspace_view';
+          isOneToOne: false;
+          isSetofReturn: true;
+        };
+      };
+      search_report_groups_for_selector: {
+        Args: {
+          p_accessible_group_ids?: string[];
+          p_limit?: number;
+          p_search: string;
+          p_ws_id: string;
+        };
+        Returns: {
+          approved_count: number;
+          id: string;
+          name: string;
+          pending_count: number;
+          rejected_count: number;
+        }[];
+      };
+      set_workspace_invitation_roles: {
+        Args: {
+          p_email?: string;
+          p_role_ids?: string[];
+          p_user_id?: string;
+          p_ws_id: string;
+        };
+        Returns: undefined;
       };
       settle_ai_live_session: {
         Args: {
@@ -33953,6 +34133,42 @@ export type Database = {
           },
         ];
       };
+      workspace_email_invite_roles: {
+        Row: {
+          created_at: string;
+          email: string;
+          role_id: string;
+          ws_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          email: string;
+          role_id: string;
+          ws_id: string;
+        };
+        Update: {
+          created_at?: string;
+          email?: string;
+          role_id?: string;
+          ws_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'workspace_email_invite_roles_ws_id_email_fkey';
+            columns: ['ws_id', 'email'];
+            isOneToOne: false;
+            referencedRelation: 'workspace_email_invites';
+            referencedColumns: ['ws_id', 'email'];
+          },
+          {
+            foreignKeyName: 'workspace_email_invite_roles_ws_id_role_id_fkey';
+            columns: ['ws_id', 'role_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspace_roles';
+            referencedColumns: ['ws_id', 'id'];
+          },
+        ];
+      };
       workspace_email_invites: {
         Row: {
           created_at: string;
@@ -36514,6 +36730,42 @@ export type Database = {
             isOneToOne: false;
             referencedRelation: 'workspaces';
             referencedColumns: ['id'];
+          },
+        ];
+      };
+      workspace_invite_roles: {
+        Row: {
+          created_at: string;
+          role_id: string;
+          user_id: string;
+          ws_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          role_id: string;
+          user_id: string;
+          ws_id: string;
+        };
+        Update: {
+          created_at?: string;
+          role_id?: string;
+          user_id?: string;
+          ws_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'workspace_invite_roles_ws_id_role_id_fkey';
+            columns: ['ws_id', 'role_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspace_roles';
+            referencedColumns: ['ws_id', 'id'];
+          },
+          {
+            foreignKeyName: 'workspace_invite_roles_ws_id_user_id_fkey';
+            columns: ['ws_id', 'user_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspace_invites';
+            referencedColumns: ['ws_id', 'user_id'];
           },
         ];
       };
@@ -42476,12 +42728,30 @@ export type Database = {
         Args: { p_history_id: string; p_task_id: string; p_ws_id: string };
         Returns: Json;
       };
+      get_task_relationships_at_snapshot_for_actor: {
+        Args: {
+          p_actor_user_id: string;
+          p_history_id: string;
+          p_task_id: string;
+          p_ws_id: string;
+        };
+        Returns: Json;
+      };
       get_task_share_permission_from_link: {
         Args: { p_share_code: string };
         Returns: Database['public']['Enums']['task_share_permission'];
       };
       get_task_snapshot_at_history: {
         Args: { p_history_id: string; p_task_id: string; p_ws_id: string };
+        Returns: Json;
+      };
+      get_task_snapshot_at_history_for_actor: {
+        Args: {
+          p_actor_user_id: string;
+          p_history_id: string;
+          p_task_id: string;
+          p_ws_id: string;
+        };
         Returns: Json;
       };
       get_task_workspace_id: { Args: { p_task_id: string }; Returns: string };
@@ -43950,6 +44220,25 @@ export type Database = {
           reason: string;
           virtual_user_id: string;
         }[];
+      };
+      revert_task_to_history: {
+        Args: {
+          p_fields: string[];
+          p_history_id: string;
+          p_task_id: string;
+          p_ws_id: string;
+        };
+        Returns: Json;
+      };
+      revert_task_to_history_for_actor: {
+        Args: {
+          p_actor_user_id: string;
+          p_fields: string[];
+          p_history_id: string;
+          p_task_id: string;
+          p_ws_id: string;
+        };
+        Returns: Json;
       };
       revoke_all_cross_app_tokens: {
         Args: { p_user_id: string };

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -15592,6 +15592,10 @@ export type Database = {
         };
         Returns: Json;
       };
+      can_join_form_realtime_topic: {
+        Args: { p_topic: string; p_user_id: string };
+        Returns: boolean;
+      };
       can_join_task_realtime_topic: {
         Args: { p_topic: string; p_user_id: string };
         Returns: boolean;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -203,6 +203,7 @@
   },
   "exports": {
     "./globals.css": "./src/globals.css",
+    "./marketing": "./src/components/ui/marketing/index.ts",
     "./postcss.config": "./postcss.config.mjs",
     "./badge": {
       "types": "./src/components/ui/badge.tsx",

--- a/packages/ui/src/components/ui/marketing/accents.ts
+++ b/packages/ui/src/components/ui/marketing/accents.ts
@@ -1,0 +1,139 @@
+/**
+ * Accent tokens for the satellite marketing kit.
+ *
+ * Tailwind cannot resolve a class name assembled at runtime, so every accent
+ * variant has to exist as a literal string somewhere in the source. Keeping the
+ * full set in one map means a new accent is added once and every marketing
+ * primitive picks it up, instead of each component carrying its own partial
+ * copy of the same lookup table.
+ */
+
+export type MarketingAccent =
+  | 'blue'
+  | 'cyan'
+  | 'green'
+  | 'indigo'
+  | 'orange'
+  | 'pink'
+  | 'purple'
+  | 'red'
+  | 'yellow';
+
+export interface MarketingAccentTokens {
+  /** Foreground colour for icons and eyebrow labels. */
+  text: string;
+  /** Mid-stop for a hairline rule that fades out at both ends. */
+  rule: string;
+  /** Soft corner glow behind a hovered surface. */
+  bloom: string;
+  /** Filled chip / dot background. */
+  solid: string;
+  /** Tinted surface for badges and inline highlights. */
+  soft: string;
+  /** Border tint that pairs with `soft`. */
+  border: string;
+  /** Two-stop gradient for primary calls to action. */
+  gradient: string;
+  /** Radial bloom colour used by `SectionBloom`, referencing the raw token. */
+  radial: string;
+}
+
+export const MARKETING_ACCENTS: Record<MarketingAccent, MarketingAccentTokens> =
+  {
+    blue: {
+      text: 'text-dynamic-blue',
+      rule: 'via-dynamic-blue/45',
+      bloom: 'bg-dynamic-blue/20',
+      solid: 'bg-dynamic-blue',
+      soft: 'bg-dynamic-blue/10',
+      border: 'border-dynamic-blue/25',
+      gradient: 'from-dynamic-blue to-dynamic-cyan',
+      radial: 'bg-[radial-gradient(closest-side,var(--blue),transparent)]',
+    },
+    cyan: {
+      text: 'text-dynamic-cyan',
+      rule: 'via-dynamic-cyan/45',
+      bloom: 'bg-dynamic-cyan/20',
+      solid: 'bg-dynamic-cyan',
+      soft: 'bg-dynamic-cyan/10',
+      border: 'border-dynamic-cyan/25',
+      gradient: 'from-dynamic-cyan to-dynamic-blue',
+      radial: 'bg-[radial-gradient(closest-side,var(--cyan),transparent)]',
+    },
+    green: {
+      text: 'text-dynamic-green',
+      rule: 'via-dynamic-green/45',
+      bloom: 'bg-dynamic-green/20',
+      solid: 'bg-dynamic-green',
+      soft: 'bg-dynamic-green/10',
+      border: 'border-dynamic-green/25',
+      gradient: 'from-dynamic-green to-dynamic-cyan',
+      radial: 'bg-[radial-gradient(closest-side,var(--green),transparent)]',
+    },
+    indigo: {
+      text: 'text-dynamic-indigo',
+      rule: 'via-dynamic-indigo/45',
+      bloom: 'bg-dynamic-indigo/20',
+      solid: 'bg-dynamic-indigo',
+      soft: 'bg-dynamic-indigo/10',
+      border: 'border-dynamic-indigo/25',
+      gradient: 'from-dynamic-indigo to-dynamic-purple',
+      radial: 'bg-[radial-gradient(closest-side,var(--indigo),transparent)]',
+    },
+    orange: {
+      text: 'text-dynamic-orange',
+      rule: 'via-dynamic-orange/45',
+      bloom: 'bg-dynamic-orange/20',
+      solid: 'bg-dynamic-orange',
+      soft: 'bg-dynamic-orange/10',
+      border: 'border-dynamic-orange/25',
+      gradient: 'from-dynamic-orange to-dynamic-pink',
+      radial: 'bg-[radial-gradient(closest-side,var(--orange),transparent)]',
+    },
+    pink: {
+      text: 'text-dynamic-pink',
+      rule: 'via-dynamic-pink/45',
+      bloom: 'bg-dynamic-pink/20',
+      solid: 'bg-dynamic-pink',
+      soft: 'bg-dynamic-pink/10',
+      border: 'border-dynamic-pink/25',
+      gradient: 'from-dynamic-pink to-dynamic-purple',
+      radial: 'bg-[radial-gradient(closest-side,var(--pink),transparent)]',
+    },
+    purple: {
+      text: 'text-dynamic-purple',
+      rule: 'via-dynamic-purple/45',
+      bloom: 'bg-dynamic-purple/20',
+      solid: 'bg-dynamic-purple',
+      soft: 'bg-dynamic-purple/10',
+      border: 'border-dynamic-purple/25',
+      gradient: 'from-dynamic-purple to-dynamic-blue',
+      radial: 'bg-[radial-gradient(closest-side,var(--purple),transparent)]',
+    },
+    red: {
+      text: 'text-dynamic-red',
+      rule: 'via-dynamic-red/45',
+      bloom: 'bg-dynamic-red/20',
+      solid: 'bg-dynamic-red',
+      soft: 'bg-dynamic-red/10',
+      border: 'border-dynamic-red/25',
+      gradient: 'from-dynamic-red to-dynamic-orange',
+      radial: 'bg-[radial-gradient(closest-side,var(--red),transparent)]',
+    },
+    yellow: {
+      text: 'text-dynamic-yellow',
+      rule: 'via-dynamic-yellow/45',
+      bloom: 'bg-dynamic-yellow/20',
+      solid: 'bg-dynamic-yellow',
+      soft: 'bg-dynamic-yellow/10',
+      border: 'border-dynamic-yellow/25',
+      gradient: 'from-dynamic-yellow to-dynamic-orange',
+      radial: 'bg-[radial-gradient(closest-side,var(--yellow),transparent)]',
+    },
+  };
+
+export function getMarketingAccent(
+  accent: MarketingAccent
+): MarketingAccentTokens {
+  return MARKETING_ACCENTS[accent];
+}

--- a/packages/ui/src/components/ui/marketing/atmosphere.tsx
+++ b/packages/ui/src/components/ui/marketing/atmosphere.tsx
@@ -1,0 +1,155 @@
+import { cn } from '@tuturuuu/utils/format';
+import { getMarketingAccent, type MarketingAccent } from './accents';
+
+/**
+ * Grain overlay.
+ *
+ * A single inlined SVG turbulence tile — no network request, no image asset.
+ * Keeps large flat areas from banding and gives surfaces a filmic tooth.
+ */
+export function Grain({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute inset-0 opacity-[0.035] mix-blend-overlay dark:opacity-[0.055]',
+        className
+      )}
+      style={{
+        backgroundImage:
+          "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
+      }}
+    />
+  );
+}
+
+/**
+ * Fine engineering grid, masked to fade at the edges so it reads as a substrate
+ * rather than graph paper.
+ */
+export function GridSubstrate({
+  className,
+  size = '64px',
+}: {
+  className?: string;
+  size?: string;
+}) {
+  const mask =
+    'radial-gradient(ellipse 80% 60% at 50% 40%, black 20%, transparent 75%)';
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute inset-0 opacity-[0.5] dark:opacity-[0.35]',
+        className
+      )}
+      style={{
+        backgroundImage:
+          'linear-gradient(to right, color-mix(in oklab, var(--foreground) 6%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--foreground) 6%, transparent) 1px, transparent 1px)',
+        backgroundSize: `${size} ${size}`,
+        maskImage: mask,
+        WebkitMaskImage: mask,
+      }}
+    />
+  );
+}
+
+interface HeroAtmosphereProps {
+  /** Bloom behind the headline. */
+  primary?: MarketingAccent;
+  /** Cool counterweight in the upper right. */
+  secondary?: MarketingAccent;
+  /** Accent under the product frame. */
+  tertiary?: MarketingAccent;
+  /** Fades the rig into the page background at the bottom edge. */
+  settle?: boolean;
+  className?: string;
+}
+
+/**
+ * The hero light rig: three placed blooms rather than a full-bleed animated
+ * wash, which smears muddy brown across the viewport in dark mode. Each bloom
+ * drifts slowly and independently; all motion stops under
+ * `prefers-reduced-motion`.
+ */
+export function HeroAtmosphere({
+  primary = 'purple',
+  secondary = 'blue',
+  tertiary = 'cyan',
+  settle = true,
+  className,
+}: HeroAtmosphereProps = {}) {
+  const bloom = (accent: MarketingAccent, strength: number) =>
+    `radial-gradient(closest-side,color-mix(in oklab,var(--${accent}) ${strength}%,transparent),transparent)`;
+
+  return (
+    <div
+      aria-hidden
+      className={cn('pointer-events-none absolute inset-0 -z-10', className)}
+    >
+      {/* Primary bloom — sits behind the headline */}
+      <div
+        className="absolute -top-32 left-1/2 h-[30rem] w-[34rem] -translate-x-1/2 rounded-full opacity-45 blur-2xl motion-reduce:animate-none sm:-top-40 sm:h-[42rem] sm:w-[52rem] sm:animate-bloom-drift sm:opacity-50 sm:blur-3xl dark:opacity-55 dark:sm:opacity-60"
+        style={{ backgroundImage: bloom(primary, 34) }}
+      />
+
+      {/* Cool counterweight — upper right */}
+      <div
+        className="absolute -top-20 right-[8%] hidden h-[30rem] w-[34rem] animate-bloom-drift-slow rounded-full opacity-45 blur-3xl motion-reduce:animate-none sm:block dark:opacity-55"
+        style={{ backgroundImage: bloom(secondary, 34) }}
+      />
+
+      {/* Warm-cool accent — under the product frame */}
+      <div
+        className="absolute top-[38%] left-[6%] hidden h-[26rem] w-[30rem] animate-bloom-drift rounded-full opacity-40 blur-3xl [animation-delay:-8s] motion-reduce:animate-none sm:block dark:opacity-50"
+        style={{ backgroundImage: bloom(tertiary, 28) }}
+      />
+
+      {/* Light seam across the top — the horizon of the rig */}
+      <div
+        className="absolute inset-x-0 top-0 h-px motion-reduce:animate-none sm:animate-sheen"
+        style={{
+          backgroundImage: `linear-gradient(90deg,transparent,color-mix(in oklab,var(--${primary}) 55%,transparent) 35%,color-mix(in oklab,var(--${tertiary}) 55%,transparent) 65%,transparent)`,
+        }}
+      />
+
+      <GridSubstrate />
+
+      {settle ? (
+        <div className="absolute inset-x-0 bottom-0 h-64 bg-gradient-to-b from-transparent to-background" />
+      ) : null}
+
+      <Grain />
+    </div>
+  );
+}
+
+/**
+ * Quieter bloom for sections below the fold — keeps colour continuity down the
+ * page without competing with the hero.
+ */
+export function SectionBloom({
+  tone = 'purple',
+  align = 'center',
+}: {
+  tone?: MarketingAccent;
+  align?: 'center' | 'left' | 'right';
+}) {
+  const positions = {
+    center: 'left-1/2 -translate-x-1/2',
+    left: 'left-[-10%]',
+    right: 'right-[-10%]',
+  } as const;
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute top-0 -z-10 h-[28rem] w-[40rem] rounded-full opacity-[0.07] blur-3xl dark:opacity-[0.12]',
+        getMarketingAccent(tone).radial,
+        positions[align]
+      )}
+    />
+  );
+}

--- a/packages/ui/src/components/ui/marketing/cta.tsx
+++ b/packages/ui/src/components/ui/marketing/cta.tsx
@@ -1,0 +1,150 @@
+import { cn } from '@tuturuuu/utils/format';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import { getMarketingAccent, type MarketingAccent } from './accents';
+
+type AnchorProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  'className' | 'href'
+>;
+
+interface CtaLinkProps extends AnchorProps {
+  href: string;
+  children: ReactNode;
+  /** Opens in a new tab with the matching `rel` hardening. */
+  external?: boolean;
+  /** Stretches to the container on small screens; `auto` never does. */
+  width?: 'responsive' | 'auto';
+  size?: 'md' | 'lg';
+  className?: string;
+}
+
+const sizes = {
+  md: 'h-11 px-6 text-sm',
+  lg: 'h-12 px-8',
+} as const;
+
+function externalProps(external?: boolean) {
+  return external ? { target: '_blank', rel: 'noopener noreferrer' } : {};
+}
+
+/**
+ * Filled gradient call to action with a sheen that sweeps on hover.
+ *
+ * The sweep is a translated pseudo-layer rather than an animated
+ * `background-position`, so it composites on the GPU and does not repaint the
+ * button's text on every frame.
+ */
+export function PrimaryCta({
+  href,
+  children,
+  accent = 'purple',
+  external,
+  width = 'responsive',
+  size = 'lg',
+  className,
+  ...props
+}: CtaLinkProps & { accent?: MarketingAccent }) {
+  return (
+    <a
+      className={cn(
+        'group relative inline-flex items-center justify-center overflow-hidden rounded-full bg-gradient-to-r font-medium text-white shadow-lg transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        width === 'responsive' && 'w-full sm:w-auto',
+        sizes[size],
+        getMarketingAccent(accent).gradient,
+        className
+      )}
+      href={href}
+      {...externalProps(external)}
+      {...props}
+    >
+      <span
+        aria-hidden
+        className="absolute inset-0 -translate-x-full bg-[linear-gradient(90deg,transparent,rgb(255_255_255/0.3),transparent)] transition-transform duration-700 group-hover:translate-x-full motion-reduce:hidden"
+      />
+      <span className="relative flex items-center gap-2">{children}</span>
+    </a>
+  );
+}
+
+/** Quiet, glassy counterpart to `PrimaryCta`. */
+export function SecondaryCta({
+  href,
+  children,
+  external,
+  width = 'responsive',
+  size = 'lg',
+  className,
+  ...props
+}: CtaLinkProps) {
+  return (
+    <a
+      className={cn(
+        'inline-flex items-center justify-center gap-2 rounded-full border border-foreground/12 bg-background/40 font-medium text-foreground/75 backdrop-blur-md transition-all duration-300 hover:-translate-y-0.5 hover:border-foreground/25 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        width === 'responsive' && 'w-full sm:w-auto',
+        sizes[size],
+        className
+      )}
+      href={href}
+      {...externalProps(external)}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}
+
+/** Rounded pill label used above hero headlines and inside product frames. */
+export function MarketingPill({
+  accent = 'purple',
+  icon: Icon,
+  children,
+  className,
+}: {
+  accent?: MarketingAccent;
+  icon?: React.ComponentType<{ className?: string }>;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-background/40 py-1.5 pr-4 pl-2.5 font-mono-ui text-[0.65rem] uppercase tracking-[0.2em] backdrop-blur-md',
+        getMarketingAccent(accent).text,
+        className
+      )}
+    >
+      {Icon ? <Icon className="h-3.5 w-3.5" /> : null}
+      {children}
+    </span>
+  );
+}
+
+/**
+ * The marketing nav's filled action button.
+ *
+ * Lives here rather than in `marketing-nav.tsx` so it stays a server component:
+ * the nav itself is `'use client'` (it tracks scroll), but the action is often
+ * rendered inside a `<Suspense>` boundary on the server and passed in as a
+ * slot.
+ */
+export function MarketingNavAction({
+  accent = 'purple',
+  href,
+  label,
+}: {
+  accent?: MarketingAccent;
+  href: string;
+  label: string;
+}) {
+  return (
+    <a
+      className={cn(
+        'inline-flex h-9 items-center justify-center whitespace-nowrap rounded-full bg-gradient-to-r px-4 font-medium text-sm text-white shadow-sm transition-transform duration-300 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        getMarketingAccent(accent).gradient
+      )}
+      href={href}
+    >
+      {label}
+    </a>
+  );
+}

--- a/packages/ui/src/components/ui/marketing/faq-list.tsx
+++ b/packages/ui/src/components/ui/marketing/faq-list.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { cn } from '@tuturuuu/utils/format';
+import type { ReactNode } from 'react';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '../accordion';
+
+export interface MarketingFaqItem {
+  /** Stable value for the accordion item; also the React key. */
+  id: string;
+  question: ReactNode;
+  answer: ReactNode;
+}
+
+/**
+ * Marketing FAQ.
+ *
+ * A single-open accordion rather than a static definition list: an FAQ block
+ * long enough to be useful is long enough to bury the closing CTA if every
+ * answer is expanded at once.
+ */
+export function MarketingFaqList({
+  items,
+  className,
+}: {
+  items: MarketingFaqItem[];
+  className?: string;
+}) {
+  return (
+    <Accordion
+      className={cn('mx-auto w-full max-w-3xl', className)}
+      collapsible
+      type="single"
+    >
+      {items.map((item) => (
+        <AccordionItem
+          className="border-foreground/[0.08] border-b"
+          key={item.id}
+          value={item.id}
+        >
+          <AccordionTrigger className="py-5 text-left font-display font-medium text-base tracking-[-0.01em] hover:no-underline sm:text-lg">
+            {item.question}
+          </AccordionTrigger>
+          <AccordionContent className="pb-5 text-foreground/55 text-sm leading-relaxed sm:text-base">
+            {item.answer}
+          </AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+}

--- a/packages/ui/src/components/ui/marketing/fonts.ts
+++ b/packages/ui/src/components/ui/marketing/fonts.ts
@@ -1,0 +1,33 @@
+import { Be_Vietnam_Pro, JetBrains_Mono } from 'next/font/google';
+
+/**
+ * Display face for marketing headlines.
+ *
+ * Be Vietnam Pro is drawn for Vietnamese typography, so `vi` headlines keep
+ * their diacritics properly fitted instead of falling back mid-headline — and
+ * it carries far more character than the body face at large sizes.
+ */
+export const marketingDisplayFont = Be_Vietnam_Pro({
+  subsets: ['latin', 'vietnamese'],
+  weight: ['500', '600', '700', '800'],
+  display: 'swap',
+  variable: '--font-be-vietnam-pro',
+});
+
+/**
+ * Micro-label / numeric face: section eyebrows, indices, stat values. Also
+ * covers Vietnamese so translated eyebrows stay in the same voice.
+ */
+export const marketingMonoFont = JetBrains_Mono({
+  subsets: ['latin', 'vietnamese'],
+  weight: ['400', '500', '600'],
+  display: 'swap',
+  variable: '--font-jetbrains-mono',
+});
+
+/**
+ * Apply to the marketing layout's root element. `--font-display` and
+ * `--font-mono-ui` in `globals.css` resolve through these variables and fall
+ * back to the app font wherever the marketing faces are not loaded.
+ */
+export const marketingFontVariables = `${marketingDisplayFont.variable} ${marketingMonoFont.variable}`;

--- a/packages/ui/src/components/ui/marketing/index.ts
+++ b/packages/ui/src/components/ui/marketing/index.ts
@@ -1,0 +1,37 @@
+export {
+  getMarketingAccent,
+  MARKETING_ACCENTS,
+  type MarketingAccent,
+  type MarketingAccentTokens,
+} from './accents';
+export {
+  Grain,
+  GridSubstrate,
+  HeroAtmosphere,
+  SectionBloom,
+} from './atmosphere';
+export {
+  MarketingNavAction,
+  MarketingPill,
+  PrimaryCta,
+  SecondaryCta,
+} from './cta';
+export { type MarketingFaqItem, MarketingFaqList } from './faq-list';
+export {
+  marketingDisplayFont,
+  marketingFontVariables,
+  marketingMonoFont,
+} from './fonts';
+export {
+  MarketingFooter,
+  type MarketingFooterColumn,
+  type MarketingFooterLink,
+} from './marketing-footer';
+export { MarketingNav, type MarketingNavLink } from './marketing-nav';
+export {
+  SectionEyebrow,
+  SectionShell,
+  type SectionWidth,
+} from './section-shell';
+export { type MarketingStat, MarketingStatBand } from './stat-band';
+export { SurfaceCard } from './surface-card';

--- a/packages/ui/src/components/ui/marketing/marketing-footer.tsx
+++ b/packages/ui/src/components/ui/marketing/marketing-footer.tsx
@@ -1,0 +1,90 @@
+import { cn } from '@tuturuuu/utils/format';
+import type { ReactNode } from 'react';
+import { TuturuuLogo } from '../custom/tuturuuu-logo';
+
+export interface MarketingFooterLink {
+  href: string;
+  label: string;
+  external?: boolean;
+}
+
+export interface MarketingFooterColumn {
+  id: string;
+  title: string;
+  links: MarketingFooterLink[];
+}
+
+interface MarketingFooterProps {
+  appName: string;
+  /** One-line positioning statement under the wordmark. */
+  tagline: string;
+  columns: MarketingFooterColumn[];
+  /** Rendered at the bottom left, e.g. "© 2026 Tuturuuu". */
+  legal: ReactNode;
+  /** Locale switcher or social row, supplied by the host app. */
+  utilities?: ReactNode;
+  className?: string;
+}
+
+/** Shared satellite marketing footer: wordmark column plus link columns. */
+export function MarketingFooter({
+  appName,
+  tagline,
+  columns,
+  legal,
+  utilities,
+  className,
+}: MarketingFooterProps) {
+  return (
+    <footer
+      className={cn(
+        'relative border-foreground/[0.08] border-t px-4 py-16 sm:px-6 lg:px-8',
+        className
+      )}
+    >
+      <div className="mx-auto grid w-full max-w-6xl gap-12 lg:grid-cols-[1.5fr_repeat(3,1fr)]">
+        <div className="max-w-sm">
+          <div className="flex items-center gap-2.5">
+            <TuturuuLogo className="h-7 w-7" height={28} width={28} />
+            <span className="font-display font-semibold text-[0.95rem] tracking-[-0.01em]">
+              {appName}
+            </span>
+          </div>
+          <p className="mt-4 text-foreground/50 text-sm leading-relaxed">
+            {tagline}
+          </p>
+        </div>
+
+        {columns.map((column) => (
+          <nav aria-label={column.title} key={column.id}>
+            <h3 className="font-mono-ui text-[0.65rem] text-foreground/40 uppercase tracking-[0.2em]">
+              {column.title}
+            </h3>
+            <ul className="mt-4 space-y-2.5">
+              {column.links.map((link) => (
+                <li key={`${column.id}-${link.href}`}>
+                  <a
+                    className="text-foreground/55 text-sm transition-colors hover:text-foreground"
+                    href={link.href}
+                    {...(link.external
+                      ? { target: '_blank', rel: 'noopener noreferrer' }
+                      : {})}
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ))}
+      </div>
+
+      <div className="mx-auto mt-14 flex w-full max-w-6xl flex-col items-center justify-between gap-4 border-foreground/[0.06] border-t pt-8 sm:flex-row">
+        <p className="text-foreground/40 text-xs">{legal}</p>
+        {utilities ? (
+          <div className="flex items-center gap-3">{utilities}</div>
+        ) : null}
+      </div>
+    </footer>
+  );
+}

--- a/packages/ui/src/components/ui/marketing/marketing-nav.tsx
+++ b/packages/ui/src/components/ui/marketing/marketing-nav.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { Menu, X } from '@tuturuuu/icons';
+import { cn } from '@tuturuuu/utils/format';
+import { type ReactNode, useEffect, useState } from 'react';
+import { TuturuuLogo } from '../custom/tuturuuu-logo';
+
+export interface MarketingNavLink {
+  /** In-page anchor (`#pricing`) or absolute URL. */
+  href: string;
+  label: string;
+}
+
+interface MarketingNavProps {
+  /** App name shown next to the logo, e.g. "Forms". */
+  appName: string;
+  /** Where the wordmark links back to. Defaults to the landing root. */
+  homeHref?: string;
+  links: MarketingNavLink[];
+  /**
+   * Primary action button. Taken as a node rather than `{href,label}` so the
+   * host can wrap it in `<Suspense>` and let a session-dependent label stream
+   * in without making the whole marketing page dynamic. Render
+   * `MarketingNavAction` for the standard treatment.
+   */
+  action: ReactNode;
+  /** Secondary text action shown beside the primary on desktop. */
+  secondaryAction?: { href: string; label: string };
+  /** Locale/theme switchers supplied by the host app. */
+  utilities?: ReactNode;
+}
+
+/**
+ * Sticky marketing header.
+ *
+ * Starts transparent over the hero and only fades in its border and blur once
+ * the page scrolls, so the hero light rig is not cropped by a hard bar on load.
+ */
+export function MarketingNav({
+  appName,
+  homeHref = '/',
+  links,
+  action,
+  secondaryAction,
+  utilities,
+}: MarketingNavProps) {
+  const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 12);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // A menu left open while the viewport grows to desktop would keep the page
+  // scroll-locked behind an invisible panel.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const media = window.matchMedia('(min-width: 768px)');
+    const close = () => media.matches && setMenuOpen(false);
+    close();
+    media.addEventListener('change', close);
+    return () => media.removeEventListener('change', close);
+  }, [menuOpen]);
+
+  return (
+    <header
+      className={cn(
+        'fixed inset-x-0 top-0 z-50 transition-all duration-300',
+        scrolled || menuOpen
+          ? 'border-foreground/[0.08] border-b bg-background/80 backdrop-blur-xl'
+          : 'border-transparent border-b bg-transparent'
+      )}
+    >
+      <nav
+        aria-label={appName}
+        className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8"
+      >
+        <a
+          className="flex shrink-0 items-center gap-2.5 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          href={homeHref}
+        >
+          <TuturuuLogo className="h-7 w-7" height={28} width={28} />
+          <span className="font-display font-semibold text-[0.95rem] tracking-[-0.01em]">
+            {appName}
+          </span>
+        </a>
+
+        <div className="hidden items-center gap-1 md:flex">
+          {links.map((link) => (
+            <a
+              className="rounded-full px-3.5 py-2 text-foreground/55 text-sm transition-colors hover:bg-foreground/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              href={link.href}
+              key={link.href}
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {utilities}
+          {secondaryAction ? (
+            <a
+              className="hidden rounded-full px-3.5 py-2 text-foreground/55 text-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex"
+              href={secondaryAction.href}
+            >
+              {secondaryAction.label}
+            </a>
+          ) : null}
+          {action}
+          <button
+            aria-expanded={menuOpen}
+            aria-label={appName}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-foreground/10 text-foreground/70 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:hidden"
+            onClick={() => setMenuOpen((open) => !open)}
+            type="button"
+          >
+            {menuOpen ? (
+              <X className="h-4 w-4" />
+            ) : (
+              <Menu className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      </nav>
+
+      {menuOpen ? (
+        <div className="border-foreground/[0.06] border-t px-4 pb-4 md:hidden">
+          <div className="flex flex-col py-2">
+            {links.map((link) => (
+              <a
+                className="rounded-lg px-3 py-3 text-foreground/70 text-sm transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
+                href={link.href}
+                key={link.href}
+                onClick={() => setMenuOpen(false)}
+              >
+                {link.label}
+              </a>
+            ))}
+            {secondaryAction ? (
+              <a
+                className="rounded-lg px-3 py-3 text-foreground/70 text-sm transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
+                href={secondaryAction.href}
+                onClick={() => setMenuOpen(false)}
+              >
+                {secondaryAction.label}
+              </a>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/packages/ui/src/components/ui/marketing/section-shell.tsx
+++ b/packages/ui/src/components/ui/marketing/section-shell.tsx
@@ -1,0 +1,148 @@
+import { cn } from '@tuturuuu/utils/format';
+import type { ReactNode } from 'react';
+import type { MarketingAccent } from './accents';
+import { SectionBloom } from './atmosphere';
+
+const widths = {
+  narrow: 'max-w-4xl',
+  default: 'max-w-6xl',
+  wide: 'max-w-7xl',
+  full: 'max-w-none',
+} as const;
+
+export type SectionWidth = keyof typeof widths;
+
+/**
+ * The mono eyebrow, optionally preceded by a two-digit section index sitting in
+ * its own hairline rule. Exported on its own because hero sections want the
+ * label without the surrounding section chrome.
+ */
+export function SectionEyebrow({
+  children,
+  index,
+  className,
+}: {
+  children: ReactNode;
+  index?: string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-3 font-mono-ui text-[0.65rem] text-foreground/45 uppercase tracking-[0.24em]',
+        className
+      )}
+    >
+      {index ? (
+        <>
+          <span className="text-foreground/30 tabular-nums">{index}</span>
+          <span aria-hidden className="h-px w-8 bg-foreground/15" />
+        </>
+      ) : null}
+      {children}
+    </span>
+  );
+}
+
+interface SectionShellProps {
+  id?: string;
+  /** Two-digit index rendered in the rule beside the eyebrow, e.g. "02". */
+  index?: string;
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  children: ReactNode;
+  /** Constrains the inner content. Defaults to the 6xl marketing column. */
+  width?: SectionWidth;
+  align?: 'center' | 'start';
+  /** Ambient brand bloom behind the section header. */
+  bloom?: MarketingAccent | 'none';
+  /** Hairline rule across the top of the section. */
+  rule?: boolean;
+  /** Vertical rhythm. `tight` is for stacked sections that read as one unit. */
+  spacing?: 'tight' | 'default';
+  className?: string;
+  headerClassName?: string;
+}
+
+/**
+ * Shared vertical rhythm and header treatment for every marketing section.
+ *
+ * Keeps eyebrow/title/subtitle typography and section padding identical down
+ * the page so sections read as one system instead of N variations.
+ */
+export function SectionShell({
+  id,
+  index,
+  eyebrow,
+  title,
+  subtitle,
+  children,
+  width = 'default',
+  align = 'center',
+  bloom = 'none',
+  rule = true,
+  spacing = 'default',
+  className,
+  headerClassName,
+}: SectionShellProps) {
+  return (
+    <section
+      className={cn(
+        // `isolate` is load-bearing: `SectionBloom` paints at `-z-10`, and
+        // without a local stacking context it slides behind any ancestor that
+        // has its own background and vanishes.
+        'relative isolate scroll-mt-24 px-4 sm:px-6 lg:px-8',
+        spacing === 'tight'
+          ? 'py-14 sm:py-18 lg:py-20'
+          : 'py-20 sm:py-28 lg:py-32',
+        className
+      )}
+      id={id}
+    >
+      {rule ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[linear-gradient(90deg,transparent,color-mix(in_oklab,var(--foreground)_12%,transparent)_25%,color-mix(in_oklab,var(--foreground)_12%,transparent)_75%,transparent)]"
+        />
+      ) : null}
+      {bloom === 'none' ? null : <SectionBloom tone={bloom} />}
+
+      <div className={cn('relative mx-auto w-full', widths[width])}>
+        <header
+          className={cn(
+            'mb-14 flex flex-col sm:mb-18',
+            align === 'center' ? 'items-center text-center' : 'items-start',
+            headerClassName
+          )}
+        >
+          {eyebrow ? (
+            <SectionEyebrow index={index}>{eyebrow}</SectionEyebrow>
+          ) : null}
+
+          <h2
+            className={cn(
+              'mt-6 max-w-3xl text-balance font-display font-semibold text-4xl tracking-[-0.03em] sm:text-5xl lg:text-[3.5rem] lg:leading-[1.05]',
+              align === 'center' && 'mx-auto'
+            )}
+          >
+            {title}
+          </h2>
+
+          {subtitle ? (
+            <p
+              className={cn(
+                'mt-5 max-w-2xl text-balance text-base text-foreground/55 leading-relaxed sm:text-lg',
+                align === 'center' && 'mx-auto'
+              )}
+            >
+              {subtitle}
+            </p>
+          ) : null}
+        </header>
+
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/ui/marketing/stat-band.tsx
+++ b/packages/ui/src/components/ui/marketing/stat-band.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@tuturuuu/utils/format';
+import type { ReactNode } from 'react';
+
+export interface MarketingStat {
+  id: string;
+  /** The number itself — kept short so the row stays on one line on mobile. */
+  value: ReactNode;
+  label: ReactNode;
+}
+
+/**
+ * Row of headline figures under a hero.
+ *
+ * Values render in the mono face with `tabular-nums` so a band that animates or
+ * re-renders (live counters, locale switches) does not reflow its neighbours.
+ */
+export function MarketingStatBand({
+  stats,
+  className,
+}: {
+  stats: MarketingStat[];
+  className?: string;
+}) {
+  return (
+    <dl
+      className={cn(
+        'grid w-full grid-cols-2 gap-px overflow-hidden rounded-2xl border border-foreground/[0.08] bg-foreground/[0.06] sm:grid-cols-4',
+        className
+      )}
+    >
+      {stats.map((stat) => (
+        <div
+          className="flex flex-col items-center gap-1 bg-background px-4 py-6 text-center"
+          key={stat.id}
+        >
+          <dt className="order-2 text-[0.7rem] text-foreground/45 uppercase tracking-[0.16em]">
+            {stat.label}
+          </dt>
+          <dd className="order-1 font-display font-semibold text-2xl tabular-nums tracking-[-0.02em] sm:text-3xl">
+            {stat.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/packages/ui/src/components/ui/marketing/surface-card.tsx
+++ b/packages/ui/src/components/ui/marketing/surface-card.tsx
@@ -1,0 +1,144 @@
+import { ArrowUpRight } from '@tuturuuu/icons';
+import { cn } from '@tuturuuu/utils/format';
+import type { ComponentType, ReactNode } from 'react';
+import { getMarketingAccent, type MarketingAccent } from './accents';
+
+interface SurfaceCardProps {
+  accent: MarketingAccent;
+  icon?: ComponentType<{ className?: string }>;
+  title: ReactNode;
+  description: ReactNode;
+  /** Small mono label above the title (a role, a category). */
+  eyebrow?: ReactNode;
+  /** Renders the card as a link and reveals a corner arrow. */
+  href?: string;
+  /** Opens the link in a new tab — used for apps on their own domain. */
+  external?: boolean;
+  /** `stack` puts the icon above the copy; `inline` places it alongside. */
+  layout?: 'stack' | 'inline';
+  size?: 'md' | 'lg';
+  /** Extra content rendered under the description (a chip row, a mini preview). */
+  footer?: ReactNode;
+  className?: string;
+}
+
+/**
+ * The marketing card surface: border, lit top edge, corner bloom, hover lift.
+ *
+ * Every feature grid, use-case tile and app link on a satellite landing page
+ * routes through this, so a change to the treatment lands everywhere at once
+ * instead of being re-typed per section.
+ */
+export function SurfaceCard({
+  accent,
+  icon: Icon,
+  title,
+  description,
+  eyebrow,
+  href,
+  external,
+  layout = 'stack',
+  size = 'md',
+  footer,
+  className,
+}: SurfaceCardProps) {
+  const styles = getMarketingAccent(accent);
+  const Root = href ? 'a' : 'div';
+  const isLarge = size === 'lg';
+
+  return (
+    <Root
+      {...(href ? { href } : {})}
+      {...(href && external
+        ? { target: '_blank', rel: 'noopener noreferrer' }
+        : {})}
+      className={cn(
+        'group relative flex h-full overflow-hidden rounded-2xl border border-foreground/[0.08] bg-foreground/[0.015] transition-all duration-500',
+        'hover:-translate-y-1 hover:border-foreground/15 hover:bg-foreground/[0.03]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        layout === 'inline' ? 'items-start gap-3 p-4' : 'flex-col',
+        layout === 'stack' && (isLarge ? 'p-6 sm:p-7' : 'p-5'),
+        className
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent to-transparent transition-opacity duration-500 group-hover:opacity-100',
+          layout === 'inline' ? 'opacity-0' : 'opacity-40',
+          styles.rule
+        )}
+      />
+      <span
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute -top-16 -right-10 h-40 w-40 rounded-full opacity-0 blur-3xl transition-opacity duration-700 group-hover:opacity-100',
+          styles.bloom
+        )}
+      />
+
+      {Icon ? (
+        layout === 'inline' ? (
+          <span
+            className={cn(
+              'relative flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-foreground/10 bg-foreground/[0.03] transition-transform duration-500 group-hover:scale-105',
+              styles.text
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+          </span>
+        ) : (
+          <Icon
+            className={cn(
+              'relative transition-transform duration-500 group-hover:scale-110',
+              isLarge ? 'h-5 w-5' : 'h-4 w-4',
+              styles.text
+            )}
+          />
+        )
+      ) : null}
+
+      <span className={cn('relative min-w-0', layout === 'inline' && 'flex-1')}>
+        {eyebrow ? (
+          <span
+            className={cn(
+              'block font-mono-ui text-[0.6rem] uppercase tracking-[0.18em]',
+              layout === 'stack' && Icon && 'mt-4',
+              styles.text
+            )}
+          >
+            {eyebrow}
+          </span>
+        ) : null}
+
+        <span
+          className={cn(
+            'flex items-center gap-1.5 font-display font-semibold tracking-[-0.01em]',
+            layout === 'stack' &&
+              !eyebrow &&
+              Icon &&
+              (isLarge ? 'mt-5' : 'mt-4'),
+            eyebrow && 'mt-1.5',
+            isLarge ? 'text-xl sm:text-2xl' : 'text-[0.95rem]'
+          )}
+        >
+          {title}
+          {href ? (
+            <ArrowUpRight className="h-3 w-3 shrink-0 text-foreground/25 transition-all duration-300 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground/50" />
+          ) : null}
+        </span>
+
+        <span
+          className={cn(
+            'mt-2 block text-foreground/50 leading-relaxed',
+            isLarge ? 'max-w-md text-sm' : 'text-xs'
+          )}
+        >
+          {description}
+        </span>
+
+        {footer ? <span className="relative mt-4 block">{footer}</span> : null}
+      </span>
+    </Root>
+  );
+}

--- a/packages/utils/src/next-config.test.ts
+++ b/packages/utils/src/next-config.test.ts
@@ -500,4 +500,35 @@ describe('trimTrailingSlashes', () => {
       'https://example.com/path'
     );
   });
+
+  it('excludes opted-in paths from the anti-framing rule', async () => {
+    const config = createTuturuuuNextConfig({
+      framablePathPatterns: ['embed/[^/]+'],
+    });
+
+    const headers = await config.headers?.();
+    const source = headers?.[0]?.source ?? '';
+
+    expect(source).toContain('embed/[^/]+(?:/|$)');
+    // The platform default must survive an app adding its own patterns.
+    expect(source).toContain('external-projects/assets/[^/]+/webgl(?:/|$)');
+
+    // The `source` is a path-to-regexp pattern, so assert the lookahead does
+    // what it claims: opted-in paths must not match the deny rule, and
+    // everything else still must.
+    const lookahead = new RegExp(`^${source.slice('/:path('.length, -1)}$`);
+    expect(lookahead.test('embed/abc123')).toBe(false);
+    expect(lookahead.test('embed/abc123/preview')).toBe(false);
+    expect(lookahead.test('embedded-elsewhere')).toBe(true);
+    expect(lookahead.test('f/abc123')).toBe(true);
+    expect(lookahead.test('personal/forms')).toBe(true);
+  });
+
+  it('does not leak framablePathPatterns into the Next config object', () => {
+    const config = createTuturuuuNextConfig({
+      framablePathPatterns: ['embed/[^/]+'],
+    });
+
+    expect(config).not.toHaveProperty('framablePathPatterns');
+  });
 });

--- a/packages/utils/src/next-config.ts
+++ b/packages/utils/src/next-config.ts
@@ -41,8 +41,31 @@ export const TUTURUUU_NEXT_IMAGE_REMOTE_PATTERNS = [
 
 export const TUTURUUU_NEXT_IMAGE_MINIMUM_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60;
 
-const TUTURUUU_ANTI_FRAMING_SOURCE =
-  '/:path((?!api/v1/workspaces/[^/]+/external-projects/assets/[^/]+/webgl(?:/|$)).*)';
+/**
+ * Paths every app excludes from the anti-framing headers.
+ *
+ * Framing is denied by default across the platform; anything listed here has
+ * been deliberately designed to be embedded in a third-party page.
+ */
+const TUTURUUU_DEFAULT_FRAMABLE_PATTERNS = [
+  'api/v1/workspaces/[^/]+/external-projects/assets/[^/]+/webgl',
+];
+
+/**
+ * Builds the anti-framing `source` as a negative lookahead over every framable
+ * path, so those paths simply never match the deny rule.
+ *
+ * A later permissive header would not reliably win: `X-Frame-Options` has no
+ * "allow from any origin" value, so the deny header has to be absent rather
+ * than overridden.
+ */
+function buildAntiFramingSource(framablePathPatterns: readonly string[]) {
+  const alternatives = framablePathPatterns
+    .map((pattern) => `${pattern}(?:/|$)`)
+    .join('|');
+
+  return `/:path((?!${alternatives}).*)`;
+}
 
 const TUTURUUU_ANTI_FRAMING_HEADERS = [
   {
@@ -111,14 +134,32 @@ export function getTuturuuuNextOptimizePackageImports(
     : mergeStringArrays(TUTURUUU_NEXT_OPTIMIZE_PACKAGE_IMPORTS, appImports);
 }
 
-export function createTuturuuuNextConfig(config: NextConfig = {}): NextConfig {
+export interface TuturuuuNextConfigOptions extends NextConfig {
+  /**
+   * Path patterns (no leading slash, regex fragments) that this app allows to
+   * be framed by third-party sites. Excluded from the platform-wide
+   * `frame-ancestors 'none'` / `X-Frame-Options: DENY` rule.
+   *
+   * Opt in per route, never per app: everything not listed here stays denied.
+   */
+  framablePathPatterns?: readonly string[];
+}
+
+export function createTuturuuuNextConfig(
+  config: TuturuuuNextConfigOptions = {}
+): NextConfig {
   const experimentalConfig = config.experimental ?? {};
   const imageConfig = config.images ?? {};
+  const { framablePathPatterns, ...nextConfig } = config;
+  const antiFramingSource = buildAntiFramingSource([
+    ...TUTURUUU_DEFAULT_FRAMABLE_PATTERNS,
+    ...(framablePathPatterns ?? []),
+  ]);
 
   return {
     reactStrictMode: true,
     poweredByHeader: false,
-    ...config,
+    ...nextConfig,
     reactCompiler: isTuturuuuNextReactCompilerEnabled(),
     cacheComponents:
       config.cacheComponents ?? isTuturuuuNextCacheComponentsEnabled(),
@@ -159,10 +200,10 @@ export function createTuturuuuNextConfig(config: NextConfig = {}): NextConfig {
     async headers() {
       return [
         {
-          source: TUTURUUU_ANTI_FRAMING_SOURCE,
+          source: antiFramingSource,
           headers: TUTURUUU_ANTI_FRAMING_HEADERS,
         },
-        ...((await config.headers?.()) ?? []),
+        ...((await nextConfig.headers?.()) ?? []),
       ];
     },
   };


### PR DESCRIPTION
## Summary

`forms.tuturuuu.com/` served a redirect and had no marketing surface; forms had no
per-form SEO control, no way to be embedded in a third-party page, and no signal
that someone else was editing the same form. This adds all four, plus a
Typeform-style one-question-at-a-time runtime mode.

Picked up from an abandoned session — the four feature commits were authored on
2026-08-25 and pushed but never opened as a PR. Rebased onto current `main`
(clean, no conflicts) and re-verified from scratch.

## What's in it

**Landing page** — 11 sections at `forms.tuturuuu.com/`. The product demo is the
real `FormRuntime` with a working theme switcher, so the marketing demo cannot
drift from the shipped product. Statically prerendered; only the session-dependent
CTAs stream in.

**Per-form SEO** — new `private.forms.seo` `jsonb` column (title, description,
social card, keywords, canonical, `noIndex`), a studio panel with a live
search-result preview showing where Google truncates, wired into `/f/<code>`
metadata, OG/Twitter cards and robots.

**Realtime studio collaboration** — presence + broadcast on private
`form-studio-<formId>` channels, authorized by
`private.can_join_form_realtime_topic` against `manage_forms`. A remote save
refreshes your copy immediately when it's clean, but raises a reload prompt when
it's dirty — blindly refetching would discard unsaved work.

**Six embed modes + SDK** — `/embed/<code>` route, a dependency-free
`public/embed.js`, and a studio snippet builder. `createTuturuuuNextConfig` gains
`framablePathPatterns` so a route can opt out of the platform-wide framing deny.

**One-question-at-a-time + welcome screen** — layered over the existing section
navigation via `runtime/step-plan.ts`, so branching stays a single engine.

**Docs** — new `platform/features/forms-embedding-and-seo` page covering the embed
attribute contract, the `postMessage` protocol, the SEO column shape, and the
realtime authorization model.

## Migrations

Two additive migrations, **not yet applied to production**:

- `20260825045312_forms_seo_metadata.sql` — adds `private.forms.seo` with an
  object-type check constraint.
- `20260825053118_forms_realtime_collaboration.sql` — adds
  `private.can_join_form_realtime_topic` and two `realtime.messages` policies
  (select + insert), additive alongside the existing task-realtime policy.

## Verification

Re-run from scratch after the rebase, not inherited from the original session:

- `bun check` — exit 0, all 20 categories pass
- `apps/forms` real `bun run build` — exit 0, no `cacheComponents` violations
- 103 tests pass across 19 files in `apps/forms`
- en/vi message bundles at exact key parity (290 new keys each, genuinely
  translated)
- Every authored file under the 700-LOC ceiling; `settings-panel.tsx` split from
  699 lines into 5 modules

## Not in scope

New question types (email/phone/number/NPS/ranking) and the studio 3-pane
redesign. Both are substantial and worth scoping separately.

## Two things worth knowing repo-wide

- **`packages/satellite` is not in Tailwind's content scan set.** Classes used
  only from there emit no CSS at all — markup renders unstyled rather than
  failing loudly. That's why the marketing kit landed in
  `packages/ui/src/components/ui/marketing` (`@tuturuuu/ui/marketing`).
- **`connection()` at a page root forces the whole page dynamic.** Scoping it to
  the session-dependent subtree took the landing page from 281ms to 86ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
