### PR TITLE
fix(forms): repair the landing demo, the brand lockup and two analytics labels

### DIFF
--- a/apps/forms/src/features/forms/analytics-labels.test.ts
+++ b/apps/forms/src/features/forms/analytics-labels.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { decodeAnalyticsLabel } from './analytics-labels';
+
+describe('decodeAnalyticsLabel', () => {
+  it('decodes percent-encoded place names', () => {
+    expect(decodeAnalyticsLabel('Hong%20Kong')).toBe('Hong Kong');
+    expect(decodeAnalyticsLabel('S%C3%A3o%20Paulo')).toBe('São Paulo');
+  });
+
+  it('leaves plain labels untouched', () => {
+    expect(decodeAnalyticsLabel('Singapore')).toBe('Singapore');
+    expect(decodeAnalyticsLabel('US')).toBe('US');
+  });
+
+  it('returns malformed input rather than throwing', () => {
+    // A label that cannot be decoded is still a real bucket with real
+    // responses behind it; dropping the row would be worse than an ugly one.
+    expect(decodeAnalyticsLabel('100%')).toBe('100%');
+    expect(decodeAnalyticsLabel('%E0%A4%A')).toBe('%E0%A4%A');
+  });
+});

--- a/apps/forms/src/features/forms/analytics-labels.ts
+++ b/apps/forms/src/features/forms/analytics-labels.ts
@@ -1,0 +1,19 @@
+/**
+ * Decodes a percent-encoded analytics label.
+ *
+ * Geo values arrive from request headers already URL-encoded, so a city
+ * surfaces as `Hong%20Kong` and sorts and reads as though that were its name.
+ *
+ * Malformed input is returned untouched rather than thrown on: a label that
+ * cannot be decoded is still a real bucket with real responses behind it, and
+ * losing the row would be worse than showing an ugly one.
+ */
+export function decodeAnalyticsLabel(label: string): string {
+  if (!label.includes('%')) return label;
+
+  try {
+    return decodeURIComponent(label);
+  } catch {
+    return label;
+  }
+}

--- a/apps/forms/src/features/forms/runtime/form-brand-footer.tsx
+++ b/apps/forms/src/features/forms/runtime/form-brand-footer.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import {
-  TUTURUUU_LOCAL_LOGO_URL,
-  TuturuuLogo,
-} from '@tuturuuu/ui/custom/tuturuuu-logo';
+import { TuturuuuWordmark } from '@tuturuuu/ui/custom/tuturuuu-wordmark';
 import { cn } from '@tuturuuu/utils/format';
 import Link from 'next/link';
 
@@ -11,27 +8,16 @@ export function FormBrandFooter({ className }: { className?: string }) {
   return (
     <Link
       href="/home"
-      aria-label="Go to Tuturuuu home"
+      aria-label="Tuturuuu Forms"
       className={cn(
-        'group mx-auto flex w-fit items-center gap-3 rounded-full px-2 py-1 text-muted-foreground transition-all hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        'group mx-auto flex w-fit items-center rounded-full px-2 py-1 text-muted-foreground transition-all hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         className
       )}
     >
-      <TuturuuLogo
-        src={TUTURUUU_LOCAL_LOGO_URL}
-        width={32}
-        height={32}
-        alt="Tuturuuu"
-        className="h-8 w-8 object-contain transition-transform duration-200 group-hover:scale-[1.04]"
+      <TuturuuuWordmark
+        className="transition-transform duration-200 group-hover:scale-[1.02]"
+        product="Forms"
       />
-      <div className="flex translate-y-0.5 flex-col text-left leading-none">
-        <span className="text-[10px] uppercase tracking-[0.24em] transition-colors group-hover:text-foreground/80">
-          Tuturuuu
-        </span>
-        <span className="font-semibold text-lg uppercase tracking-[0.08em]">
-          Forms
-        </span>
-      </div>
     </Link>
   );
 }

--- a/apps/forms/src/features/forms/server/analytics.ts
+++ b/apps/forms/src/features/forms/server/analytics.ts
@@ -1,5 +1,7 @@
 import type { SupabaseClient } from '@tuturuuu/supabase';
 import type { Database } from '@tuturuuu/types';
