### PR TITLE
perf(vercel): pin teach to sin1 and correct the region policy

### DIFF
--- a/apps/docs/build/devops/vercel-cost-controls.mdx
+++ b/apps/docs/build/devops/vercel-cost-controls.mdx
@@ -91,8 +91,9 @@ correct region; the lever is **sending fewer bytes from it**, not relocating it.
 
 The reviewable question is region *count*, not region choice.
 
-Every app that deploys from this repo now pins `"regions": ["sin1"]` in its
-`vercel.json`. Previously most listed three (for example `platform` used
+Every app that deploys from this repo pins `"regions": ["sin1"]` in its
+`vercel.json`, and every other project on the team is set to `sin1` through the
+API. Previously most listed three (for example `platform` used
 `['sin1', 'iad1', 'fra1']`), which cost on two fronts:
 
 - **Provisioned memory.** Fluid bills memory per *instance*, and each region
@@ -101,14 +102,17 @@ Every app that deploys from this repo now pins `"regions": ["sin1"]` in its
 - **Latency.** A request served from `iad1` or `fra1` still reaches a Singapore
   database, so the extra regions were slower *and* billed.
 
-`teach` is deliberately left on `iad1`: it is already single-region, and moving
-it to `sin1` would raise its origin-transfer rate 4.5x without consolidating
-anything. Consolidate multi-region apps; do not relocate single-region ones.
+**Exactly four projects keep three regions: `exocorpse`, `richfield`, `kendra`,
+and `yashie`.** These are client sites with their own audiences and their own
+backends, so the `sin1` argument — which rests on *this* platform's database
+being in `ap-southeast-1` — does not apply to them. Everything else on the team
+is single-region `sin1`, including projects that were previously single-region on
+`iad1`.
 
-External client projects — `exocorpse`, `richfield`, `kendra`, `yashie`, `noah`
-and the rest — **keep their three regions on purpose**. The argument for `sin1`
-rests on this platform's database being in `ap-southeast-1`; a client site with
-its own audience and its own backend does not inherit that reasoning.
+Moving an already-single-region project from `iad1` to `sin1` does raise its
+origin-transfer rate ($0.06 -> $0.27/GB), so it is not a saving on its own; it is
+chosen for latency and for having one predictable region across the fleet.
+Consolidation is where the money is; relocation is a consistency call.
 
 ## Instance Size
 

--- a/apps/teach/vercel.json
+++ b/apps/teach/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && bun turbo:local run build --filter=@tuturuuu/teach",
   "installCommand": "cd ../.. && bun install --frozen-lockfile --minimum-release-age=0",
+  "regions": ["sin1"],
   "git": {
     "deploymentEnabled": false
   },


### PR DESCRIPTION
## Why

Follow-up to [#5172](https://github.com/tutur3u/platform/pull/5172), closing the two gaps it left.

**`teach` was the one app still on `iad1`.** #5172 skipped it on the reasoning that moving an already-single-region project doesn't consolidate anything — which is true, but one predictable region across the fleet is worth more than the rate difference on a single low-traffic app.

**The runbook was wrong about the exclusions.** It said external client projects keep three regions *as a class*. They don't. Exactly four do — `exocorpse`, `richfield`, `kendra`, `yashie` — because those have their own audiences and their own backends, so the `sin1` argument (which rests on *this* platform's database being in `ap-southeast-1`) doesn't apply to them. Every other project on the team is now single-region `sin1`.

## Final state across all 51 projects

| | Regions | Instance size |
|---|---|---|
| `exocorpse`, `richfield`, `kendra`, `yashie` | 3 regions | `standard` |
| Everything else (47) | `sin1` | `standard` |

Nothing is left on `performance`.

## An honest correction recorded in the runbook

`iad1` → `sin1` **raises** origin transfer from $0.06 to $0.27/GB. So relocating a single-region app is a consistency and latency call, not a saving — consolidating a multi-region app is where the money actually is. Those two moves look alike and the runbook now says so explicitly, to stop a future reader citing this change as a cost win.

## Verification

- `apps/teach/vercel.json` re-parsed as valid JSON; `biome check` clean
- Re-queried all 51 projects after the API sweep: exactly four multi-region, zero on `performance`, no deviations from spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `teach` app to `sin1` and corrects the Vercel cost runbook's region policy. `teach` was the last app on `iad1`; it now joins the rest as single-region. The docs now correctly state that exactly four client projects (`exocorpse`, `richfield`, `kendra`, `yashie`) keep three regions, and that relocating a single-region app raises origin-transfer cost ($0.06 → $0.27/GB) — a consistency and latency call, not a saving.

<sup>Written for commit c8a2d633df56173b284fe1f87f888d0cf2a9d106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

