### PR TITLE
docs: adopt stacked pull requests for dependent work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,15 @@ surface you are changing:
   the shared main checkout onto the PR branch. Run `bun setup` immediately after
   creating the worktree. After the PR is confirmed merged into `main`, remove
   the completed worktree and delete its local task branch.
+- When a change is large enough to review in stages, or when follow-up work
+  builds on a branch that is still open, split it into a stack of pull requests
+  instead of growing one branch or waiting for the first to merge. Base each PR
+  on the branch below it (`gh pr create --base <parent-branch>`), keep each one
+  independently green, and state the stack position and parent PR in the body.
+  Merge strictly bottom-up: GitHub retargets an open PR to its parent's base
+  when the parent merges, so never merge a PR whose parent is still open. Do not
+  stack when the parts are genuinely independent — separate PRs off `main` are
+  simpler and can merge in any order.
 - When the user authorizes ongoing integration, periodically checkpoint verified
   work instead of leaving it indefinitely only in retained worktrees: create
   scoped commits, integrate them into `main`, wait for every workflow on the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,15 @@ surface you are changing:
   instead of growing one branch or waiting for the first to merge. Base each PR
   on the branch below it (`gh pr create --base <parent-branch>`), keep each one
   independently green, and state the stack position and parent PR in the body.
-  Merge strictly bottom-up: GitHub retargets an open PR to its parent's base
-  when the parent merges, so never merge a PR whose parent is still open. Do not
+  Merge strictly bottom-up and never merge a PR whose parent is still open.
+  Merge a stack parent with a merge commit (`gh pr merge --merge`): squash and
+  rebase merges leave the parent's commits outside `main`'s ancestry, so the
+  retargeted child re-shows changes that already landed. Do not assume
+  retargeting happened — GitHub retargets children only when the merged parent
+  branch is deleted through the pull-request flow, and deleting it with `gh` or
+  `git push --delete` can close them instead. After each parent merge, check
+  every child's `baseRefName` and retarget with `gh pr edit <n> --base <base>`
+  before the parent branch is deleted, then re-run the child's gates. Do not
   stack when the parts are genuinely independent — separate PRs off `main` are
   simpler and can merge in any order.
 - When the user authorizes ongoing integration, periodically checkpoint verified

--- a/apps/docs/build/development-tools/git-conventions.mdx
+++ b/apps/docs/build/development-tools/git-conventions.mdx
@@ -480,4 +480,8 @@ checks local refs only.
 
 Following these Git conventions helps us maintain a clean, understandable repository history, automate release processes, and improve collaboration across the team. By standardizing both commit messages and branch names, we create a more efficient development workflow.
 
