### PR TITLE
feat(forms): give auto-sizing embeds a real minimum height

### DIFF
--- a/apps/docs/platform/features/forms-embedding-and-seo.mdx
+++ b/apps/docs/platform/features/forms-embedding-and-seo.mdx
@@ -112,11 +112,17 @@ re-run cannot double-mount it.
 | `data-tuturuuu-form` | all | — | The form's share code. Required. |
 | `data-mode` | all | `inline` | `inline`, `fullpage`, `popup`, `slider`, `popover`, or `sidetab`. |
 | `data-height` | inline modes | `520` | Fixed pixel height. Omit to let the embed auto-size. |
+| `data-min-height` | auto-sizing inline | `320` | Shortest the embed shrinks to while auto-sizing. Ignored when `data-height` is set. |
 | `data-title` | all | — | `title` on the generated iframe, for screen readers. |
 | `data-launcher-text` | overlay modes | localized default | Launcher button label. |
 | `data-launcher-color` | overlay modes | `#6d28d9` | Launcher button background. |
 | `data-open` | overlay modes | `false` | `true` opens the overlay on load. |
 | `data-close-on-submit` | overlay modes | `true` | `false` keeps the overlay open after submit. |
+
+An auto-sizing embed never renders shorter than `data-min-height`. The default
+of 320px is the smallest height at which a single question stays answerable
+without scrolling inside the frame — the previous floor was 120px, which
+predates one-question-at-a-time forms and left the host page showing a sliver.
 
 `inline` and `fullpage` render in place. `popup`, `slider`, `popover`, and
 `sidetab` are overlay modes: they render a launcher and only mount the form when

--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -3038,7 +3038,10 @@
       "welcome_button": "Button label",
       "welcome_button_placeholder": "Start",
       "auto_advance": "Advance automatically",