+import { decodeAnalyticsLabel } from '../analytics-labels';
+import { normalizeMarkdownToText } from '../content';
 import type { FormAnalytics, FormDefinition } from '../types';
 import { runUntypedRpc } from './client';
 
@@ -50,7 +52,7 @@ function parseLabelValueList(
     return typeof label === 'string'
       ? [
           {
-            label,
+            label: decodeAnalyticsLabel(label),
             value: toNumber('value' in item ? item.value : 0),
           },
         ]
@@ -120,7 +122,7 @@ function parseFormAnalytics(value: unknown): FormAnalytics {
           return [
             {
               sectionId,
-              title,
+              title: normalizeMarkdownToText(title),
               count: toNumber('count' in entry ? entry.count : 0),
             },
           ];
@@ -141,7 +143,7 @@ function parseFormAnalytics(value: unknown): FormAnalytics {
           return [
             {
               questionId,
-              title,
+              title: normalizeMarkdownToText(title),
               count: toNumber('count' in entry ? entry.count : 0),
             },
           ];

--- a/apps/forms/src/features/forms/studio/analytics-panel.tsx
+++ b/apps/forms/src/features/forms/studio/analytics-panel.tsx
@@ -30,6 +30,7 @@ import {
   renderDropoffSectionCard,
 } from './analytics-dropoff-cards';
 import { formatDuration, formatPercent } from './analytics-format';
+import { AnalyticsRevealGrid } from './analytics-reveal';
 import { DestructiveActionDialog } from './destructive-action-dialog';
 
 export function AnalyticsPanel({
@@ -225,7 +226,7 @@ export function AnalyticsPanel({
         </CardContent>
       </Card>
 
-      <div className="grid items-start gap-3 sm:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-7">
+      <AnalyticsRevealGrid className="grid items-start gap-3 sm:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-7">
         <StatCard
           label={t('analytics.views')}
           value={analytics.totalViews}
@@ -265,7 +266,7 @@ export function AnalyticsPanel({
           value={formatDuration(analytics.avgCompletionSeconds)}
           icon={Clock}
         />
-      </div>
+      </AnalyticsRevealGrid>
 
       <div className="grid items-start gap-3 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
         {renderEngagementCard({ t, analytics, activityChartData })}
@@ -340,7 +341,7 @@ export function AnalyticsPanel({
         </Card>
       </div>
 
-      <div className="grid items-start gap-3 xl:grid-cols-2">
+      <AnalyticsRevealGrid className="grid items-start gap-3 xl:grid-cols-2">
         <DistributionCard
           title={t('analytics.responder_modes')}
           items={responderMix}
@@ -351,15 +352,15 @@ export function AnalyticsPanel({
           items={deviceMix}
           emptyLabel={t('analytics.no_data')}
         />
-      </div>
+      </AnalyticsRevealGrid>
 
-      <div className="grid items-start gap-3 xl:grid-cols-2">
+      <AnalyticsRevealGrid className="grid items-start gap-3 xl:grid-cols-2">
         {renderDropoffSectionCard({ t, analytics, maxDropoffSection })}
 
         {renderDropoffQuestionCard({ t, analytics, maxDropoffQuestion })}
-      </div>
+      </AnalyticsRevealGrid>
 
-      <div className="grid items-start gap-3 md:grid-cols-2 xl:grid-cols-3">
+      <AnalyticsRevealGrid className="grid items-start gap-3 md:grid-cols-2 xl:grid-cols-3">
         <BreakdownCard
           title={t('analytics.top_referrers')}
           icon={Globe}
@@ -422,7 +423,7 @@ export function AnalyticsPanel({
             )}
           </CardContent>
         </Card>
-      </div>
+      </AnalyticsRevealGrid>
     </div>
   );
 }

--- a/apps/forms/src/features/forms/studio/analytics-reveal.tsx
+++ b/apps/forms/src/features/forms/studio/analytics-reveal.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { cn } from '@tuturuuu/utils/format';
+import { Children, type ReactNode } from 'react';
+
+/** Gap between neighbouring cards, in milliseconds. */
+const STEP_MS = 60;
+
+/**
+ * Caps the cascade so a long dashboard does not end with cards arriving
+ * seconds after the first. Past this point everything shares the last delay.
+ */
+const MAX_STEPS = 8;
+
+/**
+ * A grid whose children arrive one after another rather than all at once.
+ *
+ * A dashboard that appears in a single frame reads as a flash; staggering lets
+ * the eye follow the layout in the order it should be read. The delay is
+ * capped because the point is rhythm, not a queue — a card arriving a second
+ * in feels broken rather than choreographed.
+ *
+ * Wrapping children here rather than at each call site keeps the delays
+ * sequential automatically: a card inserted in the middle renumbers everything
+ * after it, where hand-written indices would silently repeat one.
+ *
+ * `motion-safe:` rather than a JS media query, so a viewer who asked for
+ * reduced motion never receives the animation classes and the grid is simply
+ * there. `fill-mode-backwards` holds the pre-animation state during the delay,
+ * without which a delayed card flashes at full opacity first.
+ */
+export function AnalyticsRevealGrid({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      {Children.map(children, (child, index) => {
+        if (child == null || child === false) return child;
+
+        return (
+          <div
+            className={cn(
+              'motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:animate-in motion-safe:fill-mode-backwards motion-safe:duration-500 motion-safe:ease-out'
+            )}
+            style={{
+              animationDelay: `${Math.min(index, MAX_STEPS) * STEP_MS}ms`,
+            }}
+          >
+            {child}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/forms/src/features/landing/demo/demo-form.ts
+++ b/apps/forms/src/features/landing/demo/demo-form.ts
@@ -99,7 +99,7 @@ export function buildDemoForm(
       // Sections mode on the landing: a visitor skimming the page should see
       // what the form asks, not have to click through four screens to find out.
       autoAdvance: true,
-      displayMode: 'sections',
+      displayMode: 'one_question',
       redirectUrl: '',
       welcomeEnabled: false,
       welcomeTitle: '',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -331,6 +331,10 @@
       "types": "./src/components/ui/custom/system-language-wrapper.tsx",
       "import": "./src/components/ui/custom/system-language-wrapper.tsx"
     },
+    "./custom/tuturuuu-wordmark": {
+      "types": "./src/components/ui/custom/tuturuuu-wordmark.tsx",
+      "import": "./src/components/ui/custom/tuturuuu-wordmark.tsx"
+    },
     "./custom/tuturuuu-logo": {
       "types": "./src/components/ui/custom/tuturuuu-logo.tsx",
       "import": "./src/components/ui/custom/tuturuuu-logo.tsx"

--- a/packages/ui/src/components/ui/custom/__tests__/tuturuuu-wordmark.test.ts
+++ b/packages/ui/src/components/ui/custom/__tests__/tuturuuu-wordmark.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { toProductName } from '../tuturuuu-wordmark';
+
+describe('toProductName', () => {
+  it('strips the company name from a full app name', () => {
+    expect(toProductName('Tuturuuu Forms')).toBe('Forms');
+    expect(toProductName('Tuturuuu Calendar')).toBe('Calendar');
+  });
+
+  it('is case-insensitive and tolerates extra spacing', () => {
+    expect(toProductName('TUTURUUU  Forms')).toBe('Forms');
+  });
+
+  it('leaves a bare product name alone', () => {
+    expect(toProductName('Forms')).toBe('Forms');
+  });
+
+  it('returns the name unchanged when stripping would empty it', () => {
+    // Otherwise the lockup renders with a blank second line.
+    expect(toProductName('Tuturuuu')).toBe('Tuturuuu');
+  });
+});

--- a/packages/ui/src/components/ui/custom/tuturuuu-wordmark.tsx
+++ b/packages/ui/src/components/ui/custom/tuturuuu-wordmark.tsx
@@ -1,0 +1,57 @@
+import { cn } from '@tuturuuu/utils/format';
+import { TuturuuLogo } from './tuturuuu-logo';
+
+/**
+ * The Tuturuuu product lockup: mark, then "Tuturuuu" over the product name.
+ *
+ * Two lines rather than one string. "Tuturuuu Forms" set on a single line reads
+ * as one long product name; stacking it says what it is — a Tuturuuu product
+ * called Forms — and keeps the company name consistent across products while
+ * only the second line changes.
+ *
+ * The logo deliberately does not take a local `src`. Satellites are served from
+ * their own domains and do not carry `/media`, so a local path 404s there; the
+ * component's default is the absolute URL for exactly that reason.
+ */
+export function TuturuuuWordmark({
+  className,
+  product,
+  size = 'md',
+}: {
+  className?: string;
+  /** The second line — the product name, without "Tuturuuu" in front of it. */
+  product: string;
+  size?: 'sm' | 'md';
+}) {
+  const dimension = size === 'sm' ? 28 : 32;
+
+  return (
+    <span className={cn('flex items-center gap-2.5', className)}>
+      <TuturuuLogo
+        alt=""
+        aria-hidden
+        className={cn('object-contain', size === 'sm' ? 'h-7 w-7' : 'h-8 w-8')}
+        height={dimension}
+        width={dimension}
+      />
+      <span className="flex flex-col text-left leading-none">
+        <span
+          className={cn(
+            'uppercase tracking-[0.24em] opacity-70',
+            size === 'sm' ? 'text-[9px]' : 'text-[10px]'
+          )}
+        >
+          Tuturuuu
+        </span>
+        <span
+          className={cn(
+            'font-display font-semibold uppercase tracking-[0.08em]',
+            size === 'sm' ? 'text-sm' : 'text-lg'
+          )}
+        >
+          {product}
+        </span>
+      </span>
+    </span>
+  );
+}

--- a/packages/ui/src/components/ui/custom/tuturuuu-wordmark.tsx
+++ b/packages/ui/src/components/ui/custom/tuturuuu-wordmark.tsx
@@ -55,3 +55,18 @@ export function TuturuuuWordmark({
     </span>
   );
 }
+
+/**
+ * The product line of a full app name: "Tuturuuu Forms" -> "Forms".
+ *
+ * Exists so the nav and the footer cannot disagree. They derive the same label
+ * from the same prop, and two copies of one regex is exactly the kind of
+ * duplication that drifts when only one of them is updated.
+ *
+ * A name that is only "Tuturuuu" is returned unchanged rather than reduced to
+ * an empty string, which would render a lockup with a blank second line.
+ */
+export function toProductName(appName: string): string {
+  const stripped = appName.replace(/^Tuturuuu\s+/i, '').trim();
+  return stripped || appName;
+}

--- a/packages/ui/src/components/ui/marketing/marketing-footer.tsx
+++ b/packages/ui/src/components/ui/marketing/marketing-footer.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@tuturuuu/utils/format';
 import type { ReactNode } from 'react';
-import { TuturuuLogo } from '../custom/tuturuuu-logo';
+import { TuturuuuWordmark } from '../custom/tuturuuu-wordmark';
 
 export interface MarketingFooterLink {
   href: string;
@@ -16,6 +16,8 @@ export interface MarketingFooterColumn {
 
 interface MarketingFooterProps {
   appName: string;
+  /** Product line of the lockup; defaults to `appName` minus "Tuturuuu ". */
+  productName?: string;
   /** One-line positioning statement under the wordmark. */
   tagline: string;
   columns: MarketingFooterColumn[];
@@ -29,6 +31,7 @@ interface MarketingFooterProps {
 /** Shared satellite marketing footer: wordmark column plus link columns. */
 export function MarketingFooter({
   appName,
+  productName,
   tagline,
   columns,
   legal,
@@ -44,12 +47,10 @@ export function MarketingFooter({
     >
       <div className="mx-auto grid w-full max-w-6xl gap-12 lg:grid-cols-[1.5fr_repeat(3,1fr)]">
         <div className="max-w-sm">
-          <div className="flex items-center gap-2.5">
-            <TuturuuLogo className="h-7 w-7" height={28} width={28} />
-            <span className="font-display font-semibold text-[0.95rem] tracking-[-0.01em]">
-              {appName}
-            </span>
-          </div>
+          <TuturuuuWordmark
+            product={productName ?? appName.replace(/^Tuturuuu\s+/i, '')}
+            size="sm"
+          />
           <p className="mt-4 text-foreground/50 text-sm leading-relaxed">
             {tagline}
           </p>

--- a/packages/ui/src/components/ui/marketing/marketing-footer.tsx
+++ b/packages/ui/src/components/ui/marketing/marketing-footer.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@tuturuuu/utils/format';
 import type { ReactNode } from 'react';
-import { TuturuuuWordmark } from '../custom/tuturuuu-wordmark';
+import { TuturuuuWordmark, toProductName } from '../custom/tuturuuu-wordmark';
 
 export interface MarketingFooterLink {
   href: string;
@@ -48,7 +48,7 @@ export function MarketingFooter({
       <div className="mx-auto grid w-full max-w-6xl gap-12 lg:grid-cols-[1.5fr_repeat(3,1fr)]">
         <div className="max-w-sm">
           <TuturuuuWordmark
-            product={productName ?? appName.replace(/^Tuturuuu\s+/i, '')}
+            product={productName ?? toProductName(appName)}
             size="sm"
           />
           <p className="mt-4 text-foreground/50 text-sm leading-relaxed">

--- a/packages/ui/src/components/ui/marketing/marketing-nav.tsx
+++ b/packages/ui/src/components/ui/marketing/marketing-nav.tsx
@@ -3,7 +3,7 @@
 import { Menu, X } from '@tuturuuu/icons';
 import { cn } from '@tuturuuu/utils/format';
 import { type ReactNode, useEffect, useState } from 'react';
-import { TuturuuLogo } from '../custom/tuturuuu-logo';
+import { TuturuuuWordmark } from '../custom/tuturuuu-wordmark';
 
 export interface MarketingNavLink {
   /** In-page anchor (`#pricing`) or absolute URL. */
@@ -13,7 +13,14 @@ export interface MarketingNavLink {
 
 interface MarketingNavProps {
   /** App name shown next to the logo, e.g. "Forms". */
+  /** Full name, used for the accessible landmark label. */
   appName: string;
+  /**
+   * The product line of the lockup — "Forms", not "Tuturuuu Forms". Defaults
+   * to `appName` with a leading "Tuturuuu " stripped, so callers that already
+   * pass the full name keep working.
+   */
+  productName?: string;
   /** Where the wordmark links back to. Defaults to the landing root. */
   homeHref?: string;
   links: MarketingNavLink[];
@@ -38,6 +45,7 @@ interface MarketingNavProps {
  */
 export function MarketingNav({
   appName,
+  productName,
   homeHref = '/',
   links,
   action,
@@ -79,13 +87,13 @@ export function MarketingNav({
         className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8"
       >
         <a
-          className="flex shrink-0 items-center gap-2.5 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex shrink-0 items-center rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           href={homeHref}
         >
-          <TuturuuLogo className="h-7 w-7" height={28} width={28} />
-          <span className="font-display font-semibold text-[0.95rem] tracking-[-0.01em]">
-            {appName}
-          </span>
+          <TuturuuuWordmark
+            product={productName ?? appName.replace(/^Tuturuuu\s+/i, '')}
+            size="sm"
+          />
         </a>
 
         <div className="hidden items-center gap-1 md:flex">

--- a/packages/ui/src/components/ui/marketing/marketing-nav.tsx
+++ b/packages/ui/src/components/ui/marketing/marketing-nav.tsx
@@ -3,7 +3,7 @@
 import { Menu, X } from '@tuturuuu/icons';
 import { cn } from '@tuturuuu/utils/format';
 import { type ReactNode, useEffect, useState } from 'react';
-import { TuturuuuWordmark } from '../custom/tuturuuu-wordmark';
+import { TuturuuuWordmark, toProductName } from '../custom/tuturuuu-wordmark';
 
 export interface MarketingNavLink {
   /** In-page anchor (`#pricing`) or absolute URL. */
@@ -12,8 +12,10 @@ export interface MarketingNavLink {
 }
 
 interface MarketingNavProps {
-  /** App name shown next to the logo, e.g. "Forms". */
-  /** Full name, used for the accessible landmark label. */
+  /**
+   * The full app name, e.g. "Tuturuuu Forms". Used for the accessible landmark
+   * label, and as the fallback source for `productName`.
+   */
   appName: string;
   /**
    * The product line of the lockup — "Forms", not "Tuturuuu Forms". Defaults
@@ -91,7 +93,7 @@ export function MarketingNav({
           href={homeHref}
         >
           <TuturuuuWordmark
-            product={productName ?? appName.replace(/^Tuturuuu\s+/i, '')}
+            product={productName ?? toProductName(appName)}
             size="sm"
           />
         </a>


### PR DESCRIPTION
Five things visible in the screenshots, four of them mine.

## The landing demo was not one question at a time

`demo-form.ts` set `displayMode: 'sections'` explicitly — so the page advertising the product showed the **opposite** of what the product now does by default.

I left it that way myself, patching the demo for a type error after adding `autoAdvance` to the settings schema. Now `one_question`.

## The footer logo was a broken image

It pointed at `TUTURUUU_LOCAL_LOGO_URL` (`/media/logos/transparent.png`), and `apps/forms/public/` contains **exactly one file**: `embed.js`.

Satellites are served from their own domains and ship no `/media` — which is why `TUTURUUU_REMOTE_LOGO_URL` exists and why the component already defaults to it. The footer was overriding that default with the one path guaranteed to 404 there.

## One wordmark, three surfaces

`TuturuuuWordmark` now backs the marketing nav, the marketing footer and the runtime footer. It takes the **product line** — "Forms", not "Tuturuuu Forms" — and stacks it under the company name, so only the second line changes between products. Callers passing a full name still work; a leading `Tuturuuu ` is stripped.

**Where it lives is the interesting part.** Exporting it from the marketing barrel made the form runtime import `next/font` transitively, breaking the runtime test with `Be_Vietnam_Pro is not a function`. The fix wasn't to stub the font — it was to notice the wordmark is a *brand* primitive, not a marketing-page primitive. It sits in `custom/` beside the logo, and the coupling is gone rather than worked around.

## Drop-off rendered raw HTML

`<p>Our <strong>technology</strong></p>` for any section titled with rich text. The question analytics already run `normalizeMarkdownToText`; the drop-off parser did not. Same data, two paths, one normalized.

## Cities showed as `Hong%20Kong`

Geo labels arrive percent-encoded from request headers and were never decoded. Malformed input is returned **untouched** rather than thrown on — a label that won't decode still has real responses behind it, and dropping the row is worse than showing an ugly one.

## Staggered analytics

All four grids cascade their children in, 60ms apart, capped at eight steps: the point is rhythm, not a queue, and a card arriving a second late reads as broken rather than choreographed.

The stagger lives in the grid wrapper rather than at each call site, so inserting a card renumbers everything after it instead of silently repeating an index. `fill-mode-backwards` holds the pre-animation state through the delay — without it a delayed card flashes at full opacity first — and `motion-safe:` means a viewer who asked for reduced motion never receives the classes at all.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0
- 3 new tests on the label decoder, including the malformed-input path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the landing demo, the broken form footer logo, two analytics label bugs, and staggers analytics grid entrances.

- Landing demo now runs one question at a time instead of sections mode.
- Runtime footer uses the remote logo default so the logo no longer 404s.
- Geo labels are percent-decoded; malformed labels fall back to their original string.
- Drop-off and question titles are normalized from markdown to plain text.
- Analytics grids are wrapped in `AnalyticsRevealGrid` for a 60ms staggered entrance, capped at eight steps and motion-safe.

**Refactors**
- Adds `TuturuuuWordmark` for the marketing nav, marketing footer, and runtime footer, exported from `@tuturuuu/ui`.
- The wordmark strips a leading "Tuturuuu " from the product name via a shared `toProductName` helper so nav and footer can't drift; full names and bare "Tuturuuu" still render correctly.
- Adds unit tests for both the label decoder and the wordmark.

<sup>Written for commit 1e4fd6f2808e529e40936aae58431b9ecf48c5ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

