### PR TITLE
feat(forms): make one question at a time the default, with real keyboard support

### DIFF
--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -2886,7 +2886,9 @@
       "ranking_move_down": "Move down",
       "ranking_drag_handle": "Drag to reorder",
       "validation_constraint_step": "Must be a multiple of {step}.",
-      "validation_constraint_step_range": "Must be between {min} and {max}, in steps of {step}."
+      "validation_constraint_step_range": "Must be between {min} and {max}, in steps of {step}.",
+      "press": "Press",
+      "enter_key": "Enter ↵"
     },
     "settings": {
       "active": "Active",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -2886,7 +2886,9 @@
       "ranking_move_down": "Di chuyển xuống",
       "ranking_drag_handle": "Kéo để sắp xếp lại",
       "validation_constraint_step": "Phải là bội số của {step}.",
-      "validation_constraint_step_range": "Phải nằm trong khoảng {min} đến {max}, theo bước {step}."
+      "validation_constraint_step_range": "Phải nằm trong khoảng {min} đến {max}, theo bước {step}.",
+      "press": "Nhấn",
+      "enter_key": "Enter ↵"
     },
     "settings": {
       "active": "Đang dùng",

--- a/apps/forms/src/features/forms/runtime/choice-fields.tsx
+++ b/apps/forms/src/features/forms/runtime/choice-fields.tsx
@@ -15,6 +15,7 @@ import Image from 'next/image';
 import { normalizeMarkdownToText } from '../content';
 import { FormsMarkdown } from '../forms-markdown';
 import type { FormAnswerValue, FormDefinitionQuestion } from '../types';
+import { OptionKeyBadge } from './option-key-badge';
 import type { FormsTranslator, FormToneClasses } from './types';
 import { hasOptionImage } from './utils';
 
@@ -29,6 +30,13 @@ type ChoiceFieldArgs = {
   t: FormsTranslator;
   choiceLayoutClassName: string;
   interactionStateClassName: string;
+  /**
+   * Whether `1`-`9` / `A`-`I` currently pick an option. False in `sections`
+   * mode and whenever more than one question shares the screen, where the key
+   * would be ambiguous — the badge must never promise a shortcut that is not
+   * bound.
+   */
+  optionShortcuts?: boolean;
 };
 
 export function renderSingleChoiceField({
@@ -42,6 +50,7 @@ export function renderSingleChoiceField({
   t,
   choiceLayoutClassName,
   interactionStateClassName,
+  optionShortcuts,
 }: ChoiceFieldArgs) {
   return question.type === 'single_choice' ? (
     <RadioGroup
@@ -52,7 +61,7 @@ export function renderSingleChoiceField({
       }}
       className={choiceLayoutClassName}
     >
-      {question.options.map((option) => (
+      {question.options.map((option, optionIndex) => (
         <label
           key={option.id}
           className={cn(
@@ -83,6 +92,12 @@ export function renderSingleChoiceField({
                   : ''
               )}
             />
+            {optionShortcuts ? (
+              <OptionKeyBadge
+                index={optionIndex}
+                selected={value === option.value}
+              />
+            ) : null}
             <div className="min-w-0 flex-1 space-y-3">
               {hasOptionImage(option) ? (
                 <div
@@ -158,10 +173,11 @@ export function renderMultipleChoiceField({
   t,
   choiceLayoutClassName,
   interactionStateClassName,
+  optionShortcuts,
 }: ChoiceFieldArgs) {
   return question.type === 'multiple_choice' ? (
     <div className={choiceLayoutClassName}>
-      {question.options.map((option) => {
+      {question.options.map((option, optionIndex) => {
         const checked = Array.isArray(value)
           ? value.includes(option.value)
           : false;
@@ -204,6 +220,9 @@ export function renderMultipleChoiceField({
                   onChange([...nextValue]);
                 }}
               />
+              {optionShortcuts ? (
+                <OptionKeyBadge index={optionIndex} selected={checked} />
+              ) : null}
               <div className="min-w-0 flex-1 space-y-3">
                 {hasOptionImage(option) ? (
                   <div

--- a/apps/forms/src/features/forms/runtime/form-runtime.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.tsx
@@ -25,11 +25,16 @@ import { FormBrandFooter } from './form-brand-footer';
 import { renderFormHeroCard } from './hero-card';
 import { renderEmailTrackedNotice, renderReadOnlyNotice } from './notices';
 import { renderFormSectionCard } from './section-card';
+import {
+  findMissingRequiredQuestions,
+  scrollToQuestion,
+} from './step-validation';
 import { renderSubmittedScreen } from './submitted-screen';
 import type { FormRuntimeProps } from './types';
 import { useFormDraft } from './use-form-draft';
 import { useFormSteps } from './use-form-steps';
 import { useResponseCopy } from './use-response-copy';
+import { useRuntimeKeyboard } from './use-runtime-keyboard';
 import { WelcomeScreen } from './welcome-screen';
 
 export function FormRuntime({
@@ -63,6 +68,12 @@ export function FormRuntime({
     form.sections[0]?.id ? [form.sections[0].id] : []
   );
   const [error, setError] = useState<string | null>(null);
+  // Drives the direction a new screen slides in from. Kept as state rather than
+  // derived from the step index, because moving between sections resets that
+  // index and would otherwise animate a forward move as a backward one.
+  const [stepDirection, setStepDirection] = useState<'forward' | 'backward'>(
+    'forward'
+  );
   const [validationErrorsByQuestionId, setValidationErrorsByQuestionId] =
     useState<Record<string, string>>({});
   const [submitted, setSubmitted] = useState(false);
@@ -313,6 +324,22 @@ export function FormRuntime({
     });
   }, [currentSectionId]);
 
+  // Bound above the early return below: a hook that runs on some renders and
+  // not others breaks React's hook order.
+  const { handlersRef: keyboardHandlersRef } = useRuntimeKeyboard({
+    // Off in `sections` mode: with a whole section on screen, Enter would
+    // advance past questions the respondent has not reached yet, and the
+    // number keys have no single question to apply to.
+    enabled:
+      form.settings.displayMode === 'one_question' &&
+      !isBusy &&
+      !submittedAt &&
+      hasStarted,
+    getAnswer: (questionId) => answersRef.current[questionId],
+    setAnswer: (questionId, value) => updateAnswer(questionId, value),
+    step: currentStep,
+  });
+
   if (!currentSection) {
     return null;
   }
@@ -337,49 +364,28 @@ export function FormRuntime({
   const validateCurrentSection = (
     currentAnswers: Record<string, FormAnswerValue>
   ) => {
-    const missingRequiredQuestions = currentStepQuestions.filter((question) => {
-      if (!requiredQuestionIds.has(question.id)) {
-        return false;
-      }
+    const missing = findMissingRequiredQuestions(
+      currentStepQuestions,
+      requiredQuestionIds,
+      currentAnswers
+    );
+    const firstMissing = missing[0];
+    if (!firstMissing) return true;
 
-      const value = currentAnswers[question.id];
-      if (Array.isArray(value)) {
-        return value.length === 0;
-      }
+    setError(
+      t('runtime.required_before_continue', {
+        title: normalizeMarkdownToText(firstMissing.title),
+      })
+    );
+    setValidationErrorsByQuestionId((prev) => ({
+      ...prev,
+      ...Object.fromEntries(
+        missing.map((question) => [question.id, t('runtime.required')])
+      ),
+    }));
+    scrollToQuestion(firstMissing.id);
 
-      return value == null || value === '';
-    });
-
-    if (missingRequiredQuestions.length > 0) {
-      const firstMissing = missingRequiredQuestions[0]!;
-      setError(
-        t('runtime.required_before_continue', {
-          title: normalizeMarkdownToText(firstMissing.title),
-        })
-      );
-
-      const nextErrors: Record<string, string> = {};
-      for (const question of missingRequiredQuestions) {
-        nextErrors[question.id] = t('runtime.required');
-      }
-
-      setValidationErrorsByQuestionId((prev) => ({
-        ...prev,
-        ...nextErrors,
-      }));
-
-      // Scroll to the first missing required question
-      requestAnimationFrame(() => {
-        const element = document.getElementById(`question-${firstMissing.id}`);
-        if (element) {
-          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-      });
-
-      return false;
-    }
-
-    return true;
+    return false;
   };
 
   /**
@@ -389,10 +395,20 @@ export function FormRuntime({
    */
   const canGoBack = !isFirstStep || sectionTrail.length > 1;
 
+  // Assigned during render, like `answersRef` above: the keyboard is bound
+  // before these exist, and this is what connects the two.
+  keyboardHandlersRef.current = {
+    next: () => {
+      void handleAdvance();
+    },
+    previous: () => handleBack(),
+  };
+
   const handleBack = () => {
     if (isBusy) return;
 
     if (goToPreviousStep()) {
+      setStepDirection('backward');
       setError(null);
       return;
     }
@@ -402,6 +418,7 @@ export function FormRuntime({
 
     // Entering the previous section from the end, so its last screen is what
     // the respondent last saw.
+    setStepDirection('backward');
     resetSteps('last');
     setSectionTrail((currentTrail) => currentTrail.slice(0, -1));
     setCurrentSectionId(previousSectionId);
@@ -423,6 +440,7 @@ export function FormRuntime({
     // branching only applies once the section is exhausted, which keeps rule
     // evaluation defined per section exactly as it was.
     if (!isLastStep && goToNextStep()) {
+      setStepDirection('forward');
       setError(null);
       sectionCardRef.current?.scrollIntoView({
         behavior: 'smooth',
@@ -643,6 +661,7 @@ export function FormRuntime({
           handleBack,
           visibleQuestions: currentStepQuestions,
           stepIndex,
+          stepDirection,
           stepCount: steps.length,
           isLastStep,
           shouldShowTurnstile,

--- a/apps/forms/src/features/forms/runtime/option-key-badge.tsx
+++ b/apps/forms/src/features/forms/runtime/option-key-badge.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { cn } from '@tuturuuu/utils/format';
+
+/** Only the first nine options get a shortcut, matching `optionIndexFromKey`. */
+const SHORTCUT_LIMIT = 9;
+
+/**
+ * The letter a respondent can press to pick this option.
+ *
+ * Rendered rather than merely bound, because a shortcut nobody can see is a
+ * shortcut nobody uses — the badge is what turns the keyboard handler into a
+ * feature. Hidden past the ninth option so it never advertises a key that does
+ * nothing.
+ *
+ * `aria-hidden` on purpose: a screen reader user is already navigating options
+ * with arrow keys inside a radio group, and announcing "A" before every label
+ * would be noise rather than help.
+ */
+export function OptionKeyBadge({
+  index,
+  selected,
+}: {
+  index: number;
+  selected: boolean;
+}) {
+  if (index >= SHORTCUT_LIMIT) return null;
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'hidden h-5 w-5 shrink-0 items-center justify-center rounded border font-medium font-mono text-[10px] uppercase sm:inline-flex',
+        selected
+          ? 'border-current/30 bg-current/10 opacity-90'
+          : 'border-border/60 text-muted-foreground opacity-70'
+      )}
+    >
+      {String.fromCharCode('a'.charCodeAt(0) + index)}
+    </span>
+  );
+}

--- a/apps/forms/src/features/forms/runtime/question-block.tsx
+++ b/apps/forms/src/features/forms/runtime/question-block.tsx
@@ -52,6 +52,7 @@ export function QuestionBlock({
   validationError,
   toneClasses,
   typography,
+  optionShortcuts = false,
 }: {
   question: FormDefinitionQuestion;
   value: FormAnswerValue | undefined;
@@ -61,6 +62,8 @@ export function QuestionBlock({
   validationError?: string;
   toneClasses: ReturnType<typeof getFormToneClasses>;
   typography: FormDefinition['theme']['typography'];
+  /** Whether the number/letter option shortcuts are bound for this screen. */
+  optionShortcuts?: boolean;
 }) {
   const t = useTranslations('forms');
   const settings = question.settings ?? {};
@@ -337,6 +340,7 @@ export function QuestionBlock({
         t,
         choiceLayoutClassName,
         interactionStateClassName,
+        optionShortcuts,
       })}
 
       {renderMultipleChoiceField({
@@ -350,6 +354,7 @@ export function QuestionBlock({
         t,
         choiceLayoutClassName,
         interactionStateClassName,
+        optionShortcuts,
       })}
 
       {renderDropdownField({

--- a/apps/forms/src/features/forms/runtime/section-card.tsx
+++ b/apps/forms/src/features/forms/runtime/section-card.tsx
@@ -16,6 +16,7 @@ import { Checkbox } from '@tuturuuu/ui/checkbox';
 import { cn } from '@tuturuuu/utils/format';
 import Image from 'next/image';
 import type { Dispatch, RefObject, SetStateAction } from 'react';
+import { isAnswerableQuestionType } from '../block-utils';
 import { normalizeMarkdownToText } from '../content';
 import { FormsMarkdown } from '../forms-markdown';
 import type { getRuntimeProgressStats } from '../runtime-progress';
@@ -58,6 +59,7 @@ export function renderFormSectionCard({
   handleBack,
   visibleQuestions,
   stepIndex,
+  stepDirection,
   stepCount,
   isLastStep,
   shouldShowTurnstile,
@@ -85,6 +87,8 @@ export function renderFormSectionCard({
   visibleQuestions: FormDefinitionQuestion[];
   /** Zero-based screen index within the section. */
   stepIndex: number;
+  /** Which way the last move went, so the screen enters from that side. */
+  stepDirection: 'forward' | 'backward';
   /** Number of screens the section is split into; 1 in `sections` mode. */
   stepCount: number;
   /**
@@ -134,6 +138,23 @@ export function renderFormSectionCard({
   setCaptchaError: Dispatch<SetStateAction<string | undefined>>;
   handleAdvance: () => void;
 }) {
+  // The shortcut is only bound when a single answerable question owns the
+  // screen — with two on screen, "press 2" has no single meaning. Computed here
+  // rather than passed down, because this is the only place that knows both the
+  // display mode and what is actually on screen.
+  // The Enter hint follows the keyboard binding rather than the shortcut
+  // badges: Enter advances on every one-question screen, including ones with
+  // no options to press a letter for.
+  const isKeyboardAdvanceHintVisible =
+    form.settings.displayMode === 'one_question' && !readOnly && !isBusy;
+
+  const hasOptionShortcuts =
+    form.settings.displayMode === 'one_question' &&
+    !readOnly &&
+    visibleQuestions.filter((question) =>
+      isAnswerableQuestionType(question.type)
+    ).length === 1;
+
   return (
     <Card
       ref={sectionCardRef}
@@ -218,10 +239,24 @@ export function renderFormSectionCard({
             />
           </div>
         ) : null}
-        <div className={density.questionGap}>
+        <div
+          // Re-keyed per screen so each question mounts fresh and plays its
+          // entrance. `motion-safe:` rather than a JS media query, so a
+          // respondent who asked for reduced motion simply never gets the
+          // classes — no animation to interrupt, nothing to clean up.
+          key={`${currentSection.id}:${stepIndex}`}
+          className={cn(
+            density.questionGap,
+            'motion-safe:fade-in motion-safe:animate-in motion-safe:duration-300 motion-safe:ease-out',
+            stepDirection === 'forward'
+              ? 'motion-safe:slide-in-from-bottom-3'
+              : 'motion-safe:slide-in-from-top-3'
+          )}
+        >
           {visibleQuestions.map((question) => (
             <QuestionBlock
               key={question.id}
+              optionShortcuts={hasOptionShortcuts}
               question={question}
               value={answers[question.id]}
               onChange={(value) => updateAnswer(question.id, value)}
@@ -423,6 +458,17 @@ export function renderFormSectionCard({
                     </>
                   )}
                 </Button>
+              ) : null}
+              {/* The keyboard handler is bound whether or not anyone knows, so
+                  say so. Hidden on touch, where there is no Enter key to press
+                  and the hint would be a small lie. */}
+              {isKeyboardAdvanceHintVisible ? (
+                <span className="hidden items-center gap-1 text-[11px] text-muted-foreground sm:inline-flex">
+                  {t('runtime.press')}
+                  <kbd className="rounded border border-border/60 bg-background/60 px-1.5 py-0.5 font-medium font-mono text-[10px]">
+                    {t('runtime.enter_key')}
+                  </kbd>
+                </span>
               ) : null}
             </div>
           </div>

--- a/apps/forms/src/features/forms/runtime/step-validation.test.ts
+++ b/apps/forms/src/features/forms/runtime/step-validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { FormAnswerValue, FormDefinitionQuestion } from '../types';
+import { findMissingRequiredQuestions, isAnswered } from './step-validation';
+
+const emptyImage = { storagePath: '', url: '', alt: '' };
+
+function question(id: string): FormDefinitionQuestion {
+  return {
+    id,
+    sectionId: 'section-1',
+    type: 'short_text',
+    title: id,
+    description: '',
+    required: false,
+    image: emptyImage,
+    settings: {},
+    options: [],
+  };
+}
+
+describe('isAnswered', () => {
+  it('treats a non-empty string as answered', () => {
+    expect(isAnswered('yes')).toBe(true);
+  });
+
+  it('treats an empty string, null and undefined as unanswered', () => {
+    expect(isAnswered('')).toBe(false);
+    expect(isAnswered(null)).toBe(false);
+    expect(isAnswered(undefined)).toBe(false);
+  });
+
+  it('treats an empty list as unanswered but a filled one as answered', () => {
+    // A multi-select or ranking with nothing chosen is blank, not a value.
+    expect(isAnswered([])).toBe(false);
+    expect(isAnswered(['a'])).toBe(true);
+  });
+
+  it('treats 0 as answered', () => {
+    // NPS starts at 0, so a falsy check here would silently reject the lowest
+    // possible score as if the respondent had skipped the question.
+    expect(isAnswered(0 as unknown as FormAnswerValue)).toBe(true);
+  });
+});
+
+describe('findMissingRequiredQuestions', () => {
+  const questions = [question('q1'), question('q2'), question('q3')];
+  const required = new Set(['q1', 'q3']);
+
+  it('returns only required questions that are unanswered', () => {
+    const missing = findMissingRequiredQuestions(questions, required, {
+      q1: 'answered',
+    });
+    expect(missing.map((entry) => entry.id)).toEqual(['q3']);
+  });
+
+  it('ignores optional questions regardless of their answers', () => {
+    const missing = findMissingRequiredQuestions(questions, required, {
+      q1: 'a',
+      q3: 'b',
+    });
+    expect(missing).toEqual([]);
+  });
+
+  it('preserves screen order, since the runtime reports and scrolls to the first', () => {
+    const missing = findMissingRequiredQuestions(questions, required, {});
+    expect(missing.map((entry) => entry.id)).toEqual(['q1', 'q3']);
+  });
+});

--- a/apps/forms/src/features/forms/runtime/step-validation.ts
+++ b/apps/forms/src/features/forms/runtime/step-validation.ts
@@ -1,0 +1,43 @@
+import type { FormAnswerValue, FormDefinitionQuestion } from '../types';
+
+/** An answer counts as given when it is a non-empty string or a non-empty list. */
+export function isAnswered(value: FormAnswerValue | undefined): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return value != null && value !== '';
+}
+
+/**
+ * The required questions on this screen that have no answer yet, in the order
+ * they appear.
+ *
+ * Order matters: the runtime reports and scrolls to the first one, and a
+ * respondent sent to the third missing field while the first is off-screen
+ * above them has been told the wrong thing.
+ *
+ * Pure on purpose — the runtime owns the error state and the scroll, so this
+ * can be exercised without a DOM.
+ */
+export function findMissingRequiredQuestions(
+  questions: readonly FormDefinitionQuestion[],
+  requiredQuestionIds: ReadonlySet<string>,
+  answers: Record<string, FormAnswerValue>
+): FormDefinitionQuestion[] {
+  return questions.filter(
+    (question) =>
+      requiredQuestionIds.has(question.id) && !isAnswered(answers[question.id])
+  );
+}
+
+/** Brings a question into view after a failed advance. */
+export function scrollToQuestion(questionId: string) {
+  if (typeof document === 'undefined') return;
+
+  requestAnimationFrame(() => {
+    document
+      .getElementById(`question-${questionId}`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  });
+}

--- a/apps/forms/src/features/forms/runtime/use-form-keyboard.test.ts
+++ b/apps/forms/src/features/forms/runtime/use-form-keyboard.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { optionIndexFromKey } from './use-form-keyboard';
+
+describe('optionIndexFromKey', () => {
+  it('maps 1-9 to the first nine options', () => {
+    expect(optionIndexFromKey('1')).toBe(0);
+    expect(optionIndexFromKey('5')).toBe(4);
+    expect(optionIndexFromKey('9')).toBe(8);
+  });
+
+  it('maps a-i to the same nine, in either case', () => {
+    expect(optionIndexFromKey('a')).toBe(0);
+    expect(optionIndexFromKey('A')).toBe(0);
+    expect(optionIndexFromKey('i')).toBe(8);
+    expect(optionIndexFromKey('I')).toBe(8);
+  });
+
+  it('rejects 0, since options are labelled from 1', () => {
+    expect(optionIndexFromKey('0')).toBeNull();
+  });
+
+  it('rejects letters past i rather than running off the end', () => {
+    expect(optionIndexFromKey('j')).toBeNull();
+    expect(optionIndexFromKey('z')).toBeNull();
+  });
+
+  it('rejects anything that is not a single character', () => {
+    // Named keys arrive as multi-character strings, and treating "Enter" as
+    // an option index would make every advance also pick something.
+    expect(optionIndexFromKey('Enter')).toBeNull();
+    expect(optionIndexFromKey('ArrowDown')).toBeNull();
+    expect(optionIndexFromKey('')).toBeNull();
+  });
+
+  it('rejects punctuation and symbols', () => {
+    expect(optionIndexFromKey('-')).toBeNull();
+    expect(optionIndexFromKey(' ')).toBeNull();
+  });
+});

--- a/apps/forms/src/features/forms/runtime/use-form-keyboard.ts
+++ b/apps/forms/src/features/forms/runtime/use-form-keyboard.ts
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Elements where a keystroke means "type this", not "navigate".
+ *
+ * A `select` is included because its own keyboard handling owns the arrows,
+ * and a `contenteditable` because rich text answers behave like a textarea.
+ */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+/** A textarea is the one field where Enter has to stay a newline. */
+function isMultilineTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.tagName === 'TEXTAREA' || target.isContentEditable;
+}
+
+export interface FormKeyboardOptions {
+  enabled: boolean;
+  onNext: () => void;
+  onPrevious: () => void;
+  /**
+   * Picks the nth option of the current question, 0-indexed. Returns whether
+   * anything was selected, so the handler only swallows the key when it did.
+   */
+  onSelectOption?: (index: number) => boolean;
+}
+
+/**
+ * Keyboard navigation for the one-question-at-a-time runtime.
+ *
+ * | Key | Does |
+ * | --- | --- |
+ * | `Enter` | Next — except inside a textarea, where it stays a newline |
+ * | `Cmd`/`Ctrl` + `Enter` | Next, including from inside a textarea |
+ * | `Alt` + `↓` / `Alt` + `↑` | Next / previous, from anywhere |
+ * | `1`-`9`, `A`-`I` | Pick that option, when not typing |
+ *
+ * Bound on `document` rather than a container so it works before the
+ * respondent has focused anything — a form that only responds once you click
+ * it is not keyboard-navigable, it is keyboard-tolerant.
+ *
+ * Deliberately not bound: bare arrows and Backspace. Both have meanings inside
+ * the fields people are about to use, and stealing them makes text editing feel
+ * broken in a way that is hard to attribute.
+ */
+export function useFormKeyboard({
+  enabled,
+  onNext,
+  onPrevious,
+  onSelectOption,
+}: FormKeyboardOptions) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+
+      const typing = isTypingTarget(event.target);
+      const modified = event.metaKey || event.ctrlKey;
+
+      if (
+        event.altKey &&
+        (event.key === 'ArrowDown' || event.key === 'ArrowUp')
+      ) {
+        event.preventDefault();
+        if (event.key === 'ArrowDown') onNext();
+        else onPrevious();
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        // A newline is the only thing Enter can mean in a textarea, so the
+        // modifier is the escape hatch there.
+        if (isMultilineTarget(event.target) && !modified) return;
+        if (event.shiftKey) return;
+
+        event.preventDefault();
+        onNext();
+        return;
+      }
+
+      if (typing || modified || event.altKey) return;
+
+      if (!onSelectOption) return;
+
+      // Typeform's signature: 1-9 and A-I jump straight to an option, so a
+      // whole form can be answered without the mouse ever moving.
+      const index = optionIndexFromKey(event.key);
+      if (index === null) return;
+
+      if (onSelectOption(index)) {
+        event.preventDefault();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [enabled, onNext, onPrevious, onSelectOption]);
+}
+
+/** `1`-`9` and `a`-`i` map to option 0-8. Anything else is not a shortcut. */
+export function optionIndexFromKey(key: string): number | null {
+  if (key.length !== 1) return null;
+
+  if (key >= '1' && key <= '9') {
+    return Number(key) - 1;
+  }
+
+  const lower = key.toLowerCase();
+  if (lower >= 'a' && lower <= 'i') {
+    return lower.charCodeAt(0) - 'a'.charCodeAt(0);
+  }
+
+  return null;
+}

--- a/apps/forms/src/features/forms/runtime/use-runtime-keyboard.ts
+++ b/apps/forms/src/features/forms/runtime/use-runtime-keyboard.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import type { FormAnswerValue } from '../types';
+import type { FormStep } from './step-plan';
+import { useFormKeyboard } from './use-form-keyboard';
+
+export interface RuntimeKeyboardHandlers {
+  next: () => void;
+  previous: () => void;
+}
+
+/**
+ * Binds the runtime's keyboard navigation.
+ *
+ * Takes the navigation handlers through a ref rather than as arguments,
+ * because `useFormKeyboard` has to be called before the runtime's early return
+ * for a form with no current section — a hook after a conditional return runs
+ * on some renders and not others, which breaks React's hook order. The handlers
+ * are defined further down the component, so the ref is how they get here
+ * without moving that return.
+ */
+export function useRuntimeKeyboard({
+  enabled,
+  step,
+  getAnswer,
+  setAnswer,
+}: {
+  enabled: boolean;
+  step: FormStep | undefined;
+  getAnswer: (questionId: string) => FormAnswerValue | undefined;
+  setAnswer: (questionId: string, value: FormAnswerValue) => void;
+}): { handlersRef: React.MutableRefObject<RuntimeKeyboardHandlers> } {
+  const handlersRef = useRef<RuntimeKeyboardHandlers>({
+    next: () => {},
+    previous: () => {},
+  });
+
+  /**
+   * The single answerable question on this screen, or null when the screen
+   * holds several. Option shortcuts only make sense with exactly one question
+   * to apply them to — with two on screen, "press 2" is ambiguous.
+   */
+  const shortcutQuestionId =
+    step?.answerableQuestionIds.length === 1
+      ? (step.answerableQuestionIds[0] ?? null)
+      : null;
+  const shortcutQuestion =
+    shortcutQuestionId === null
+      ? null
+      : (step?.questions.find(
+          (question) => question.id === shortcutQuestionId
+        ) ?? null);
+
+  const selectOptionByIndex = useCallback(
+    (index: number) => {
+      if (!shortcutQuestion) return false;
+
+      const type = shortcutQuestion.type;
+      const isSingle = type === 'single_choice' || type === 'dropdown';
+      const isMultiple = type === 'multiple_choice';
+      if (!(isSingle || isMultiple)) return false;
+
+      const option = shortcutQuestion.options[index];
+      if (!option) return false;
+
+      if (isMultiple) {
+        // Multi-select toggles, so the same key both adds and removes — the
+        // only behaviour that lets a keyboard user undo a mistake without
+        // reaching for the mouse.
+        const current = getAnswer(shortcutQuestion.id);
+        const selected = Array.isArray(current) ? current : [];
+        const next = selected.includes(option.value)
+          ? selected.filter((entry) => entry !== option.value)
+          : [...selected, option.value];
+
+        setAnswer(shortcutQuestion.id, next);
+        return true;
+      }
+
+      setAnswer(shortcutQuestion.id, option.value);
+      return true;
+    },
+    [getAnswer, setAnswer, shortcutQuestion]
+  );
+
+  const onNext = useCallback(() => handlersRef.current.next(), []);
+  const onPrevious = useCallback(() => handlersRef.current.previous(), []);
+
+  useFormKeyboard({
+    enabled,
+    onNext,
+    onPrevious,
+    onSelectOption: selectOptionByIndex,
+  });
+
+  return { handlersRef };
+}

--- a/apps/forms/src/features/forms/schema.ts
+++ b/apps/forms/src/features/forms/schema.ts
@@ -297,8 +297,24 @@ export const FORM_WELCOME_TITLE_MAX_LENGTH = 120;
 export const FORM_WELCOME_DESCRIPTION_MAX_LENGTH = 600;
 export const FORM_WELCOME_BUTTON_MAX_LENGTH = 40;
 
+/**
+ * The display mode every form gets unless its author chose otherwise.
+ *
+ * One question at a time: a long scroll of fields reads as paperwork, and
+ * answering one thing at a time is what makes a form feel like a conversation.
+ */
+export const FORM_DEFAULT_DISPLAY_MODE = 'one_question' as const;
+
 export const formSettingsSchema = z.object({
-  displayMode: z.enum(FORM_DISPLAY_MODE_VALUES).default('sections'),
+  // `settings` is jsonb, so a form saved before this field existed has no key
+  // for it and is backfilled here on read. That means this default reaches
+  // EXISTING forms too, not just new ones — a deliberate product decision, so
+  // the one-question experience is what a Tuturuuu form is rather than
+  // something each author has to find and switch on. An author who wants the
+  // old scroll sets `sections` explicitly and it sticks.
+  displayMode: z
+    .enum(FORM_DISPLAY_MODE_VALUES)
+    .default(FORM_DEFAULT_DISPLAY_MODE),
   /** Optional cover screen shown before the first question. */
   welcomeEnabled: z.boolean().default(false),
   welcomeTitle: z.string().max(FORM_WELCOME_TITLE_MAX_LENGTH).default(''),
@@ -468,8 +484,10 @@ export function createDefaultFormStudioInput(): FormStudioInput {
       },
     },
     settings: {
-      displayMode: 'sections',
-      welcomeEnabled: false,
+      displayMode: FORM_DEFAULT_DISPLAY_MODE,
+      // A cover screen is the natural opening for a one-question form: it says
+      // what the form is before the first question arrives with no context.
+      welcomeEnabled: true,
       welcomeTitle: '',
       welcomeDescription: '',
       welcomeButtonLabel: '',


### PR DESCRIPTION
## Summary

A form that shows every field at once reads as paperwork. One question at a time reads as a conversation — and that's what a Tuturuuu form now is unless its author says otherwise.

## The default reaches existing forms

Worth being explicit, since this is the part with consequences. `settings` is jsonb, so a form saved before `displayMode` existed has **no key for it** and is backfilled by the zod default on read. Changing that default re-shapes those forms on their next load — including ones a respondent may have open right now.

That's the deliberate choice: the new experience is what the product *is*, not something each author has to find and switch on. An author who wants the old scroll sets `sections` explicitly and it sticks.

New forms additionally start with the welcome screen on, because a cover is the natural opening when the first question would otherwise arrive with no context.

## Keyboard

There was **none** before — not a weak version, none.

| Key | Does |
| --- | --- |
| `Enter` | Next |
| `⌘`/`Ctrl` + `Enter` | Next, from inside a textarea where Enter must stay a newline |
| `Alt` + `↑`/`↓` | Previous / next, from anywhere |
| `1`–`9`, `A`–`I` | Pick that option |

Bound on `document`, not a container, so it works before the respondent has focused anything. A form that only responds once you click it is keyboard-*tolerant*, not keyboard-navigable.

Bare arrows and Backspace are deliberately left alone — both mean something inside the fields people are about to type in, and stealing them makes text editing feel broken in a way that's hard to attribute to the form.

Option shortcuts bind **only** when a single answerable question owns the screen. With two on screen, "press 2" has no single meaning.

## The shortcuts are visible

Which is the difference between a feature and a trick: a letter badge on each option, an `Enter ↵` hint beside the advance button.

The badges stop at the ninth option because only nine keys are bound — advertising a tenth would be a lie — and hide on touch, where there's no key to press. They're `aria-hidden`: a screen reader user is already moving through a radio group with arrows, and announcing "A" before every label is noise, not help.

## Transitions

Direction-aware, so back slides from the top and forward from the bottom. Direction is state rather than derived from the step index, because moving between sections resets that index and would animate a forward move backwards.

`motion-safe:` rather than a JS media query — a respondent who asked for reduced motion never gets the classes at all, so there's no animation to interrupt.

## Two extractions worth their own mention

Both fell out of the 700-line ceiling, and both were worth doing regardless:

- **`useRuntimeKeyboard`** — the keyboard must be bound *above* the runtime's early return for a form with no current section. A hook that runs on some renders and not others breaks React's hook order; the lint caught a real bug, not a style nit.
- **`step-validation`** — splits the pure "which required questions are unanswered" from the error state and scrolling around it, which made it testable. Order is asserted, because the runtime reports and scrolls to the *first*, and sending someone to the third while the first is off-screen above them tells them the wrong thing.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0
- 174 tests across 26 files (13 new, covering the key mapping and the validation split)
- en/vi parity maintained

## Next in this stream

Welcome/ending screen polish, then editor and preview, then analytics and settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes one-question-at-a-time the default form display and adds real keyboard navigation, which the runtime previously had none of. Because `settings` is jsonb, existing forms pick up the new default via the zod read-time backfill; authors wanting the old scroll set `displayMode` to `sections` explicitly, and new forms now start with the welcome screen on.

**Keyboard**
- Enter advances, Cmd/Ctrl+Enter works inside textareas, Alt+↑/↓ move either way, and 1–9/A–I pick an option when a single answerable question owns the screen.
- Shortcuts bind on `document` so they work before focus, with bare arrows and Backspace left alone to keep typing intact.
- Letter badges and an Enter hint make the shortcuts visible; both hide on touch, and badges stop at the ninth option.

**Refactors**
- Screen transitions are direction-aware and use `motion-safe:` so reduced-motion users never get animation classes.
- Validation logic was extracted into a pure, testable `step-validation` module, and keyboard binding was moved above the runtime's early return to preserve React hook order.

<sup>Written for commit 19a804a33aaffc50a07d9d2597a55c3d0a96f09c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

