### PR TITLE
fix(infrastructure): authorize blocked IP management

### DIFF
--- a/apps/infrastructure/src/app/api/v1/infrastructure/blocked-ips/route.test.ts
+++ b/apps/infrastructure/src/app/api/v1/infrastructure/blocked-ips/route.test.ts
@@ -1,23 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  createAdminClient: vi.fn(),
-  createClient: vi.fn(),
+  authorize: vi.fn(),
+  connection: vi.fn(),
   from: vi.fn(),
   getUpstashRestRedisClient: vi.fn(),
-  resolveAuthenticatedSessionUser: vi.fn(),
-  serverLoggerError: vi.fn(),
+  redisSet: vi.fn(),
   unblockIP: vi.fn(),
 }));
 
-vi.mock('@tuturuuu/supabase/next/auth-session-user', () => ({
-  resolveAuthenticatedSessionUser: (...args: unknown[]) =>
-    mocks.resolveAuthenticatedSessionUser(...args),
+vi.mock('@/lib/infrastructure-admin-access', () => ({
+  authorizeInfrastructureAdminRequest: (...args: unknown[]) =>
+    mocks.authorize(...args),
 }));
 
-vi.mock('@tuturuuu/supabase/next/server', () => ({
-  createAdminClient: (...args: unknown[]) => mocks.createAdminClient(...args),
-  createClient: (...args: unknown[]) => mocks.createClient(...args),
+vi.mock('next/server', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('next/server')>()),
+  connection: (...args: unknown[]) => mocks.connection(...args),
 }));
 
 vi.mock('@tuturuuu/utils/abuse-protection', () => ({
@@ -42,115 +41,316 @@ vi.mock('@tuturuuu/utils/upstash-rest', () => ({
     mocks.getUpstashRestRedisClient(...args),
 }));
 
-vi.mock('@/lib/infrastructure/log-drain', () => ({
-  serverLogger: {
-    error: (...args: unknown[]) => mocks.serverLoggerError(...args),
-  },
-}));
+import { DELETE, GET, POST } from './route';
 
-import { DELETE } from './route';
+const USER_ID = '42529372-c669-4833-bb32-2cab1f4ffd83';
 
-function makeDeleteRequest(body: unknown) {
-  return new Request('http://localhost/api/v1/infrastructure/blocked-ips', {
-    body: JSON.stringify(body),
-    method: 'DELETE',
+function createRequest(method: string, body?: unknown, query = '') {
+  return new Request(
+    `https://infrastructure.example/api/v1/infrastructure/blocked-ips${query}`,
+    {
+      body: body === undefined ? undefined : JSON.stringify(body),
+      method,
+    }
+  );
+}
+
+function authorize() {
+  mocks.authorize.mockResolvedValue({
+    ok: true,
+    sbAdmin: { from: mocks.from },
+    user: { id: USER_ID },
   });
 }
 
-function mockRootWorkspaceMembership(data: unknown) {
-  const single = vi.fn().mockResolvedValue({ data, error: null });
-  const secondEq = vi.fn(() => ({ single }));
-  const firstEq = vi.fn(() => ({ eq: secondEq }));
-  const select = vi.fn(() => ({ eq: firstEq }));
-
-  mocks.from.mockReturnValue({ select });
-
-  return {
-    firstEq,
-    secondEq,
-    select,
-    single,
-  };
+function deny(status: 401 | 403) {
+  mocks.authorize.mockResolvedValue({
+    ok: false,
+    response: Response.json(
+      { error: status === 401 ? 'Unauthorized' : 'Forbidden' },
+      { status }
+    ),
+  });
 }
+
+type GetQueryResult = {
+  count: number | null;
+  data: Array<{ id: string }> | null;
+  error: { message: string } | null;
+};
+
+function mockGetQuery(
+  result: GetQueryResult = {
+    count: 1,
+    data: [{ id: 'block-1' }],
+    error: null,
+  }
+) {
+  const query = {
+    eq: vi.fn(() => query),
+    ilike: vi.fn(() => query),
+    order: vi.fn(() => query),
+    range: vi.fn(() => Promise.resolve(result)),
+    select: vi.fn(() => query),
+  };
+  mocks.from.mockReturnValue(query);
+  return query;
+}
+
+function mockPostQueries(options?: {
+  existingBlock?: unknown;
+  insertError?: unknown;
+}) {
+  const existingSingle = vi.fn().mockResolvedValue({
+    data: options?.existingBlock ?? null,
+    error: null,
+  });
+  const existingSecondEq = vi.fn(() => ({ single: existingSingle }));
+  const existingFirstEq = vi.fn(() => ({ eq: existingSecondEq }));
+  const existingSelect = vi.fn(() => ({ eq: existingFirstEq }));
+
+  const insertedRecord = { id: 'block-1', ip_address: '203.0.113.10' };
+  const insertSingle = vi.fn().mockResolvedValue({
+    data: insertedRecord,
+    error: options?.insertError ?? null,
+  });
+  const insertSelect = vi.fn(() => ({ single: insertSingle }));
+  const insert = vi.fn(() => ({ select: insertSelect }));
+
+  mocks.from.mockReturnValue({ insert, select: existingSelect });
+  return { insert, insertedRecord };
+}
+
+describe('blocked IP authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUpstashRestRedisClient.mockResolvedValue({ set: mocks.redisSet });
+    mocks.redisSet.mockResolvedValue('OK');
+    mocks.unblockIP.mockResolvedValue(true);
+  });
+
+  for (const status of [401, 403] as const) {
+    it(`denies GET with ${status} before querying the denylist`, async () => {
+      deny(status);
+
+      const response = await GET(createRequest('GET'));
+
+      expect(response.status).toBe(status);
+      expect(mocks.authorize).toHaveBeenCalledWith('view_infrastructure');
+      expect(mocks.from).not.toHaveBeenCalled();
+      expect(mocks.getUpstashRestRedisClient).not.toHaveBeenCalled();
+    });
+
+    it(`denies POST with ${status} before parsing or writing`, async () => {
+      deny(status);
+
+      const response = await POST(createRequest('POST', { invalid: true }));
+
+      expect(response.status).toBe(status);
+      expect(mocks.authorize).toHaveBeenCalledWith('view_infrastructure');
+      expect(mocks.from).not.toHaveBeenCalled();
+      expect(mocks.getUpstashRestRedisClient).not.toHaveBeenCalled();
+    });
+
+    it(`denies DELETE with ${status} before unblocking`, async () => {
+      deny(status);
+
+      const response = await DELETE(
+        createRequest('DELETE', { ip_address: '203.0.113.10' })
+      );
+
+      expect(response.status).toBe(status);
+      expect(mocks.authorize).toHaveBeenCalledWith('view_infrastructure');
+      expect(mocks.unblockIP).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe('blocked IP route GET', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+  });
+
+  it('uses the authorized admin client for filtered pagination', async () => {
+    const query = mockGetQuery();
+
+    const response = await GET(
+      createRequest(
+        'GET',
+        undefined,
+        '?status=active&page=2&pageSize=10&ip=203'
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.from).toHaveBeenCalledWith('blocked_ips');
+    expect(query.eq).toHaveBeenCalledWith('status', 'active');
+    expect(query.ilike).toHaveBeenCalledWith('ip_address', '%203%');
+    expect(query.range).toHaveBeenCalledWith(10, 19);
+    await expect(response.json()).resolves.toMatchObject({
+      count: 1,
+      page: 2,
+      pageSize: 10,
+    });
+  });
+
+  it('returns a sanitized database error', async () => {
+    mockGetQuery({
+      count: null,
+      data: null,
+      error: { message: 'private detail' },
+    });
+
+    const response = await GET(createRequest('GET'));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Error fetching blocked IPs',
+    });
+  });
+});
+
+describe('blocked IP route POST', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorize();
+    mocks.getUpstashRestRedisClient.mockResolvedValue({ set: mocks.redisSet });
+    mocks.redisSet.mockResolvedValue('OK');
+  });
+
+  it.each([
+    { blockLevel: 1, expectedSeconds: 300 },
+    { blockLevel: 0, expectedSeconds: 100 * 365 * 24 * 60 * 60 },
+  ])(
+    'preserves block duration semantics for level $blockLevel',
+    async ({ blockLevel, expectedSeconds }) => {
+      const { insert, insertedRecord } = mockPostQueries();
+      const now = Date.now();
+      const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      const response = await POST(
+        createRequest('POST', {
+          block_level: blockLevel,
+          ip_address: '203.0.113.10',
+          notes: 'Confirmed abuse',
+          reason: 'manual',
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          block_level: blockLevel,
+          expires_at: new Date(now + expectedSeconds * 1000).toISOString(),
+          metadata: {
+            blocked_by: USER_ID,
+            manual: true,
+            notes: 'Confirmed abuse',
+          },
+        })
+      );
+      expect(mocks.redisSet).toHaveBeenCalledTimes(2);
+      await expect(response.json()).resolves.toEqual({
+        data: insertedRecord,
+        message: 'IP blocked successfully',
+      });
+      dateNow.mockRestore();
+    }
+  );
+
+  it('rejects malformed input without database or Redis work', async () => {
+    const response = await POST(createRequest('POST', { block_level: 9 }));
+
+    expect(response.status).toBe(400);
+    expect(mocks.from).not.toHaveBeenCalled();
+    expect(mocks.getUpstashRestRedisClient).not.toHaveBeenCalled();
+  });
+
+  it('does not insert or cache an already blocked IP', async () => {
+    const { insert } = mockPostQueries({ existingBlock: { id: 'existing' } });
+
+    const response = await POST(
+      createRequest('POST', {
+        block_level: 2,
+        ip_address: '203.0.113.10',
+        reason: 'manual',
+      })
+    );
+
+    expect(response.status).toBe(409);
+    expect(insert).not.toHaveBeenCalled();
+    expect(mocks.getUpstashRestRedisClient).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when the denylist insert fails', async () => {
+    mockPostQueries({ insertError: { message: 'insert failed' } });
+
+    const response = await POST(
+      createRequest('POST', {
+        block_level: 2,
+        ip_address: '203.0.113.10',
+        reason: 'manual',
+      })
+    );
+
+    expect(response.status).toBe(500);
+    expect(mocks.getUpstashRestRedisClient).not.toHaveBeenCalled();
+  });
+
+  it('keeps the database write successful when Redis is unavailable', async () => {
+    mockPostQueries();
+    mocks.getUpstashRestRedisClient.mockRejectedValue(new Error('redis down'));
+
+    const response = await POST(
+      createRequest('POST', {
+        block_level: 2,
+        ip_address: '203.0.113.10',
+        reason: 'manual',
+      })
+    );
+
+    expect(response.status).toBe(200);
+  });
+});
 
 describe('blocked IP route DELETE', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.createClient.mockResolvedValue({ from: mocks.from });
+    authorize();
     mocks.unblockIP.mockResolvedValue(true);
   });
 
-  it('allows exact @tuturuuu.com users to unblock an IP without root membership lookup', async () => {
-    mocks.resolveAuthenticatedSessionUser.mockResolvedValue({
-      user: {
-        email: 'ops@tuturuuu.com',
-        id: 'staff-1',
-      },
-    });
-    mockRootWorkspaceMembership(null);
-
+  it('unblocks with the authorized app-session actor', async () => {
     const response = await DELETE(
-      makeDeleteRequest({
+      createRequest('DELETE', {
         ip_address: '203.0.113.10',
-        reason: 'False-positive diagnostics clear',
+        reason: 'False positive',
       })
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.from).not.toHaveBeenCalled();
     expect(mocks.unblockIP).toHaveBeenCalledWith(
       '203.0.113.10',
-      'staff-1',
-      'False-positive diagnostics clear'
+      USER_ID,
+      'False positive'
     );
   });
 
-  it('allows non-staff root workspace users to unblock an IP', async () => {
-    mocks.resolveAuthenticatedSessionUser.mockResolvedValue({
-      user: {
-        email: 'admin@example.com',
-        id: 'admin-1',
-      },
-    });
-    const membershipQuery = mockRootWorkspaceMembership({
-      platform_user_id: 'admin-1',
-    });
+  it('rejects malformed input before unblocking', async () => {
+    const response = await DELETE(createRequest('DELETE', {}));
 
-    const response = await DELETE(
-      makeDeleteRequest({
-        ip_address: '203.0.113.10',
-      })
-    );
-
-    expect(response.status).toBe(200);
-    expect(mocks.from).toHaveBeenCalledWith('workspace_user_linked_users');
-    expect(membershipQuery.secondEq).toHaveBeenCalledWith(
-      'ws_id',
-      '00000000-0000-0000-0000-000000000000'
-    );
-    expect(mocks.unblockIP).toHaveBeenCalledWith(
-      '203.0.113.10',
-      'admin-1',
-      undefined
-    );
-  });
-
-  it('rejects non-staff users without root workspace membership', async () => {
-    mocks.resolveAuthenticatedSessionUser.mockResolvedValue({
-      user: {
-        email: 'member@example.com',
-        id: 'member-1',
-      },
-    });
-    mockRootWorkspaceMembership(null);
-
-    const response = await DELETE(
-      makeDeleteRequest({
-        ip_address: '203.0.113.10',
-      })
-    );
-
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(400);
     expect(mocks.unblockIP).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when the unblock helper fails', async () => {
+    mocks.unblockIP.mockResolvedValue(false);
+
+    const response = await DELETE(
+      createRequest('DELETE', { ip_address: '203.0.113.10' })
+    );
+
+    expect(response.status).toBe(500);
   });
 });

--- a/apps/infrastructure/src/app/api/v1/infrastructure/blocked-ips/route.ts
+++ b/apps/infrastructure/src/app/api/v1/infrastructure/blocked-ips/route.ts
@@ -1,9 +1,3 @@
-import { resolveAuthenticatedSessionUser } from '@tuturuuu/supabase/next/auth-session-user';
-import {
-  createAdminClient,
-  createClient,
-} from '@tuturuuu/supabase/next/server';
-import type { TypedSupabaseClient } from '@tuturuuu/supabase/types';
 import type { IPBlockStatus } from '@tuturuuu/utils/abuse-protection';
 import {
   BLOCK_DURATIONS,
@@ -11,15 +5,11 @@ import {
   unblockIP,
   WINDOW_MS,
 } from '@tuturuuu/utils/abuse-protection';
-import {
-  MAX_IP_LENGTH,
-  MAX_SEARCH_LENGTH,
-  ROOT_WORKSPACE_ID,
-} from '@tuturuuu/utils/constants';
-import { isExactTuturuuuDotComEmail } from '@tuturuuu/utils/email/client';
+import { MAX_IP_LENGTH, MAX_SEARCH_LENGTH } from '@tuturuuu/utils/constants';
 import { getUpstashRestRedisClient } from '@tuturuuu/utils/upstash-rest';
 import { connection, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { authorizeInfrastructureAdminRequest } from '@/lib/infrastructure-admin-access';
 
 const UnblockSchema = z.object({
   ip_address: z.string().max(MAX_IP_LENGTH).min(1),
@@ -45,59 +35,11 @@ const BlockIPSchema = z.object({
 // 100 years in seconds for permanent blocks
 const PERMANENT_BLOCK_DURATION = 100 * 365 * 24 * 60 * 60;
 
-type AuthenticatedBlockedIpUser = {
-  email?: string | null;
-  id: string;
-};
-
-async function hasRootWorkspaceMembership(
-  supabase: TypedSupabaseClient,
-  userId: string
-) {
-  const { data: rootWorkspaceUser } = await supabase
-    .from('workspace_user_linked_users')
-    .select('platform_user_id')
-    .eq('platform_user_id', userId)
-    .eq('ws_id', ROOT_WORKSPACE_ID)
-    .single();
-
-  return Boolean(rootWorkspaceUser);
-}
-
-async function canDeleteBlockedIp(
-  supabase: TypedSupabaseClient,
-  user: AuthenticatedBlockedIpUser
-) {
-  if (isExactTuturuuuDotComEmail(user.email)) {
-    return true;
-  }
-
-  return hasRootWorkspaceMembership(supabase, user.id);
-}
-
 export async function GET(req: Request) {
   await connection();
 
-  const supabase = await createClient();
-
-  // Check if user is authenticated
-  const { user } = await resolveAuthenticatedSessionUser(supabase);
-
-  if (!user) {
-    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
-  }
-
-  // Check if user is from root workspace
-  const { data: rootWorkspaceUser } = await supabase
-    .from('workspace_user_linked_users')
-    .select('*')
-    .eq('platform_user_id', user.id)
-    .eq('ws_id', ROOT_WORKSPACE_ID)
-    .single();
-
-  if (!rootWorkspaceUser) {
-    return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
-  }
+  const auth = await authorizeInfrastructureAdminRequest('view_infrastructure');
+  if (!auth.ok) return auth.response;
 
   // Parse query parameters
   const url = new URL(req.url);
@@ -107,7 +49,7 @@ export async function GET(req: Request) {
   const ipFilter = url.searchParams.get('ip');
 
   // Build query
-  let query = supabase
+  let query = auth.sbAdmin
     .from('blocked_ips')
     .select('*, unblocked_by_user:unblocked_by(id, display_name)', {
       count: 'exact',
@@ -148,26 +90,14 @@ export async function GET(req: Request) {
 }
 
 export async function DELETE(req: Request) {
-  const supabase = await createClient();
-
-  // Check if user is authenticated
-  const { user } = await resolveAuthenticatedSessionUser(supabase);
-
-  if (!user) {
-    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
-  }
-
-  const canDelete = await canDeleteBlockedIp(supabase, user);
-
-  if (!canDelete) {
-    return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
-  }
+  const auth = await authorizeInfrastructureAdminRequest('view_infrastructure');
+  if (!auth.ok) return auth.response;
 
   try {
     const body = await req.json();
     const { ip_address, reason } = UnblockSchema.parse(body);
 
-    const success = await unblockIP(ip_address, user.id, reason);
+    const success = await unblockIP(ip_address, auth.user.id, reason);
 
     if (!success) {
       return NextResponse.json(
@@ -194,33 +124,13 @@ export async function DELETE(req: Request) {
 }
 
 export async function POST(req: Request) {
-  const supabase = await createClient();
-
-  // Check if user is authenticated
-  const { user } = await resolveAuthenticatedSessionUser(supabase);
-
-  if (!user) {
-    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
-  }
-
-  // Check if user is from root workspace
-  const { data: rootWorkspaceUser } = await supabase
-    .from('workspace_user_linked_users')
-    .select('*')
-    .eq('platform_user_id', user.id)
-    .eq('ws_id', ROOT_WORKSPACE_ID)
-    .single();
-
-  if (!rootWorkspaceUser) {
-    return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
-  }
+  const auth = await authorizeInfrastructureAdminRequest('view_infrastructure');
+  if (!auth.ok) return auth.response;
 
   try {
     const body = await req.json();
     const { ip_address, reason, block_level, notes } =
       BlockIPSchema.parse(body);
-
-    const sbAdmin = await createAdminClient();
 
     // Calculate expiration based on block level (0 = permanent)
     const blockDuration =
@@ -230,7 +140,7 @@ export async function POST(req: Request) {
     const expiresAt = new Date(Date.now() + blockDuration * 1000);
 
     // Check if IP is already actively blocked
-    const { data: existingBlock } = await sbAdmin
+    const { data: existingBlock } = await auth.sbAdmin
       .from('blocked_ips')
       .select('id')
       .eq('ip_address', ip_address)
@@ -245,7 +155,7 @@ export async function POST(req: Request) {
     }
 
     // Insert block record
-    const { data: blockRecord, error } = await sbAdmin
+    const { data: blockRecord, error } = await auth.sbAdmin
       .from('blocked_ips')
       .insert({
         ip_address,
@@ -254,7 +164,7 @@ export async function POST(req: Request) {
         expires_at: expiresAt.toISOString(),
         metadata: {
           manual: true,
-          blocked_by: user.id,
+          blocked_by: auth.user.id,
           notes: notes || null,
         },
       })


### PR DESCRIPTION
## Summary
- replace legacy cookie/root-workspace checks with canonical Infrastructure app-session authorization
- require `view_infrastructure` for listing, blocking, and unblocking IPs
- use the authorized admin client and actor id consistently
- expand route coverage for authorization, validation, database, Redis, and unblock failures

## Validation
- `bun run test -- src/app/api/v1/infrastructure/blocked-ips/route.test.ts` (17 passed)
- `bun run type-check`
- `bun check`
- `bun run build` reached Turbopack but the local harness blocks Turbopack worker port binding with EPERM; CI is the canonical build gate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the blocked IPs route's legacy cookie-session and root-workspace checks with the canonical Infrastructure app-session authorization, requiring `view_infrastructure` for listing, blocking, and unblocking IPs.

- All three handlers now call `authorizeInfrastructureAdminRequest('view_infrastructure')` and return its response on failure.
- GET, POST, and DELETE use the authorized admin client and actor ID instead of resolving the session independently.
- Tests now cover 401/403 denials before any database or Redis work, plus validation, database, Redis, and unblock failure paths.

<sup>Written for commit 6015f3555b39a07b3c96476d5443a90adf7cdaaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