+When a branch grows large enough that one pull request cannot be reviewed
+comfortably, split it into a chain of dependent PRs — see [Stacked Pull
+Requests](/build/development-tools/stacked-pull-requests).
+
 For more information, refer to the official documentation for [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and [Conventional Branch](https://conventional-branch.github.io/).

--- a/apps/docs/build/development-tools/stacked-pull-requests.mdx
+++ b/apps/docs/build/development-tools/stacked-pull-requests.mdx
@@ -20,9 +20,9 @@ or when follow-up work builds on a branch that has not merged yet.
 gh pr create --base feat/parent-branch --head feat/child-branch
 ```
 
-Merge strictly bottom-up. GitHub retargets the child to the parent's base once
-the parent merges, so the chain survives on its own — but only if you merge in
-order.
+Merge strictly bottom-up, with a merge commit, and check afterwards that each
+child was actually retargeted. GitHub usually does it for you; "usually" is why
+you check.
 
 ## When to stack
 
@@ -83,8 +83,15 @@ Run the usual gates in the child's worktree, not just at the top of the stack:
 bun check
 ```
 
-`bun check` does not compile Next apps, so also run the affected app's real
-build when the slice touches routes, pages or dependencies.
+`bun check` does not compile Next apps, so a slice that touches routes, pages
+or dependencies also needs the affected app's real build before it can be
+called verified.
+
+<Warning>
+  Agents must not run `bun run build` on their own — the repo-wide prohibition
+  on long-running build commands applies inside a stack too. Report that the
+  build is required and ask; run it only once the user says so.
+</Warning>
 
 ## Merging the stack
 
@@ -92,17 +99,46 @@ Merge **bottom-up**, one at a time, and never merge a PR whose parent is still
 open — doing so pulls the parent's unreviewed commits into `main` through the
 child.
 
-When the parent merges and its branch is deleted, GitHub automatically
-retargets any open PR that had it as a base onto the parent's base. In
-practice: merge slice 1 into `main`, and slice 2's PR silently switches its base
-from `feat/slice-one` to `main`, with its diff shrinking to just its own
-changes.
+### Merge a stack parent with a merge commit
+
+```bash
+gh pr merge <parent-number> --merge
+```
+
+Not `--squash` and not `--rebase`. Both rewrite the parent's commits into new
+ones, so the originals never become part of `main`'s ancestry — and the
+retargeted child then shows the parent's changes all over again, as if they had
+never landed. A merge commit keeps the parent's commits reachable from `main`,
+which is what makes the child's diff shrink to its own work.
+
+If a stack parent has already been squash-merged, the fix is to rebase the
+child onto `main`, drop the duplicated commits, and re-run its gates.
+
+### Check the retargeting actually happened
+
+When a merged parent's branch is deleted through the pull-request flow — the
+merge button, or the repository's automatic head-branch deletion — GitHub
+retargets any open PR that had it as a base onto the parent's base. Slice 2's
+PR switches from `feat/slice-one` to `main` on its own.
 
 <Warning>
-  Automatic retargeting fires on merge, not on close. If you close a parent PR
-  without merging it, its children keep pointing at a dead branch and must be
-  retargeted by hand with `gh pr edit <number> --base main`.
+  Do not assume it happened. Deleting the branch another way — `gh` or
+  `git push origin --delete` — can **close** the dependent PRs instead of
+  retargeting them, and a closed PR whose base branch is gone is awkward to
+  reopen. Closing a parent PR without merging does not delete its branch at
+  all, so its children keep pointing at a live but abandoned base.
 </Warning>
+
+After every parent merge, check each child and retarget it by hand if needed,
+before the parent branch disappears:
+
+```bash
+gh pr view <child-number> --json baseRefName -q .baseRefName
+gh pr edit <child-number> --base main
+```
+
+Then re-run the child's gates: its merge base moved, so its diff is not the one
+that was last verified.
 
 Each PR in the stack still needs its own approving review from a code owner and
 its own resolved review threads — the repository ruleset applies per PR, not per

--- a/apps/docs/build/development-tools/stacked-pull-requests.mdx
+++ b/apps/docs/build/development-tools/stacked-pull-requests.mdx
@@ -1,0 +1,148 @@
+---
+title: "Stacked Pull Requests"
+description: "Split large work into a stack of dependent pull requests so each one stays reviewable, and merge the stack bottom-up without losing the chain."
+updatedAt: "2026-08-26"
+---
+
+<Info>
+  **Prerequisite**: You should be comfortable with [Git
+  Conventions](/build/development-tools/git-conventions) and with creating
+  worktrees, since every PR in a stack gets its own.
+</Info>
+
+## TL;DR
+
+A stack is a chain of pull requests where each one targets the branch below it
+instead of `main`. Use it when a change is too large to review in one sitting,
+or when follow-up work builds on a branch that has not merged yet.
+
+```bash
+gh pr create --base feat/parent-branch --head feat/child-branch
+```
+
+Merge strictly bottom-up. GitHub retargets the child to the parent's base once
+the parent merges, so the chain survives on its own — but only if you merge in
+order.
+
+## When to stack
+
+Stack when the parts are **genuinely dependent**:
+
+- A large feature that splits into reviewable slices, where slice 2 imports
+  code slice 1 introduces.
+- Follow-up work on a branch that is still waiting for review — stacking lets
+  you keep building instead of idling or piling more into a PR someone has
+  already started reviewing.
+- A refactor that must land before the change that depends on it, where you
+  want them reviewed separately but merged together.
+
+**Do not stack when the parts are independent.** Two unrelated fixes should be
+two PRs off `main`: they can merge in any order, neither blocks the other, and
+neither needs a rebase when the other lands. A stack buys ordering at the cost
+of rebasing, so only pay it when you need the ordering.
+
+## Creating a stack
+
+Each PR gets its own worktree, per the repo-wide rule that PR work never
+switches the shared checkout:
+
+```bash
+git worktree add -b feat/slice-one .worktrees/slice-one origin/main
+git worktree add -b feat/slice-two .worktrees/slice-two feat/slice-one
+```
+
+Then open each PR against the branch below it. The first targets `main`; every
+later one targets its parent:
+
+```bash
+gh pr create --base main --head feat/slice-one
+gh pr create --base feat/slice-one --head feat/slice-two
+```
+
+Basing the child on the parent is what keeps the diff honest: GitHub diffs
+against the merge base, so the child PR shows only its own commits rather than
+re-displaying everything in the parent.
+
+### Say where each PR sits
+
+Reviewers cannot see the stack from the PR page alone. Put the position and the
+parent in the body of every PR above the base:
+
+```markdown
+**Stack**: 2 of 3 — based on #5145, which must merge first.
+```
+
+## Keeping each PR green
+
+Every PR in the stack must pass on its own. A child that only compiles once its
+parent is merged is not reviewable, and CI will say so.
+
+Run the usual gates in the child's worktree, not just at the top of the stack:
+
+```bash
+bun check
+```
+
+`bun check` does not compile Next apps, so also run the affected app's real
+build when the slice touches routes, pages or dependencies.
+
+## Merging the stack
+
+Merge **bottom-up**, one at a time, and never merge a PR whose parent is still
+open — doing so pulls the parent's unreviewed commits into `main` through the
+child.
+
+When the parent merges and its branch is deleted, GitHub automatically
+retargets any open PR that had it as a base onto the parent's base. In
+practice: merge slice 1 into `main`, and slice 2's PR silently switches its base
+from `feat/slice-one` to `main`, with its diff shrinking to just its own
+changes.
+
+<Warning>
+  Automatic retargeting fires on merge, not on close. If you close a parent PR
+  without merging it, its children keep pointing at a dead branch and must be
+  retargeted by hand with `gh pr edit <number> --base main`.
+</Warning>
+
+Each PR in the stack still needs its own approving review from a code owner and
+its own resolved review threads — the repository ruleset applies per PR, not per
+stack. Follow the normal merge closeout (quiet window, main-green verification,
+`bun git-sync`, production verification) for each one.
+
+## Rebasing a stack
+
+If you rebase or amend a parent branch, every branch above it still points at
+the old commits and must be rebased too, from the bottom up:
+
+```bash
+git -C .worktrees/slice-one rebase origin/main
+git -C .worktrees/slice-two rebase --onto feat/slice-one <old-parent-sha> feat/slice-two
+```
+
+Both then need a force-push. Use `--force-with-lease` so a push is refused if
+someone else moved the branch:
+
+```bash
+git push --force-with-lease origin feat/slice-one
+```
+
+<Warning>
+  Force-pushing rewrites published history. It is routine for a branch only you
+  are working on, but confirm with the owner before rewriting a branch anyone
+  else has pulled or reviewed.
+</Warning>
+
+Rebasing a whole stack is the main cost of stacking, and it grows with depth.
+Three PRs is comfortable; much beyond that, prefer merging the lower slices
+sooner so the stack stays shallow.
+
+## Cleaning up
+
+Remove a worktree and delete its local branch only after that PR is confirmed
+merged into `main`. Never remove a worktree that is dirty, blocked, unmerged, or
+owned by someone else.
+
+```bash
+git worktree remove .worktrees/slice-one
+git branch -d feat/slice-one
+```

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -292,6 +292,7 @@
               "build/development-tools/codex-plugin",
               "build/development-tools/monorepo-architecture",
               "build/development-tools/git-conventions",
+              "build/development-tools/stacked-pull-requests",
               "build/development-tools/local-supabase-development",
               "build/development-tools/remote-devboxes",
               "build/development-tools/ci-cd-pipelines",

--- a/plugins/tuturuuu/skills/tuturuuu-pr-merge-sync/SKILL.md
+++ b/plugins/tuturuuu/skills/tuturuuu-pr-merge-sync/SKILL.md
@@ -22,14 +22,23 @@ comments: quiet-window watching, merge, mandatory main-green verification,
 
 ## Required Gates
 
-0. Check whether the PR is part of a stack (its base is a branch other than
-   `main`). If so, its parent must be merged first: merging a child while its
+0. Check whether the PR is part of a stack. A base other than `main` is not
+   proof: a PR can legitimately target `production`, a release branch, or a
+   maintenance branch with no parent PR at all, and treating those as stacked
+   blocks valid closeout work. It is a stack only when the base branch is the
+   head branch of an open pull request, or the PR body names its parent:
+
+       gh pr list --state open --json number,headRefName \
+         --jq '.[] | select(.headRefName == "<this-pr-base>") | .number'
+
+   When it is stacked, the parent must merge first — merging a child while its
    parent is open pulls the parent's unreviewed commits into `main` through the
-   child. Merge the stack bottom-up, one PR at a time, running every gate below
-   for each. GitHub retargets an open child onto the parent's base once the
-   parent merges, so do not retarget by hand unless the parent was closed
-   without merging. See
-   `/build/development-tools/stacked-pull-requests` in `apps/docs`.
+   child. Merge bottom-up, one PR at a time, running every gate below for each,
+   and merge stack parents with `gh pr merge --merge`: a squash or rebase merge
+   leaves the parent's commits outside `main`'s ancestry, so the retargeted
+   child re-shows changes that already landed. After each parent merge, confirm
+   each child's `baseRefName` actually moved and retarget by hand if it did
+   not. See `/build/development-tools/stacked-pull-requests` in `apps/docs`.
 1. Perform all open-PR work in an isolated `.worktrees/` checkout and run
    `bun setup` immediately after creating it.
 2. Confirm GitHub auth and rate limits:

--- a/plugins/tuturuuu/skills/tuturuuu-pr-merge-sync/SKILL.md
+++ b/plugins/tuturuuu/skills/tuturuuu-pr-merge-sync/SKILL.md
@@ -22,6 +22,14 @@ comments: quiet-window watching, merge, mandatory main-green verification,
 
 ## Required Gates
 
+0. Check whether the PR is part of a stack (its base is a branch other than
+   `main`). If so, its parent must be merged first: merging a child while its
+   parent is open pulls the parent's unreviewed commits into `main` through the
+   child. Merge the stack bottom-up, one PR at a time, running every gate below
+   for each. GitHub retargets an open child onto the parent's base once the
+   parent merges, so do not retarget by hand unless the parent was closed
+   without merging. See
+   `/build/development-tools/stacked-pull-requests` in `apps/docs`.
 1. Perform all open-PR work in an isolated `.worktrees/` checkout and run
    `bun setup` immediately after creating it.
 2. Confirm GitHub auth and rate limits:


### PR DESCRIPTION
## Summary

Large changes and follow-up work on an unmerged branch had two bad options here:
grow one branch until nobody can review it, or idle until the first PR lands.
A stack of dependent PRs is the third, and GitHub already supports the mechanics
— a non-default base branch, and automatic retargeting of open children when a
parent merges.

This writes the practice down in the three places an agent or a person would
look for it.

## What changed

**`AGENTS.md`** gains the mandate. It belongs at the root rather than in a
focused skill because it is cross-cutting, and because the failure it prevents
is silent: merging a child whose parent is still open drags the parent's
unreviewed commits into `main` through the child, and nothing in CI flags that.

**`tuturuuu-pr-merge-sync`** gains it as gate 0, not a footnote — merge order is
that skill's whole subject, and every other gate is per-PR anyway, so a stack
needs the full checklist run once per PR rather than once per stack.

**`apps/docs/build/development-tools/stacked-pull-requests`** is the how-to:
creating the stack with one worktree per PR, keeping each independently green,
merging bottom-up, GitHub's automatic retargeting, and rebasing a stack when a
parent moves. Cross-linked from `git-conventions`, which stays about naming
commits and branches.

## Deliberately documented as a cost

Stacking buys ordering and pays for it in rebases that compound with depth. The
page says plainly not to stack independent work — two unrelated fixes should be
two PRs off `main`, mergeable in any order — and to keep stacks shallow.

## Proven on the way in

This was written while stacking [#5146](https://github.com/tutur3u/platform/pull/5146)
on [#5145](https://github.com/tutur3u/platform/pull/5145). The retargeting and
diff-scoping behaviour described here is what those two PRs actually do: #5146
shows only its own 21 files rather than re-displaying #5145's 103.

## Verification

`bun check` passes every category except one **pre-existing failure on `main`**,
unrelated to this change — see the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
