### PR TITLE
test(forms): drive the one-question runtime end to end

### DIFF
--- a/apps/forms/src/features/forms/runtime/form-runtime.test.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.test.tsx
@@ -1,0 +1,321 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestFormDefinition } from '../test-support/form-fixtures';
+import type { FormDefinition, FormDefinitionQuestion } from '../types';
+import { FormRuntime } from './form-runtime';
+
+// Keys render as themselves, so assertions read against the key rather than
+// English copy that translation churn would break.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@tuturuuu/icons', () => {
+  const iconStub = (props: Record<string, unknown>) => <svg {...props} />;
+
+  return new Proxy(
+    { __esModule: true },
+    {
+      get: (target: Record<string, unknown>, property: string | symbol) => {
+        if (typeof property !== 'string' || property === 'then') {
+          return Reflect.get(target, property);
+        }
+        return property in target ? target[property] : iconStub;
+      },
+      has: (target: Record<string, unknown>, property: string | symbol) =>
+        typeof property === 'string' && property !== 'then'
+          ? true
+          : Reflect.has(target, property),
+      getOwnPropertyDescriptor: (
+        target: Record<string, unknown>,
+        property: string | symbol
+      ) =>
+        typeof property === 'string' && property !== 'then'
+          ? { configurable: true, enumerable: true, value: iconStub }
+          : Reflect.getOwnPropertyDescriptor(target, property),
+    }
+  );
+});
+
+const emptyImage = { storagePath: '', url: '', alt: '' };
+
+function textQuestion(id: string, title: string): FormDefinitionQuestion {
+  return {
+    id,
+    sectionId: 'section-1',
+    type: 'short_text',
+    title,
+    description: '',
+    required: false,
+    image: emptyImage,
+    settings: {},
+    options: [],
+  };
+}
+
+function choiceQuestion(id: string, title: string): FormDefinitionQuestion {
+  return {
+    ...textQuestion(id, title),
+    type: 'single_choice',
+    options: [
+      { id: `${id}-a`, label: 'Alpha', value: 'alpha', image: emptyImage },
+      { id: `${id}-b`, label: 'Beta', value: 'beta', image: emptyImage },
+    ],
+  };
+}
+
+function buildForm(
+  questions: FormDefinitionQuestion[],
+  settings: Partial<FormDefinition['settings']> = {}
+): FormDefinition {
+  const base = createTestFormDefinition();
+
+  return {
+    ...base,
+    settings: {
+      ...base.settings,
+      autoAdvance: false,
+      displayMode: 'one_question',
+      welcomeEnabled: false,
+      ...settings,
+    },
+    sections: [
+      {
+        id: 'section-1',
+        title: 'Section one',
+        description: '',
+        image: emptyImage,
+        questions,
+      },
+    ],
+  };
+}
+
+describe('FormRuntime in one-question mode', () => {
+  it('shows one question at a time rather than the whole section', () => {
+    render(
+      <FormRuntime
+        form={buildForm([
+          textQuestion('q1', 'First question'),
+          textQuestion('q2', 'Second question'),
+        ])}
+        mode="public"
+      />
+    );
+
+    expect(screen.getByText('First question')).toBeDefined();
+    expect(screen.queryByText('Second question')).toBeNull();
+  });
+
+  it('advances to the next question on Enter', () => {
+    render(
+      <FormRuntime
+        form={buildForm([
+          textQuestion('q1', 'First question'),
+          textQuestion('q2', 'Second question'),
+        ])}
+        mode="public"
+      />
+    );
+
+    // Bound on document, so it works without focusing anything first — the
+    // difference between keyboard-navigable and keyboard-tolerant.
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(screen.getByText('Second question')).toBeDefined();
+    expect(screen.queryByText('First question')).toBeNull();
+  });
+
+  it('goes back with Alt+ArrowUp', () => {
+    render(
+      <FormRuntime
+        form={buildForm([
+          textQuestion('q1', 'First question'),
+          textQuestion('q2', 'Second question'),
+        ])}
+        mode="public"
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(screen.getByText('Second question')).toBeDefined();
+
+    fireEvent.keyDown(document, { key: 'ArrowUp', altKey: true });
+    expect(screen.getByText('First question')).toBeDefined();
+  });
+
+  it('renders every question at once in sections mode', () => {
+    render(
+      <FormRuntime
+        form={buildForm(
+          [
+            textQuestion('q1', 'First question'),
+            textQuestion('q2', 'Second question'),
+          ],
+          { displayMode: 'sections' }
+        )}
+        mode="public"
+      />
+    );
+
+    expect(screen.getByText('First question')).toBeDefined();
+    expect(screen.getByText('Second question')).toBeDefined();
+  });
+
+  it('does not advance on Enter in sections mode', () => {
+    // With a whole section on screen, Enter would carry the respondent past
+    // questions they have not reached.
+    render(
+      <FormRuntime
+        form={buildForm(
+          [
+            textQuestion('q1', 'First question'),
+            textQuestion('q2', 'Second question'),
+          ],
+          { displayMode: 'sections' }
+        )}
+        mode="public"
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+
+    expect(screen.getByText('First question')).toBeDefined();
+  });
+
+  it('picks an option with its letter shortcut', () => {
+    render(
+      <FormRuntime
+        form={buildForm([
+          choiceQuestion('q1', 'Pick one'),
+          textQuestion('q2', 'Second question'),
+        ])}
+        mode="public"
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'b' });
+
+    const beta = screen.getByRole('radio', { name: /Beta/ });
+    expect(beta.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('renders the welcome screen before the first question when enabled', () => {
+    render(
+      <FormRuntime
+        form={buildForm([textQuestion('q1', 'First question')], {
+          welcomeEnabled: true,
+        })}
+        mode="public"
+      />
+    );
+
+    // The cover owns the screen; the first question has not arrived yet.
+    expect(screen.queryByText('First question')).toBeNull();
+  });
+
+  it('renders nothing for a form with no sections', () => {
+    // The guard that keeps every hook in the runtime unconditional.
+    const form = { ...createTestFormDefinition(), sections: [] };
+    const { container } = render(<FormRuntime form={form} mode="public" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('auto-advance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function renderChoiceForm(autoAdvance: boolean) {
+    return render(
+      <FormRuntime
+        form={buildForm(
+          [
+            choiceQuestion('q1', 'Pick one'),
+            textQuestion('q2', 'Second question'),
+          ],
+          { autoAdvance }
+        )}
+        mode="public"
+      />
+    );
+  }
+
+  it('moves on shortly after a single choice is picked', () => {
+    renderChoiceForm(true);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Alpha/ }));
+    expect(screen.getByText('Pick one')).toBeDefined();
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByText('Second question')).toBeDefined();
+  });
+
+  it('does not move on when the author turned it off', () => {
+    renderChoiceForm(false);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Alpha/ }));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Pick one')).toBeDefined();
+  });
+
+  it('advances once when the answer is changed several times', () => {
+    // Each change reschedules rather than queues, so a respondent who tries
+    // three options lands on the next question, not three questions on.
+    renderChoiceForm(true);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Alpha/ }));
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    fireEvent.click(screen.getByRole('radio', { name: /Beta/ }));
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByText('Second question')).toBeDefined();
+    // A second pending advance would have carried past the end of the section.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('Second question')).toBeDefined();
+  });
+
+  it('does not advance from a free-text answer', () => {
+    render(
+      <FormRuntime
+        form={buildForm(
+          [
+            textQuestion('q1', 'Type here'),
+            textQuestion('q2', 'Second question'),
+          ],
+          { autoAdvance: true }
+        )}
+        mode="public"
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'partial answ' } });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // Leaving mid-sentence is the failure this guard exists for.
+    expect(screen.getByText('Type here')).toBeDefined();
+  });
+});

