### PR TITLE
perf(vercel): serve every monorepo app from one function region

### DIFF
--- a/apps/ai/vercel.json
+++ b/apps/ai/vercel.json
@@ -3,6 +3,7 @@
   "framework": "nextjs",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/ai-studio",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/apps/vercel.json
+++ b/apps/apps/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/apps",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/calendar/vercel.json
+++ b/apps/calendar/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/calendar",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/chat/vercel.json
+++ b/apps/chat/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/chat",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/cms/vercel.json
+++ b/apps/cms/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/cms",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/contacts/vercel.json
+++ b/apps/contacts/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/contacts",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/docs/build/devops/vercel-cost-controls.mdx
+++ b/apps/docs/build/devops/vercel-cost-controls.mdx
@@ -89,11 +89,55 @@ would add a cross-Pacific round trip to every database call. `sin1` is the
 correct region; the lever is **sending fewer bytes from it**, not relocating it.
 </Note>
 
-The reviewable question is region *count*, not region choice. Projects currently
-list three function regions (for example `platform` uses
-`['sin1', 'iad1', 'fra1']`). Requests routed to `iad1` or `fra1` still reach a
-Singapore database, so the extra regions add cross-ocean latency while spreading
-deployments wider. Single-region `sin1` is usually the better default here.
+The reviewable question is region *count*, not region choice.
+
+Every app that deploys from this repo now pins `"regions": ["sin1"]` in its
+`vercel.json`. Previously most listed three (for example `platform` used
+`['sin1', 'iad1', 'fra1']`), which cost on two fronts:
+
+- **Provisioned memory.** Fluid bills memory per *instance*, and each region
+  keeps its own warm pool. Three regions means up to three pools held warm for
+  the same request volume — close to pure waste for a low-traffic satellite.
+- **Latency.** A request served from `iad1` or `fra1` still reaches a Singapore
+  database, so the extra regions were slower *and* billed.
+
+`teach` is deliberately left on `iad1`: it is already single-region, and moving
+it to `sin1` would raise its origin-transfer rate 4.5x without consolidating
+anything. Consolidate multi-region apps; do not relocate single-region ones.
+
+External client projects — `exocorpse`, `richfield`, `kendra`, `yashie`, `noah`
+and the rest — **keep their three regions on purpose**. The argument for `sin1`
+rests on this platform's database being in `ap-southeast-1`; a client site with
+its own audience and its own backend does not inherit that reasoning.
+
+## Instance Size
+
+`functionDefaultMemoryType` is a project setting with no `vercel.json`
+equivalent, so it is set through the API and recorded here rather than in the
+repo:
+
+```bash
+# PATCH /v9/projects/<name>?teamId=<team>
+{"resourceConfig": {"functionDefaultRegions": ["sin1"],
+                    "functionDefaultMemoryType": "standard"}}
+```
+
+`performance` provisions a larger instance, so it bills more memory-hours for
+the same wall time. **Every project on the team now runs `standard`.** A URL
+shortener sitting on a performance instance was the clearest tell that the tier
+had been set by habit rather than measurement.
+
+Treat `standard` as the default and `performance` as something a project has to
+earn with a measured number — an observed out-of-memory or a profiled CPU
+ceiling — not by analogy with another app that looks busy.
+
+Instance size is independent of region count, and the two were decided
+separately: external client sites were moved to `standard` while **keeping their
+three regions**, because their audiences are not Singapore-centric the way the
+internal dashboards are.
+
+Both settings take effect on the **next deployment**, and both are reversible
+without a code change.
 
 ## Always-On Crons
 

--- a/apps/drive/vercel.json
+++ b/apps/drive/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/drive",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/finance/vercel.json
+++ b/apps/finance/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/finance",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/forms/vercel.json
+++ b/apps/forms/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/forms",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/git/vercel.json
+++ b/apps/git/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/git",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/infrastructure/vercel.json
+++ b/apps/infrastructure/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/infrastructure",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/inventory/vercel.json
+++ b/apps/inventory/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/inventory",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "crons": [
     {
       "path": "/api/cron/inventory/checkout-expiry",

--- a/apps/learn/vercel.json
+++ b/apps/learn/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/learn",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/mail/vercel.json
+++ b/apps/mail/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/mail",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/meet/vercel.json
+++ b/apps/meet/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/meet",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/mind/vercel.json
+++ b/apps/mind/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/mind",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/nova/vercel.json
+++ b/apps/nova/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/nova",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/pay/vercel.json
+++ b/apps/pay/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/pay",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/rewise/vercel.json
+++ b/apps/rewise/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/rewise",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/shortener/vercel.json
+++ b/apps/shortener/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/shortener",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/storefront/vercel.json
+++ b/apps/storefront/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/storefront",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/tasks/vercel.json
+++ b/apps/tasks/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/tasks",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/tools/vercel.json
+++ b/apps/tools/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/tools",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/track/vercel.json
+++ b/apps/track/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/track",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/web",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },


