### PR TITLE
feat(forms): bring the three-pane studio to parity with the stacked layout

### DIFF
--- a/apps/docs/platform/features/forms-studio-layouts.mdx
+++ b/apps/docs/platform/features/forms-studio-layouts.mdx
@@ -43,22 +43,30 @@ Two implementation choices worth keeping:
   than a second editor. A field added to the accordion shows up here with no
   extra work; the alternative was two editors that drift.
 
-## Why it is opt-in
+## Why it is still opt-in
+
+Three-pane now covers what stacked covers:
+
+- **Reordering** — drag blocks within a section from the outline. A `DndContext`
+  per section means a drag cannot cross a section boundary; moving a block
+  between sections would rewrite two arrays and re-key the branching rules that
+  reference it, so that stays stacked-only until it is designed properly.
+- **Section fields** — selecting a section shows its title, description and
+  cover in the properties pane, rendered by the same `SectionFields` component
+  the stacked accordion uses.
+- **Form details and logic rules** — the same elements the stacked layout
+  builds, hoisted and rendered above and below the canvas.
 
 <Warning>
-  Three-pane is not yet a superset of stacked. Making it the default on wide
-  screens would take working features away from people who have them.
+  It stays opt-in anyway, for one reason: **nobody has verified it in a
+  browser.** It type-checks, passes `bun check` and builds clean, and the
+  selection and reorder logic are unit-tested — but a layout bug would not have
+  been caught by any of that. The toggle is what contains that risk.
 </Warning>
 
-Not covered yet:
-
-- **Reordering from the outline.** The outline selects; it does not drag.
-  Reordering still needs the stacked layout.
-- **Section fields.** Selecting a section highlights it, but the properties
-  pane only edits blocks. A section's own title, description and cover are
-  stacked-only.
-- **Form details and logic rules.** Both live below the block list in stacked
-  and have no place in three-pane yet.
+A reordering drop that would lose or duplicate a question is refused outright
+rather than written: silently dropping a block is far worse than ignoring the
+drag that caused it.
 
 The preference is stored per browser under
 `tuturuuu:form-studio:build-layout`, and a viewport below `1280px` always falls
@@ -66,6 +74,8 @@ back to stacked — three panes in 600px is three unusable columns.
 
 ## Changing the default
 
-Once the three gaps above are closed, flipping the default is a one-line change
-in `useStudioBuildLayout`. Until then, treat three-pane as a preview and keep
-new studio features working in stacked first.
+Flipping the default is a one-line change in `useStudioBuildLayout`. The
+remaining blocker is a person looking at it, not missing functionality.
+
+Until that happens, treat three-pane as a preview and keep new studio features
+working in stacked first.

