### PR TITLE
fix(contacts): hide superseded attendance sessions

### DIFF
--- a/packages/users-ui/src/components/group-attendance-utils.test.ts
+++ b/packages/users-ui/src/components/group-attendance-utils.test.ts
@@ -83,6 +83,41 @@ describe('group attendance state helpers', () => {
     ).toEqual(['past-cancelled', 'today-cancelled', 'future-scheduled']);
   });
 
+  it('keeps superseded cancellations hidden after their calendar date passes', () => {
+    const superseded = session(
+      'superseded-cancelled',
+      '2026-08-30T10:30:00.000Z',
+      'cancelled'
+    );
+    superseded.recurrence = {
+      daysOfWeek: [0, 6],
+      intervalWeeks: 1,
+      startDate: '2026-07-01',
+      untilDate: '2026-08-21',
+    };
+    superseded.recurrenceInstanceDate = '2026-08-30';
+
+    const historical = session(
+      'historical-cancelled',
+      '2026-08-20T10:30:00.000Z',
+      'cancelled'
+    );
+    historical.recurrence = {
+      daysOfWeek: [4],
+      intervalWeeks: 1,
+      startDate: '2026-07-01',
+      untilDate: '2026-08-21',
+    };
+    historical.recurrenceInstanceDate = '2026-08-20';
+
+    expect(
+      filterAttendanceSessions(
+        [superseded, historical],
+        new Date('2026-08-30T12:00:00.000Z')
+      ).map(({ id }) => id)
+    ).toEqual(['historical-cancelled']);
+  });
+
   it('uses each session timezone when deciding whether a cancellation is historical', () => {
     const asOf = new Date('2026-08-20T00:30:00.000Z');
     const sessions = [

--- a/packages/users-ui/src/components/group-attendance-utils.tsx
+++ b/packages/users-ui/src/components/group-attendance-utils.tsx
@@ -65,8 +65,9 @@ export function sessionAttendanceDate(session: WorkspaceUserGroupSession) {
 
 /**
  * Cancelled sessions remain useful as immutable attendance history once their
- * local date arrives. Future cancellations, however, are obsolete occurrences
- * left behind by a schedule change and must not appear as upcoming classes.
+ * local date arrives. Future cancellations and occurrences beyond their
+ * recurrence end are obsolete rows left behind by a schedule change and must
+ * not appear as attendance classes.
  */
 export function filterAttendanceSessions(
   sessions: WorkspaceUserGroupSession[],
@@ -74,6 +75,16 @@ export function filterAttendanceSessions(
 ) {
   return sessions.filter((session) => {
     if (session.status !== 'cancelled') return true;
+
+    const recurrenceUntilDate = session.recurrence?.untilDate;
+    if (
+      recurrenceUntilDate &&
+      session.recurrenceInstanceDate &&
+      session.recurrenceInstanceDate > recurrenceUntilDate
+    ) {
+      return false;
+    }
+
     const timezone = session.startTimezone || DEFAULT_ATTENDANCE_TIMEZONE;
     return sessionAttendanceDate(session) <= localIsoDate(asOf, timezone);
   });


### PR DESCRIPTION
# Description

## What?

- hide cancelled attendance occurrences that fall beyond their recurrence series end
- keep valid historical cancelled sessions visible for read-only attendance history
- cover the Easy Center production regression with a live-shaped unit test

## Why?

A prior filter hid superseded cancellations only while their date was in the future. Once the occurrence date arrived, stale rows from an ended recurring series reappeared, were selected as cancelled, and disabled every attendance control.

The affected production occurrence had a recurrence end of `2026-08-21` but an occurrence date of `2026-08-30`.

## How?

The attendance-session filter now permanently excludes cancelled recurrence occurrences whose instance date falls after the recurrence end date. Valid historical cancellations inside the recurrence range remain visible as immutable history.

## Validation

- `bun vitest run src/components/group-attendance-utils.test.ts` in `packages/users-ui`: 8/8 passed
- `bun run type-check` in `packages/users-ui`: passed
- `bun check`: passed all gates (rerun with loopback permission required by request-tracker tests)
- authenticated production reproduction confirmed the stale beyond-series occurrence and the active replacement series

## Screenshots for proof (must have)

The authenticated reproduction screenshot contains customer workspace data and is intentionally not attached to this public PR. It is preserved in the private recipient PDF requested for this incident. The post-deployment screenshot will be captured from the canonical Contacts host after this PR is merged and the exact SHA reaches production; attaching an “after” image before that point would not be valid production evidence.

## Local build note

Contacts Turbopack compilation was blocked by the managed environment denying its PostCSS helper an internal port. The exact-SHA GitHub/Vercel build remains the release gate.
