### PR TITLE
test(forms): drive the one-question runtime end to end

### DIFF
--- a/apps/forms/src/features/forms/runtime/form-runtime.test.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.test.tsx
@@ -1,0 +1,321 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestFormDefinition } from '../test-support/form-fixtures';
+import type { FormDefinition, FormDefinitionQuestion } from '../types';
+import { FormRuntime } from './form-runtime';
+
+// Keys render as themselves, so assertions read against the key rather than
+// English copy that translation churn would break.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@tuturuuu/icons', () => {
+  const iconStub = (props: Record<string, unknown>) => <svg {...props} />;
+
+  return new Proxy(
+    { __esModule: true },
+    {
+      get: (target: Record<string, unknown>, property: string | symbol) => {
+        if (typeof property !== 'string' || property === 'then') {
+          return Reflect.get(target, property);
+        }
+        return property in target ? target[property] : iconStub;
+      },
+      has: (target: Record<string, unknown>, property: string | symbol) =>
+        typeof property === 'string' && property !== 'then'
+          ? true
+          : Reflect.has(target, property),
+      getOwnPropertyDescriptor: (
+        target: Record<string, unknown>,
+        property: string | symbol
+      ) =>
+        typeof property === 'string' && property !== 'then'
+          ? { configurable: true, enumerable: true, value: iconStub }
+          : Reflect.getOwnPropertyDescriptor(target, property),
+    }
+  );
+});
+
+const emptyImage = { storagePath: '', url: '', alt: '' };
+
+function textQuestion(id: string, title: string): FormDefinitionQuestion {
+  return {
+    id,
+    sectionId: 'section-1',
+    type: 'short_text',
+    title,
+    description: '',
+    required: false,
+    image: emptyImage,
+    settings: {},
+    options: [],
+  };
+}
+
+function choiceQuestion(id: string, title: string): FormDefinitionQuestion {
+  return {
+    ...textQuestion(id, title),
+    type: 'single_choice',
+    options: [
+      { id: `${id}-a`, label: 'Alpha', value: 'alpha', image: emptyImage },
+      { id: `${id}-b`, label: 'Beta', value: 'beta', image: emptyImage },
+    ],
+  };
+}
+
+function buildForm(
+  questions: FormDefinitionQuestion[],
+  settings: Partial<FormDefinition['settings']> = {}
+): FormDefinition {
+  const base = createTestFormDefinition();
+
+  return {
+    ...base,
+    settings: {
+      ...base.settings,
+      autoAdvance: false,
+      displayMode: 'one_question',
+      welcomeEnabled: false,
+      ...settings,
+    },
+    sections: [
+      {
+        id: 'section-1',
+        title: 'Section one',
+        description: '',
+        image: emptyImage,
+        questions,
+      },
+    ],
+  };
+}
+
+describe('FormRuntime in one-question mode', () => {
+  it('shows one question at a time rather than the whole section', () => {
+    render(
+      <FormRuntime
+        form={buildForm([
+          textQuestion('q1', 'First question'),
+          textQuestion('q2', 'Second question'),
+        ])}
+        mode="public"
+      />
+    );
+
+    expect(screen.getByText('First question')).toBeDefined();
+    expect(screen.queryByText('Second question')).toBeNull();
+  });
+
+  it('advances to the next question on Enter', () => {
+    render(
+      <FormRuntime
+        form={buildForm([
+          textQuestion('q1', 'First question'),
+          textQuestion('q2', 'Second question'),
+        ])}
+        mode="public"
+      />
+    );
+
+    // Bound on document, so it works without focusing anything first — the
+    // difference between keyboard-navigable and keyboard-tolerant.
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(screen.getByText('Second question')).toBeDefined();
+    expect(screen.queryByText('First question')).toBeNull();
+  });
+
+  it('goes back with Alt+ArrowUp', () => {
+    render(
+      <FormRuntime
+        form={buildForm([
+          textQuestion('q1', 'First question'),
+          textQuestion('q2', 'Second question'),
+        ])}
+        mode="public"
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(screen.getByText('Second question')).toBeDefined();
+
+    fireEvent.keyDown(document, { key: 'ArrowUp', altKey: true });
+    expect(screen.getByText('First question')).toBeDefined();
+  });
+
+  it('renders every question at once in sections mode', () => {
+    render(
+      <FormRuntime
+        form={buildForm(
+          [
+            textQuestion('q1', 'First question'),
+            textQuestion('q2', 'Second question'),
+          ],
+          { displayMode: 'sections' }
+        )}
+        mode="public"
+      />
+    );
+
+    expect(screen.getByText('First question')).toBeDefined();
+    expect(screen.getByText('Second question')).toBeDefined();
+  });
+
+  it('does not advance on Enter in sections mode', () => {
+    // With a whole section on screen, Enter would carry the respondent past
+    // questions they have not reached.
+    render(
+      <FormRuntime
+        form={buildForm(
+          [
+            textQuestion('q1', 'First question'),
+            textQuestion('q2', 'Second question'),
+          ],
+          { displayMode: 'sections' }
+        )}
+        mode="public"
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(screen.getByText('First question')).toBeDefined();
+  });
+
+  it('picks an option with its letter shortcut', () => {
+    render(
+      <FormRuntime
+        form={buildForm([
+          choiceQuestion('q1', 'Pick one'),
+          textQuestion('q2', 'Second question'),
+        ])}
+        mode="public"
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'b' });
+
+    const beta = screen.getByRole('radio', { name: /Beta/ });
+    expect(beta.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('renders the welcome screen before the first question when enabled', () => {
+    render(
+      <FormRuntime
+        form={buildForm([textQuestion('q1', 'First question')], {
+          welcomeEnabled: true,
+        })}
+        mode="public"
+      />
+    );
+
+    // The cover owns the screen; the first question has not arrived yet.
+    expect(screen.queryByText('First question')).toBeNull();
+  });
+
+  it('renders nothing for a form with no sections', () => {
+    // The guard that keeps every hook in the runtime unconditional.
+    const form = { ...createTestFormDefinition(), sections: [] };
+    const { container } = render(<FormRuntime form={form} mode="public" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('auto-advance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function renderChoiceForm(autoAdvance: boolean) {
+    return render(
+      <FormRuntime
+        form={buildForm(
+          [
+            choiceQuestion('q1', 'Pick one'),
+            textQuestion('q2', 'Second question'),
+          ],
+          { autoAdvance }
+        )}
+        mode="public"
+      />
+    );
+  }
+
+  it('moves on shortly after a single choice is picked', () => {
+    renderChoiceForm(true);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Alpha/ }));
+    expect(screen.getByText('Pick one')).toBeDefined();
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByText('Second question')).toBeDefined();
+  });
+
+  it('does not move on when the author turned it off', () => {
+    renderChoiceForm(false);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Alpha/ }));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Pick one')).toBeDefined();
+  });
+
+  it('advances once when the answer is changed several times', () => {
+    // Each change reschedules rather than queues, so a respondent who tries
+    // three options lands on the next question, not three questions on.
+    renderChoiceForm(true);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Alpha/ }));
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    fireEvent.click(screen.getByRole('radio', { name: /Beta/ }));
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByText('Second question')).toBeDefined();
+    // A second pending advance would have carried past the end of the section.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('Second question')).toBeDefined();
+  });
+
+  it('does not advance from a free-text answer', () => {
+    render(
+      <FormRuntime
+        form={buildForm(
+          [
+            textQuestion('q1', 'Type here'),
+            textQuestion('q2', 'Second question'),
+          ],
+          { autoAdvance: true }
+        )}
+        mode="public"
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'partial answ' } });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // Leaving mid-sentence is the failure this guard exists for.
+    expect(screen.getByText('Type here')).toBeDefined();
+  });
+});

