### PR TITLE
fix(forms): survive the deploy window before the seo migration lands

### DIFF
--- a/apps/forms/src/features/forms/server/mutations.test.ts
+++ b/apps/forms/src/features/forms/server/mutations.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { upsertFormRow } from './mutations';
+
+type UpsertResult = { error: { code?: string; message: string } | null };
+
+function createClient(results: UpsertResult[]) {
+  const calls: Record<string, unknown>[] = [];
+  const upsert = vi.fn((payload: Record<string, unknown>) => {
+    calls.push(payload);
+    return Promise.resolve(results[calls.length - 1] ?? { error: null });
+  });
+
+  return {
+    calls,
+    upsert,
+    client: { from: () => ({ upsert }) },
+  };
+}
+
+const payload = { id: 'form-1', title: 'Intake', seo: { title: 'Custom' } };
+
+describe('upsertFormRow', () => {
+  it('writes once when the schema has the column', async () => {
+    const { client, calls } = createClient([{ error: null }]);
+
+    const result = await upsertFormRow(client, payload);
+
+    expect(result.error).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toHaveProperty('seo');
+  });
+
+  it('retries without seo when the column does not exist yet', async () => {
+    // Production migrations apply after the deployment, so this is the window
+    // on every release where the new code meets the old schema.
+    const { client, calls } = createClient([
+      {
+        error: {
+          code: '42703',
+          message: `column "seo" of relation "forms" does not exist`,
+        },
+      },
+      { error: null },
+    ]);
+
+    const result = await upsertFormRow(client, payload);
+
+    expect(result.error).toBeNull();
+    expect(calls).toHaveLength(2);
+    // The author's edit still lands; only the SEO overrides are dropped, and
+    // only until the migration is applied.
+    expect(calls[1]).not.toHaveProperty('seo');
+    expect(calls[1]).toMatchObject({ id: 'form-1', title: 'Intake' });
+  });
+
+  it('does not retry when a different column is missing', async () => {
+    // A genuinely missing column is a bug and must surface rather than be
+    // silently papered over by dropping an unrelated field.
+    const { client, calls } = createClient([
+      {
+        error: {
+          code: '42703',
+          message: `column "closed_at" of relation "forms" does not exist`,
+        },
+      },
+    ]);
+
+    const result = await upsertFormRow(client, payload);
+
+    expect(result.error?.code).toBe('42703');
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does not retry on an unrelated failure', async () => {
+    const { client, calls } = createClient([
+      { error: { code: '23505', message: 'duplicate key value' } },
+    ]);
+
+    const result = await upsertFormRow(client, payload);
+
+    expect(result.error?.code).toBe('23505');
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does not retry when the payload never carried seo', async () => {
+    const { client, calls } = createClient([
+      {
+        error: {
+          code: '42703',
+          message: `column "seo" of relation "forms" does not exist`,
+        },
+      },
+    ]);
+
+    const result = await upsertFormRow(client, { id: 'form-1' });
+
+    expect(result.error?.code).toBe('42703');
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/apps/forms/src/features/forms/server/mutations.ts
+++ b/apps/forms/src/features/forms/server/mutations.ts
@@ -21,6 +21,66 @@ function buildFormTimestamps(existing: FormRow | null, input: FormStudioInput) {
   return { publishedAt, closedAt };
 }
 
+/**
+ * Postgres error for a column the schema does not have. Supabase surfaces it
+ * as-is through PostgREST.
+ */
+const UNDEFINED_COLUMN = '42703';
+
+/**
+ * The slice of the forms client this needs. Narrowed so the retry can be
+ * tested without standing up a Supabase client.
+ */
+type UpsertCapableClient = {
+  from: (table: 'forms') => {
+    upsert: (payload: Record<string, unknown>) => PromiseLike<{
+      error: { code?: string; message: string } | null;
+    }>;
+  };
+};
+
+/**
+ * Upserts the form row, retrying once without `seo` if the column is not there
+ * yet.
+ *
+ * Production migrations are applied AFTER the deployment, not before it, so
+ * there is a window on every release where this code is live against the old
+ * schema. Reads already survive it — the row is fetched with `select('*')` and
+ * `parseFormSeo` falls back to defaults — but the write named the column
+ * explicitly, so saving any form during that window failed outright.
+ *
+ * Dropping `seo` from the retry loses only the SEO overrides for that one save,
+ * and only until the migration lands. Failing the whole save instead loses the
+ * author's entire edit.
+ */
+export async function upsertFormRow(
+  formsClient: UpsertCapableClient,
+  payload: Record<string, unknown>
+) {
+  const first = await formsClient.from('forms').upsert(payload);
+
+  if (first.error?.code !== UNDEFINED_COLUMN) {
+    return first;
+  }
+
+  if (!('seo' in payload)) {
+    return first;
+  }
+
+  // Only retry when `seo` is the column being complained about; any other
+  // missing column is a real bug and must surface.
+  if (!first.error.message.includes('seo')) {
+    return first;
+  }
+
+  const { seo: _omitted, ...withoutSeo } = payload;
+  console.warn(
+    'forms: private.forms.seo is missing; saving without SEO overrides until the migration is applied.'
+  );
+
+  return formsClient.from('forms').upsert(withoutSeo);
+}
+
 export async function saveFormDefinition({
   supabase,
   wsId,
@@ -82,9 +142,7 @@ export async function saveFormDefinition({
     closed_at: timestamps.closedAt,
   };
 
-  const { error: formError } = await formsClient
-    .from('forms')
-    .upsert(upsertPayload);
+  const { error: formError } = await upsertFormRow(formsClient, upsertPayload);
 
   if (formError) {
     throw new Error(formError.message);


### PR DESCRIPTION
## The problem

Production Supabase migrations apply **after** the Vercel deployment, not before it. From this repo's own runbook:

> `supabase-production.yaml` can apply production migrations after the deployment and staging prerequisites pass

So every release has a window where new code runs against the old schema. The `private.forms.seo` column from [#5145](https://github.com/tutur3u/platform/pull/5145) opens one, and it is now on `main`.

**Reads already survive it**, by accident of how they were written — the row is fetched with `select('*')` so a missing column is simply absent, and `parseFormSeo` falls back to defaults when the shape does not parse.

**Writes did not.** The upsert names `seo` in the payload, so during that window saving *any* form fails with `42703` — losing the author's entire edit over a field most of them never set.

## The fix

The upsert retries once without `seo`, and only when that specific column is the one reported missing. A different missing column is a real bug and still surfaces; so does any other error code, and so does a payload that never carried `seo`.

The retry costs the SEO overrides for that one save, and only until the migration lands. Against losing the whole edit, that is not a close call.

## Tests

This path only fires during a deploy window nobody will exercise by hand, so it is tested directly rather than through `saveFormDefinition`. The client type is narrowed to the single method it needs, and all five branches are covered.

## Verification

`bun run type-check` clean, 143 tests pass across 22 files (5 new).

## Worth considering separately

The ordering itself is the root cause — an additive column is fine, but any migration the code depends on has this window. Applying migrations before the deployment, or gating the deploy on the migration, would remove a class of bug rather than one instance. That is a pipeline change, not a forms change, so I have not touched it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)