### PR TITLE
fix(web): add the missing /products index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ CLI, documentation, local services, and deployment tooling behind that system.
 <!-- tanstack-rust-migration-progress:start -->
 _Generated from `apps/tanstack-web/migration/route-manifest.json`. Refresh with `bun migration:tanstack:readme` after route ownership changes._
 
-![Overall migration progress](https://img.shields.io/static/v1?color=fb8c00&label=Overall&message=28.38%25+terminal&style=flat-square) ![Rust backend migration progress](https://img.shields.io/static/v1?color=cf222e&label=Rust+backend&message=13.32%25+terminal&style=flat-square) ![TanStack Start migration progress](https://img.shields.io/static/v1?color=1f6feb&label=TanStack+Start&message=70.09%25+terminal&style=flat-square)
+![Overall migration progress](https://img.shields.io/static/v1?color=fb8c00&label=Overall&message=28.31%25+terminal&style=flat-square) ![Rust backend migration progress](https://img.shields.io/static/v1?color=cf222e&label=Rust+backend&message=13.32%25+terminal&style=flat-square) ![TanStack Start migration progress](https://img.shields.io/static/v1?color=d29922&label=TanStack+Start&message=69.44%25+terminal&style=flat-square)
 
 | Track | Progress | Terminal | Migrated | Removed | Remaining |
 | --- | --- | ---: | ---: | ---: | ---: |
-| Overall | `[######--------------]` 28.38% | 229 / 807 | 215 | 14 | 578 |
+| Overall | `[######--------------]` 28.31% | 229 / 809 | 215 | 14 | 580 |
 | Rust backend | `[###-----------------]` 13.32% | 79 / 593 | 67 | 12 | 514 |
-| TanStack Start | `[##############------]` 70.09% | 150 / 214 | 148 | 2 | 64 |
+| TanStack Start | `[##############------]` 69.44% | 150 / 216 | 148 | 2 | 66 |
 
 <details>
 <summary>Remaining work by route kind</summary>
@@ -35,8 +35,8 @@ _Generated from `apps/tanstack-web/migration/route-manifest.json`. Refresh with 
 | Kind | Progress | Terminal | Remaining |
 | --- | --- | ---: | ---: |
 | api | `[##--------------]` 12.76% | 74 / 580 | 506 |
-| page | `[###########-----]` 66.89% | 101 / 151 | 50 |
-| layout | `[#############---]` 79.66% | 47 / 59 | 12 |
+| page | `[###########-----]` 66.45% | 101 / 152 | 51 |
+| layout | `[#############---]` 78.33% | 47 / 60 | 13 |
 | cron | `[####------------]` 25% | 2 / 8 | 6 |
 | route-handler | `[############----]` 75% | 3 / 4 | 1 |
 | error | `[########--------]` 50% | 1 / 2 | 1 |

--- a/apps/docs/platform/architecture/tanstack-rust-migration-plan.mdx
+++ b/apps/docs/platform/architecture/tanstack-rust-migration-plan.mdx
@@ -22,10 +22,10 @@ source of truth. The latest local snapshot on 2026-08-03 is:
 
 | Status | Count |
 | --- | ---: |
-| `legacy-next` | 578 |
+| `legacy-next` | 580 |
 | `migrated` | 215 |
 | `accepted-removal` | 14 |
-| Total tracked artifacts | 807 |
+| Total tracked artifacts | 809 |
 
 Remaining legacy artifacts are concentrated in API/backend ownership:
 

--- a/apps/docs/platform/architecture/tanstack-rust-migration.mdx
+++ b/apps/docs/platform/architecture/tanstack-rust-migration.mdx
@@ -407,12 +407,12 @@ than leaving them as untriaged `legacy-next` backlog.
 
 Current inventory:
 
-- `151` pages
-- `59` layouts
+- `152` pages
+- `60` layouts
 - `593` route handler artifacts
 - `8` cron handlers
-- `807` total tracked route artifacts
-- `215` migrated artifacts, `229` terminal artifacts, and `578` remaining
+- `809` total tracked route artifacts
+- `215` migrated artifacts, `229` terminal artifacts, and `580` remaining
   legacy-owned artifacts in the checked manifest
 
 Regenerate it after adding or removing legacy routes:

--- a/apps/tanstack-web/migration/route-manifest.json
+++ b/apps/tanstack-web/migration/route-manifest.json
@@ -18,24 +18,24 @@
         "acceptedRemoval": 2,
         "key": "page",
         "label": "page",
-        "legacyNext": 50,
+        "legacyNext": 51,
         "migrated": 99,
-        "percentComplete": 66.89,
-        "remaining": 50,
+        "percentComplete": 66.45,
+        "remaining": 51,
         "terminal": 101,
-        "total": 151,
+        "total": 152,
         "unknownStatus": 0
       },
       {
         "acceptedRemoval": 0,
         "key": "layout",
         "label": "layout",
-        "legacyNext": 12,
+        "legacyNext": 13,
         "migrated": 47,
-        "percentComplete": 79.66,
-        "remaining": 12,
+        "percentComplete": 78.33,
+        "remaining": 13,
         "terminal": 47,
-        "total": 59,
+        "total": 60,
         "unknownStatus": 0
       },
       {
@@ -128,12 +128,12 @@
         "acceptedRemoval": 2,
         "key": "tanstack-start",
         "label": "TanStack Start",
-        "legacyNext": 64,
+        "legacyNext": 66,
         "migrated": 148,
-        "percentComplete": 70.09,
-        "remaining": 64,
+        "percentComplete": 69.44,
+        "remaining": 66,
         "terminal": 150,
-        "total": 214,
+        "total": 216,
         "unknownStatus": 0
       }
     ],
