### PR TITLE
fix(forms): stop the runtime claiming a viewport it does not own

### DIFF
--- a/apps/forms/src/app/[locale]/f/[shareCode]/content.tsx
+++ b/apps/forms/src/app/[locale]/f/[shareCode]/content.tsx
@@ -25,8 +25,11 @@ export default function SharedFormContent({
   canRequestResponseCopy,
   responseCopyAlreadySent,
   onSubmitted,
+  layout = 'page',
 }: {
   form: FormDefinition;
+  /** `inline` when this is embedded rather than the whole page. */
+  layout?: 'page' | 'inline';
   shareCode: string;
   sessionId?: string;
   readOnly?: boolean;
@@ -47,6 +50,7 @@ export default function SharedFormContent({
   return (
     <FormRuntime
       form={form}
+      layout={layout}
       mode="public"
       readOnly={readOnly}
       initialAnswers={initialAnswers}

--- a/apps/forms/src/features/forms/embed/embed-content.tsx
+++ b/apps/forms/src/features/forms/embed/embed-content.tsx
@@ -28,6 +28,7 @@ export function EmbedContent({
         answerIssues={data.answerIssues}
         canRequestResponseCopy={data.canRequestResponseCopy}
         form={data.form}
+        layout="inline"
         initialAnswers={data.initialAnswers}
         onSubmitted={() => setSubmitted(true)}
         readOnly={data.readOnly}

--- a/apps/forms/src/features/forms/runtime/form-runtime.test.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.test.tsx
@@ -344,3 +344,41 @@ describe('auto-advance', () => {
     expect(screen.getByText('Type here')).toBeDefined();
   });
 });
+
+describe('layout', () => {
+  function renderWithLayout(layout: 'page' | 'inline') {
+    return render(
+      <FormRuntime
+        form={buildForm([textQuestion('q1', 'First question')])}
+        layout={layout}
+        mode="public"
+      />
+    );
+  }
+
+  it('claims the viewport on the hosted page', () => {
+    const { container } = renderWithLayout('page');
+    expect(container.querySelector('.min-h-screen')).not.toBeNull();
+  });
+
+  it('does not claim the viewport when embedded', () => {
+    // The bug this guards: the runtime kept `min-h-screen` inside the embed,
+    // the studio preview and the landing demo. `EmbedFrame` measures this
+    // subtree and posts the height to the host, so every embed reported at
+    // least a full viewport no matter how little the form contained — and the
+    // landing demo showed one short question above a screen of blank space.
+    const { container } = renderWithLayout('inline');
+    expect(container.querySelector('.min-h-screen')).toBeNull();
+  });
+
+  it('defaults to claiming the viewport', () => {
+    // The hosted form is the common case and must not change silently.
+    const { container } = render(
+      <FormRuntime
+        form={buildForm([textQuestion('q1', 'First question')])}
+        mode="public"
+      />
+    );
+    expect(container.querySelector('.min-h-screen')).not.toBeNull();
+  });
+});

--- a/apps/forms/src/features/forms/runtime/form-runtime.tsx
+++ b/apps/forms/src/features/forms/runtime/form-runtime.tsx
@@ -80,6 +80,7 @@ function FormRuntimeContent({
   onSubmit,
   onRequestResponseCopy,
   isSubmitting = false,
+  layout = 'page',
   readOnly = false,
   className,
 }: FormRuntimeProps) {
@@ -558,6 +559,7 @@ function FormRuntimeContent({
   if (submitted) {
     return renderSubmittedScreen({
       form,
+      layout,
       t,
       className,
       toneClasses,
@@ -575,6 +577,7 @@ function FormRuntimeContent({
     return (
       <RuntimeShell
         bodyFontStyle={bodyFontStyle}
+        layout={layout}
         className={className}
         toneClasses={toneClasses}
         width="narrow"
@@ -597,6 +600,7 @@ function FormRuntimeContent({
     <RuntimeShell
       bodyFontStyle={bodyFontStyle}
       className={className}
+      layout={layout}
       toneClasses={toneClasses}
     >
       {renderFormHeroCard({

--- a/apps/forms/src/features/forms/runtime/runtime-shell.tsx
+++ b/apps/forms/src/features/forms/runtime/runtime-shell.tsx
@@ -16,12 +16,27 @@ export function RuntimeShell({
   bodyFontStyle,
   children,
   className,
+  layout = 'page',
   toneClasses,
   width = 'wide',
 }: {
   bodyFontStyle: CSSProperties;
   children: ReactNode;
   className?: string;
+  /**
+   * Whether the runtime owns the viewport.
+   *
+   * `page` is the hosted form at `/f/<shareCode>`, where filling the form is
+   * the entire page and a full-height themed background is correct.
+   *
+   * `inline` is everywhere the runtime is a component inside something else —
+   * an embed, the studio preview, the landing demo. `min-h-screen` there
+   * claims a viewport it does not have: the landing demo showed one short
+   * question above a screen of empty space with its own scrollbar, and the
+   * embed reported at least 100vh to its host on every resize, so an embedded
+   * form was always a full screen tall no matter how little it contained.
+   */
+  layout?: 'page' | 'inline';
   toneClasses: FormToneClasses;
   /** The question flow is wider than the screens that bookend it. */
   width?: 'wide' | 'narrow';
@@ -29,7 +44,7 @@ export function RuntimeShell({
   return (
     <div
       className={cn(
-        'min-h-screen py-10',
+        layout === 'page' ? 'min-h-screen py-10' : 'py-6',
         FORM_FONT_VARIABLES,
         toneClasses.pageClassName,
         className

--- a/apps/forms/src/features/forms/runtime/submitted-screen.tsx
+++ b/apps/forms/src/features/forms/runtime/submitted-screen.tsx
@@ -24,6 +24,7 @@ export function renderSubmittedScreen({
   submittedResponseCopyEmail,
   submittedResponseCopyRequested,
   submittedResponseCopyStatus,
+  layout = 'page',
 }: {
   form: FormDefinition;
   t: FormsTranslator;
@@ -36,11 +37,14 @@ export function renderSubmittedScreen({
   submittedResponseCopyEmail: string | null;
   submittedResponseCopyRequested: boolean;
   submittedResponseCopyStatus: 'sent' | 'rate_limited' | 'failed' | null;
+  /** Matches the runtime's: an embedded confirmation must not claim a screen. */
+  layout?: 'page' | 'inline';
 }) {
   return (
     <div
       className={cn(
-        'flex min-h-screen items-center justify-center px-4 py-10',
+        'flex items-center justify-center px-4',
+        layout === 'page' ? 'min-h-screen py-10' : 'py-8',
         FORM_FONT_VARIABLES,
         toneClasses.pageClassName,
         className

--- a/apps/forms/src/features/forms/runtime/types.ts
+++ b/apps/forms/src/features/forms/runtime/types.ts
@@ -49,6 +49,11 @@ export interface FormRuntimeProps {
         responseCopySentTo?: string | null;
       }
   >;
+  /**
+   * Whether the runtime owns the viewport. `page` for the hosted form,
+   * `inline` when it is embedded in something else. See `RuntimeShell`.
+   */
+  layout?: 'page' | 'inline';
   isSubmitting?: boolean;
   readOnly?: boolean;
   className?: string;

--- a/apps/forms/src/features/forms/studio/preview-panel.tsx
+++ b/apps/forms/src/features/forms/studio/preview-panel.tsx
@@ -114,6 +114,7 @@ export function PreviewPanel({
             data-active="true"
             form={form}
             key={runId}
+            layout="inline"
             mode="preview"
           />
         </div>

--- a/apps/forms/src/features/landing/demo/live-demo.tsx
+++ b/apps/forms/src/features/landing/demo/live-demo.tsx
@@ -117,8 +117,19 @@ export function LiveDemo({ copy, themeLabel, className }: LiveDemoProps) {
           aria-hidden
           className="pointer-events-none absolute inset-x-10 top-0 h-px bg-[linear-gradient(90deg,transparent,color-mix(in_oklab,var(--foreground)_22%,transparent),transparent)]"
         />
-        <div className="max-h-[34rem] overflow-y-auto overscroll-contain p-3 sm:p-5">
-          <FormRuntime form={form} key={presetId} mode="preview" />
+        {/* Grows with the question rather than scrolling inside a fixed box.
+            The runtime is `inline` here, so it no longer claims a viewport —
+            a 34rem scroller around content that is usually one short question
+            produced a pane of empty space with its own scrollbar, and reading
+            the demo meant scrolling a second time inside the page. The floor
+            keeps the frame from snapping between question heights. */}
+        <div className="min-h-[26rem] p-3 sm:p-5">
+          <FormRuntime
+            form={form}
+            key={presetId}
+            layout="inline"
+            mode="preview"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## The weird scrolling was the visible half of a bigger bug

`RuntimeShell` applied `min-h-screen` unconditionally. Correct for the hosted form at `/f/<shareCode>`, where filling the form *is* the page — wrong in the three places the runtime is a component inside something else.

**Landing demo:** a 34rem scroll box wrapped around content demanding ≥100vh. One short question, a screen of blank space beneath it, and its own scrollbar inside a page that already scrolls.

**Embed — worse, and silent.** `EmbedFrame` measures this subtree and posts the height to the host page. With `min-h-screen`, every embedded form has reported **at least a full viewport regardless of content**. An embed was always a screen tall and the resize protocol never did anything useful. That has been true since embeds shipped.

It also means the minimum height I added in #5166 was raising a floor while the ceiling was broken.

**Confirmation screen:** same rule, so submitting inside an embed produced another full-viewport panel.

## The fix

A `layout` prop:

| Value | Where | Behaviour |
| --- | --- | --- |
| `page` (default) | Hosted form `/f/<shareCode>` | `min-h-screen`, unchanged |
| `inline` | Embed, studio preview, landing demo | Natural height |

Default stays `page` so the hosted form cannot change by accident.

With the runtime no longer forcing 100vh, the demo's fixed `max-h-[34rem]` scroller was the remaining problem. It now grows with the question, with a floor so the frame doesn't snap between question heights.

## The tests assert the dimension, not the wiring

That is the gap that let this ship. Everything about the runtime was covered — one question at a time, keyboard, auto-advance, guards — except **how tall it tries to be**, which is the one axis every recent visual bug has failed on.

Verified by restoring the unconditional `min-h-screen` and watching the embedded case fail.

## Verification

- `bun check` — exit 0
- `apps/forms` real `bun run build` — exit 0
- 212 tests pass (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the form runtime from applying `min-h-screen` when it's embedded inside another page, so embedded forms report their natural height instead of always signaling a full viewport to the host.

**Bug Fixes**

- Adds a `layout` prop; `inline` (embeds, studio preview, landing demo) uses natural height while `page` keeps the old `min-h-screen` behavior.
- Grows the landing demo's question box with content instead of scrolling inside a fixed `max-h-[34rem]` container.
- Adds tests asserting the height class, which previously went unverified.

<sup>Written for commit 0ca19aa6fcaf0749d837dd15c2639b30efdbd7f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

