### PR TITLE
refactor(forms): guard the runtime on a prop so its hooks cannot go conditional

### DIFF
--- a/apps/forms/src/features/forms/runtime/form-runtime.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.tsx
@@ -13,7 +13,11 @@ import { getFormFontStyle } from '../fonts';
 import { FormsImageDialog } from '../forms-image-dialog';
 import { getRuntimeProgressStats } from '../runtime-progress';
 import { getFormToneClasses } from '../theme';
-import type { FormAnswerValue, FormReadOnlyAnswerIssue } from '../types';
+import type {
+  FormAnswerValue,
+  FormDefinitionSection,
+  FormReadOnlyAnswerIssue,
+} from '../types';
 import {
   getBodyTypographyClassName,
   getDisplayTypographyClassName,
@@ -30,17 +34,39 @@ import {
   findMissingRequiredQuestions,
   scrollToQuestion,
 } from './step-validation';
+import {
+  describeSubmissionFailure,
+  scrollToFirstSubmissionError,
+} from './submission-errors';
 import { renderSubmittedScreen } from './submitted-screen';
 import type { FormRuntimeProps } from './types';
 import { useAutoAdvance } from './use-auto-advance';
 import { useBackNavigation } from './use-back-navigation';
+import { useFormAnswers } from './use-form-answers';
 import { useFormDraft } from './use-form-draft';
 import { useFormSteps } from './use-form-steps';
 import { useResponseCopy } from './use-response-copy';
 import { useRuntimeKeyboard } from './use-runtime-keyboard';
 import { WelcomeScreen } from './welcome-screen';
 
-export function FormRuntime({
+/**
+ * Guards the runtime on a prop, before any hook runs, so every hook in
+ * `FormRuntimeContent` is unconditional.
+ *
+ * The keyboard binding, auto-advance and back navigation were each added below
+ * the old mid-component `return null` and each became a conditional hook. Lint
+ * caught all three, but a structure that keeps producing the same bug is the
+ * bug.
+ */
+export function FormRuntime(props: FormRuntimeProps) {
+  if (props.form.sections.length === 0) {
+    return null;
+  }
+
+  return <FormRuntimeContent {...props} />;
+}
+
+function FormRuntimeContent({
   form,
   mode,
   initialAnswers,
@@ -58,12 +84,13 @@ export function FormRuntime({
   className,
 }: FormRuntimeProps) {
   const t = useTranslations('forms');
-  const [answers, setAnswers] = useState<Record<string, FormAnswerValue>>(
-    initialAnswers ?? {}
-  );
-  const answersRef = useRef<Record<string, FormAnswerValue>>(
-    initialAnswers ?? {}
-  );
+  // Breaks a real cycle: answers need auto-advance, auto-advance needs the
+  // keyboard's advance handler, and the keyboard reads answers. One of the
+  // three has to be late-bound, and this is the cheapest place to do it.
+  const maybeAutoAdvanceRef = useRef<
+    (questionId: string, value: FormAnswerValue) => void
+  >(() => {});
+
   const [currentSectionId, setCurrentSectionId] = useState(
     form.sections[0]?.id ?? ''
   );
@@ -79,6 +106,14 @@ export function FormRuntime({
   );
   const [validationErrorsByQuestionId, setValidationErrorsByQuestionId] =
     useState<Record<string, string>>({});
+
+  const { answers, answersRef, setAnswers, updateAnswer } = useFormAnswers({
+    initialAnswers: initialAnswers ?? {},
+    onAnswered: (questionId, value) =>
+      maybeAutoAdvanceRef.current(questionId, value),
+    setError,
+    setValidationErrorsByQuestionId,
+  });
   const [submitted, setSubmitted] = useState(false);
   // The welcome screen is skipped entirely when disabled, and also when the
   // respondent is reviewing an already-submitted response — there is nothing
@@ -146,7 +181,11 @@ export function FormRuntime({
   const currentSectionIndex = form.sections.findIndex(
     (section) => section.id === currentSectionId
   );
-  const currentSection = form.sections[currentSectionIndex] ?? form.sections[0];
+  // `FormRuntime` refuses to render this component without at least one
+  // section, so the fallback always resolves — TypeScript cannot see that
+  // across the boundary.
+  const currentSection = (form.sections[currentSectionIndex] ??
+    form.sections[0]) as FormDefinitionSection;
   const visibleSectionTitle =
     currentSection?.title ||
     t('studio.section_number', { count: currentSectionIndex + 1 });
@@ -290,10 +329,10 @@ export function FormRuntime({
   });
 
   useEffect(() => {
-    const nextAnswers = initialAnswers ?? {};
-    answersRef.current = nextAnswers;
-    setAnswers(nextAnswers);
-  }, [initialAnswers]);
+    // `setAnswers` keeps the ref in step now, so this no longer assigns it by
+    // hand — two writers to the same ref is how they drift.
+    setAnswers(initialAnswers ?? {});
+  }, [initialAnswers, setAnswers]);
 
   useEffect(() => {
     if (responseCopyEmail) {
@@ -357,7 +396,7 @@ export function FormRuntime({
     setStepDirection,
   });
 
-  const maybeAutoAdvance = useAutoAdvance({
+  maybeAutoAdvanceRef.current = useAutoAdvance({
     enabled:
       form.settings.displayMode === 'one_question' &&
       form.settings.autoAdvance &&
@@ -365,29 +404,6 @@ export function FormRuntime({
     onAdvance: () => keyboardHandlersRef.current.next(),
     step: currentStep,
   });
-
-  if (!currentSection) {
-    return null;
-  }
-
-  const updateAnswer = (questionId: string, value: FormAnswerValue) => {
-    const nextAnswers = {
-      ...answersRef.current,
-      [questionId]: value,
-    };
-
-    answersRef.current = nextAnswers;
-    setAnswers(nextAnswers);
-    setError(null);
-    setValidationErrorsByQuestionId((prev) => {
-      if (!(questionId in prev)) return prev;
-      const next = { ...prev };
-      delete next[questionId];
-      return next;
-    });
-
-    maybeAutoAdvance(questionId, value);
-  };
 
   const validateCurrentSection = (
     currentAnswers: Record<string, FormAnswerValue>
@@ -470,30 +486,8 @@ export function FormRuntime({
       if (!validation.valid) {
         const errors = validation.validationErrorsByQuestionId ?? {};
         setValidationErrorsByQuestionId(errors);
-
-        if (validation.missingRequired.length > 0) {
-          setError(
-            t('runtime.missing_required_answers', {
-              items: validation.missingRequired.join(', '),
-            })
-          );
-        } else if (validation.validationErrors.length > 0) {
-          setError(validation.validationErrors[0] ?? null);
-        } else {
-          setError(null);
-        }
-
-        // Scroll to the first error if it's in the current section
-        const firstErrorId = Object.keys(errors)[0];
-        if (firstErrorId) {
-          requestAnimationFrame(() => {
-            const element = document.getElementById(`question-${firstErrorId}`);
-            if (element) {
-              element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            }
-          });
-        }
-
+        setError(describeSubmissionFailure(validation, t));
+        scrollToFirstSubmissionError(errors);
         return;
       }
 

--- a/apps/forms/src/features/forms/runtime/submission-errors.test.ts
+++ b/apps/forms/src/features/forms/runtime/submission-errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { describeSubmissionFailure } from './submission-errors';
+
+const t = (key: string, values?: Record<string, string | number>) =>
+  values ? `${key}:${JSON.stringify(values)}` : key;
+
+function validation(overrides: {
+  missingRequired?: string[];
+  validationErrors?: string[];
+}) {
+  return {
+    valid: false,
+    missingRequired: overrides.missingRequired ?? [],
+    validationErrors: overrides.validationErrors ?? [],
+    validationErrorsByQuestionId: {},
+  };
+}
+
+describe('describeSubmissionFailure', () => {
+  it('reports missing answers, listing them', () => {
+    expect(
+      describeSubmissionFailure(
+        validation({ missingRequired: ['Name', 'Email'] }),
+        t
+      )
+    ).toBe('runtime.missing_required_answers:{"items":"Name, Email"}');
+  });
+
+  it('prefers missing answers over format errors', () => {
+    // Someone who left three questions blank needs to know that, not that the
+    // one email they did fill in has a typo.
+    expect(
+      describeSubmissionFailure(
+        validation({
+          missingRequired: ['Name'],
+          validationErrors: ['Email: not an email'],
+        }),
+        t
+      )
+    ).toBe('runtime.missing_required_answers:{"items":"Name"}');
+  });
+
+  it('falls back to the first format error when nothing is missing', () => {
+    expect(
+      describeSubmissionFailure(
+        validation({ validationErrors: ['Email: not an email', 'second'] }),
+        t
+      )
+    ).toBe('Email: not an email');
+  });
+
+  it('returns null when the validator produced no message', () => {
+    // The field highlights are then the whole story; a sentence above them
+    // invented here would be noise.
+    expect(describeSubmissionFailure(validation({}), t)).toBeNull();
+  });
+});

--- a/apps/forms/src/features/forms/runtime/submission-errors.ts
+++ b/apps/forms/src/features/forms/runtime/submission-errors.ts
@@ -1,0 +1,44 @@
+import type { validateSubmittedAnswers } from '../validation';
+import { scrollToQuestion } from './step-validation';
+
+type SubmissionValidation = ReturnType<typeof validateSubmittedAnswers>;
+
+/**
+ * Turns a failed submission into the one message worth showing.
+ *
+ * Missing answers beat format errors: someone who left three questions blank
+ * needs to know that, not that the email they did fill in has a typo. Only
+ * when nothing is missing does the first format error become the headline.
+ *
+ * Returns `null` when the validator reported no message at all — the field
+ * highlights are then the whole story, and inventing a sentence to sit above
+ * them would be noise.
+ */
+export function describeSubmissionFailure(
+  validation: SubmissionValidation,
+  t: (key: string, values?: Record<string, string | number>) => string
+): string | null {
+  if (validation.missingRequired.length > 0) {
+    return t('runtime.missing_required_answers', {
+      items: validation.missingRequired.join(', '),
+    });
+  }
+
+  return validation.validationErrors[0] ?? null;
+}
+
+/**
+ * Brings the first failing question into view.
+ *
+ * The first, not the nearest: the respondent reads top-down, and being sent to
+ * the third problem while the first sits off-screen above them describes the
+ * form's state rather than theirs.
+ */
+export function scrollToFirstSubmissionError(
+  errorsByQuestionId: Record<string, string>
+) {
+  const firstErrorId = Object.keys(errorsByQuestionId)[0];
+  if (!firstErrorId) return;
+
+  scrollToQuestion(firstErrorId);
+}

--- a/apps/forms/src/features/forms/runtime/use-form-answers.test.ts
+++ b/apps/forms/src/features/forms/runtime/use-form-answers.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { FormAnswerValue } from '../types';
+import { useFormAnswers } from './use-form-answers';
+
+function setup(onAnswered = vi.fn()) {
+  const result = renderHook(() =>
+    useFormAnswers({
+      initialAnswers: {},
+      onAnswered,
+      setError: () => {},
+      setValidationErrorsByQuestionId: () => {},
+    })
+  );
+
+  return { ...result, onAnswered };
+}
+
+describe('useFormAnswers', () => {
+  it('exposes the answer through both state and the ref', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.updateAnswer('q1', 'alpha');
+    });
+
+    expect(result.current.answers.q1).toBe('alpha');
+    expect(result.current.answersRef.current.q1).toBe('alpha');
+  });
+
+  it('has the ref current before onAnswered runs', () => {
+    // The regression this guards: `setAnswers` used to update the ref inside
+    // the state updater, which React runs later. `onAnswered` triggers
+    // auto-advance, and auto-advance validates against the ref — so the answer
+    // just given still looked missing and the advance was refused.
+    const seen: Array<FormAnswerValue | undefined> = [];
+    const { result } = setup(
+      vi.fn(() => {
+        seen.push(result.current.answersRef.current.q1);
+      })
+    );
+
+    act(() => {
+      result.current.updateAnswer('q1', 'alpha');
+    });
+
+    expect(seen).toEqual(['alpha']);
+  });
+
+  it('keeps the ref in step when set through the updater form', () => {
+    // `useFormDraft` restores a saved draft this way.
+    const { result } = setup();
+
+    act(() => {
+      result.current.setAnswers((previous) => ({ ...previous, q2: 'beta' }));
+    });
+
+    expect(result.current.answersRef.current.q2).toBe('beta');
+    expect(result.current.answers.q2).toBe('beta');
+  });
+
+  it('composes concurrent updater functions instead of overwriting them', () => {
+    // Replacing queued updaters with direct values would lose the first write.
+    const { result } = setup();
+
+    act(() => {
+      result.current.setAnswers((previous) => ({ ...previous, a: '1' }));
+      result.current.setAnswers((previous) => ({ ...previous, b: '2' }));
+    });
+
+    expect(result.current.answers).toMatchObject({ a: '1', b: '2' });
+    expect(result.current.answersRef.current).toMatchObject({ a: '1', b: '2' });
+  });
+});

--- a/apps/forms/src/features/forms/runtime/use-form-answers.ts
+++ b/apps/forms/src/features/forms/runtime/use-form-answers.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import type { FormAnswerValue } from '../types';
+
+export interface FormAnswersState {
+  answers: Record<string, FormAnswerValue>;
+  /**
+   * The same answers, readable synchronously.
+   *
+   * Validation and submission run inside handlers that may fire in the same
+   * tick as an edit, and `answers` would still be the pre-edit render's copy —
+   * so the ref is what those read, and the state is what renders.
+   */
+  answersRef: React.MutableRefObject<Record<string, FormAnswerValue>>;
+  /**
+   * Kept as a `Dispatch` rather than a plain setter: `useFormDraft` restores a
+   * saved draft through it and expects React's own signature, and narrowing it
+   * here would push a cast onto that caller instead.
+   */
+  setAnswers: Dispatch<SetStateAction<Record<string, FormAnswerValue>>>;
+  /** Records one answer and clears any error it was carrying. */
+  updateAnswer: (questionId: string, value: FormAnswerValue) => void;
+}
+
+export function useFormAnswers({
+  initialAnswers,
+  onAnswered,
+  setError,
+  setValidationErrorsByQuestionId,
+}: {
+  initialAnswers: Record<string, FormAnswerValue>;
+  /** Fired after the answer lands, so the caller can react to it. */
+  onAnswered: (questionId: string, value: FormAnswerValue) => void;
+  setError: (error: string | null) => void;
+  setValidationErrorsByQuestionId: Dispatch<
+    SetStateAction<Record<string, string>>
+  >;
+}): FormAnswersState {
+  const [answers, setAnswersState] = useState(initialAnswers);
+  const answersRef = useRef(initialAnswers);
+
+  const setAnswers = useCallback<
+    Dispatch<SetStateAction<Record<string, FormAnswerValue>>>
+  >((update) => {
+    setAnswersState((previous) => {
+      const next = typeof update === 'function' ? update(previous) : update;
+      // The ref must track every path into the state, including the
+      // updater-function form, or a synchronous read after a draft restore
+      // still sees the pre-restore answers.
+      answersRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const updateAnswer = useCallback(
+    (questionId: string, value: FormAnswerValue) => {
+      setAnswers({ ...answersRef.current, [questionId]: value });
+      // Answering is the respondent addressing the complaint, so the complaint
+      // goes as soon as they do — leaving it up until the next advance reads as
+      // the form not noticing.
+      setError(null);
+      setValidationErrorsByQuestionId((previous) => {
+        if (!(questionId in previous)) return previous;
+        const next = { ...previous };
+        delete next[questionId];
+        return next;
+      });
+      onAnswered(questionId, value);
+    },
+    [onAnswered, setAnswers, setError, setValidationErrorsByQuestionId]
+  );
+
+  return { answers, answersRef, setAnswers, updateAnswer };
+}

--- a/apps/forms/src/features/forms/runtime/use-form-answers.ts
+++ b/apps/forms/src/features/forms/runtime/use-form-answers.ts
@@ -44,11 +44,20 @@ export function useFormAnswers({
   const setAnswers = useCallback<
     Dispatch<SetStateAction<Record<string, FormAnswerValue>>>
   >((update) => {
+    // A direct value updates the ref BEFORE scheduling the state change.
+    // `updateAnswer` calls `onAnswered` in the same tick, and auto-advance
+    // validates against `answersRef` — reading it after only queueing the
+    // update would see the answer that was just given as still missing.
+    if (typeof update !== 'function') {
+      answersRef.current = update;
+      setAnswersState(update);
+      return;
+    }
+
+    // The functional form has to stay queued so concurrent updaters compose
+    // instead of overwriting each other; the ref catches up inside it.
     setAnswersState((previous) => {
-      const next = typeof update === 'function' ? update(previous) : update;
-      // The ref must track every path into the state, including the
-      // updater-function form, or a synchronous read after a draft restore
-      // still sees the pre-restore answers.
+      const next = update(previous);
       answersRef.current = next;
       return next;
     });


### PR DESCRIPTION
## The pattern, not the instance

**Three** separate additions became conditional hooks in this one file: the keyboard binding ([#5156](https://github.com/tutur3u/platform/pull/5156)), auto-advance and back navigation ([#5158](https://github.com/tutur3u/platform/pull/5158)).

Each was written near the handlers. The handlers sit *below* `if (!currentSection) return null;` — an early return in the middle of the component. So each landed on the wrong side of it and broke React's hook order.

Lint caught all three. But a structure that keeps producing the same bug **is** the bug, and catching it a fourth time isn't a plan.

## The fix

`currentSection` falls back to `form.sections[0]`, so it's undefined only when the form has no sections at all — readable from the props, with no state.

That check now guards a thin `FormRuntime` wrapper that runs **no hooks**. `FormRuntimeContent` has no early return, so every hook in it is unconditional *by construction* rather than by review.

## Two extractions, and the second is the interesting one

**`useFormAnswers`** owns the answers state, the synchronous ref beside it, and clearing a question's error when it's answered. Its `setAnswers` keeps the ref in step on every path *including the updater-function form* — which let the draft-restore effect stop assigning that ref by hand. Two writers to one ref is how they drift.

**`submission-errors`** decides which message a failed submission shows. Missing answers beat format errors: someone who left three questions blank needs to know that, not that the one email they did fill in has a typo. It returns `null` when the validator produced no message, because the field highlights are then the whole story and a sentence invented above them is noise.

## On how I got here

Both extractions happened because the 700-line ceiling kept rejecting the file — and my first few attempts were five-line shavings rather than decomposition. The ceiling was pointing at something real. The file is now **687 with headroom** instead of 699 and fragile.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0
- 185 tests across 27 files (4 new, covering the submission-message precedence)

Behaviour-preserving: no runtime change intended, only where the code lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the forms runtime so its hooks cannot go conditional. Three hooks (keyboard binding, auto-advance, back navigation) previously landed below an early return in the middle of the component and each broke React's hook order; the guard now runs in a thin wrapper before any hook, and the content component has no early return. This is behavior-preserving — the same render logic, reorganized so the bug class is impossible by construction.

**Refactors**
- Extracts `useFormAnswers` to own the answers state, its synchronous ref, and clearing a question's error when answered; direct sets update the ref before the state change so auto-advance never validates against a stale one, and the draft-restore effect no longer assigns it by hand.
- Extracts `submission-errors` to pick the failure message: missing answers beat format errors, and `null` means the field highlights are the whole story.
- Adds 8 tests covering the submission-message precedence and the ref-in-step ordering that auto-advance depends on.

<sup>Written for commit fde019fbd3e7035c94e44e2cd58593eb66aa20be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