### PR DESCRIPTION
## Why

Follow-up to [#5167](https://github.com/tutur3u/platform/pull/5167). That PR established that essentially the whole Vercel bill is **Fast Origin Transfer + Fluid Active CPU** — the two meters with no free tier — while edge requests sit at 1.8% of the included allowance. This one goes after the structural driver.

**42 of 51 projects were running three function regions.** Fluid bills provisioned memory *per instance*, and each region keeps its own warm pool. Three regions meant up to three pools held warm to serve one region's worth of traffic — close to pure waste for a satellite with a handful of users.

The extra regions weren't buying speed either. Supabase and SES are both `ap-southeast-1`, so a request served from `iad1` or `fra1` still crossed an ocean to reach its data: **slower *and* billed**. Pinning `sin1` puts functions next to the database, and because traffic already landed there, it doesn't move anything onto a worse transfer rate.

## What changes

`"regions": ["sin1"]` in 25 `apps/*/vercel.json`, plus the matching project-level setting via the API so the dashboard reflects the repo instead of drifting from it.

**Instance size** has no `vercel.json` equivalent, so it's applied through the API and written into the runbook rather than left as invisible dashboard state. Every project now runs `standard` rather than `performance`, which provisions a larger instance and bills more memory-hours for the same wall time. A URL shortener on a performance instance was the clearest sign the tier had been set by habit rather than measurement.

## What is deliberately excluded

- **`teach`** keeps `iad1`. It's already single-region, so moving it would raise its origin transfer 4.5x while consolidating nothing. Relocating a single-region app and consolidating a multi-region one are different operations, and only the second saves money.
- **External client projects** (`exocorpse`, `richfield`, `kendra`, `yashie`, `noah`, the `pktm-*` six) keep their three regions. The case for `sin1` rests on *this* platform's database being in `ap-southeast-1`; a client site with its own audience and backend doesn't inherit that reasoning. They were moved to `standard` instance size, which is independent of region count.
- The `pktm-*` projects deploy from `tutur3u/pktm`, so this repo's `vercel.json` files don't reach them at all.

## Verification

- `bun check` — clean (exit 0)
- All 25 `vercel.json` re-parsed as valid JSON; `biome check` clean
- Re-queried all 51 projects after the change: the only remaining multi-region projects are the intentionally-excluded external ones, and nothing is left on `performance`

## Risk

Both settings take effect on the **next deployment** and revert without a code change (`PATCH` the same field back).

Users far from Singapore lose the nearby edge *function* region. Static assets still serve from the global CDN, so this only affects dynamic responses — and those already round-tripped to a Singapore database, so the regions being removed were never actually fast for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates every monorepo app onto the single `sin1` function region, replacing the three regions most apps previously used. This cuts provisioned-memory waste — Fluid bills per instance per region — and removes cross-ocean latency, since requests already round-trip to a Singapore database.

**Changes**
- Adds `"regions": ["sin1"]` to 25 `apps/*/vercel.json`.
- Documents cost controls and instance sizing in the devops runbook.
- Moves all projects to the `standard` instance via the API; the setting has no `vercel.json` equivalent, so it is recorded in the runbook instead.

**Exclusions**
- `teach` stays on `iad1`; it was already single-region, so moving would raise origin transfer 4.5x without consolidating anything.
- External client projects (`exocorpse`, `richfield`, `kendra`, `yashie`, `noah`, and the `pktm-*` set) keep their three regions since their backends aren't Singapore-based, but they also move to `standard`.
- Both settings take effect on the next deployment and revert with a single `PATCH` — no code change needed.

<sup>Written for commit 4f0bf52450899267b4ac9cd2bdecfcf07e3ea427. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