--- a/apps/forms/src/features/forms/runtime/form-runtime.test.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.test.tsx
@@ -210,7 +210,12 @@ describe('FormRuntime in one-question mode', () => {
       />
     );
 
-    // The cover owns the screen; the first question has not arrived yet.
+    // Asserting the start button, not just the question's absence: a runtime
+    // that rendered nothing at all would satisfy the absence on its own, so
+    // the negative assertion alone proves nothing.
+    expect(
+      screen.getByRole('button', { name: 'runtime.welcome_start' })
+    ).toBeDefined();
     expect(screen.queryByText('First question')).toBeNull();
   });
 
@@ -272,26 +277,46 @@ describe('auto-advance', () => {
   });
 
   it('advances once when the answer is changed several times', () => {
-    // Each change reschedules rather than queues, so a respondent who tries
-    // three options lands on the next question, not three questions on.
-    renderChoiceForm(true);
+    // Three questions, not two: with two, a duplicate advance would land on
+    // the terminal question and the assertions would pass anyway. The third
+    // is what makes a second advance observable.
+    render(
+      <FormRuntime
+        form={buildForm(
+          [
+            choiceQuestion('q1', 'Pick one'),
+            textQuestion('q2', 'Second question'),
+            textQuestion('q3', 'Third question'),
+          ],
+          { autoAdvance: true }
+        )}
+        mode="public"
+      />
+    );
 
     fireEvent.click(screen.getByRole('radio', { name: /Alpha/ }));
     act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    // The first timer's original deadline passes here without firing, because
+    // changing the answer rescheduled it rather than queueing a second one.
+    fireEvent.click(screen.getByRole('radio', { name: /Beta/ }));
+    act(() => {
       vi.advanceTimersByTime(100);
     });
-    fireEvent.click(screen.getByRole('radio', { name: /Beta/ }));
+    expect(screen.getByText('Pick one')).toBeDefined();
 
     act(() => {
       vi.advanceTimersByTime(400);
     });
-
     expect(screen.getByText('Second question')).toBeDefined();
-    // A second pending advance would have carried past the end of the section.
+
+    // A surviving second timer would carry straight on to the third.
     act(() => {
-      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(2000);
     });
     expect(screen.getByText('Second question')).toBeDefined();
+    expect(screen.queryByText('Third question')).toBeNull();
   });
 
   it('does not advance from a free-text answer', () => {

--- a/apps/forms/vitest.setup.ts
+++ b/apps/forms/vitest.setup.ts
@@ -67,3 +67,17 @@ if (
     },
   });
 }