--- a/apps/forms/vitest.setup.ts
+++ b/apps/forms/vitest.setup.ts
@@ -67,3 +67,17 @@ if (
     },
   });
 }
+
+// jsdom implements no layout, so `scrollIntoView` does not exist on elements.
+// The runtime calls it whenever it moves between screens or points at a
+// validation error, and an unimplemented method there surfaces as an unhandled
+// error from a passing test — noise that hides real ones.
+if (
+  typeof Element !== 'undefined' &&
+  typeof Element.prototype.scrollIntoView !== 'function'
+) {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: () => {},
+  });
+}


### PR DESCRIPTION
## Why

Everything shipped for the new filling experience was verified by type-check, lint, unit tests over extracted helpers, and a production build. **None of that renders a form.** Nobody has opened one in a browser, and I can't — it needs an authenticated session.

What I *can* do is drive the real component.

## What these assert

- **One question on screen at a time** — and the second genuinely absent, not merely hidden
- **Enter advances, Alt+ArrowUp goes back**
- **The keyboard works without focusing anything first** — the whole difference between keyboard-navigable and keyboard-*tolerant*
- **A letter key selects the option it advertises** — the badge and the binding agree
- **`sections` mode still shows the whole section, and Enter does *not* advance there** — with several questions on screen it would carry the respondent past ones they hadn't reached
- **The welcome screen owns the screen** before the first question
- **A form with no sections renders nothing** — the guard from [#5160](https://github.com/tutur3u/platform/pull/5160) that keeps every hook unconditional

## Auto-advance gets fake timers

It's the one behaviour that happens on its own, so it's the one you can't confirm by reading:

- fires after a single choice
- stays put when the author disabled it
- never fires from a half-typed text answer — leaving mid-sentence is the failure that guard exists for
- **changing the answer three times advances once.** Each change reschedules rather than queues, so a respondent trying three options lands on the next question rather than three questions on

## A stub that belongs in the shared setup

jsdom implements no layout, so `scrollIntoView` doesn't exist. The runtime calls it on every screen change, and the result was an **unhandled error thrown from tests that passed** — exactly the noise that hides a real one. Stubbed once in `vitest.setup.ts` rather than per suite.

## Honest scope

This is **not** a substitute for someone looking at it. Layout, spacing, contrast, whether the transitions feel right — none of that is here. It's the part of the gap that can be closed without a browser.

## Verification

- `bun check` — exit 0
- 193 tests across 27 files (12 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end tests that render the one-question form runtime, closing the gap where the new filling experience was only verified by type-check, lint, and extracted-helper unit tests, never an actual render. The tests cover single-question display, Enter/Alt+ArrowUp navigation, letter-key option selection, auto-advance timing and rescheduling (so multiple choice changes advance once), and edge cases like disabled auto-advance, free-text answers, and forms without sections. Also stubs `scrollIntoView` in the vitest setup to prevent unhandled errors from jsdom.

<sup>Written for commit 42689ab08fd3deebd9c43c6b655689d6df9b3300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

