### PR TITLE
perf(infrastructure): stop alerting Docker recovery every minute

### DIFF
--- a/apps/docs/build/devops/vercel-cost-controls.mdx
+++ b/apps/docs/build/devops/vercel-cost-controls.mdx
@@ -1,0 +1,155 @@
+---
+title: "Vercel Cost Controls"
+description: "Where Vercel spend actually comes from on this account, and which levers move it."
+updatedAt: "2026-08-28"
+---
+
+Tuturuuu runs ~30 monorepo apps plus client projects as separate Vercel
+projects on a single Pro team. This runbook records how that spend is shaped, so
+future changes are made against measured behavior instead of intuition.
+
+## The Shape Of The Bill
+
+The important thing to internalize: **traffic volume is not the problem.**
+
+| Metric | Usage | Included | Share of allowance used |
+| --- | --- | --- | --- |
+| Edge Requests | 182.6K | 10M | 1.8% |
+| Fast Data Transfer | 5 GB | 1 TB | 0.5% |
+| Fast Origin Transfer | 4 GB | — | billed from the first byte |
+| Fluid Active CPU | 3 hours | — | billed from the first second |
+
+Edge requests and data transfer sit far inside the included allowance and cost
+nothing. Essentially the entire bill is **Fast Origin Transfer** and **Fluid
+Active CPU**, both of which are billed from zero with no free tier.
+
+The consequence is that spend tracks *how* bytes are produced, not how many
+requests arrive. Adding traffic to a cached route is close to free. Adding one
+uncached dynamic route, or one always-on cron, is not.
+
+## Why Origin Transfer Dominates
+
+Fast Origin Transfer (4 GB) is ~80% of Fast Data Transfer (5 GB). Origin
+transfer is only charged when a response travels from a function to the CDN, so
+that ratio says roughly **four out of five bytes we serve bypass the CDN and are
+generated fresh by a function.**
+
+That is expected for the authenticated dashboard surface — 343 files across the
+apps call `await connection()`, which is the correct way to opt an authed page
+into request-time rendering under `cacheComponents`. It is *not* expected for
+public surfaces. Any public, unauthenticated route served without
+`Vercel-CDN-Cache-Control` pays origin transfer on every single hit.
+
+`apps/web/next.config.ts` already demonstrates the pattern for the auth shell:
+
+```ts
+const authShellHeaders = [
+  { key: 'Cache-Control', value: 'public, max-age=0, must-revalidate' },
+  {
+    key: 'CDN-Cache-Control',
+    value: 'public, max-age=86400, stale-while-revalidate=604800',
+  },
+  {
+    key: 'Vercel-CDN-Cache-Control',
+    value: 'public, max-age=86400, stale-while-revalidate=604800',
+  },
+];
+```
+
+`Cache-Control: max-age=0` keeps the browser honest while
+`Vercel-CDN-Cache-Control` lets the CDN serve the shared copy. Extending this to
+public marketing pages, the public form-filling surface at `/f/<shareCode>`, and
+storefront pages is the single largest available reduction in origin transfer.
+
+<Warning>
+Never add shared-CDN cache headers to a response whose body varies by user,
+workspace, or session. `Vercel-CDN-Cache-Control` caches at a shared edge, so a
+per-user body cached once is served to everyone.
+</Warning>
+
+## Region Pricing Is Not Uniform
+
+Function region changes the unit price substantially:
+
+| Region | Origin transfer / GB | Fluid CPU / hour |
+| --- | --- | --- |
+| `iad1`, `pdx1`, `cle1` | $0.06 | $0.128 |
+| `fra1`, `lhr1`, `cdg1`, `arn1`, `dub1` | $0.06 | $0.155 – $0.184 |
+| `sin1` | **$0.27** | $0.16 |
+| `hkg1`, `hnd1`, `kix1` | $0.27 | $0.176 – $0.202 |
+| `syd1` | $0.29 | $0.18 |
+
+`sin1` charges **4.5x** the `iad1` rate for origin transfer.
+
+<Note>
+Do not "fix" this by moving functions to `iad1`. Supabase runs in
+`ap-southeast-1` and `SES_DEFAULT_REGION` is `ap-southeast-1`, so `sin1` is the
+region that keeps functions next to their data. Moving compute to North America
+would add a cross-Pacific round trip to every database call. `sin1` is the
+correct region; the lever is **sending fewer bytes from it**, not relocating it.
+</Note>
+
+The reviewable question is region *count*, not region choice. Projects currently
+list three function regions (for example `platform` uses
+`['sin1', 'iad1', 'fra1']`). Requests routed to `iad1` or `fra1` still reach a
+Singapore database, so the extra regions add cross-ocean latency while spreading
+deployments wider. Single-region `sin1` is usually the better default here.
+
+## Always-On Crons
+
+Cron invocations run forever, whether or not anyone is looking at the result.
+Current scheduled load:
+
+| App | Jobs | Invocations / day |
+| --- | --- | --- |
+| `infrastructure` | 3 | 1,872 |
+| `inventory` | 1 | 288 |
+| `web` | 5 | 342 |
+| `calendar` | 2 | 100 |
+| `pay` | 1 | 2 |
+
+`infrastructure` is the majority of all scheduled work on the account because it
+samples at one-minute resolution.
+
+### Rules For Adding A Cron
+
+1. **Prefer a persisted watermark to a fixed lookback.** A job that scans from
+   `lastCheckedAt` is cadence-independent: slowing it delays the result but never
+   drops work. `docker-recovery-alerts` is the reference implementation, which is
+   why it safely runs every 5 minutes instead of every minute.
+2. **Justify sub-5-minute schedules.** `* * * * *` is 43,200 invocations per
+   month per job. Only `sample-resources` earns it, because the monitoring
+   dashboard renders a one-minute series and flags data stale after five minutes
+   (`RESOURCE_SAMPLE_MIN_INTERVAL_MS`). Changing that cadence means changing that
+   constant too, and accepting coarser graphs.
+3. **Ask whether it should be on-demand.** A dashboard that is viewed a few
+   minutes a week does not need a 24/7 sampler. Sampling on page view, or behind
+   a feature flag, removes the cost floor entirely.
+
+## What Is Already Optimized
+
+Verified, so nobody re-investigates these:
+
+- **Image optimization** — `minimumCacheTTL` is 7 days in
+  `createTuturuuuNextConfig`, not the 60-second default.
+- **Client polling** — shared hooks (`use-notifications`,
+  `use-active-timer-session`, `use-calendar-sync`) all set
+  `refetchIntervalInBackground: false`, so hidden tabs stop polling.
+- **Canceled Git deployments** — `vercel.json` sets `git.deploymentEnabled:
+  false`, so pushes create a deployment record that is canceled with **0 build
+  seconds**. The long list of `CANCELED` deployments in the dashboard is
+  cosmetic, not billed.
+- **Preview deployments** — the `vercel-preview-*.yaml` workflows are
+  `workflow_dispatch` only and gated on `TRUSTED_PREVIEW_DEPLOY_ACTORS`.
+- **Builds** — `vercel build` runs on GitHub Actions runners, so build compute is
+  not billed as Vercel build minutes.
+- **Web Analytics** — `@vercel/analytics` is not mounted in any app, so the
+  per-event meter stays near zero even though the dashboard toggle is on.
+
+## Checking Current Spend
+
+The dashboard breakdown lives under **Usage**, switchable between *By Project*
+and *By Product*. Read it *By Product* first: that tells you which meter is
+moving. Only then switch to *By Project* to find the owner. Reading it the other
+way around leads to optimizing a project that is merely large rather than a meter
+that is actually expensive.

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -282,6 +282,7 @@
                   "build/devops/log-drain-observability",
                   "build/devops/adaptive-abuse-rate-limits",
                   "build/devops/github-actions-runbook",
