### PR TITLE
fix(turnstile): support trusted server relays

### DIFF
--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.test.ts
@@ -289,7 +289,7 @@ describe('POST submission Turnstile gate', () => {
     expect(mocks.verifyTurnstileToken).toHaveBeenCalledWith(
       expect.anything(),
       'token-abc',
-      { secretKey: 'secret-key' }
+      { includeRemoteIp: false, secretKey: 'secret-key' }
     );
     expect(mocks.createWorkspaceExternalProjectEntry).toHaveBeenCalled();
     delete process.env.TURNSTILE_SECRET_KEY;
@@ -310,7 +310,7 @@ describe('POST submission Turnstile gate', () => {
     expect(mocks.verifyTurnstileToken).toHaveBeenCalledWith(
       expect.anything(),
       'token-abc',
-      { secretKey: 'richfield-secret' }
+      { includeRemoteIp: false, secretKey: 'richfield-secret' }
     );
   });
 });

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.ts
@@ -60,7 +60,15 @@ async function verifySubmissionTurnstile(
   }
 
   try {
-    await verifyTurnstileToken(request, token, { secretKey });
+    // This request is relayed by the authenticated external app's server, so
+    // its forwarding headers describe the relay rather than the browser that
+    // completed the challenge. Cloudflare treats remoteip as optional; omit it
+    // here and verify the signed token itself instead of binding it to the
+    // wrong machine.
+    await verifyTurnstileToken(request, token, {
+      includeRemoteIp: false,
+      secretKey,
+    });
     return null;
   } catch (error) {
     if (isTurnstileError(error)) {

--- a/packages/turnstile/src/server.test.ts
+++ b/packages/turnstile/src/server.test.ts
@@ -111,6 +111,31 @@ describe('verifyTurnstileToken', () => {
     expect((init.body as URLSearchParams).get('remoteip')).toBe('203.0.113.15');
   });
 
+  it('omits the remote ip for trusted server-to-server relays', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    await verifyTurnstileToken(
+      {
+        headers: new Headers({
+          'x-forwarded-for': '198.51.100.20',
+        }),
+      },
+      'captcha-token',
+      {
+        devMode: false,
+        fetch: fetchMock,
+        includeRemoteIp: false,
+        secretKey: 'secret-key',
+      }
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.body as URLSearchParams).has('remoteip')).toBe(false);
+  });
+
   it('throws a typed error when verification fails', async () => {
     try {
       await verifyTurnstileToken({ headers: new Headers() }, 'captcha-token', {

--- a/packages/turnstile/src/server.ts
+++ b/packages/turnstile/src/server.ts
@@ -111,6 +111,7 @@ export interface VerifyTurnstileTokenOptions {
   devMode?: boolean;
   secretKey?: string | null;
   remoteIp?: string | null;
+  includeRemoteIp?: boolean;
   fetch?: typeof fetch;
   timeoutMs?: number;
 }
@@ -139,7 +140,10 @@ export async function verifyTurnstileToken(
   }
 
   const remoteIp =
-    normalizeEnvValue(options.remoteIp) ?? extractTurnstileRemoteIp(request);
+    options.includeRemoteIp === false
+      ? undefined
+      : (normalizeEnvValue(options.remoteIp) ??
+        extractTurnstileRemoteIp(request));
   const body = new URLSearchParams({
     secret: secretKey,
     response: normalizedToken,


### PR DESCRIPTION
## Description
Fix Richfield contact submissions that are relayed from the satellite server to Tuturuuu. Cloudflare Turnstile tokens were being verified against the relay server IP rather than the visitor context, so the email could send while inbox persistence returned 403.

## What?
- add an opt-out for forwarding remote IP during Turnstile verification
- use it only for authenticated external-project submission relays
- preserve existing client-IP verification by default
- add focused verifier and route coverage

## Why?
Cloudflare treats remoteip as optional. For a trusted server relay, Tuturuuu cannot reliably recover the original browser IP from the second request, so sending the relay IP creates a false mismatch.

## How?
The shared verifier accepts includeRemoteIp: false. The Richfield external-project route sets that option after app-secret and workspace-binding authorization.

## Validation
- 19 focused tests passed
- @tuturuuu/turnstile and @tuturuuu/web type-check passed
- Screenshots: N/A (server-side API behavior; production browser verification follows after deployment)