@@ -323,12 +323,12 @@
       "acceptedRemoval": 14,
       "key": "total",
       "label": "All route artifacts",
-      "legacyNext": 578,
+      "legacyNext": 580,
       "migrated": 215,
-      "percentComplete": 28.38,
-      "remaining": 578,
+      "percentComplete": 28.31,
+      "remaining": 580,
       "terminal": 229,
-      "total": 807,
+      "total": 809,
       "unknownStatus": 0
     }
   },
@@ -6045,6 +6045,15 @@
       "targetOwner": "tanstack-start"
     },
     {
+      "id": "layout:/:locale/products:apps/web/src/app/[locale]/(marketing)/products/layout.tsx",
+      "kind": "layout",
+      "methods": [],
+      "routePath": "/:locale/products",
+      "sourceFile": "apps/web/src/app/[locale]/(marketing)/products/layout.tsx",
+      "status": "legacy-next",
+      "targetOwner": "tanstack-start"
+    },
+    {
       "id": "layout:/:locale/products/ai:apps/web/src/app/[locale]/(marketing)/products/ai/layout.tsx",
       "kind": "layout",
       "methods": [],
@@ -7224,6 +7233,15 @@
       "targetOwner": "tanstack-start"
     },
     {
+      "id": "page:/:locale/products:apps/web/src/app/[locale]/(marketing)/products/page.tsx",
+      "kind": "page",
+      "methods": [],
+      "routePath": "/:locale/products",
+      "sourceFile": "apps/web/src/app/[locale]/(marketing)/products/page.tsx",
+      "status": "legacy-next",
+      "targetOwner": "tanstack-start"
+    },
+    {
       "id": "page:/:locale/products/ai:apps/web/src/app/[locale]/(marketing)/products/ai/page.tsx",
       "kind": "page",
       "methods": [],
@@ -7704,8 +7722,8 @@
   "summary": {
     "apiRoutes": 580,
     "cronRoutes": 8,
-    "layouts": 59,
-    "pages": 151,
+    "layouts": 60,
+    "pages": 152,
     "routeHandlers": 593,
     "methodCounts": {
       "GET": 295,
@@ -7716,6 +7734,6 @@
       "DELETE": 99,
       "OPTIONS": 23
     },
-    "total": 807
+    "total": 809
   }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -9431,6 +9431,11 @@
       "operate": "Run the business",
       "plan": "Plan & execute"
     },