+                  "build/devops/vercel-cost-controls",
                   "build/devops/mobile-store-deployment",
                   "build/devops/secrets-and-configuration",
                   "build/devops/sepay-testing-guide",

--- a/apps/infrastructure/cron.config.json
+++ b/apps/infrastructure/cron.config.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "id": "infrastructure-docker-recovery-alerts",
       "path": "/api/cron/infrastructure/docker-recovery-alerts",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "description": "Synchronize infrastructure abuse trust cache entries.",

--- a/apps/infrastructure/src/app/api/cron/infrastructure/docker-recovery-alerts/route.ts
+++ b/apps/infrastructure/src/app/api/cron/infrastructure/docker-recovery-alerts/route.ts
@@ -14,6 +14,13 @@ import { withCronLogDrain } from '@/lib/infrastructure/log-drain';
 
 const JOB_ID = 'infrastructure-docker-recovery-alerts';
 const PATH = '/api/cron/infrastructure/docker-recovery-alerts';
+/**
+ * Only used on the very first run, before `lastCheckedAt` exists. Every later
+ * run scans from the persisted watermark instead, so incident coverage does not
+ * depend on the cron cadence — a slower schedule only delays the alert email, it
+ * never drops an incident. That is why `vercel.json` runs this every 5 minutes
+ * rather than every minute; see the Vercel cost controls runbook.
+ */
 const DEFAULT_LOOKBACK_MS = 15 * 60_000;
 
 interface DockerRecoveryIncident {

--- a/apps/infrastructure/vercel.json
+++ b/apps/infrastructure/vercel.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "/api/cron/infrastructure/docker-recovery-alerts",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/cron/infrastructure/sync-trust-cache",


### PR DESCRIPTION
## Why

A look at where Vercel spend actually goes on the Pro team turned up a shape worth writing down, and one clearly over-frequent cron.

The counterintuitive part: **traffic volume is not what we pay for.**

| Meter | Usage | Included | Used |
| --- | --- | --- | --- |
| Edge Requests | 182.6K | 10M | 1.8% |
| Fast Data Transfer | 5 GB | 1 TB | 0.5% |
| Fast Origin Transfer | 4 GB | — | billed from byte one |
| Fluid Active CPU | 3 hours | — | billed from second one |

Requests and transfer sit far inside the free allowance. Essentially the entire bill is origin transfer + active CPU, both of which bill from zero. So spend tracks *how* responses are produced — uncached function output and always-on schedules — not how much traffic arrives.

## What changes

`docker-recovery-alerts` ran on `* * * * *`: 43,200 invocations a month for a job whose output is an email to operators.

It is safe to slow down because it scans from a persisted `lastCheckedAt` watermark, not a fixed lookback window — so coverage is independent of cadence. A slower schedule delays the alert, it never drops an incident. The watcher buffer it reads holds 500 entries, far more than 5 minutes of events. Moving to `*/5 * * * *` removes ~34,500 invocations/month at a cost of up to 4 minutes of alert latency.

`cron.config.json` declares the *expected* schedule for cron health monitoring, so it moves in step. Left behind, the monitor would report this job overdue on four runs out of five.

**Deliberately unchanged:** `sample-resources` stays on `* * * * *`. The monitoring dashboard renders a one-minute series and flags data stale after five (`RESOURCE_SAMPLE_MIN_INTERVAL_MS`). Slowing it degrades a real feature rather than trimming waste — that is a product call, not a cleanup.

## The runbook

`apps/docs/build/devops/vercel-cost-controls.mdx` records the analysis so it does not have to be redone, including what was measured and **ruled out**:

- Canceled Git deployments consume **0 build seconds** — the long `CANCELED` list in the dashboard is cosmetic, not billed.
- `@vercel/analytics` is not mounted in any app, so the per-event meter stays near zero.
- Image `minimumCacheTTL` is already 7 days, not the 60s default.
- Shared polling hooks already set `refetchIntervalInBackground: false`.
- Preview deploy workflows are `workflow_dispatch` only.

It also records the region economics: `sin1` bills origin transfer at **$0.27/GB vs $0.06 in `iad1`** (4.5x). The runbook explicitly warns *against* "fixing" that by relocating — Supabase and SES are both `ap-southeast-1`, so `sin1` is the region that keeps functions next to their data. The lever is sending fewer bytes from it.

## Verification

- `bun check` — clean (exit 0)
- `vitest` cron-monitoring (13 passed), docker-recovery-alerts route + blue-green-monitoring-controls (7 passed)
- `biome check` — clean

## Risk

Docker daemon recovery alert emails arrive up to 5 minutes later. Incident coverage is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slows `docker-recovery-alerts` from every minute to every 5 minutes, cutting ~34,500 invocations per month. Coverage is unchanged because the job scans from a persisted `lastCheckedAt` watermark — the slower cadence only delays alert emails by up to 4 minutes.

- `vercel.json` and `cron.config.json` both move to `*/5 * * * *` so the cron health monitor stays in sync.
- `sample-resources` deliberately stays at every minute; the monitoring dashboard renders a one-minute series and flags data stale after five.

**Runbook**
- Adds `vercel-cost-controls.mdx` recording where account spend originates: origin transfer and active CPU bill from zero, so spend tracks how responses are produced, not traffic volume.
- Documents ruled-out optimizations (canceled deployments cost 0 build seconds, `@vercel/analytics` is unmounted) and warns `sin1` is correct despite 4.5x origin transfer pricing.

<sup>Written for commit e0b96b3f9654be3921e28737b2284a4ad42639dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

