### PR TITLE
fix(external-projects): preserve long submission messages

### DIFF
--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.test.ts
@@ -314,6 +314,20 @@ describe('POST submission Turnstile gate', () => {
     expect(entry.slug).toHaveLength(80);
   });
 
+  it('stores a bounded summary without losing the full submission message', async () => {
+    const { POST } = await import('./route');
+    const message = '🌱 Long-form distribution enquiry. '.repeat(140);
+
+    const response = await POST(postRequest({ ...body, message }), params);
+
+    expect(response.status).toBe(201);
+    const [entry] = mocks.createWorkspaceExternalProjectEntry.mock.calls[0] as [
+      { profile_data: { message: string }; summary: string },
+    ];
+    expect(Array.from(entry.summary)).toHaveLength(512);
+    expect(entry.profile_data.message).toBe(message.trim());
+  });
+
   it('uses the Richfield-specific secret without changing other apps', async () => {
     process.env.TURNSTILE_SECRET_KEY = 'global-secret';
     process.env.TURNSTILE_SECRET_KEY_RICHFIELD = 'richfield-secret';

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/external-projects/submissions/route.ts
@@ -14,6 +14,7 @@ import { createWorkspaceExternalProjectEntry } from '@/lib/external-projects/sto
 
 const CONTACT_SUBMISSIONS_COLLECTION_SLUG = 'contact-submissions';
 const ENTRY_SLUG_MAX_LENGTH = 80;
+const ENTRY_SUMMARY_MAX_LENGTH = 512;
 const SUBMISSION_SLUG_SUFFIX_LENGTH = 8;
 const SUBMISSION_SLUG_BASE_MAX_LENGTH =
   ENTRY_SLUG_MAX_LENGTH - SUBMISSION_SLUG_SUFFIX_LENGTH - 1;
@@ -208,6 +209,10 @@ function slugifySubmission(value: string) {
     .slice(0, SUBMISSION_SLUG_BASE_MAX_LENGTH);
 }
 
+function summarizeSubmissionMessage(message: string) {
+  return Array.from(message).slice(0, ENTRY_SUMMARY_MAX_LENGTH).join('');
+}
+
 const EMAIL_NOTIFICATION_STATUSES = ['pending', 'sent', 'failed'] as const;
 const DEFAULT_SUBMISSION_PAGE_SIZE = 50;
 const MAX_SUBMISSION_PAGE_SIZE = 200;
@@ -345,6 +350,7 @@ export async function POST(
           email: payload.email,
           emailNotificationStatus: 'pending',
           inquiryType: payload.inquiryType,
+          message: payload.message,
           name: payload.name,
           receivedAt,
           submissionStatus: 'new',
@@ -353,7 +359,7 @@ export async function POST(
         slug,
         status: 'draft',
         subtitle: payload.email,
-        summary: payload.message,
+        summary: summarizeSubmissionMessage(payload.message),
         title: `${payload.company} - ${payload.name}`,
         workspaceId: wsId,
       },


### PR DESCRIPTION
## Summary
- bound external submission summaries to the database field limit
- retain the complete contact message in profile data
- cover long Unicode enquiry messages with a regression test

## Validation
- focused Vitest suite: 12 passed
- Biome check: passed
- apps/web type-check: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes external project submission messages so long contact messages no longer get cut off in the entry summary. The summary is now capped at 512 characters, and the full message is kept in the entry's profile data. Adds a regression test for long Unicode messages.

<sup>Written for commit 8c4c8c11999bac8f4bd69a3afc63f2e893c8e662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

