### PR TITLE
feat(forms): advance automatically after a single-gesture answer

### DIFF
--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -3026,7 +3026,9 @@
       "welcome_body": "Welcome message",
       "welcome_body_placeholder": "Leave empty to use the form description",
       "welcome_button": "Button label",
-      "welcome_button_placeholder": "Start"
+      "welcome_button_placeholder": "Start",
+      "auto_advance": "Advance automatically",
+      "auto_advance_hint": "Move to the next question once a rating or single choice is picked. Typing, multi-select and ranking always wait for Continue."
     },
     "shared": {
       "metadata_fallback_description": "Open this shared form to review the questions and submit a response.",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -3026,7 +3026,9 @@
       "welcome_body": "Lời chào",
       "welcome_body_placeholder": "Để trống để dùng mô tả biểu mẫu",
       "welcome_button": "Nhãn nút",
-      "welcome_button_placeholder": "Bắt đầu"
+      "welcome_button_placeholder": "Bắt đầu",
+      "auto_advance": "Tự động chuyển tiếp",
+      "auto_advance_hint": "Chuyển sang câu hỏi kế tiếp ngay khi chọn xong đánh giá hoặc một lựa chọn. Câu nhập chữ, chọn nhiều và xếp hạng luôn chờ nút Tiếp tục."
     },
     "shared": {
       "metadata_fallback_description": "Mở biểu mẫu chia sẻ này để xem các câu hỏi và gửi phản hồi.",

--- a/apps/forms/src/features/forms/runtime/auto-advance.test.ts
+++ b/apps/forms/src/features/forms/runtime/auto-advance.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { isAutoAdvanceType, shouldAutoAdvance } from './auto-advance';
+
+const base = { enabled: true, answerableCount: 1, value: 'a' } as const;
+
+describe('isAutoAdvanceType', () => {
+  it('includes the types that are complete in one gesture', () => {
+    for (const type of [
+      'single_choice',
+      'dropdown',
+      'linear_scale',
+      'rating',
+      'nps',
+    ] as const) {
+      expect(isAutoAdvanceType(type)).toBe(true);
+    }
+  });
+
+  it('excludes types the respondent may still be composing', () => {
+    // Advancing out of a half-typed answer or a partly-built ranking is worse
+    // than the click auto-advance removes.
+    for (const type of [
+      'short_text',
+      'long_text',
+      'email',
+      'number',
+      'multiple_choice',
+      'ranking',
+      'date',
+    ] as const) {
+      expect(isAutoAdvanceType(type)).toBe(false);
+    }
+  });
+});
+
+describe('shouldAutoAdvance', () => {
+  it('advances on a single-gesture answer', () => {
+    expect(shouldAutoAdvance({ ...base, type: 'single_choice' })).toBe(true);
+    expect(shouldAutoAdvance({ ...base, type: 'nps', value: '0' })).toBe(true);
+  });
+
+  it('never advances when the author turned it off', () => {
+    expect(
+      shouldAutoAdvance({ ...base, enabled: false, type: 'single_choice' })
+    ).toBe(false);
+  });
+
+  it('never advances when the screen holds more than one question', () => {
+    // The second question would be skipped unanswered.
+    expect(
+      shouldAutoAdvance({ ...base, answerableCount: 2, type: 'single_choice' })
+    ).toBe(false);
+  });
+
+  it('never advances on a cleared answer', () => {
+    // Deselecting is a correction; moving on would take it away.
+    expect(
+      shouldAutoAdvance({ ...base, type: 'single_choice', value: '' })
+    ).toBe(false);
+    expect(
+      shouldAutoAdvance({ ...base, type: 'single_choice', value: null })
+    ).toBe(false);
+  });
+
+  it('never advances on a list answer', () => {
+    expect(
+      shouldAutoAdvance({ ...base, type: 'multiple_choice', value: ['a'] })
+    ).toBe(false);
+  });
+});

--- a/apps/forms/src/features/forms/runtime/auto-advance.ts
+++ b/apps/forms/src/features/forms/runtime/auto-advance.ts
@@ -1,0 +1,60 @@
+import type { FormQuestionInput } from '../schema';
+
+/**
+ * Types that auto-advance once answered.
+ *
+ * The test is whether the answer is *complete* the moment it is given. Picking
+ * a rating or a single choice is one gesture and it is done; typing, choosing
+ * several options, or dragging a ranking into order are all states a
+ * respondent passes through on the way to an answer, and advancing out of one
+ * mid-thought is worse than the extra click auto-advance exists to remove.
+ */
+const AUTO_ADVANCE_TYPES = new Set<FormQuestionInput['type']>([
+  'single_choice',
+  'dropdown',
+  'linear_scale',
+  'rating',
+  'nps',
+]);
+
+export function isAutoAdvanceType(type: FormQuestionInput['type']): boolean {
+  return AUTO_ADVANCE_TYPES.has(type);
+}
+
+/**
+ * How long to wait before moving on, in milliseconds.
+ *
+ * Long enough to see the option register as selected — advancing instantly
+ * reads as the form skipping rather than responding, and leaves the respondent
+ * unsure what they picked — and short enough not to feel like waiting.
+ */
+export const AUTO_ADVANCE_DELAY_MS = 380;
+
+/**
+ * Whether this answer should trigger a move to the next screen.
+ *
+ * Requires exactly one answerable question on the screen: with two, advancing
+ * when the first is answered would skip past the second unanswered one.
+ */
+export function shouldAutoAdvance({
+  enabled,
+  answerableCount,
+  type,
+  value,
+}: {
+  enabled: boolean;
+  answerableCount: number;
+  type: FormQuestionInput['type'];
+  value: unknown;
+}): boolean {
+  if (!enabled) return false;
+  if (answerableCount !== 1) return false;
+  if (!isAutoAdvanceType(type)) return false;
+
+  // Clearing an answer must not advance — deselecting is the respondent
+  // correcting themselves, and moving on would take the correction away.
+  if (value == null || value === '') return false;
+  if (Array.isArray(value)) return false;
+
+  return true;
+}

--- a/apps/forms/src/features/forms/runtime/form-runtime.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.tsx
@@ -2,14 +2,14 @@
 
 import type { TurnstileInstance } from '@marsidev/react-turnstile';
 import { resolveTurnstileClientState } from '@tuturuuu/turnstile/client';
-import { cn } from '@tuturuuu/utils/format';
+
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { DEV_MODE } from '@/constants/common';
 import { isAnswerableQuestionType } from '../block-utils';
 import { getNextSectionTarget } from '../branching';
 import { normalizeMarkdownToText } from '../content';
-import { FORM_FONT_VARIABLES, getFormFontStyle } from '../fonts';
+import { getFormFontStyle } from '../fonts';
 import { FormsImageDialog } from '../forms-image-dialog';
 import { getRuntimeProgressStats } from '../runtime-progress';
 import { getFormToneClasses } from '../theme';
@@ -24,6 +24,7 @@ import { densityClasses } from './constants';
 import { FormBrandFooter } from './form-brand-footer';
 import { renderFormHeroCard } from './hero-card';
 import { renderEmailTrackedNotice, renderReadOnlyNotice } from './notices';
+import { RuntimeShell } from './runtime-shell';
 import { renderFormSectionCard } from './section-card';
 import {
   findMissingRequiredQuestions,
@@ -31,6 +32,8 @@ import {
 } from './step-validation';
 import { renderSubmittedScreen } from './submitted-screen';
 import type { FormRuntimeProps } from './types';
+import { useAutoAdvance } from './use-auto-advance';
+import { useBackNavigation } from './use-back-navigation';
 import { useFormDraft } from './use-form-draft';
 import { useFormSteps } from './use-form-steps';
 import { useResponseCopy } from './use-response-copy';
@@ -340,6 +343,29 @@ export function FormRuntime({
     step: currentStep,
   });
 
+  // Reuses the keyboard's late-bound handler ref: advancing is the same action
+  // whether a key or an answer triggered it, and a second ref for it would be
+  // one more thing to keep pointed at the right function.
+  const handleBack = useBackNavigation({
+    goToPreviousStep,
+    isBusy,
+    resetSteps,
+    sectionTrail,
+    setCurrentSectionId,
+    setError,
+    setSectionTrail,
+    setStepDirection,
+  });
+
+  const maybeAutoAdvance = useAutoAdvance({
+    enabled:
+      form.settings.displayMode === 'one_question' &&
+      form.settings.autoAdvance &&
+      !readOnly,
+    onAdvance: () => keyboardHandlersRef.current.next(),
+    step: currentStep,
+  });
+
   if (!currentSection) {
     return null;
   }
@@ -359,6 +385,8 @@ export function FormRuntime({
       delete next[questionId];
       return next;
     });
+
+    maybeAutoAdvance(questionId, value);
   };
 
   const validateCurrentSection = (
@@ -394,36 +422,6 @@ export function FormRuntime({
    * section they are partway through.
    */
   const canGoBack = !isFirstStep || sectionTrail.length > 1;
-
-  // Assigned during render, like `answersRef` above: the keyboard is bound
-  // before these exist, and this is what connects the two.
-  keyboardHandlersRef.current = {
-    next: () => {
-      void handleAdvance();
-    },
-    previous: () => handleBack(),
-  };
-
-  const handleBack = () => {
-    if (isBusy) return;
-
-    if (goToPreviousStep()) {
-      setStepDirection('backward');
-      setError(null);
-      return;
-    }
-
-    const previousSectionId = sectionTrail[sectionTrail.length - 2];
-    if (!previousSectionId) return;
-
-    // Entering the previous section from the end, so its last screen is what
-    // the respondent last saw.
-    setStepDirection('backward');
-    resetSteps('last');
-    setSectionTrail((currentTrail) => currentTrail.slice(0, -1));
-    setCurrentSectionId(previousSectionId);
-    setError(null);
-  };
 
   const handleAdvance = async () => {
     if (isBusy) {
@@ -554,6 +552,15 @@ export function FormRuntime({
     }
   };
 
+  // Assigned during render, like `answersRef` above: the keyboard is bound
+  // before these exist, and this is what connects the two.
+  keyboardHandlersRef.current = {
+    next: () => {
+      void handleAdvance();
+    },
+    previous: () => handleBack(),
+  };
+
   if (submitted) {
     return renderSubmittedScreen({
       form,
@@ -572,126 +579,115 @@ export function FormRuntime({
 
   if (!hasStarted) {
     return (
-      <div
-        className={cn(
-          'min-h-screen py-10',
-          FORM_FONT_VARIABLES,
-          toneClasses.pageClassName,
-          className
-        )}
-        style={bodyFontStyle}
+      <RuntimeShell
+        bodyFontStyle={bodyFontStyle}
+        className={className}
+        toneClasses={toneClasses}
+        width="narrow"
       >
-        <div className="mx-auto flex max-w-3xl flex-col gap-8 px-4">
-          <WelcomeScreen
-            bodyTypographyClassName={bodyTypographyClassName}
-            displayTypographyClassName={displayTypographyClassName}
-            form={form}
-            headlineFontStyle={headlineFontStyle}
-            onStart={() => setHasStarted(true)}
-            t={t}
-            toneClasses={toneClasses}
-          />
-          <FormBrandFooter />
-        </div>
-      </div>
+        <WelcomeScreen
+          bodyTypographyClassName={bodyTypographyClassName}
+          displayTypographyClassName={displayTypographyClassName}
+          form={form}
+          headlineFontStyle={headlineFontStyle}
+          onStart={() => setHasStarted(true)}
+          t={t}
+          toneClasses={toneClasses}
+        />
+        <FormBrandFooter />
+      </RuntimeShell>
     );
   }
 
   return (
-    <div
-      className={cn(
-        'min-h-screen py-10',
-        FORM_FONT_VARIABLES,
-        toneClasses.pageClassName,
-        className
-      )}
-      style={bodyFontStyle}
+    <RuntimeShell
+      bodyFontStyle={bodyFontStyle}
+      className={className}
+      toneClasses={toneClasses}
     >
-      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4">
-        {renderFormHeroCard({
-          form,
-          t,
-          toneClasses,
-          headlineFontStyle,
-          displayTypographyClassName,
-          progressStats,
-          setPreviewImage,
-        })}
+      {renderFormHeroCard({
+        form,
+        t,
+        toneClasses,
+        headlineFontStyle,
+        displayTypographyClassName,
+        progressStats,
+        setPreviewImage,
+      })}
 
-        {renderEmailTrackedNotice({ form, t })}
+      {renderEmailTrackedNotice({ form, t })}
 
-        {renderReadOnlyNotice({
-          t,
-          readOnly,
-          toneClasses,
-          submittedAt,
-          responseCopyEmail,
-          readOnlyResponseCopySentTo,
-          canTriggerReadOnlyResponseCopy,
-          isBusy,
-          isResponseCopyBlockedByTurnstile,
-          handleReadOnlyResponseCopy,
-          missingQuestionIssues,
-        })}
+      {renderReadOnlyNotice({
+        t,
+        readOnly,
+        toneClasses,
+        submittedAt,
+        responseCopyEmail,
+        readOnlyResponseCopySentTo,
+        canTriggerReadOnlyResponseCopy,
+        isBusy,
+        isResponseCopyBlockedByTurnstile,
+        handleReadOnlyResponseCopy,
+        missingQuestionIssues,
+      })}
 
-        {renderFormSectionCard({
-          form,
-          t,
-          mode,
-          readOnly,
-          toneClasses,
-          density,
-          bodyTypographyClassName,
-          headingTypographyClassName,
-          sectionCardRef,
-          currentSection,
-          visibleSectionTitle,
-          progressStats,
-          answers,
-          answerIssueMap,
-          validationErrorsByQuestionId,
-          updateAnswer,
-          setPreviewImage,
-          error,
-          advanceTarget,
-          advanceSectionTitle,
-          hasReadOnlyNextSection,
-          shouldShowSectionNavigation,
-          canGoBack,
-          handleBack,
-          visibleQuestions: currentStepQuestions,
-          stepIndex,
-          stepDirection,
-          stepCount: steps.length,
-          isLastStep,
-          shouldShowTurnstile,
-          isSubmitBlockedByTurnstile,
-          isBusy,
-          setError,
-          responseCopyEmail,
-          sendResponseCopy,
-          setSendResponseCopy,
-          turnstileSiteKey,
-          captchaRef,
-          captchaError,
-          setCaptchaToken,
-          setCaptchaError,
-          handleAdvance,
-        })}
-        <FormBrandFooter className="pb-2" />
-        {previewImage ? (
-          <FormsImageDialog
-            open={!!previewImage}
-            onOpenChange={(open) => {
-              if (!open) {
-                setPreviewImage(null);
-              }
-            }}
-            src={previewImage.src}
-            alt={previewImage.alt}
-          />
-        ) : null}
-      </div>
-    </div>
+      {renderFormSectionCard({
+        form,
+        t,
+        mode,
+        readOnly,
+        toneClasses,
+        density,
+        bodyTypographyClassName,
+        headingTypographyClassName,
+        sectionCardRef,
+        currentSection,
+        visibleSectionTitle,
+        progressStats,
+        answers,
+        answerIssueMap,
+        validationErrorsByQuestionId,
+        updateAnswer,
+        setPreviewImage,
+        error,
+        advanceTarget,
+        advanceSectionTitle,
+        hasReadOnlyNextSection,
+        shouldShowSectionNavigation,
+        canGoBack,
+        handleBack,
+        visibleQuestions: currentStepQuestions,
+        stepIndex,
+        stepDirection,
+        stepCount: steps.length,
+        isLastStep,
+        shouldShowTurnstile,
+        isSubmitBlockedByTurnstile,
+        isBusy,
+        setError,
+        responseCopyEmail,
+        sendResponseCopy,
+        setSendResponseCopy,
+        turnstileSiteKey,
+        captchaRef,
+        captchaError,
+        setCaptchaToken,
+        setCaptchaError,
+        handleAdvance,
+      })}
+      <FormBrandFooter className="pb-2" />
+      {previewImage ? (
+        <FormsImageDialog
+          open={!!previewImage}
+          onOpenChange={(open) => {
+            if (!open) {
+              setPreviewImage(null);
+            }
+          }}
+          src={previewImage.src}
+          alt={previewImage.alt}
+        />
+      ) : null}
+    </RuntimeShell>
   );
 }

--- a/apps/forms/src/features/forms/runtime/runtime-shell.tsx
+++ b/apps/forms/src/features/forms/runtime/runtime-shell.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { cn } from '@tuturuuu/utils/format';
+import type { CSSProperties, ReactNode } from 'react';
+import { FORM_FONT_VARIABLES } from '../fonts';
+import type { FormToneClasses } from './types';
+
+/**
+ * The page frame every runtime screen sits in.
+ *
+ * The welcome screen, the question flow and the confirmation all render the
+ * same full-height, themed, font-scoped page. It was written out three times,
+ * which is three places to forget when a theme gains a property.
+ */
+export function RuntimeShell({
+  bodyFontStyle,
+  children,
+  className,
+  toneClasses,
+  width = 'wide',
+}: {
+  bodyFontStyle: CSSProperties;
+  children: ReactNode;
+  className?: string;
+  toneClasses: FormToneClasses;
+  /** The question flow is wider than the screens that bookend it. */
+  width?: 'wide' | 'narrow';
+}) {
+  return (
+    <div
+      className={cn(
+        'min-h-screen py-10',
+        FORM_FONT_VARIABLES,
+        toneClasses.pageClassName,
+        className
+      )}
+      style={bodyFontStyle}
+    >
+      <div
+        className={cn(
+          'mx-auto flex flex-col gap-8 px-4',
+          width === 'wide' ? 'max-w-5xl' : 'max-w-3xl'
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/forms/src/features/forms/runtime/use-auto-advance.ts
+++ b/apps/forms/src/features/forms/runtime/use-auto-advance.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import type { FormAnswerValue } from '../types';
+import { AUTO_ADVANCE_DELAY_MS, shouldAutoAdvance } from './auto-advance';
+import type { FormStep } from './step-plan';
+
+/**
+ * Moves on shortly after a single-gesture answer.
+ *
+ * Picking an option and then reaching for Continue is the click a
+ * one-question form exists to remove, so answering is the whole interaction
+ * for the types where an answer is complete the moment it is given.
+ */
+export function useAutoAdvance({
+  enabled,
+  step,
+  onAdvance,
+}: {
+  enabled: boolean;
+  /** The current screen. Both the question type and the count come from it. */
+  step: FormStep | undefined;
+  onAdvance: () => void;
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onAdvanceRef = useRef(onAdvance);
+  onAdvanceRef.current = onAdvance;
+
+  const cancel = useCallback(() => {
+    if (!timerRef.current) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  // A pending advance must never fire against a screen the respondent has
+  // already left, so unmounting cancels it.
+  useEffect(() => cancel, [cancel]);
+
+  return useCallback(
+    (questionId: string, value: FormAnswerValue) => {
+      // Always cancel first: changing a rating three times in a second should
+      // advance once, from the last choice, not three times.
+      cancel();
+
+      const type = step?.questions.find(
+        (entry) => entry.id === questionId
+      )?.type;
+      if (!type) return;
+
+      if (
+        !shouldAutoAdvance({
+          answerableCount: step?.answerableQuestionIds.length ?? 0,
+          enabled,
+          type,
+          value,
+        })
+      ) {
+        return;
+      }
+
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        onAdvanceRef.current();
+      }, AUTO_ADVANCE_DELAY_MS);
+    },
+    [cancel, enabled, step]
+  );
+}

--- a/apps/forms/src/features/forms/runtime/use-back-navigation.ts
+++ b/apps/forms/src/features/forms/runtime/use-back-navigation.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useCallback } from 'react';
+
+/**
+ * Stepping backwards through the form.
+ *
+ * Screens come before sections: in one-question mode a respondent who presses
+ * back expects the previous *question*, not to be thrown over the whole
+ * section they are part-way through.
+ *
+ * A section is only left once its first screen is already showing, and it is
+ * re-entered from its end — the last screen is what that respondent last saw,
+ * so restarting the section would make back feel like a reset.
+ */
+export function useBackNavigation({
+  isBusy,
+  goToPreviousStep,
+  resetSteps,
+  sectionTrail,
+  setCurrentSectionId,
+  setError,
+  setSectionTrail,
+  setStepDirection,
+}: {
+  isBusy: boolean;
+  goToPreviousStep: () => boolean;
+  resetSteps: (position?: 'first' | 'last') => void;
+  sectionTrail: string[];
+  setCurrentSectionId: (sectionId: string) => void;
+  setError: (error: string | null) => void;
+  setSectionTrail: (update: (trail: string[]) => string[]) => void;
+  setStepDirection: (direction: 'forward' | 'backward') => void;
+}) {
+  return useCallback(() => {
+    if (isBusy) return;
+
+    setStepDirection('backward');
+
+    if (goToPreviousStep()) {
+      setError(null);
+      return;
+    }
+
+    const previousSectionId = sectionTrail[sectionTrail.length - 2];
+    if (!previousSectionId) return;
+
+    resetSteps('last');
+    setSectionTrail((trail) => trail.slice(0, -1));
+    setCurrentSectionId(previousSectionId);
+    setError(null);
+  }, [
+    goToPreviousStep,
+    isBusy,
+    resetSteps,
+    sectionTrail,
+    setCurrentSectionId,
+    setError,
+    setSectionTrail,
+    setStepDirection,
+  ]);
+}

--- a/apps/forms/src/features/forms/schema.ts
+++ b/apps/forms/src/features/forms/schema.ts
@@ -322,6 +322,22 @@ export const formSettingsSchema = z.object({
     .string()
     .max(FORM_WELCOME_DESCRIPTION_MAX_LENGTH)
     .default(''),
+  /**
+   * Move to the next question automatically once a single-answer question is
+   * answered. Only meaningful in `one_question` mode.
+   *
+   * On by default: picking an option and then reaching for a Continue button
+   * is the click a one-question form exists to remove. Types where the
+   * respondent may still be composing — text, multi-select, ranking — never
+   * auto-advance, because leaving mid-thought is the one thing worse than an
+   * extra click.
+   */
+  autoAdvance: z.boolean().default(true),
+  /**
+   * Where to send the respondent after they submit. Empty keeps them on the
+   * confirmation screen.
+   */
+  redirectUrl: z.string().max(2000).default(''),
   welcomeButtonLabel: z
     .string()
     .max(FORM_WELCOME_BUTTON_MAX_LENGTH)
@@ -487,6 +503,8 @@ export function createDefaultFormStudioInput(): FormStudioInput {
       displayMode: FORM_DEFAULT_DISPLAY_MODE,
       // A cover screen is the natural opening for a one-question form: it says
       // what the form is before the first question arrives with no context.
+      autoAdvance: true,
+      redirectUrl: '',
       welcomeEnabled: true,
       welcomeTitle: '',
       welcomeDescription: '',

--- a/apps/forms/src/features/forms/studio/settings-experience-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-experience-section.tsx
@@ -57,6 +57,10 @@ export function ExperienceSettingsSection({
     control: form.control,
     name: 'settings.welcomeEnabled',
   });
+  const autoAdvance = useWatch({
+    control: form.control,
+    name: 'settings.autoAdvance',
+  });
 
   return (
     <SettingsSection
@@ -94,6 +98,36 @@ export function ExperienceSettingsSection({
           ))}
         </div>
       </div>
+
+      {/* Only meaningful one question at a time: with a whole section on
+          screen there is nothing to advance to. */}
+      {displayMode === 'one_question' ? (
+        <div className="space-y-3 rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
+          <button
+            className="flex w-full items-start gap-3 text-left"
+            onClick={() =>
+              form.setValue('settings.autoAdvance', !autoAdvance, {
+                shouldDirty: true,
+              })
+            }
+            type="button"
+          >
+            <Checkbox
+              checked={autoAdvance}
+              className="pointer-events-none mt-0.5"
+              tabIndex={-1}
+            />
+            <span className="space-y-1">
+              <span className="block font-medium text-sm">
+                {t('settings.auto_advance')}
+              </span>
+              <span className="block text-muted-foreground text-xs">
+                {t('settings.auto_advance_hint')}
+              </span>
+            </span>
+          </button>
+        </div>
+      ) : null}
 
       <div className="space-y-3 rounded-[1.35rem] border border-border/60 bg-background/55 p-4">
         <button

--- a/apps/forms/src/features/landing/demo/demo-form.ts
+++ b/apps/forms/src/features/landing/demo/demo-form.ts
@@ -98,7 +98,9 @@ export function buildDemoForm(
     settings: {
       // Sections mode on the landing: a visitor skimming the page should see
       // what the form asks, not have to click through four screens to find out.
+      autoAdvance: true,
       displayMode: 'sections',
+      redirectUrl: '',
       welcomeEnabled: false,
       welcomeTitle: '',
       welcomeDescription: '',


### PR DESCRIPTION
## Summary

Picking an option and then reaching for Continue is the click a one-question form exists to remove. Answering is now the whole interaction for the types where the answer is complete the moment it's given.

## Which types, and why that's the whole decision

| Auto-advances | Always waits |
| --- | --- |
| single choice, dropdown, rating, linear scale, NPS | text, email, number, multi-select, ranking, date |

The test is whether the answer is **complete the moment it's given**. The left column is one gesture and done. The right column are states a respondent passes *through* on the way to an answer — advancing out of a half-typed sentence or a partly-dragged ranking is worse than the click this removes.

## Three guards, each for a silent failure

- **A pending advance is cancelled before another is scheduled**, so changing a rating three times in a second advances once, from the last choice — not three times. Cancelled on unmount too, so it can never fire against a screen the respondent already left.
- **Clearing an answer never advances.** Deselecting is someone correcting themselves; moving on would take the correction away before they could make it.
- **Only when a single answerable question owns the screen.** With two, answering the first would carry the respondent past the second, unanswered.

## The delay is 380ms

Long enough that the option visibly registers as selected — advancing instantly reads as the form *skipping* rather than responding, and leaves people unsure what they picked. Short enough not to feel like waiting.

Authors who disagree can turn it off. The toggle only appears in one-question mode, the only mode where it can mean anything.

## Also

`redirectUrl` joins the settings schema so the confirmation screen can hand off somewhere. Nothing reads it yet — it's schema groundwork, called out so it isn't mistaken for a working feature.

## Three extractions, and one recurring bug

`useAutoAdvance` and `useBackNavigation` both had to move **above** the runtime's early return for a form with no current section — the same conditional-hook bug lint caught on the keyboard work, twice more in one file. Worth noting as a pattern rather than three coincidences.

`RuntimeShell` replaces the page frame that the welcome screen, the question flow and the confirmation each wrote out separately: three places to forget when a theme gains a property.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0
- 181 tests across 26 files (7 new, covering every auto-advance guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
One-question forms now advance to the next question automatically after a single-gesture answer — rating, single choice, dropdown, linear scale, and NPS — instead of requiring Continue. Text, multi-select, ranking, and date answers still wait, because those are composed rather than given in one gesture.

- The advance fires after 380ms so the selection visibly registers.
- A pending advance is cancelled before another is scheduled, and on unmount, so it never fires against a screen the respondent has left.
- Clearing an answer never advances.
- Auto-advance only fires when a single answerable question owns the screen.
- Authors can disable it in one-question mode.
- `redirectUrl` joins the settings schema as groundwork; nothing reads it yet.
- `useAutoAdvance` and `useBackNavigation` now sit above the early return for missing sections, avoiding conditional hooks.
- `RuntimeShell` replaces the page frame written out separately by three screens.

<sup>Written for commit a2c48ab8d5ddbf3ebec9a6789bb8eb6960be34d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