+
+// jsdom implements no layout, so `scrollIntoView` does not exist on elements.
+// The runtime calls it whenever it moves between screens or points at a
+// validation error, and an unimplemented method there surfaces as an unhandled
+// error from a passing test — noise that hides real ones.
+if (
+  typeof Element !== 'undefined' &&
+  typeof Element.prototype.scrollIntoView !== 'function'
+) {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: () => {},
+  });
+}


### PR DESCRIPTION
Reopened from #5161 under an allowed branch prefix — `test/` isn't in the repo's accepted list, so the branch-name check failed. Same commits.

## Why

Everything shipped for the new filling experience was verified by type-check, lint, unit tests over extracted helpers, and a production build. **None of that renders a form.** Nobody has opened one in a browser, and I can't — it needs an authenticated session.

What I *can* do is drive the real component.

## What these assert

- **One question on screen at a time** — the second genuinely absent, not merely hidden
- **Enter advances, Alt+ArrowUp goes back**
- **The keyboard works without focusing anything first** — the difference between keyboard-navigable and keyboard-*tolerant*
- **A letter key selects the option it advertises** — badge and binding agree
- **`sections` mode still shows the whole section, and Enter does *not* advance there** — it would carry the respondent past questions they hadn't reached
- **The welcome screen owns the screen** before the first question
- **A form with no sections renders nothing** — the guard from #5160 that keeps every hook unconditional

## Auto-advance gets fake timers

The one behaviour that happens on its own, so the one you can't confirm by reading:

- fires after a single choice
- stays put when the author disabled it
- never fires from a half-typed text answer — leaving mid-sentence is the failure that guard exists for
- **changing the answer three times advances once.** Each change reschedules rather than queues

## A stub that belongs in the shared setup

jsdom implements no layout, so `scrollIntoView` doesn't exist. The runtime calls it on every screen change, and the result was an **unhandled error thrown from tests that passed** — the noise that hides real ones. Stubbed once in `vitest.setup.ts`.

## Honest scope

Not a substitute for someone looking at it. Layout, spacing, contrast, whether the transitions feel right — none of that is here. It's the part of the gap that closes without a browser.

## Verification

`bun check` exit 0; 193 tests across 27 files (12 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end tests that render the real `FormRuntime` component, since the one-question filling experience was previously verified only by type-check, lint, unit tests over extracted helpers, and a production build — none of which render a form.

**Coverage**
- One question at a time with the next absent rather than hidden; `sections` mode shows the whole section and Enter does not advance there.
- Enter advances and Alt+ArrowUp goes back via document-bound keys that work without any prior focus; letter shortcuts select the advertised option.
- The welcome screen owns the screen before the first question, asserted by the start button's presence rather than the question's absence; a form with no sections renders nothing.
- Auto-advance fires after a single choice, stays off when the author disabled it, never fires from a free-text answer, and three answer changes advance once — three questions make a queued second advance observable.

**Test setup**
- Stubs `Element.prototype.scrollIntoView` in `vitest.setup.ts`; jsdom has no layout and the runtime calls it on every screen change, so an unimplemented method threw unhandled errors from passing tests.

<sup>Written for commit d5c8ab3d86e0a819bc445222a41766836dd158e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

