### PR TITLE
feat(forms): show the NPS and ranking results that were already being computed

### DIFF
--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -2806,7 +2806,17 @@
       "unmatched_answer_hint": "Saved answer no longer matches the current choices: {value}",
       "unmatched_answers_description": "{count} saved response(s) no longer match the current choices, so they are shown separately from the live breakdown.",
       "unmatched_answers_title": "Saved answers outside the current choices",
-      "written_response_count": "{count} response(s) ({percentage}%)"
+      "written_response_count": "{count} response(s) ({percentage}%)",
+      "nps_score": "NPS score",
+      "nps_promoter": "Promoters",
+      "nps_passive": "Passives",
+      "nps_detractor": "Detractors",
+      "nps_distribution": "Score distribution",
+      "nps_bar_title": "{score}: {count} responses",
+      "ranking_results": "Ranking results",
+      "ranking_hint": "Best first, by average position",
+      "ranking_average": "avg {average} · {first} first",
+      "ranking_unranked": "Not ranked"
     },
     "runtime": {
       "already_responded": "You have already responded to this form. You can view your answers below.",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -2806,7 +2806,17 @@
       "unmatched_answer_hint": "Câu trả lời đã lưu không còn khớp với các lựa chọn hiện tại: {value}",
       "unmatched_answers_description": "{count} phản hồi đã lưu không còn khớp với các lựa chọn hiện tại, nên được hiển thị riêng khỏi biểu đồ đang hoạt động.",
       "unmatched_answers_title": "Câu trả lời đã lưu nằm ngoài các lựa chọn hiện tại",
-      "written_response_count": "{count} phản hồi ({percentage}%)"
+      "written_response_count": "{count} phản hồi ({percentage}%)",
+      "nps_score": "Điểm NPS",
+      "nps_promoter": "Người ủng hộ",
+      "nps_passive": "Người trung lập",
+      "nps_detractor": "Người phản đối",
+      "nps_distribution": "Phân bố điểm",
+      "nps_bar_title": "{score}: {count} phản hồi",
+      "ranking_results": "Kết quả xếp hạng",
+      "ranking_hint": "Tốt nhất trước, theo vị trí trung bình",
+      "ranking_average": "TB {average} · {first} hạng nhất",
+      "ranking_unranked": "Chưa được xếp hạng"
     },
     "runtime": {
       "already_responded": "Bạn đã gửi phản hồi cho biểu mẫu này. Bạn có thể xem lại bên dưới.",

--- a/apps/forms/src/features/forms/studio/analytics-nps-card.tsx
+++ b/apps/forms/src/features/forms/studio/analytics-nps-card.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { cn } from '@tuturuuu/utils/format';
+import { getNpsBand, type NpsBand } from '../nps';
+import type { FormResponsesQuestionAnalytics } from '../types';
+
+const BAND_BAR: Record<NpsBand, string> = {
+  detractor: 'bg-dynamic-red',
+  passive: 'bg-dynamic-orange',
+  promoter: 'bg-dynamic-green',
+};
+
+const BAND_TEXT: Record<NpsBand, string> = {
+  detractor: 'text-dynamic-red',
+  passive: 'text-dynamic-orange',
+  promoter: 'text-dynamic-green',
+};
+
+/**
+ * NPS results: the score, the three bands, and the 0-10 spread.
+ *
+ * The score is shown, not an average. Averaging 0-10 answers gives a number
+ * that looks like NPS and is not comparable to anyone else's NPS, which is
+ * worse than showing nothing — the whole value of the metric is that it means
+ * the same thing everywhere.
+ *
+ * The distribution is included because the score alone hides its own shape: a
+ * 0 made of all sevens and a 0 made of half tens and half zeros are the same
+ * number about very different sets of customers.
+ */
+export function AnalyticsNpsCard({
+  nps,
+  t,
+}: {
+  nps: NonNullable<FormResponsesQuestionAnalytics['nps']>;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}) {
+  const total = nps.promoters + nps.passives + nps.detractors;
+  const maxCount = Math.max(...nps.distribution.map((entry) => entry.count), 1);
+
+  const bands = [
+    { band: 'promoter' as const, count: nps.promoters },
+    { band: 'passive' as const, count: nps.passives },
+    { band: 'detractor' as const, count: nps.detractors },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-4 rounded-2xl border border-border/50 bg-background/45 p-4">
+        <div>
+          <p className="text-[11px] text-muted-foreground uppercase tracking-[0.2em]">
+            {t('responses.nps_score')}
+          </p>
+          <p
+            className={cn(
+              'font-bold text-4xl tabular-nums',
+              nps.score > 0
+                ? 'text-dynamic-green'
+                : nps.score < 0
+                  ? 'text-dynamic-red'
+                  : ''
+            )}
+          >
+            {nps.score > 0 ? `+${nps.score}` : nps.score}
+          </p>
+        </div>
+
+        <div className="flex flex-1 flex-wrap gap-4">
+          {bands.map(({ band, count }) => (
+            <div key={band} className="min-w-20">
+              <p
+                className={cn(
+                  'font-semibold text-lg tabular-nums',
+                  BAND_TEXT[band]
+                )}
+              >
+                {count}
+              </p>
+              <p className="text-[11px] text-muted-foreground">
+                {t(`responses.nps_${band}`)}
+                {total > 0 ? ` · ${Math.round((count / total) * 100)}%` : ''}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-border/50 bg-background/45 p-4">
+        <p className="mb-3 font-medium text-sm">
+          {t('responses.nps_distribution')}
+        </p>
+        <div className="flex items-end gap-1">
+          {nps.distribution.map((entry) => (
+            <div
+              key={entry.score}
+              className="flex flex-1 flex-col items-center gap-1"
+              title={t('responses.nps_bar_title', {
+                score: entry.score,
+                count: entry.count,
+              })}
+            >
+              <div
+                className={cn(
+                  'w-full rounded-t',
+                  BAND_BAR[getNpsBand(entry.score)],
+                  entry.count === 0 ? 'opacity-25' : ''
+                )}
+                // Scaled against the busiest score rather than the total, so a
+                // flat spread is still readable instead of eleven slivers.
+                style={{
+                  height: `${Math.max((entry.count / maxCount) * 72, 3)}px`,
+                }}
+              />
+              <span className="text-[10px] text-muted-foreground tabular-nums">
+                {entry.score}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/forms/src/features/forms/studio/analytics-ranking-card.tsx
+++ b/apps/forms/src/features/forms/studio/analytics-ranking-card.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { cn } from '@tuturuuu/utils/format';
+import type { FormResponsesQuestionAnalytics } from '../types';
+
+/**
+ * Ranking results, best-first by mean position.
+ *
+ * Mean position rather than first-choice count, because a poll can have a
+ * winner nobody put first: an option ranked second by everyone beats one that
+ * half the respondents love and half put last. First-choice count is shown
+ * beside it, since that is the number people reach for and the two disagreeing
+ * is itself the interesting result.
+ *
+ * An option nobody ranked has no mean, so it renders as "not ranked" rather
+ * than a zero that would sort it to the top as everyone's favourite.
+ */
+export function AnalyticsRankingCard({
+  ranking,
+  t,
+}: {
+  ranking: NonNullable<FormResponsesQuestionAnalytics['ranking']>;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}) {
+  const ranked = ranking.filter((entry) => entry.count > 0);
+  // The scale runs 1..n, so a bar is filled by how far from last it sits.
+  const worstRank = Math.max(...ranked.map((entry) => entry.averageRank), 1);
+
+  return (
+    <div className="space-y-2 rounded-2xl border border-border/50 bg-background/45 p-4">
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <p className="font-medium text-sm">{t('responses.ranking_results')}</p>
+        <p className="text-[11px] text-muted-foreground">
+          {t('responses.ranking_hint')}
+        </p>
+      </div>
+
+      {ranking.map((entry, index) => {
+        const isRanked = entry.count > 0;
+        const fill = isRanked
+          ? Math.max(((worstRank - entry.averageRank) / worstRank) * 100, 6)
+          : 0;
+
+        return (
+          <div key={entry.value} className="flex items-center gap-3">
+            <span className="w-5 shrink-0 text-right font-semibold text-muted-foreground text-xs tabular-nums">
+              {isRanked ? index + 1 : '—'}
+            </span>
+
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="truncate font-medium text-sm">
+                  {entry.label}
+                </span>
+                <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+                  {isRanked
+                    ? t('responses.ranking_average', {
+                        average: entry.averageRank,
+                        first: entry.firstChoiceCount,
+                      })
+                    : t('responses.ranking_unranked')}
+                </span>
+              </div>
+              <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-foreground/10">
+                <div
+                  className={cn(
+                    'h-full rounded-full',
+                    isRanked ? 'bg-dynamic-blue' : 'bg-transparent'
+                  )}
+                  style={{ width: `${fill}%` }}
+                />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/forms/src/features/forms/studio/responses-question-analytics-card.tsx
+++ b/apps/forms/src/features/forms/studio/responses-question-analytics-card.tsx
@@ -16,6 +16,8 @@ import {
 } from 'recharts';
 
 import type { FormResponsesQuestionAnalytics } from '../types';
+import { AnalyticsNpsCard } from './analytics-nps-card';
+import { AnalyticsRankingCard } from './analytics-ranking-card';
 import { ChartTooltipContent } from './chart-tooltip-content';
 
 export function QuestionAnalyticsCard({
@@ -103,6 +105,15 @@ export function QuestionAnalyticsCard({
         </p>
       </CardHeader>
       <CardContent className="space-y-4">
+        {/* NPS and ranking come before the generic distribution: both were
+            already computed by `buildQuestionAnalytics` and had no renderer,
+            so the data existed and nobody could see it. */}
+        {analytics.nps ? <AnalyticsNpsCard nps={analytics.nps} t={t} /> : null}
+
+        {analytics.ranking?.length ? (
+          <AnalyticsRankingCard ranking={analytics.ranking} t={t} />
+        ) : null}
+
         {distribution.length > 0 ? (
           <>
             <div className="rounded-2xl border border-border/50 bg-background/45 p-2">


### PR DESCRIPTION
## The gap

`buildQuestionAnalytics` has produced `analytics.nps` and `analytics.ranking` since [#5146](https://github.com/tutur3u/platform/pull/5146). **Nothing rendered them.**

The question analytics card handles choices, scale, free text and mean score, and falls straight through for those two — so every NPS score and every ranking result has been computed, stored, and shown to nobody. My gap, from three PRs ago, and the same shape as the three-pane one: data exists, UI never reaches it.

Worth saying what was *already* there, since I nearly rebuilt it: completion rate, average completion time, and drop-off by section and by question all exist and work. This adds the two missing renderers rather than a second analytics surface.

## NPS

Reports **the score, never an average**. Averaging 0–10 answers gives a number that looks like NPS and isn't comparable to anyone else's NPS — worse than showing nothing, because the entire value of the metric is that it means the same thing everywhere.

The 0–10 spread sits beside it because the score hides its own shape. A zero made of all sevens and a zero made of half tens and half zeros are the same number describing very different customers, and only one of them is a problem you can act on.

Bars scale against the busiest score rather than the total, so a flat spread stays readable instead of collapsing into eleven slivers.

## Ranking

Leads with **mean position**, not first-choice count — a poll can have a winner nobody put first, and an option everyone ranks second beats one that half love and half put last. First-choice count sits next to it, since that's the number people reach for, and the two disagreeing is itself the interesting result.

An option nobody ranked reads "not ranked" rather than showing a zero, which would sort it to the top as everyone's favourite. That's the same trap the analytics builder already avoids by leaving its average as `NaN`.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0
- 174 tests pass across 25 files
- en/vi parity maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders the NPS and ranking results that `buildQuestionAnalytics` has been computing since #5146 but nothing displayed. The question analytics card now shows both instead of falling through to the generic distribution.

**Key decisions**
- NPS shows the score, never a 0–10 average, with the full score distribution beside it.
- Ranking sorts by mean position, shows first-choice counts, and marks unranked options as "not ranked."

<sup>Written for commit 7e7850355e0e216186aeb76a4d6e45390a3b0b09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

