### PR TITLE
fix(forms): send /dashboard to a workspace instead of a dead end

### DIFF
--- a/apps/forms/src/app/[locale]/dashboard/page.tsx
+++ b/apps/forms/src/app/[locale]/dashboard/page.tsx
@@ -1,17 +1,37 @@
-import { ClipboardList } from '@tuturuuu/icons';
+import {
+  getCurrentUserDefaultWorkspace,
+  InternalApiError,
+  listWorkspaces,
+  withForwardedInternalApiAuth,
+} from '@tuturuuu/internal-api';
 import { getSatelliteAppSession } from '@tuturuuu/satellite/auth';
 import {
   getPendingWorkspaceInvitations,
   SatelliteWorkspaceInvitationList,
 } from '@tuturuuu/satellite/workspace-invitation';
+import { toWorkspaceSlug } from '@tuturuuu/utils/constants';
 import { headers } from 'next/headers';
+import { connection } from 'next/server';
 import { redirect } from '@/i18n/navigation';
 
+/**
+ * `/dashboard` is the app's entry point, not a page.
+ *
+ * It used to end at a static "Forms — build, share, and analyze" card with no
+ * link, button or navigation on it: a signed-in user who landed here had no way
+ * forward except editing the URL. It now resolves the workspace to open and
+ * sends them there, matching what every other satellite does.
+ *
+ * Pending invitations still render inline, because those are a real decision to
+ * make before picking a workspace.
+ */
 export default async function DashboardEntryPage({
   params,
 }: {
   params: Promise<{ locale: string }>;
 }) {
+  await connection();
+
   const { locale } = await params;
   const requestHeaders = await headers();
   const appSession = await getSatelliteAppSession('forms');
@@ -31,17 +51,37 @@ export default async function DashboardEntryPage({
     );
   }
 
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-root-background p-6">
-      <div className="max-w-lg border-2 border-border bg-background p-8 text-center shadow-[9px_9px_0_var(--border)]">
-        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center border-2 border-border bg-dynamic-blue/15 shadow-[4px_4px_0_var(--border)]">
-          <ClipboardList className="h-8 w-8" />
-        </div>
-        <h1 className="font-black text-3xl tracking-normal">Forms</h1>
-        <p className="mt-3 text-muted-foreground leading-7">
-          Build, share, and analyze workspace forms and their responses.
-        </p>
-      </div>
-    </div>
-  );
+  try {
+    const auth = withForwardedInternalApiAuth(requestHeaders);
+
+    // Prefer the user's default (or personal) workspace; otherwise fall back to
+    // the first workspace they belong to — never the root/admin workspace.
+    const defaultWorkspace = await getCurrentUserDefaultWorkspace(auth);
+    const workspace =
+      defaultWorkspace ?? (await listWorkspaces(auth))?.[0] ?? null;
+
+    if (!workspace) {
+      // No accessible workspace yet. Bounce through the central login, which is
+      // the only surface that can run onboarding — landing here with nothing to
+      // open is exactly the dead end this page used to be.
+      return redirect({ href: '/login?next=/dashboard&refresh=1', locale });
+    }
+
+    const workspaceSlug = toWorkspaceSlug(workspace.id, {
+      personal: !!workspace.personal,
+    });
+
+    // `/[wsId]` itself redirects on to `/[wsId]/forms`, so this lands on the
+    // form list rather than another intermediate screen.
+    redirect({ href: `/${workspaceSlug}`, locale });
+  } catch (error) {
+    if (
+      error instanceof InternalApiError &&
+      (error.status === 401 || error.status === 403)
+    ) {
+      redirect({ href: '/login?next=/dashboard&refresh=1', locale });
+    }
+
+    throw error;
+  }
 }


### PR DESCRIPTION
## The bug

`forms.tuturuuu.com/dashboard` renders a static card — an icon, the word "Forms", and a sentence describing the product. **No link, no button, no navigation.** A signed-in user with no pending invitations has no way forward except editing the URL.

## The fix

`/dashboard` is an entry point, not a page. It now resolves the workspace to open and redirects there — the same thing `apps/contacts` already does:

- prefer the user's default (or personal) workspace
- fall back to the first they belong to
- never the root/admin workspace

`/[wsId]` already redirects on to `/[wsId]/forms`, so this lands on the form list rather than another intermediate screen.

A user with **no** accessible workspace bounces through the central login with `refresh=1`, because that is the only surface that can run onboarding. Returning them to a card describing forms they cannot reach would be the same dead end in a different shape.

**Pending invitations still render inline.** Those are a real decision to make before picking a workspace, and skipping past them into a workspace the user hasn't accepted would be worse than the card was.

## Also gone

The card hard-coded English copy ("Build, share, and analyze workspace forms and their responses.") in a product that ships en and vi. Since nothing renders it any more, it goes rather than needing translating.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns `forms` `/dashboard` from a static card with no navigation into a redirect into the user's workspace, so signed-in users land on the form list instead of a dead end.

- Prefers the user's default or personal workspace; falls back to the first workspace they belong to, never the root/admin workspace.
- Users with no accessible workspace are sent through login with `refresh=1` so onboarding can run.
- Pending invitations still render inline before the redirect, since they require a decision before picking a workspace.
- Removed the hard-coded English card copy that only existed on this page.

<sup>Written for commit e13b001e5b0bb079e7f54b9799b405875c890fa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

