### PR TITLE
feat(forms): give the preview a device width and a restart

### DIFF
--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -3243,7 +3243,12 @@
       "move_block_up": "Move block up",
       "move_block_down": "Move block down",
       "duplicate_block": "Duplicate block",
-      "delete_block": "Delete block"
+      "delete_block": "Delete block",
+      "preview_width": "Preview width",
+      "preview_desktop": "Desktop",
+      "preview_tablet": "Tablet",
+      "preview_mobile": "Mobile",
+      "preview_restart": "Restart"
     },
     "tabs": {
       "analytics": "Analytics",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -3243,7 +3243,12 @@
       "move_block_up": "Di chuyển khối lên",
       "move_block_down": "Di chuyển khối xuống",
       "duplicate_block": "Nhân bản khối",
-      "delete_block": "Xoá khối"
+      "delete_block": "Xoá khối",
+      "preview_width": "Chiều rộng xem thử",
+      "preview_desktop": "Máy tính",
+      "preview_tablet": "Máy tính bảng",
+      "preview_mobile": "Điện thoại",
+      "preview_restart": "Bắt đầu lại"
     },
     "tabs": {
       "analytics": "Analytics",

--- a/apps/forms/src/features/forms/studio/form-studio.tsx
+++ b/apps/forms/src/features/forms/studio/form-studio.tsx
@@ -33,7 +33,6 @@ import {
 } from '../collaboration';
 import { normalizeMarkdownToText } from '../content';
 import { FORM_FONT_VARIABLES } from '../fonts';
-import { FormRuntime } from '../form-runtime';
 import { FormsMarkdown } from '../forms-markdown';
 import type {
   FormAnalytics,
@@ -47,6 +46,7 @@ import { FontPreviewPanel } from './font-preview-panel';
 import { renderBuildTab } from './form-studio-build-tab';
 import { useFormStudioSave } from './form-studio-save';
 import { useFormStudioState } from './form-studio-state';
+import { PreviewPanel } from './preview-panel';
 import { ResponsesPanel } from './responses-panel';
 import { SettingsPanel } from './settings-panel';
 import { StudioSaveButton, type StudioSaveState } from './studio-save-button';
@@ -545,14 +545,15 @@ export function FormStudio({
           })}
 
           <TabsContent value="preview" className="mt-0 min-w-0">
-            <FormRuntime
-              data-active="true"
+            <PreviewPanel
               form={previewDefinition}
-              mode="preview"
-              className={cn(
-                'rounded-xl border',
-                studioToneClasses.tabTriggerClassName
-              )}
+              t={
+                t as (
+                  key: string,
+                  values?: Record<string, string | number>
+                ) => string
+              }
+              toneClasses={studioToneClasses}
             />
           </TabsContent>
 

--- a/apps/forms/src/features/forms/studio/preview-panel.tsx
+++ b/apps/forms/src/features/forms/studio/preview-panel.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { Monitor, RotateCcw, Smartphone, Tablet } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { cn } from '@tuturuuu/utils/format';
+import { useState } from 'react';
+import { FormRuntime } from '../form-runtime';
+import type { getFormToneClasses } from '../theme';
+import type { FormDefinition } from '../types';
+
+type PreviewDevice = 'desktop' | 'tablet' | 'mobile';
+
+/**
+ * Widths chosen to match where forms are actually filled in, not to be round
+ * numbers: 390px is an iPhone 15/16, 834px an iPad in portrait.
+ */
+const DEVICE_WIDTH: Record<PreviewDevice, string> = {
+  desktop: '100%',
+  tablet: '834px',
+  mobile: '390px',
+};
+
+const DEVICES: Array<{
+  id: PreviewDevice;
+  icon: typeof Monitor;
+  labelKey: string;
+}> = [
+  { id: 'desktop', icon: Monitor, labelKey: 'studio.preview_desktop' },
+  { id: 'tablet', icon: Tablet, labelKey: 'studio.preview_tablet' },
+  { id: 'mobile', icon: Smartphone, labelKey: 'studio.preview_mobile' },
+];
+
+/**
+ * The preview tab: the real runtime, at a chosen width, restartable.
+ *
+ * Width matters more than it used to. Most forms are answered on a phone, and
+ * a preview that only ever shows the desktop layout hides exactly the problems
+ * worth catching — a question title that wraps to four lines, options that
+ * stop being tappable, a progress bar that crowds the question.
+ *
+ * Restart matters more too. One question at a time means walking a form to its
+ * end, and before this the only way back to the first question was leaving the
+ * tab and returning.
+ */
+export function PreviewPanel({
+  form,
+  toneClasses,
+  t,
+}: {
+  form: FormDefinition;
+  toneClasses: ReturnType<typeof getFormToneClasses>;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}) {
+  const [device, setDevice] = useState<PreviewDevice>('desktop');
+  const [runId, setRunId] = useState(0);
+
+  return (
+    <div className="min-w-0 space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <fieldset className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-card/60 p-1">
+          <legend className="sr-only">{t('studio.preview_width')}</legend>
+          {DEVICES.map(({ id, icon: Icon, labelKey }) => (
+            <Button
+              key={id}
+              aria-pressed={device === id}
+              className="h-7 gap-1.5 rounded-full px-3 text-xs"
+              onClick={() => setDevice(id)}
+              size="sm"
+              type="button"
+              variant={device === id ? 'secondary' : 'ghost'}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {t(labelKey)}
+            </Button>
+          ))}
+        </fieldset>
+
+        <Button
+          className="h-7 gap-1.5 rounded-full px-3 text-xs"
+          // Remounting is the restart: the runtime holds the respondent's
+          // position and answers in its own state, so a new key is the only
+          // way back to a genuinely blank first question.
+          onClick={() => setRunId((current) => current + 1)}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+          {t('studio.preview_restart')}
+        </Button>
+      </div>
+
+      <div className="flex min-w-0 justify-center">
+        <div
+          className={cn(
+            'min-w-0 transition-[max-width] duration-300 ease-out',
+            device === 'desktop' ? 'w-full' : 'w-full'
+          )}
+          style={{ maxWidth: DEVICE_WIDTH[device] }}
+        >
+          <FormRuntime
+            className={cn('rounded-xl border', toneClasses.tabTriggerClassName)}
+            data-active="true"
+            form={form}
+            key={runId}
+            mode="preview"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
First slice of the editor/preview work, deliberately small enough to evaluate in about ten seconds.

## Two gaps the one-question default made worse

**Width.** The preview rendered the runtime full-bleed, so it only ever showed the desktop layout. Most forms are answered on a phone, and desktop hides exactly the problems worth catching before publishing — a title wrapping to four lines, options that stop being tappable, a progress bar crowding the question it describes.

390px and 834px rather than round numbers: those are an iPhone and an iPad in portrait.

**Restart.** One question at a time means walking a form to its end, and before this the only way back to question one was leaving the preview tab and returning.

It remounts the runtime rather than resetting state from outside. The runtime owns the respondent's position and answers, so a new key is the only genuine reset — anything else leaves half of it behind.

## A small correctness note

The panel imports `FormRuntime` from the app's `form-runtime` shim rather than reaching into `runtime/form-runtime` directly. That shim exists to carry the `'use client'` boundary, and bypassing it works right up until it doesn't.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0
- 204 tests pass

## Why slices

The last two rounds both shipped bugs that were obvious to anyone who opened the page. The cause was batching: each piece verified in isolation, the whole never looked at. Smaller slices don't fix that I can't see the page — they make each one cheap for someone else to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds device width presets and a restart button to the form preview. The preview previously rendered full-bleed, showing only the desktop layout, and the only way back to the first question was leaving the tab; now editors can preview at 390px and 834px (an iPhone and iPad in portrait) and restart a walkthrough by remounting the runtime.

**Bug Fixes**
- Imports `FormRuntime` from the app's `form-runtime` shim to preserve the `'use client'` boundary.

<sup>Written for commit ed53091ab98b0754b749ca848323fea9e5c95e05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