-      "auto_advance_hint": "Move to the next question once a rating or single choice is picked. Typing, multi-select and ranking always wait for Continue."
+      "auto_advance_hint": "Move to the next question once a rating or single choice is picked. Typing, multi-select and ranking always wait for Continue.",
+      "embed_min_height": "Minimum height",
+      "embed_min_height_placeholder": "320",
+      "embed_min_height_hint": "The shortest the embed will shrink to while auto-sizing. Leave blank for the default of 320px, which keeps a single question answerable without scrolling inside the frame."
     },
     "shared": {
       "metadata_fallback_description": "Open this shared form to review the questions and submit a response.",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -3038,7 +3038,10 @@
       "welcome_button": "Nhãn nút",
       "welcome_button_placeholder": "Bắt đầu",
       "auto_advance": "Tự động chuyển tiếp",
-      "auto_advance_hint": "Chuyển sang câu hỏi kế tiếp ngay khi chọn xong đánh giá hoặc một lựa chọn. Câu nhập chữ, chọn nhiều và xếp hạng luôn chờ nút Tiếp tục."
+      "auto_advance_hint": "Chuyển sang câu hỏi kế tiếp ngay khi chọn xong đánh giá hoặc một lựa chọn. Câu nhập chữ, chọn nhiều và xếp hạng luôn chờ nút Tiếp tục.",
+      "embed_min_height": "Chiều cao tối thiểu",
+      "embed_min_height_placeholder": "320",
+      "embed_min_height_hint": "Mức thấp nhất mà khung nhúng co lại khi tự động điều chỉnh. Để trống để dùng mặc định 320px, đủ chỗ trả lời một câu hỏi mà không phải cuộn bên trong khung."
     },
     "shared": {
       "metadata_fallback_description": "Mở biểu mẫu chia sẻ này để xem các câu hỏi và gửi phản hồi.",

--- a/apps/forms/public/embed.js
+++ b/apps/forms/public/embed.js
@@ -18,6 +18,19 @@
   const MODES = ['inline', 'fullpage', 'popup', 'slider', 'popover', 'sidetab'];
   const OVERLAY_MODES = ['popup', 'slider', 'popover', 'sidetab'];
   const DEFAULT_HEIGHT = 520;
+  /**
+   * Floor for auto-sized embeds.
+   *
+   * The old floor was 120px, which predates one-question-at-a-time forms. A
+   * single question needs room for its title, its input and the continue
+   * button; at 120px the host page shows a sliver and the respondent scrolls
+   * inside a box the size of a banner. 320px is the smallest height where a
+   * short question is still answerable without scrolling the frame.
+   *
+   * Overridable per embed with `data-min-height`, because a host that has
+   * reserved space knows better than this default does.
+   */
+  const DEFAULT_MIN_HEIGHT = 320;
 
   /**
    * Resolve the origin from this script's own src, so a self-hosted or staging
@@ -263,6 +276,22 @@
       entry.iframe.style.height = `${height}px`;
     }
 
+    const minHeight = parseInt(
+      element.getAttribute('data-min-height') || '',
+      10
+    );
+    entry.minHeight =
+      !Number.isNaN(minHeight) && minHeight > 0
+        ? minHeight
+        : DEFAULT_MIN_HEIGHT;
+
+    // Applied to the iframe as well as used in the resize clamp, so the embed
+    // never renders shorter than its floor even before the first resize
+    // message arrives.
+    if (!entry.fixedHeight) {
+      entry.iframe.style.minHeight = `${entry.minHeight}px`;
+    }
+
     if (mode === 'inline') {
       mountInline(element, entry);
     } else if (mode === 'fullpage') {
@@ -292,7 +321,7 @@
       // Overlay panels are sized by their own CSS; only flow-positioned
       // embeds grow with their content.
       if (entry.mode === 'inline') {
-        entry.iframe.style.height = `${Math.max(data.height || 0, 120)}px`;
+        entry.iframe.style.height = `${Math.max(data.height || 0, entry.minHeight || DEFAULT_MIN_HEIGHT)}px`;
       }
       return;
     }

--- a/apps/forms/src/features/forms/embed/embed-snippet.test.ts
+++ b/apps/forms/src/features/forms/embed/embed-snippet.test.ts
@@ -100,3 +100,52 @@ describe('isOverlayEmbedMode', () => {
     expect(isOverlayEmbedMode(mode)).toBe(false)
   );
 });
+
+describe('buildEmbedSnippet min-height', () => {
+  const base = { baseUrl: 'https://forms.tuturuuu.com', shareCode: 'abc' };
+
+  it('emits a floor for an auto-sizing inline embed', () => {
+    const snippet = buildEmbedSnippet({
+      ...base,
+      mode: 'inline',
+      minHeight: 480,
+    });
+    expect(snippet).toContain('data-min-height="480"');
+  });
+
+  it('omits the floor when a fixed height is set', () => {
+    // A floor beside a fixed height controls nothing; emitting it would
+    // advertise a knob that does not turn.
+    const snippet = buildEmbedSnippet({
+      ...base,
+      mode: 'inline',
+      height: 600,
+      minHeight: 480,
+    });
+    expect(snippet).toContain('data-height="600"');
+    expect(snippet).not.toContain('data-min-height');
+  });
+
+  it('omits the floor on overlay modes, which size themselves', () => {
+    const snippet = buildEmbedSnippet({
+      ...base,
+      mode: 'popup',
+      minHeight: 480,
+    });
+    expect(snippet).not.toContain('data-min-height');
+  });
+
+  it('omits the floor when unset, so the SDK default applies', () => {
+    const snippet = buildEmbedSnippet({ ...base, mode: 'inline' });
+    expect(snippet).not.toContain('data-min-height');
+  });
+
+  it('rounds a fractional floor', () => {
+    const snippet = buildEmbedSnippet({
+      ...base,
+      mode: 'inline',
+      minHeight: 480.6,
+    });
+    expect(snippet).toContain('data-min-height="481"');
+  });
+});

--- a/apps/forms/src/features/forms/embed/embed-snippet.ts
+++ b/apps/forms/src/features/forms/embed/embed-snippet.ts
@@ -6,6 +6,11 @@ export interface EmbedSnippetOptions {
   mode: EmbedMode;
   /** Fixed pixel height; omit to let inline embeds auto-size. */
   height?: number | null;
+  /**
+   * Floor for an auto-sizing embed. Omit to use the SDK's default, which is
+   * the smallest height a single question stays answerable at.
+   */
+  minHeight?: number | null;
   /** Launcher label for the overlay modes. */
   launcherText?: string | null;
 }