--- a/apps/forms/src/features/forms/studio/form-studio-build-tab.tsx
+++ b/apps/forms/src/features/forms/studio/form-studio-build-tab.tsx
@@ -76,6 +76,111 @@ export function renderBuildTab({
   getBlockEditors: (blockId: string) => FormCollaboratorPresence[];
   previewDefinition: FormStudioState['previewDefinition'];
 }) {
+  // Hoisted so both layouts render the same element rather than one of them
+  // simply not having it. Three-pane previously had no form details at all,
+  // which meant the form's own title, description and cover could not be
+  // edited in that layout.
+  const formDetails = (
+    <Collapsible open={isFormDetailsOpen} onOpenChange={setIsFormDetailsOpen}>
+      <Card className="border-border/60 bg-card/80 shadow-sm">
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-auto w-full justify-start whitespace-normal rounded-3xl px-5 py-4 hover:bg-transparent"
+          >
+            <div className="flex w-full items-start gap-4 text-left">
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-semibold text-base">
+                    {t('studio.form_details')}
+                  </p>
+                  <Badge
+                    variant="outline"
+                    className="rounded-full px-2 py-0.5 text-[11px]"
+                  >
+                    {values.theme.coverImage.url ||
+                    values.theme.coverImage.storagePath
+                      ? t('studio.cover_set')
+                      : t('studio.cover_not_set')}
+                  </Badge>
+                </div>
+                <div className="line-clamp-2 text-muted-foreground text-sm">
+                  <FormsMarkdown
+                    content={
+                      values.description?.trim() ||
+                      t('studio.first_impression_hint')
+                    }
+                    variant="inline"
+                    className="line-clamp-2"
+                  />
+                </div>
+              </div>
+              <ChevronDown
+                className={cn(
+                  'mt-1 h-4 w-4 shrink-0 transition-transform',
+                  isFormDetailsOpen && 'rotate-180'
+                )}
+              />
+            </div>
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="border-border/60 border-t data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+          <CardContent className="space-y-4 p-5">
+            <div className="space-y-2">
+              <p className="font-medium text-[11px] text-muted-foreground uppercase tracking-[0.3em]">
+                {t('studio.first_impression')}
+              </p>
+              <p className="max-w-2xl text-muted-foreground text-sm">
+                {t('studio.first_impression_hint')}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label>{t('studio.form_title')}</Label>
+              <FormsRichTextEditor
+                value={values.title}
+                onChange={(nextValue) =>
+                  form.setValue('title', nextValue, {
+                    shouldDirty: true,
+                  })
+                }
+                placeholder={t('studio.form_title_placeholder')}
+                toneClasses={studioToneClasses}
+                compact
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>{t('studio.description')}</Label>
+              <FormsRichTextEditor
+                value={values.description}
+                onChange={(nextValue) =>
+                  form.setValue('description', nextValue, {
+                    shouldDirty: true,
+                  })
+                }
+                placeholder={t('studio.form_description_placeholder')}
+                toneClasses={studioToneClasses}
+              />
+            </div>
+            <FormMediaField
+              wsId={wsId}
+              scope="cover"
+              value={values.theme.coverImage}
+              onChange={(value) =>
+                form.setValue('theme.coverImage', value, {
+                  shouldDirty: true,
+                })
+              }
+              toneClasses={studioToneClasses}
+              label={t('studio.cover_image')}
+              hint={t('studio.cover_image_hint')}
+            />
+          </CardContent>
+        </CollapsibleContent>
+      </Card>
+    </Collapsible>
+  );
+
   return (
     <TabsContent value="build" className="mt-0 min-w-0">
       <StudioBuildLayout
@@ -95,6 +200,10 @@ export function renderBuildTab({
             addSection={addSection}
             addBlockToActiveSection={addBlockToActiveSection}
             getBlockEditors={getBlockEditors}
+            formDetails={formDetails}
+            logicRules={
+              <LogicRulesEditor form={form} toneClasses={studioToneClasses} />
+            }
           />
         }
         stacked={
@@ -105,107 +214,7 @@ export function renderBuildTab({
               onAddBlock={addBlockToActiveSection}
             />
             <div className="min-w-0 space-y-6">
-              <Collapsible
-                open={isFormDetailsOpen}
-                onOpenChange={setIsFormDetailsOpen}
-              >
-                <Card className="border-border/60 bg-card/80 shadow-sm">
-                  <CollapsibleTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      className="h-auto w-full justify-start whitespace-normal rounded-3xl px-5 py-4 hover:bg-transparent"
-                    >
-                      <div className="flex w-full items-start gap-4 text-left">
-                        <div className="min-w-0 flex-1 space-y-2">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <p className="font-semibold text-base">
-                              {t('studio.form_details')}
-                            </p>
-                            <Badge
-                              variant="outline"
-                              className="rounded-full px-2 py-0.5 text-[11px]"
-                            >
-                              {values.theme.coverImage.url ||
-                              values.theme.coverImage.storagePath
-                                ? t('studio.cover_set')
-                                : t('studio.cover_not_set')}
-                            </Badge>
-                          </div>
-                          <div className="line-clamp-2 text-muted-foreground text-sm">
-                            <FormsMarkdown
-                              content={
-                                values.description?.trim() ||
-                                t('studio.first_impression_hint')
-                              }
-                              variant="inline"
-                              className="line-clamp-2"
-                            />
-                          </div>
-                        </div>
-                        <ChevronDown
-                          className={cn(
-                            'mt-1 h-4 w-4 shrink-0 transition-transform',
-                            isFormDetailsOpen && 'rotate-180'
-                          )}
-                        />
-                      </div>
-                    </Button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent className="border-border/60 border-t data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-                    <CardContent className="space-y-4 p-5">
-                      <div className="space-y-2">
-                        <p className="font-medium text-[11px] text-muted-foreground uppercase tracking-[0.3em]">
-                          {t('studio.first_impression')}
-                        </p>
-                        <p className="max-w-2xl text-muted-foreground text-sm">
-                          {t('studio.first_impression_hint')}
-                        </p>
-                      </div>
-                      <div className="space-y-2">
-                        <Label>{t('studio.form_title')}</Label>
-                        <FormsRichTextEditor
-                          value={values.title}
-                          onChange={(nextValue) =>
-                            form.setValue('title', nextValue, {
-                              shouldDirty: true,
-                            })
-                          }
-                          placeholder={t('studio.form_title_placeholder')}
-                          toneClasses={studioToneClasses}
-                          compact
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label>{t('studio.description')}</Label>
-                        <FormsRichTextEditor
-                          value={values.description}
-                          onChange={(nextValue) =>
-                            form.setValue('description', nextValue, {
-                              shouldDirty: true,
-                            })
-                          }
-                          placeholder={t('studio.form_description_placeholder')}
-                          toneClasses={studioToneClasses}
-                        />
-                      </div>
-                      <FormMediaField
-                        wsId={wsId}
-                        scope="cover"
-                        value={values.theme.coverImage}
-                        onChange={(value) =>
-                          form.setValue('theme.coverImage', value, {
-                            shouldDirty: true,
-                          })
-                        }
-                        toneClasses={studioToneClasses}
-                        label={t('studio.cover_image')}
-                        hint={t('studio.cover_image_hint')}
-                      />
-                    </CardContent>
-                  </CollapsibleContent>
-                </Card>
-              </Collapsible>
+              {formDetails}
 
               <DndContext
                 sensors={sectionSensors}

--- a/apps/forms/src/features/forms/studio/section-editor.tsx
+++ b/apps/forms/src/features/forms/studio/section-editor.tsx
@@ -19,9 +19,7 @@ import {
   ChevronUp,
   ClipboardList,
   Copy,
-  FileText,
   GripVertical,
-  MessageSquare,
   MoreHorizontal,
   Trash,
 } from '@tuturuuu/icons';
@@ -47,14 +45,11 @@ import {
   DropdownMenuTrigger,
 } from '@tuturuuu/ui/dropdown-menu';
 import { useFieldArray, useWatch } from '@tuturuuu/ui/hooks/use-form';
-import { Label } from '@tuturuuu/ui/label';
 import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 
-import { FieldLabel } from '../form-icons';
 import { FormsMarkdown } from '../forms-markdown';
-import { FormsRichTextEditor } from '../forms-rich-text-editor';
 import type { getFormToneClasses } from '../theme';
 import {
   getBodyTypographyClassName,
@@ -63,8 +58,8 @@ import {
 import { createQuestionInput } from './block-catalog';
 import { BlockInserter } from './block-inserter';
 import { DestructiveActionDialog } from './destructive-action-dialog';
-import { FormMediaField } from './form-media-field';
 import { QuestionEditor } from './question-editor';
+import { SectionFields } from './section-fields';
 import { duplicateQuestionInput, type StudioForm } from './studio-utils';
 
 export function SectionEditor({
@@ -130,10 +125,6 @@ export function SectionEditor({
   const sectionDescription = useWatch({
     control: form.control,
     name: `sections.${index}.description`,
-  });
-  const sectionImage = useWatch({
-    control: form.control,
-    name: `sections.${index}.image`,
   });
   const watchedQuestions = useWatch({
     control: form.control,
@@ -421,70 +412,13 @@ export function SectionEditor({
                   </CollapsibleTrigger>
 
                   <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-                    <div className="grid gap-5 border-border/60 border-t px-4 pt-4 pb-5">
-                      <div className="space-y-1.5">
-                        <Label className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
-                          <FieldLabel icon={FileText}>
-                            {t('studio.section_title')}
-                          </FieldLabel>
-                        </Label>
-                        <FormsRichTextEditor
-                          value={sectionTitle || ''}
-                          onChange={(nextValue) =>
-                            form.setValue(
-                              `sections.${index}.title`,
-                              nextValue,
-                              {
-                                shouldDirty: true,
-                              }
-                            )
-                          }
-                          toneClasses={toneClasses}
-                          compact
-                        />
-                      </div>
-                      <div className="space-y-1.5">
-                        <Label className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
-                          <FieldLabel icon={MessageSquare}>
-                            {t('studio.section_description')}
-                          </FieldLabel>
-                        </Label>
-                        <FormsRichTextEditor
-                          value={sectionDescription || ''}
-                          onChange={(nextValue) =>
-                            form.setValue(
-                              `sections.${index}.description`,
-                              nextValue,
-                              {
-                                shouldDirty: true,
-                              }
-                            )
-                          }
-                          placeholder={t('studio.section_description_hint')}
-                          toneClasses={toneClasses}
-                        />
-                      </div>
-                      <div className="mt-2">
-                        <FormMediaField
-                          wsId={wsId}
-                          scope="section"
-                          value={
-                            sectionImage ?? {
-                              storagePath: '',
-                              url: '',
-                              alt: '',
-                            }
-                          }
-                          onChange={(value) =>
-                            form.setValue(`sections.${index}.image`, value, {
-                              shouldDirty: true,
-                            })
-                          }
-                          toneClasses={toneClasses}
-                          label={t('studio.section_image')}
-                          hint={t('studio.section_image_hint')}
-                        />
-                      </div>
+                    <div className="border-border/60 border-t px-4 pt-4 pb-5">
+                      <SectionFields
+                        wsId={wsId}
+                        form={form}
+                        sectionIndex={index}
+                        toneClasses={toneClasses}
+                      />
                     </div>
                   </CollapsibleContent>
                 </Collapsible>

--- a/apps/forms/src/features/forms/studio/section-fields.tsx
+++ b/apps/forms/src/features/forms/studio/section-fields.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { FileText, MessageSquare } from '@tuturuuu/icons';
+import { useWatch } from '@tuturuuu/ui/hooks/use-form';
+import { Label } from '@tuturuuu/ui/label';
+import { useTranslations } from 'next-intl';
+import { FieldLabel } from '../form-icons';
+import { FormsRichTextEditor } from '../forms-rich-text-editor';
+import type { getFormToneClasses } from '../theme';
+import { FormMediaField } from './form-media-field';
+import type { StudioForm } from './studio-utils';
+
+const EMPTY_MEDIA = { storagePath: '', url: '', alt: '' };
+
+/**
+ * A section's own title, description and cover.
+ *
+ * Extracted so the stacked layout's section accordion and the three-pane
+ * properties column render the same fields rather than two implementations
+ * that drift — the three-pane version previously had none at all, which meant
+ * a section could be selected but not edited.
+ *
+ * Watches its own values instead of taking them as props, so a caller only
+ * needs to say which section it is.
+ */
+export function SectionFields({
+  wsId,
+  form,
+  sectionIndex,
+  toneClasses,
+}: {
+  wsId: string;
+  form: StudioForm;
+  sectionIndex: number;
+  toneClasses: ReturnType<typeof getFormToneClasses>;
+}) {
+  const t = useTranslations('forms');
+  const title = useWatch({
+    control: form.control,
+    name: `sections.${sectionIndex}.title`,
+  });
+  const description = useWatch({
+    control: form.control,
+    name: `sections.${sectionIndex}.description`,
+  });
+  const image = useWatch({
+    control: form.control,
+    name: `sections.${sectionIndex}.image`,
+  });
+
+  return (
+    <div className="grid gap-5">
+      <div className="space-y-1.5">
+        <Label className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
+          <FieldLabel icon={FileText}>{t('studio.section_title')}</FieldLabel>
+        </Label>
+        <FormsRichTextEditor
+          value={title || ''}
+          onChange={(nextValue) =>
+            form.setValue(`sections.${sectionIndex}.title`, nextValue, {
+              shouldDirty: true,
+            })
+          }
+          toneClasses={toneClasses}
+          compact
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
+          <FieldLabel icon={MessageSquare}>
+            {t('studio.section_description')}
+          </FieldLabel>
+        </Label>
+        <FormsRichTextEditor
+          value={description || ''}
+          onChange={(nextValue) =>
+            form.setValue(`sections.${sectionIndex}.description`, nextValue, {
+              shouldDirty: true,
+            })
+          }
+          placeholder={t('studio.section_description_hint')}
+          toneClasses={toneClasses}
+        />
+      </div>
+
+      <FormMediaField
+        wsId={wsId}
+        scope="section"
+        value={image ?? EMPTY_MEDIA}
+        onChange={(value) =>
+          form.setValue(`sections.${sectionIndex}.image`, value, {
+            shouldDirty: true,
+          })
+        }
+        toneClasses={toneClasses}
+        label={t('studio.section_image')}
+        hint={t('studio.section_image_hint')}
+      />
+    </div>
+  );
+}

--- a/apps/forms/src/features/forms/studio/three-pane/outline-pane.tsx
+++ b/apps/forms/src/features/forms/studio/three-pane/outline-pane.tsx
@@ -1,5 +1,21 @@
 'use client';
 
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { Plus } from '@tuturuuu/icons';
 import { Button } from '@tuturuuu/ui/button';
 import { cn } from '@tuturuuu/utils/format';
@@ -21,6 +37,7 @@ export function OutlinePane({
   activeQuestionId,
   onSelectSection,
   onSelectQuestion,
+  onReorderQuestions,
   onAddSection,
   getBlockEditors,
   t,
@@ -30,18 +47,23 @@ export function OutlinePane({
   activeQuestionId: string;
   onSelectSection: (sectionId: string) => void;
   onSelectQuestion: (sectionId: string, questionId: string) => void;
+  /** Commits a new question order for one section. */
+  onReorderQuestions: (sectionIndex: number, order: string[]) => void;
   onAddSection: () => void;
   getBlockEditors: (blockId: string) => FormCollaboratorPresence[];
   t: (key: string, values?: Record<string, string | number>) => string;
 }) {
   return (
     <nav
-      aria-label={t('studio.outline')}
+      aria-labelledby="form-studio-outline-heading"
       className="flex max-h-[calc(100vh-9rem)] min-w-0 flex-col gap-3 overflow-y-auto rounded-[1.5rem] border border-border/60 bg-card/60 p-3"
     >
-      <p className="px-2 font-medium text-[11px] text-muted-foreground uppercase tracking-[0.25em]">
+      <h2
+        id="form-studio-outline-heading"
+        className="px-2 font-medium text-[11px] text-muted-foreground uppercase tracking-[0.25em]"
+      >
         {t('studio.outline')}
-      </p>
+      </h2>
 
       <ol className="min-w-0 space-y-3">
         {sections.map((section, sectionIndex) => {
@@ -64,23 +86,17 @@ export function OutlinePane({
                   t('studio.section_n', { index: sectionIndex + 1 })}
               </button>
 
-              <ol className="min-w-0 space-y-0.5 border-border/60 border-l pl-2">
-                {section.questions.map((question, questionIndex) => (
-                  <OutlineBlockRow
-                    key={question.id ?? questionIndex}
-                    question={question}
-                    index={questionIndex}
-                    isSelected={
-                      isActiveSection && question.id === activeQuestionId
-                    }
-                    editors={getBlockEditors(question.id ?? '')}
-                    onSelect={() =>
-                      onSelectQuestion(sectionId, question.id ?? '')
-                    }
-                    t={t}
-                  />
-                ))}
-              </ol>
+              <OutlineBlockList
+                section={section}
+                sectionIndex={sectionIndex}
+                sectionId={sectionId}
+                isActiveSection={isActiveSection}
+                activeQuestionId={activeQuestionId}
+                onSelectQuestion={onSelectQuestion}
+                onReorderQuestions={onReorderQuestions}
+                getBlockEditors={getBlockEditors}
+                t={t}
+              />
             </li>
           );
         })}
@@ -104,6 +120,87 @@ export function OutlinePane({
   );
 }
 
+/**
+ * One section's blocks, reorderable within that section.
+ *
+ * A DndContext per section rather than one for the outline means a drag simply
+ * cannot cross a section boundary — moving a block between sections would have
+ * to rewrite two arrays and re-key branching rules that reference it, so it is
+ * left to the stacked layout until that is designed properly.
+ */
+function OutlineBlockList({
+  section,
+  sectionIndex,
+  sectionId,
+  isActiveSection,
+  activeQuestionId,
+  onSelectQuestion,
+  onReorderQuestions,
+  getBlockEditors,
+  t,
+}: {
+  section: FormStudioInput['sections'][number];
+  sectionIndex: number;
+  sectionId: string;
+  isActiveSection: boolean;
+  activeQuestionId: string;
+  onSelectQuestion: (sectionId: string, questionId: string) => void;
+  onReorderQuestions: (sectionIndex: number, order: string[]) => void;
+  getBlockEditors: (blockId: string) => FormCollaboratorPresence[];
+  t: (key: string, values?: Record<string, string | number>) => string;
+}) {
+  const sensors = useSensors(
+    // The same 8px threshold the rest of the studio uses, so a click to select
+    // is not swallowed as the start of a drag.
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const order = section.questions.map((question) => question.id ?? '');
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const from = order.indexOf(String(active.id));
+    const to = order.indexOf(String(over.id));
+    if (from < 0 || to < 0) return;
+
+    const next = [...order];
+    const [moved] = next.splice(from, 1);
+    if (moved === undefined) return;
+    next.splice(to, 0, moved);
+
+    onReorderQuestions(sectionIndex, next);
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={order} strategy={verticalListSortingStrategy}>
+        <ol className="min-w-0 space-y-0.5 border-border/60 border-l pl-2">
+          {section.questions.map((question, questionIndex) => (
+            <OutlineBlockRow
+              key={question.id ?? questionIndex}
+              question={question}
+              index={questionIndex}
+              isSelected={isActiveSection && question.id === activeQuestionId}
+              editors={getBlockEditors(question.id ?? '')}
+              onSelect={() => onSelectQuestion(sectionId, question.id ?? '')}
+              t={t}
+            />
+          ))}
+        </ol>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
 function OutlineBlockRow({
   question,
   index,
@@ -122,12 +219,26 @@ function OutlineBlockRow({
   const label =
     normalizeMarkdownToText(question.title) ||
     t(`question_type.${question.type}` as never);
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: question.id ?? '' });
 
   return (
-    <li className="min-w-0">
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn('min-w-0', isDragging && 'z-10 opacity-70')}
+    >
       <button
         type="button"
         onClick={onSelect}
+        {...attributes}
+        {...listeners}
         aria-current={isSelected ? 'true' : undefined}
         className={cn(
           'flex w-full min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs transition-colors',

--- a/apps/forms/src/features/forms/studio/three-pane/properties-pane.tsx
+++ b/apps/forms/src/features/forms/studio/three-pane/properties-pane.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@tuturuuu/utils/format';
 import type { getFormToneClasses } from '../../theme';
 import { QuestionEditor } from '../question-editor';
+import { SectionFields } from '../section-fields';
 import type { StudioForm } from '../studio-utils';
 
 function noop() {
@@ -22,6 +23,7 @@ export function PropertiesPane({
   sectionIndex,
   questionIndex,
   questionId,
+  sectionId,
   toneClasses,
   t,
 }: {
@@ -30,20 +32,25 @@ export function PropertiesPane({
   sectionIndex: number;
   questionIndex: number;
   questionId: string | null;
+  /** Empty when no section resolves; the pane then has nothing to edit. */
+  sectionId: string;
   toneClasses: ReturnType<typeof getFormToneClasses>;
   t: (key: string, values?: Record<string, string | number>) => string;
 }) {
   return (
     <aside
-      aria-label={t('studio.properties')}
+      aria-labelledby="form-studio-properties-heading"
       className={cn(
         'flex max-h-[calc(100vh-9rem)] min-w-0 flex-col overflow-y-auto',
         'rounded-[1.5rem] border border-border/60 bg-card/60'
       )}
     >
-      <p className="px-5 pt-4 pb-2 font-medium text-[11px] text-muted-foreground uppercase tracking-[0.25em]">
-        {t('studio.properties')}
-      </p>
+      <h2
+        id="form-studio-properties-heading"
+        className="px-5 pt-4 pb-2 font-medium text-[11px] text-muted-foreground uppercase tracking-[0.25em]"
+      >
+        {questionId ? t('studio.properties') : t('studio.section_details')}
+      </h2>
 
       {questionId ? (
         <QuestionEditor
@@ -70,6 +77,18 @@ export function PropertiesPane({
           onRemove={noop}
           toneClasses={toneClasses}
         />
+      ) : sectionId ? (
+        // A selected section is still something to edit. Showing "select a
+        // block" here was the gap that made sections read-only in this layout.
+        <div className="px-5 pb-5">
+          <SectionFields
+            key={sectionId}
+            wsId={wsId}
+            form={form}
+            sectionIndex={sectionIndex}
+            toneClasses={toneClasses}
+          />
+        </div>
       ) : (
         <p className="px-5 pb-5 text-muted-foreground text-sm">
           {t('studio.select_a_block')}

--- a/apps/forms/src/features/forms/studio/three-pane/selection.test.ts
+++ b/apps/forms/src/features/forms/studio/three-pane/selection.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { FormStudioInput } from '../../schema';
-import { resolveThreePaneSelection } from './selection';
+import {
+  reorderSectionQuestions,
+  resolveThreePaneSelection,
+} from './selection';
 
 const emptyImage = { storagePath: '', url: '', alt: '' };
 
@@ -102,5 +105,34 @@ describe('resolveThreePaneSelection', () => {
       questionId: null,
       sectionId: '',
     });
+  });
+});
+
+describe('reorderSectionQuestions', () => {
+  const questions = [question('q1'), question('q2'), question('q3')];
+
+  it('applies a valid new order', () => {
+    const result = reorderSectionQuestions(questions, ['q3', 'q1', 'q2']);
+    expect(result?.map((entry) => entry.id)).toEqual(['q3', 'q1', 'q2']);
+  });
+
+  it('is a no-op order when nothing moved', () => {
+    const result = reorderSectionQuestions(questions, ['q1', 'q2', 'q3']);
+    expect(result?.map((entry) => entry.id)).toEqual(['q1', 'q2', 'q3']);
+  });
+
+  it('refuses an order that drops a question', () => {
+    // Writing this would delete a question the author never asked to remove.
+    expect(reorderSectionQuestions(questions, ['q1', 'q2'])).toBeNull();
+  });
+
+  it('refuses an order that duplicates a question', () => {
+    expect(reorderSectionQuestions(questions, ['q1', 'q1', 'q2'])).toBeNull();
+  });
+
+  it('refuses an order naming a question the section does not have', () => {
+    expect(
+      reorderSectionQuestions(questions, ['q1', 'q2', 'ghost'])
+    ).toBeNull();
   });
 });

--- a/apps/forms/src/features/forms/studio/three-pane/selection.ts
+++ b/apps/forms/src/features/forms/studio/three-pane/selection.ts
@@ -57,3 +57,33 @@ export function resolveThreePaneSelection(
     sectionId: section.id ?? '',
   };
 }
+
+/**
+ * Applies a new question order to one section.
+ *
+ * Returns `null` when the requested order does not describe exactly the same
+ * set of questions — a drop that lost or duplicated an entry must not be
+ * written, because silently dropping a question is far worse than ignoring
+ * the drag that caused it.
+ */
+export function reorderSectionQuestions<T extends { id?: string | undefined }>(
+  questions: readonly T[],
+  order: readonly string[]
+): T[] | null {
+  const byId = new Map(
+    questions.map((question) => [question.id ?? '', question])
+  );
+  const seen = new Set<string>();
+  const reordered: T[] = [];
+
+  for (const id of order) {
+    if (seen.has(id)) return null;
+    const question = byId.get(id);
+    if (!question) return null;
+
+    seen.add(id);
+    reordered.push(question);
+  }
+
+  return reordered.length === questions.length ? reordered : null;
+}

--- a/apps/forms/src/features/forms/studio/three-pane/three-pane-build.tsx
+++ b/apps/forms/src/features/forms/studio/three-pane/three-pane-build.tsx
@@ -9,7 +9,10 @@ import type { FormStudioState } from '../form-studio-state';
 import { CanvasPane } from './canvas-pane';
 import { OutlinePane } from './outline-pane';
 import { PropertiesPane } from './properties-pane';
-import { resolveThreePaneSelection } from './selection';
+import {
+  reorderSectionQuestions,
+  resolveThreePaneSelection,
+} from './selection';
 import { useStudioBuildLayout } from './use-build-layout';
 
 /**
@@ -74,6 +77,8 @@ export function ThreePaneBuild({
   addSection,
   addBlockToActiveSection,
   getBlockEditors,
+  formDetails,
+  logicRules,
 }: {
   wsId: string;
   t: FormStudioState['t'];
@@ -88,6 +93,9 @@ export function ThreePaneBuild({
   addSection: () => void;
   addBlockToActiveSection: (type: FormQuestionInput['type']) => void;
   getBlockEditors: (blockId: string) => FormCollaboratorPresence[];
+  /** The form's own title, description and cover, shared with the stacked layout. */
+  formDetails: ReactNode;
+  logicRules: ReactNode;
 }) {
   const translate = t as (
     key: string,
@@ -107,6 +115,27 @@ export function ThreePaneBuild({
     setActiveQuestionForSection(sectionId, questionId);
   };
 
+  /**
+   * Commits a reordered section straight through `setValue` rather than a
+   * `useFieldArray`.
+   *
+   * A field array on `sections.<i>.questions` lives in `SectionEditor`, which
+   * only the stacked layout mounts — the two layouts never render together, so
+   * there is no array here to desync. Doing this while both were mounted would
+   * leave that array's own `fields` state pointing at the old order.
+   */
+  const reorderQuestions = (sectionIndex: number, order: string[]) => {
+    const section = values.sections[sectionIndex];
+    if (!section) return;
+
+    const reordered = reorderSectionQuestions(section.questions, order);
+    if (!reordered) return;
+
+    form.setValue(`sections.${sectionIndex}.questions`, reordered, {
+      shouldDirty: true,
+    });
+  };
+
   return (
     <div className="grid min-w-0 items-start gap-4 xl:grid-cols-[72px_minmax(200px,240px)_minmax(0,1fr)_minmax(300px,360px)]">
       <FloatingBlockToolbar
@@ -121,12 +150,15 @@ export function ThreePaneBuild({
         activeQuestionId={activeQuestionId}
         onSelectSection={setActiveSectionId}
         onSelectQuestion={selectQuestion}
+        onReorderQuestions={reorderQuestions}
         onAddSection={addSection}
         getBlockEditors={getBlockEditors}
         t={translate}
       />
 
-      <div className="min-w-0 overflow-y-auto pb-8 xl:max-h-[calc(100vh-9rem)]">
+      <div className="min-w-0 space-y-6 overflow-y-auto pb-8 xl:max-h-[calc(100vh-9rem)]">
+        {formDetails}
+
         <CanvasPane
           definition={previewDefinition}
           activeSectionId={resolvedActiveSectionId}
@@ -134,6 +166,8 @@ export function ThreePaneBuild({
           onSelectQuestion={selectQuestion}
           t={translate}
         />
+
+        {logicRules}
       </div>
 
       <PropertiesPane
@@ -142,6 +176,7 @@ export function ThreePaneBuild({
         sectionIndex={selection.sectionIndex}
         questionIndex={selection.questionIndex}
         questionId={selection.questionId}
+        sectionId={selection.sectionId}
         toneClasses={studioToneClasses}
         t={translate}
       />


### PR DESCRIPTION
## Summary

[#5148](https://github.com/tutur3u/platform/pull/5148) shipped three-pane behind a toggle because it was a **subset**, not an alternative — three things worked in stacked and simply were not there. All three are now covered, so the toggle no longer costs anyone functionality.

## What was missing

**Reordering.** Blocks now drag within a section from the outline. A `DndContext` per section rather than one for the whole outline means a drag *cannot* cross a section boundary — moving a block between sections rewrites two arrays and re-keys every branching rule that references it, which deserves its own design rather than falling out of a drag handler.

It commits through `form.setValue` instead of a `useFieldArray`, which is only safe because `StudioBuildLayout` renders one layout **or** the other: the field array that owns this path lives in `SectionEditor`, unmounted whenever three-pane is showing. Both mounted at once would leave that array's `fields` state pointing at the old order. There's a comment saying so, since nothing else would stop someone rendering both.

A drop that would lose or duplicate a question is **refused outright** rather than written. Silently deleting a block the author never asked to remove is far worse than ignoring the drag — and that's exactly the shape of bug a reorder produces when an id goes missing mid-drag.

**Section fields.** Selecting a section was possible; editing it wasn't. `SectionFields` is now one component rendered by both the accordion and the properties pane — extracted rather than reimplemented, because two copies of the same three fields drift the moment one gains a fourth.

**Form details and logic rules.** Both were built inline inside the stacked branch, so three-pane couldn't reach them at all — the form's own title was uneditable in that layout. Now hoisted and handed to both layouts.

## Also

Each pane carried an `aria-label` identical to its visible heading, so screen readers announced the name twice. Now headings with `aria-labelledby`.

## Verification

- `bun check` — exit 0, all 20 categories
- `apps/forms` real `bun run build` — exit 0
- 150 tests across 22 files; 12 cover selection and reorder, including every way a reorder can go wrong (dropped, duplicated, or unknown question)

## Still opt-in — but the reason changed

It is no longer missing anything. **Nobody has rendered it in a browser**, and none of the above catches a layout bug. Flipping the default is one line in `useStudioBuildLayout` once someone has looked at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)