### PR TITLE
fix(external-projects): cap submission slugs

### DIFF
--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.test.ts
@@ -295,6 +295,25 @@ describe('POST submission Turnstile gate', () => {
     delete process.env.TURNSTILE_SECRET_KEY;
   });
 
+  it('keeps generated submission slugs within the database limit', async () => {
+    const { POST } = await import('./route');
+
+    const response = await POST(
+      postRequest({
+        ...body,
+        company: 'Richfield Group QA '.repeat(7),
+        name: 'Production delivery verification '.repeat(4),
+      }),
+      params
+    );
+
+    expect(response.status).toBe(201);
+    const [entry] = mocks.createWorkspaceExternalProjectEntry.mock.calls[0] as [
+      { slug: string },
+    ];
+    expect(entry.slug).toHaveLength(80);
+  });
+
   it('uses the Richfield-specific secret without changing other apps', async () => {
     process.env.TURNSTILE_SECRET_KEY = 'global-secret';
     process.env.TURNSTILE_SECRET_KEY_RICHFIELD = 'richfield-secret';

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.ts
@@ -13,6 +13,10 @@ import {
 import { createWorkspaceExternalProjectEntry } from '@/lib/external-projects/store';
 
 const CONTACT_SUBMISSIONS_COLLECTION_SLUG = 'contact-submissions';
+const ENTRY_SLUG_MAX_LENGTH = 80;
+const SUBMISSION_SLUG_SUFFIX_LENGTH = 8;
+const SUBMISSION_SLUG_BASE_MAX_LENGTH =
+  ENTRY_SLUG_MAX_LENGTH - SUBMISSION_SLUG_SUFFIX_LENGTH - 1;
 
 const submissionSchema = z.object({
   appId: z.string().trim().toLowerCase().default('richfield'),
@@ -201,7 +205,7 @@ function slugifySubmission(value: string) {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .slice(0, 80);
+    .slice(0, SUBMISSION_SLUG_BASE_MAX_LENGTH);
 }
 
 const EMAIL_NOTIFICATION_STATUSES = ['pending', 'sent', 'failed'] as const;


### PR DESCRIPTION
## Description
Prevent Richfield contact submissions from exceeding the platform's 80-character entry slug limit.

## What?
Reserve space for the hyphen and 8-character unique suffix before truncating the generated slug base.

## Why?
The previous code truncated the base to 80 characters and then appended 9 more, causing production persistence to fail with TEXT_FIELD_LENGTH_EXCEEDED while the email still sent.

## How?
Define the database limit and suffix length explicitly, derive a 71-character maximum base, and add a regression test that exercises long valid form values and asserts an 80-character final slug.

## Validation
- submission route tests: 11/11 passed
- @tuturuuu/web type-check: 43/43 tasks passed
- Screenshots: N/A (server-side persistence constraint)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes external-project submission slug generation so slugs never exceed the 80-character database limit. Previously, the base was truncated to 80 characters before appending a 9-character suffix, causing persistence to fail while the email still sent.

- Reserves space for the 8-character suffix and hyphen, truncating the base to 71 characters.
- Adds a regression test that forces long input values and asserts the final slug is exactly 80 characters.

<sup>Written for commit 557684b8cb833f761108cb2aceb827913f5cf8fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