@@ -37,6 +42,7 @@ export function buildEmbedSnippet({
   shareCode,
   mode,
   height,
+  minHeight,
   launcherText,
 }: EmbedSnippetOptions) {
   const attributes = [
@@ -46,6 +52,18 @@ export function buildEmbedSnippet({
 
   if (height && height > 0 && !isOverlayEmbedMode(mode)) {
     attributes.push(`data-height="${Math.round(height)}"`);
+  }
+
+  // A floor is meaningless next to a fixed height, and meaningless on an
+  // overlay, whose panel is sized by its own CSS. Emitting it there would
+  // advertise a control that does nothing.
+  if (
+    minHeight &&
+    minHeight > 0 &&
+    !isOverlayEmbedMode(mode) &&
+    !(height && height > 0)
+  ) {
+    attributes.push(`data-min-height="${Math.round(minHeight)}"`);
   }
 
   if (launcherText?.trim() && isOverlayEmbedMode(mode)) {

--- a/apps/forms/src/features/forms/studio/preview-panel.tsx
+++ b/apps/forms/src/features/forms/studio/preview-panel.tsx
@@ -14,6 +14,14 @@ type PreviewDevice = 'desktop' | 'tablet' | 'mobile';
  * Widths chosen to match where forms are actually filled in, not to be round
  * numbers: 390px is an iPhone 15/16, 834px an iPad in portrait.
  */
+/**
+ * The same floor the embed SDK applies, for the same reason: a short form
+ * should not collapse the frame to a sliver. Kept in step deliberately — a
+ * preview that can be shorter than the embed shows authors a layout their
+ * respondents will never see.
+ */
+const PREVIEW_MIN_HEIGHT = 320;
+
 const DEVICE_WIDTH: Record<PreviewDevice, string> = {
   desktop: '100%',
   tablet: '834px',
@@ -96,7 +104,10 @@ export function PreviewPanel({
             'min-w-0 transition-[max-width] duration-300 ease-out',
             device === 'desktop' ? 'w-full' : 'w-full'
           )}
-          style={{ maxWidth: DEVICE_WIDTH[device] }}
+          style={{
+            maxWidth: DEVICE_WIDTH[device],
+            minHeight: `${PREVIEW_MIN_HEIGHT}px`,
+          }}
         >
           <FormRuntime
             className={cn('rounded-xl border', toneClasses.tabTriggerClassName)}

--- a/apps/forms/src/features/forms/studio/settings-embed-section.tsx
+++ b/apps/forms/src/features/forms/studio/settings-embed-section.tsx
@@ -83,28 +83,33 @@ export function EmbedSettingsSection({
   const t = useTranslations('forms');
   const [mode, setMode] = useState<EmbedMode>('inline');
   const [height, setHeight] = useState('');
+  const [minHeight, setMinHeight] = useState('');
   const [launcherText, setLauncherText] = useState('');
 
   const snippets = useMemo(() => {
     if (!shareCode) return null;
 
     const parsedHeight = Number.parseInt(height, 10);
+    const parsedMinHeight = Number.parseInt(minHeight, 10);
 
     return {
       embed: buildEmbedSnippet({
         baseUrl: BASE_URL,
         height: Number.isNaN(parsedHeight) ? null : parsedHeight,
+        minHeight: Number.isNaN(parsedMinHeight) ? null : parsedMinHeight,
         launcherText,
         mode,
         shareCode,
       }),
+      // The iframe fallback has no auto-resize — it takes an explicit height
+      // and keeps it — so a floor would control nothing there.
       iframe: buildIframeSnippet({
         baseUrl: BASE_URL,
         height: Number.isNaN(parsedHeight) ? null : parsedHeight,
         shareCode,
       }),
     };
-  }, [height, launcherText, mode, shareCode]);
+  }, [height, launcherText, minHeight, mode, shareCode]);
 
   return (
     <SettingsSection
@@ -170,6 +175,27 @@ export function EmbedSettingsSection({
                 <p className="text-muted-foreground text-xs">
                   {t('settings.embed_height_hint')}
                 </p>
+
+                {/* Only meaningful while the embed auto-sizes: a fixed height
+                    already decides the size, so a floor beside it does
+                    nothing. */}
+                {height.trim() ? null : (
+                  <div className="space-y-2 pt-1">
+                    <Label htmlFor="embed-min-height">
+                      {t('settings.embed_min_height')}
+                    </Label>
+                    <Input
+                      id="embed-min-height"
+                      inputMode="numeric"
+                      onChange={(event) => setMinHeight(event.target.value)}
+                      placeholder={t('settings.embed_min_height_placeholder')}
+                      value={minHeight}
+                    />
+                    <p className="text-muted-foreground text-xs">
+                      {t('settings.embed_min_height_hint')}
+                    </p>
+                  </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## The floor already existed, and it was wrong

The resize handler clamped to `Math.max(data.height || 0, **120**)` — a hardcoded 120px that predates one-question-at-a-time forms entirely.

A single question needs room for its title, its input and the continue button. At 120px the host page shows a sliver and the respondent scrolls inside a box the size of a banner. So the "sane default" here isn't a new concept, it's a corrected one.

**320px** — the smallest height where one question stays answerable without scrolling the frame. `data-min-height` overrides it for hosts that have reserved their own space.

## Applied in two places, not one

The floor is set on the iframe **and** used in the resize clamp. The clamp alone would leave the embed short in the window before the first resize message arrives — visible on every page load.

## Three places deliberately take no floor

In each, the control would do nothing, and offering it would be a lie:

| | Why not |
| --- | --- |
| Overlay modes | Panels are sized by their own CSS |
| Fixed  | Already decided its size |
| Plain-iframe fallback | No auto-resize to floor |

The studio field hides while a fixed height is set, and the snippet builder omits the attribute in all three cases. **The five new tests cover those omissions rather than the happy path** — emitting a dead attribute is the failure that would actually ship here.

## The preview uses the same number on purpose

A preview that can be shorter than the embed shows authors a layout their respondents will never see, which defeats the point of previewing. The two constants agreeing matters more than either value.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0
- 209 tests pass (5 new)
- Embed docs updated with the attribute and the reasoning behind the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the auto-sizing embed floor from a hardcoded 120px to a 320px default, so a single question stays answerable without scrolling the frame. The floor now applies to the iframe before the first resize message arrives, and hosts can override it with `data-min-height`.

**Behavior details**

- The floor is omitted when a fixed `data-height` is set, on overlay modes, and in the plain-iframe fallback, where it would control nothing.
- The studio's minimum-height field hides while a fixed height is set, and the snippet builder omits the attribute in the same cases.
- The studio preview uses the same 320px number so authors don't see a layout shorter than the real embed.
- Five new tests cover the omission cases rather than the happy path.

<sup>Written for commit 5707bc581580321d587290d79f9ff56b4098b563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