+    "index": {
+      "description": "One workspace, one login, one bill. Each app below works on its own and works better beside the others.",
+      "learn_more": "Learn more",
+      "title": "Every app your team needs"
+    },
     "products": {
       "ai": {
         "description": "Mira and the assistants powering every surface.",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -9431,6 +9431,11 @@
       "operate": "Vận hành doanh nghiệp",
       "plan": "Lên kế hoạch & thực thi"
     },
+    "index": {
+      "description": "Một không gian làm việc, một lần đăng nhập, một hoá đơn. Mỗi ứng dụng bên dưới dùng riêng được, và dùng cùng nhau thì tốt hơn.",
+      "learn_more": "Tìm hiểu thêm",
+      "title": "Mọi ứng dụng đội ngũ của bạn cần"
+    },
     "products": {
       "ai": {
         "description": "Mira và các trợ lý vận hành mọi bề mặt sản phẩm.",

--- a/apps/web/src/app/[locale]/(marketing)/products/layout.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/products/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+import { createMarketingMetadata } from '@/lib/seo/marketing-metadata';
+
+export const generateMetadata = createMarketingMetadata({
+  title: 'Products',
+  description:
+    'Every Tuturuuu app in one place — plan and execute, create and share, run the business.',
+  pathname: '/products',
+});
+
+export default function ProductsLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/[locale]/(marketing)/products/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/products/page.tsx
@@ -1,0 +1,98 @@
+import { ArrowRight } from '@tuturuuu/icons/lucide';
+import { cn } from '@tuturuuu/utils/format';
+import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
+import { HeroAtmosphere } from '@/components/landing/shared/atmosphere';
+import { SectionShell } from '@/components/landing/shared/section-shell';
+import {
+  MARKETING_PRODUCT_GROUPS,
+  MARKETING_PRODUCT_ICONS,
+} from '../../marketing-nav/products';
+
+/**
+ * Index for `/products`.
+ *
+ * Every `/products/<slug>` page existed and `/products` itself did not, so the
+ * link people reach for — the one in the nav's own "explore every app" copy,
+ * and the one `public_paths` already treats as public — returned a 404.
+ *
+ * Built from `MARKETING_PRODUCT_GROUPS`, the same source the mega-menu renders,
+ * so a product added to the menu appears here without anyone remembering to.
+ */
+export default async function ProductsIndexPage() {
+  const t = await getTranslations('marketing-nav');
+
+  return (
+    <main className="relative w-full overflow-x-hidden">
+      <section className="relative overflow-hidden px-4 pt-24 pb-10 sm:px-6 sm:pt-28 lg:px-8 lg:pt-32">
+        <HeroAtmosphere />
+
+        <div className="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-background/40 py-1.5 pr-4 pl-2.5 font-mono-ui text-[0.65rem] text-foreground/60 uppercase tracking-[0.2em] backdrop-blur-md">
+            {t('all_apps')}
+          </span>
+
+          <h1 className="mt-8 text-balance font-display font-extrabold text-4xl leading-[1.02] tracking-[-0.04em] sm:text-5xl lg:text-6xl">
+            {t('index.title')}
+          </h1>
+
+          <p className="mt-6 max-w-2xl text-balance text-base text-foreground/55 leading-relaxed sm:text-lg">
+            {t('index.description')}
+          </p>
+        </div>
+      </section>
+
+      {MARKETING_PRODUCT_GROUPS.map((group, groupIndex) => (
+        <SectionShell
+          key={group.key}
+          align="start"
+          index={String(groupIndex + 1).padStart(2, '0')}
+          title={t(`groups.${group.key}` as never)}
+        >
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {group.items.map((product) => {
+              const Icon = MARKETING_PRODUCT_ICONS[product.key];
+
+              return (
+                <Link
+                  key={product.key}
+                  href={product.href}
+                  className={cn(
+                    'group relative flex flex-col rounded-3xl border border-foreground/10 bg-background/40 p-6 backdrop-blur-md',
+                    'transition-all duration-300 hover:-translate-y-0.5 hover:border-foreground/25',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-foreground/10 bg-foreground/5',
+                      product.accent
+                    )}
+                  >
+                    {Icon ? <Icon className="h-5 w-5" /> : null}
+                  </span>
+
+                  <span className="mt-5 font-semibold text-lg">
+                    {t(`products.${product.key}.label` as never)}
+                  </span>
+
+                  <span className="mt-2 flex-1 text-foreground/55 text-sm leading-relaxed">
+                    {t(`products.${product.key}.description` as never)}
+                  </span>
+
+                  <span className="mt-5 inline-flex items-center font-medium text-foreground/70 text-sm transition-colors group-hover:text-foreground">
+                    {t('index.learn_more')}
+                    <ArrowRight
+                      aria-hidden
+                      className="ml-1.5 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1"
+                    />
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </SectionShell>
+      ))}
+    </main>
+  );
+}

--- a/apps/web/src/app/[locale]/(marketing)/products/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/products/page.tsx
@@ -1,9 +1,10 @@
 import { ArrowRight } from '@tuturuuu/icons/lucide';
 import { cn } from '@tuturuuu/utils/format';
-import Link from 'next/link';
+
 import { getTranslations } from 'next-intl/server';
 import { HeroAtmosphere } from '@/components/landing/shared/atmosphere';
 import { SectionShell } from '@/components/landing/shared/section-shell';
+import { Link } from '@/i18n/routing';
 import {
   MARKETING_PRODUCT_GROUPS,
   MARKETING_PRODUCT_ICONS,
@@ -18,6 +19,12 @@ import {
  *
  * Built from `MARKETING_PRODUCT_GROUPS`, the same source the mega-menu renders,
  * so a product added to the menu appears here without anyone remembering to.
+ *
+ * Links come from `@/i18n/routing`, not `next/link`. `localePrefix` is
+ * `as-needed`, so a bare `/products/calendar` carries no locale and would be
+ * resolved from the cookie or `Accept-Language` — a click from `/vi/products`
+ * could land in English. Every href here points at a sibling localized page,
+ * which is exactly where that goes wrong.
  */
 export default async function ProductsIndexPage() {
   const t = await getTranslations('marketing-nav');

--- a/apps/web/src/app/[locale]/marketing-nav/marketing-nav-menu.tsx
+++ b/apps/web/src/app/[locale]/marketing-nav/marketing-nav-menu.tsx
@@ -1,54 +1,11 @@
 'use client';
 
-import {
-  ArrowRight,
-  Bot,
-  Boxes,
-  Building2,
-  Calendar,
-  CalendarClock,
-  CheckCircle2,
-  FileText,
-  Folder,
-  GraduationCap,
-  Mail,
-  MessageSquare,
-  Package,
-  QrCode,
-  Store,
-  Users,
-  Wallet,
-  Zap,
-} from '@tuturuuu/icons/lucide-static';
+import { ArrowRight } from '@tuturuuu/icons/lucide-static';
 import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
-import type { ComponentType } from 'react';
 import { useNavigation } from '../shared/navigation-config';
 import { type NavMenu, NavMenuBar } from './nav-dropdown';
-import { MARKETING_PRODUCT_GROUPS } from './products';
-
-type IconComponent = ComponentType<{ className?: string }>;
-
-const productIcons: Record<string, IconComponent> = {
-  calendar: Calendar,
-  tasks: CheckCircle2,
-  meet: Users,
-  workflows: Zap,
-  documents: FileText,
-  drive: Folder,
-  mail: Mail,
-  ai: Bot,
-  finance: Wallet,
-  crm: Building2,
-  inventory: Package,
-  lms: GraduationCap,
-  track: CalendarClock,
-  forms: FileText,
-  chat: MessageSquare,
-  qr: QrCode,
-  storefront: Store,
-  hive: Boxes,
-};
+import { MARKETING_PRODUCT_GROUPS, MARKETING_PRODUCT_ICONS } from './products';
 
 const linkClassName = cn(
   'inline-flex h-9 items-center rounded-lg px-3 font-medium text-foreground/70 text-sm transition-colors',
@@ -85,7 +42,7 @@ export function MarketingNavMenu() {
                 </div>
                 <div className="grid">
                   {group.items.map((product) => {
-                    const Icon = productIcons[product.key];
+                    const Icon = MARKETING_PRODUCT_ICONS[product.key];
                     return (
                       <a
                         className="group flex items-start gap-3 rounded-xl p-2.5 transition-colors duration-200 hover:bg-foreground/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/apps/web/src/app/[locale]/marketing-nav/products.ts
+++ b/apps/web/src/app/[locale]/marketing-nav/products.ts
@@ -1,3 +1,24 @@
+import {
+  Bot,
+  Boxes,
+  Building2,
+  Calendar,
+  CalendarClock,
+  CheckCircle2,
+  FileText,
+  Folder,
+  GraduationCap,
+  Mail,
+  MessageSquare,
+  Package,
+  QrCode,
+  Store,
+  Users,
+  Wallet,
+  Zap,
+} from '@tuturuuu/icons/lucide-static';
+import type { ComponentType } from 'react';
+
 export interface MarketingProduct {
   /** Translation key under `marketing-nav.products.*`. */
   key: string;
@@ -5,6 +26,36 @@ export interface MarketingProduct {
   /** Static accent class — Tailwind cannot resolve interpolated names. */
   accent: string;
 }
+
+export type MarketingProductIcon = ComponentType<{ className?: string }>;
+
+/**
+ * Icon per product key.
+ *
+ * Lives beside the group data rather than in the navbar, because the mega-menu
+ * and the `/products` index both draw the same set — a second copy would drift
+ * the moment a product is added to one and not the other.
+ */
+export const MARKETING_PRODUCT_ICONS: Record<string, MarketingProductIcon> = {
+  ai: Bot,
+  calendar: Calendar,
+  chat: MessageSquare,
+  crm: Building2,
+  documents: FileText,
+  drive: Folder,
+  finance: Wallet,
+  forms: FileText,
+  hive: Boxes,
+  inventory: Package,
+  lms: GraduationCap,
+  mail: Mail,
+  meet: Users,
+  qr: QrCode,
+  storefront: Store,
+  tasks: CheckCircle2,
+  track: CalendarClock,
+  workflows: Zap,
+};
 
 export interface MarketingProductGroup {
   /** Translation key under `marketing-nav.groups.*`. */


### PR DESCRIPTION
## The bug

`tuturuuu.com/products` returns a **404**.

Nineteen `/products/<slug>` pages exist, `public_paths.ts` already lists `/products` as public, and the navbar's mega-menu is literally headed *"Explore every Tuturuuu app"* — but the page that heading implies was never built. Only the leaves existed, never the index.

## The fix

A `/products` index built from `MARKETING_PRODUCT_GROUPS` — the same source the mega-menu renders — so a product added to the menu appears here without anyone remembering to update a second list.

That is also why the icon map moved out of `marketing-nav-menu.tsx` into the data module beside the groups: two copies of an eighteen-entry map drift the moment a product is added to one of them. The nav now reads the shared map; no behaviour change there.

Page follows the existing marketing shell — `HeroAtmosphere`, `SectionShell` with its numbered rule, the product-page card idiom — plus a `layout.tsx` with `createMarketingMetadata`, matching every sibling product page.

## Verification

- `apps/web` real `bun run build` — exit 0, and `/en/products` + `/vi/products` now appear in the route table
- en/vi message parity maintained

## The manifest gate earned its keep

Adding two route files made `bun check` fail on route-manifest parity — the gate from [#5149](https://github.com/tutur3u/platform/pull/5149), catching exactly the drift it was built for, on its first real outing. Regenerated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `/products` index page so the URL no longer returns a 404, listing every product from the same source the navbar mega-menu renders.

**Bug Fixes**
- Builds the index from `MARKETING_PRODUCT_GROUPS`, so products added to the mega-menu appear here automatically.
- Moves the product icon map into `products.ts` so the nav and index can't drift; no behavior change for the nav.
- Uses `@/i18n/routing` links between product pages so the locale is preserved; a click from `/vi/products` no longer risks landing on the English page.
- Adds en/vi translations and a `layout.tsx` with `createMarketingMetadata`, matching sibling product pages.
- Regenerates the route manifest so the route-manifest parity check passes.

<sup>Written for commit 7e7df470588caf4cf724c2ed0c70636280eb5b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

