### PR TITLE
fix(tasks): authorize project task links

### DIFF
--- a/apps/database/supabase/migrations/20260903074200_require_manage_projects_for_task_project_links.sql
+++ b/apps/database/supabase/migrations/20260903074200_require_manage_projects_for_task_project_links.sql
@@ -1,0 +1,79 @@
+drop policy if exists "Users can manage task project tasks in their workspaces"
+on public.task_project_tasks;
+
+create policy "Managers can insert task project links"
+on public.task_project_tasks
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from public.task_projects tp
+    join public.tasks t
+      on t.id = task_project_tasks.task_id
+    join public.task_lists tl
+      on tl.id = t.list_id
+    join public.workspace_boards wb
+      on wb.id = tl.board_id
+    where tp.id = task_project_tasks.project_id
+      and wb.ws_id = tp.ws_id
+      and public.has_workspace_permission(
+        tp.ws_id,
+        (select auth.uid()),
+        'manage_projects'
+      )
+  )
+);
+
+create policy "Managers can update task project links"
+on public.task_project_tasks
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.task_projects tp
+    where tp.id = task_project_tasks.project_id
+      and public.has_workspace_permission(
+        tp.ws_id,
+        (select auth.uid()),
+        'manage_projects'
+      )
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.task_projects tp
+    join public.tasks t
+      on t.id = task_project_tasks.task_id
+    join public.task_lists tl
+      on tl.id = t.list_id
+    join public.workspace_boards wb
+      on wb.id = tl.board_id
+    where tp.id = task_project_tasks.project_id
+      and wb.ws_id = tp.ws_id
+      and public.has_workspace_permission(
+        tp.ws_id,
+        (select auth.uid()),
+        'manage_projects'
+      )
+  )
+);
+
+create policy "Managers can delete task project links"
+on public.task_project_tasks
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.task_projects tp
+    where tp.id = task_project_tasks.project_id
+      and public.has_workspace_permission(
+        tp.ws_id,
+        (select auth.uid()),
+        'manage_projects'
+      )
+  )
+);

--- a/apps/database/supabase/tests/task-project-task-permission.sql
+++ b/apps/database/supabase/tests/task-project-task-permission.sql
@@ -1,0 +1,276 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = public, extensions;
+
+select plan(19);
+
+select ok(
+  exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'task_project_tasks'
+      and policyname = 'Users can view task project tasks in their workspaces'
+      and cmd = 'SELECT'
+  ),
+  'member-readable task-project SELECT policy remains present'
+);
+
+select ok(
+  not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'task_project_tasks'
+      and policyname = 'Users can manage task project tasks in their workspaces'
+  ),
+  'membership-only task-project write policy is removed'
+);
+
+select policies_are(
+  'public',
+  'task_project_tasks',
+  array[
+    'Managers can delete task project links',
+    'Managers can insert task project links',
+    'Managers can update task project links',
+    'Users can view task project tasks in their workspaces'
+  ],
+  'task-project links expose one read and three permissioned write policies'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_proc
+    where pronamespace = 'public'::regnamespace
+      and proname in (
+        'link_task_project_with_actor',
+        'unlink_task_project_with_actor'
+      )
+      and prosecdef
+  ),
+  'task-project actor RPCs remain SECURITY INVOKER'
+);
+
+insert into auth.users (id, aud, role, email, created_at, updated_at)
+values
+  ('00000000-0000-4000-8000-00000000e901', 'authenticated', 'authenticated', 'project-manager@example.com', now(), now()),
+  ('00000000-0000-4000-8000-00000000e902', 'authenticated', 'authenticated', 'project-member@example.com', now(), now()),
+  ('00000000-0000-4000-8000-00000000e903', 'authenticated', 'authenticated', 'project-owner@example.com', now(), now())
+on conflict (id) do nothing;
+
+insert into public.users (id, display_name)
+values
+  ('00000000-0000-4000-8000-00000000e901', 'Project Manager'),
+  ('00000000-0000-4000-8000-00000000e902', 'Project Member'),
+  ('00000000-0000-4000-8000-00000000e903', 'Project Owner')
+on conflict (id) do nothing;
+
+insert into public.workspaces (id, name, creator_id, personal)
+values
+  ('00000000-0000-4000-8000-00000000e101', 'Project Link Workspace', '00000000-0000-4000-8000-00000000e903', false),
+  ('00000000-0000-4000-8000-00000000e102', 'Foreign Project Link Workspace', '00000000-0000-4000-8000-00000000e903', false)
+on conflict (id) do nothing;
+
+insert into public.workspace_members (ws_id, user_id, type)
+values
+  ('00000000-0000-4000-8000-00000000e101', '00000000-0000-4000-8000-00000000e901', 'MEMBER'),
+  ('00000000-0000-4000-8000-00000000e101', '00000000-0000-4000-8000-00000000e902', 'MEMBER')
+on conflict (ws_id, user_id) do update set type = excluded.type;
+
+insert into public.workspace_default_permissions (ws_id, permission, member_type, enabled)
+values
+  ('00000000-0000-4000-8000-00000000e101', 'admin', 'MEMBER', false),
+  ('00000000-0000-4000-8000-00000000e101', 'manage_projects', 'MEMBER', false)
+on conflict (ws_id, permission, member_type)
+do update set enabled = excluded.enabled;
+
+insert into public.workspace_roles (id, ws_id, name)
+values (
+  '00000000-0000-4000-8000-00000000e111',
+  '00000000-0000-4000-8000-00000000e101',
+  'Project manager'
+)
+on conflict (id) do nothing;
+
+insert into public.workspace_role_permissions (ws_id, role_id, permission, enabled)
+values (
+  '00000000-0000-4000-8000-00000000e101',
+  '00000000-0000-4000-8000-00000000e111',
+  'manage_projects',
+  true
+)
+on conflict (ws_id, permission, role_id)
+do update set enabled = excluded.enabled;
+
+insert into public.workspace_role_members (role_id, user_id)
+values (
+  '00000000-0000-4000-8000-00000000e111',
+  '00000000-0000-4000-8000-00000000e901'
+)
+on conflict (role_id, user_id) do nothing;
+
+insert into public.workspace_boards (id, ws_id, name, creator_id)
+values
+  ('00000000-0000-4000-8000-00000000e201', '00000000-0000-4000-8000-00000000e101', 'Local Board', '00000000-0000-4000-8000-00000000e903'),
+  ('00000000-0000-4000-8000-00000000e202', '00000000-0000-4000-8000-00000000e102', 'Foreign Board', '00000000-0000-4000-8000-00000000e903')
+on conflict (id) do nothing;
+
+insert into public.task_lists (id, name, board_id, creator_id)
+values
+  ('00000000-0000-4000-8000-00000000e301', 'Local List', '00000000-0000-4000-8000-00000000e201', '00000000-0000-4000-8000-00000000e903'),
+  ('00000000-0000-4000-8000-00000000e302', 'Foreign List', '00000000-0000-4000-8000-00000000e202', '00000000-0000-4000-8000-00000000e903')
+on conflict (id) do nothing;
+
+insert into public.tasks (id, name, list_id, creator_id)
+values
+  ('00000000-0000-4000-8000-00000000e401', 'Local Task One', '00000000-0000-4000-8000-00000000e301', '00000000-0000-4000-8000-00000000e903'),
+  ('00000000-0000-4000-8000-00000000e402', 'Local Task Two', '00000000-0000-4000-8000-00000000e301', '00000000-0000-4000-8000-00000000e903'),
+  ('00000000-0000-4000-8000-00000000e403', 'Foreign Task', '00000000-0000-4000-8000-00000000e302', '00000000-0000-4000-8000-00000000e903')
+on conflict (id) do nothing;
+
+insert into public.task_projects (id, ws_id, name, creator_id)
+values
+  ('00000000-0000-4000-8000-00000000e501', '00000000-0000-4000-8000-00000000e101', 'Local Project One', '00000000-0000-4000-8000-00000000e903'),
+  ('00000000-0000-4000-8000-00000000e502', '00000000-0000-4000-8000-00000000e101', 'Local Project Two', '00000000-0000-4000-8000-00000000e903'),
+  ('00000000-0000-4000-8000-00000000e503', '00000000-0000-4000-8000-00000000e102', 'Foreign Project', '00000000-0000-4000-8000-00000000e903')
+on conflict (id) do nothing;
+
+set local role service_role;
+insert into public.task_project_tasks (task_id, project_id)
+values ('00000000-0000-4000-8000-00000000e401', '00000000-0000-4000-8000-00000000e501');
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000e902', true);
+
+select is(
+  (select count(*)::integer from public.task_project_tasks where task_id = '00000000-0000-4000-8000-00000000e401'),
+  1,
+  'ordinary workspace members retain SELECT access'
+);
+
+select throws_ok(
+  $$insert into public.task_project_tasks (task_id, project_id)
+    values ('00000000-0000-4000-8000-00000000e402', '00000000-0000-4000-8000-00000000e501')$$,
+  '42501',
+  'new row violates row-level security policy for table "task_project_tasks"',
+  'ordinary members cannot directly insert task-project links'
+);
+
+update public.task_project_tasks
+set project_id = '00000000-0000-4000-8000-00000000e502'
+where task_id = '00000000-0000-4000-8000-00000000e401';
+select is(
+  (select project_id from public.task_project_tasks where task_id = '00000000-0000-4000-8000-00000000e401'),
+  '00000000-0000-4000-8000-00000000e501'::uuid,
+  'ordinary members cannot directly update task-project links'
+);
+
+delete from public.task_project_tasks
+where task_id = '00000000-0000-4000-8000-00000000e401';
+select is(
+  (select count(*)::integer from public.task_project_tasks where task_id = '00000000-0000-4000-8000-00000000e401'),
+  1,
+  'ordinary members cannot directly delete task-project links'
+);
+
+select throws_ok(
+  $$select * from public.link_task_project_with_actor(
+    '00000000-0000-4000-8000-00000000e402',
+    '00000000-0000-4000-8000-00000000e501',
+    '00000000-0000-4000-8000-00000000e902'
+  )$$,
+  '42501',
+  'new row violates row-level security policy for table "task_project_tasks"',
+  'ordinary members cannot link through the invoker RPC'
+);
+
+select is(
+  (select count(*)::integer from public.unlink_task_project_with_actor(
+    '00000000-0000-4000-8000-00000000e401',
+    '00000000-0000-4000-8000-00000000e501',
+    '00000000-0000-4000-8000-00000000e902'
+  )),
+  0,
+  'ordinary members cannot unlink through the invoker RPC'
+);
+
+select set_config('request.jwt.claim.sub', '00000000-0000-4000-8000-00000000e901', true);
+
+select lives_ok(
+  $$insert into public.task_project_tasks (task_id, project_id)
+    values ('00000000-0000-4000-8000-00000000e402', '00000000-0000-4000-8000-00000000e501')$$,
+  'project managers can directly insert local task-project links'
+);
+
+select lives_ok(
+  $$delete from public.task_project_tasks
+    where task_id = '00000000-0000-4000-8000-00000000e402'
+      and project_id = '00000000-0000-4000-8000-00000000e501'$$,
+  'project managers can directly delete local task-project links'
+);
+
+select lives_ok(
+  $$select * from public.link_task_project_with_actor(
+    '00000000-0000-4000-8000-00000000e402',
+    '00000000-0000-4000-8000-00000000e501',
+    '00000000-0000-4000-8000-00000000e901'
+  )$$,
+  'project managers can link through the invoker RPC'
+);
+
+select is(
+  (select count(*)::integer from public.unlink_task_project_with_actor(
+    '00000000-0000-4000-8000-00000000e402',
+    '00000000-0000-4000-8000-00000000e501',
+    '00000000-0000-4000-8000-00000000e901'
+  )),
+  1,
+  'project managers can unlink through the invoker RPC'
+);
+
+select throws_ok(
+  $$insert into public.task_project_tasks (task_id, project_id)
+    values ('00000000-0000-4000-8000-00000000e401', '00000000-0000-4000-8000-00000000e503')$$,
+  '42501',
+  'new row violates row-level security policy for table "task_project_tasks"',
+  'a local task cannot be linked to a foreign project'
+);
+
+select throws_ok(
+  $$insert into public.task_project_tasks (task_id, project_id)
+    values ('00000000-0000-4000-8000-00000000e403', '00000000-0000-4000-8000-00000000e501')$$,
+  '42501',
+  'new row violates row-level security policy for table "task_project_tasks"',
+  'a foreign task cannot be linked to a local project'
+);
+
+select throws_ok(
+  $$update public.task_project_tasks
+    set task_id = '00000000-0000-4000-8000-00000000e403'
+    where task_id = '00000000-0000-4000-8000-00000000e401'
+      and project_id = '00000000-0000-4000-8000-00000000e501'$$,
+  '42501',
+  'new row violates row-level security policy for table "task_project_tasks"',
+  'project managers cannot move an existing link to a foreign task'
+);
+
+set local role service_role;
+
+select lives_ok(
+  $$insert into public.task_project_tasks (task_id, project_id)
+    values ('00000000-0000-4000-8000-00000000e402', '00000000-0000-4000-8000-00000000e502')$$,
+  'service-role route writes continue to bypass RLS after explicit route authorization'
+);
+
+select lives_ok(
+  $$delete from public.task_project_tasks
+    where task_id = '00000000-0000-4000-8000-00000000e402'
+      and project_id = '00000000-0000-4000-8000-00000000e502'$$,
+  'service-role route cleanup remains available'
+);
+
+reset role;
+
+select * from finish();
+rollback;

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/[taskId]/route.test.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/[taskId]/route.test.ts
@@ -135,12 +135,15 @@ describe('DELETE project task link', () => {
     expect(mocks.createAdminClient).not.toHaveBeenCalled();
   });
 
-  it('fails closed when permissions cannot be resolved', async () => {
+  it('surfaces permission-resolution failures', async () => {
     mocks.getPermissions.mockResolvedValue(null);
 
     const response = await DELETE(request, context);
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to resolve workspace permissions',
+    });
     expect(mocks.createAdminClient).not.toHaveBeenCalled();
   });
 

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/[taskId]/route.test.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/[taskId]/route.test.ts
@@ -1,0 +1,169 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createAdminClient: vi.fn(),
+  getPermissions: vi.fn(),
+  normalizeWorkspaceId: vi.fn(),
+  rpc: vi.fn(),
+  sessionClient: { from: vi.fn() },
+  sessionUser: { email: 'manager@example.com', id: 'user-1' },
+  verifyWorkspaceMembershipType: vi.fn(),
+}));
+
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: (...args: unknown[]) => mocks.createAdminClient(...args),
+}));
+
+vi.mock('@tuturuuu/utils/workspace-helper', () => ({
+  getPermissions: (...args: unknown[]) => mocks.getPermissions(...args),
+  normalizeWorkspaceId: (...args: unknown[]) =>
+    mocks.normalizeWorkspaceId(...args),
+  verifyWorkspaceMembershipType: (...args: unknown[]) =>
+    mocks.verifyWorkspaceMembershipType(...args),
+}));
+
+vi.mock('@/lib/api-auth', () => ({
+  withSessionAuth:
+    (
+      handler: (
+        request: NextRequest,
+        context: {
+          supabase: typeof mocks.sessionClient;
+          user: typeof mocks.sessionUser;
+        },
+        params: Record<string, string>
+      ) => Promise<Response>
+    ) =>
+    async (
+      request: NextRequest,
+      routeContext?: { params?: Promise<Record<string, string>> }
+    ) =>
+      handler(
+        request,
+        { supabase: mocks.sessionClient, user: mocks.sessionUser },
+        await Promise.resolve(routeContext?.params ?? {})
+      ),
+}));
+
+import { DELETE } from './route';
+
+const WS_ID = '00000000-0000-4000-8000-000000000001';
+const PROJECT_ID = '00000000-0000-4000-8000-000000000002';
+const TASK_ID = '00000000-0000-4000-8000-000000000003';
+const USER = mocks.sessionUser;
+
+const request = new NextRequest(
+  `http://localhost/api/v1/workspaces/${WS_ID}/task-projects/${PROJECT_ID}/tasks/${TASK_ID}`,
+  { method: 'DELETE' }
+);
+const context = {
+  params: Promise.resolve({
+    projectId: PROJECT_ID,
+    taskId: TASK_ID,
+    wsId: WS_ID,
+  }),
+};
+
+function adminClient() {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { ws_id: WS_ID },
+            error: null,
+          }),
+        })),
+      })),
+    })),
+    rpc: mocks.rpc,
+  };
+}
+
+describe('DELETE project task link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.normalizeWorkspaceId.mockResolvedValue(WS_ID);
+    mocks.verifyWorkspaceMembershipType.mockResolvedValue({ ok: true });
+    mocks.getPermissions.mockResolvedValue({
+      containsPermission: (permission: string) =>
+        permission === 'manage_projects',
+    });
+    mocks.createAdminClient.mockResolvedValue(adminClient());
+    mocks.rpc.mockResolvedValue({
+      data: [{ project_id: PROJECT_ID }],
+      error: null,
+    });
+  });
+
+  it('returns 500 when membership lookup fails', async () => {
+    mocks.verifyWorkspaceMembershipType.mockResolvedValue({
+      error: 'membership_lookup_failed',
+      ok: false,
+    });
+
+    const response = await DELETE(request, context);
+
+    expect(response.status).toBe(500);
+    expect(mocks.getPermissions).not.toHaveBeenCalled();
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects nonmembers before permission lookup', async () => {
+    mocks.verifyWorkspaceMembershipType.mockResolvedValue({
+      error: 'membership_missing',
+      ok: false,
+    });
+
+    const response = await DELETE(request, context);
+
+    expect(response.status).toBe(403);
+    expect(mocks.getPermissions).not.toHaveBeenCalled();
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects members without manage_projects before admin work', async () => {
+    mocks.getPermissions.mockResolvedValue({ containsPermission: () => false });
+
+    const response = await DELETE(request, context);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "You don't have permission to perform this operation",
+    });
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when permissions cannot be resolved', async () => {
+    mocks.getPermissions.mockResolvedValue(null);
+
+    const response = await DELETE(request, context);
+
+    expect(response.status).toBe(403);
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('uses the resolved app-session actor for permission lookup and unlinking', async () => {
+    const response = await DELETE(request, context);
+
+    expect(response.status).toBe(200);
+    expect(mocks.getPermissions).toHaveBeenCalledWith({
+      user: USER,
+      wsId: WS_ID,
+    });
+    expect(mocks.rpc).toHaveBeenCalledWith('unlink_task_project_with_actor', {
+      p_actor_user_id: USER.id,
+      p_project_id: PROJECT_ID,
+      p_task_id: TASK_ID,
+    });
+  });
+
+  it('preserves missing-link responses', async () => {
+    mocks.rpc.mockResolvedValue({ data: [], error: null });
+
+    const response = await DELETE(request, context);
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/[taskId]/route.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/[taskId]/route.ts
@@ -56,7 +56,15 @@ export const DELETE = withSessionAuth<RouteParams>(
       }
 
       const permissions = await getPermissions({ user, wsId });
-      if (!permissions?.containsPermission('manage_projects')) {
+      if (!permissions) {
+        console.error('Failed to resolve workspace permissions');
+        return NextResponse.json(
+          { error: 'Failed to resolve workspace permissions' },
+          { status: 500 }
+        );
+      }
+
+      if (!permissions.containsPermission('manage_projects')) {
         return NextResponse.json(
           { error: "You don't have permission to perform this operation" },
           { status: 403 }

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/[taskId]/route.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/[taskId]/route.ts
@@ -2,6 +2,7 @@ import { CLI_APP_TARGET_APP } from '@tuturuuu/auth/cli-session';
 import { createAdminClient } from '@tuturuuu/supabase/next/server';
 import type { TaskActorRpcArgs } from '@tuturuuu/types/db';
 import {
+  getPermissions,
   normalizeWorkspaceId,
   verifyWorkspaceMembershipType,
 } from '@tuturuuu/utils/workspace-helper';
@@ -52,6 +53,14 @@ export const DELETE = withSessionAuth<RouteParams>(
 
       if (!membership.ok) {
         return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+
+      const permissions = await getPermissions({ user, wsId });
+      if (!permissions?.containsPermission('manage_projects')) {
+        return NextResponse.json(
+          { error: "You don't have permission to perform this operation" },
+          { status: 403 }
+        );
       }
 
       const sbAdmin = await createAdminClient();

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/route.test.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/route.test.ts
@@ -1,0 +1,195 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createAdminClient: vi.fn(),
+  getPermissions: vi.fn(),
+  normalizeWorkspaceId: vi.fn(),
+  rpc: vi.fn(),
+  sessionClient: { from: vi.fn() },
+  sessionUser: { email: 'manager@example.com', id: 'user-1' },
+  verifyWorkspaceMembershipType: vi.fn(),
+}));
+
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: (...args: unknown[]) => mocks.createAdminClient(...args),
+}));
+
+vi.mock('@tuturuuu/utils/workspace-helper', () => ({
+  getPermissions: (...args: unknown[]) => mocks.getPermissions(...args),
+  normalizeWorkspaceId: (...args: unknown[]) =>
+    mocks.normalizeWorkspaceId(...args),
+  verifyWorkspaceMembershipType: (...args: unknown[]) =>
+    mocks.verifyWorkspaceMembershipType(...args),
+}));
+
+vi.mock('@/lib/api-auth', () => ({
+  withSessionAuth:
+    (
+      handler: (
+        request: NextRequest,
+        context: {
+          supabase: typeof mocks.sessionClient;
+          user: typeof mocks.sessionUser;
+        },
+        params: Record<string, string>
+      ) => Promise<Response>
+    ) =>
+    async (
+      request: NextRequest,
+      routeContext?: { params?: Promise<Record<string, string>> }
+    ) =>
+      handler(
+        request,
+        { supabase: mocks.sessionClient, user: mocks.sessionUser },
+        await Promise.resolve(routeContext?.params ?? {})
+      ),
+}));
+
+import { POST } from './route';
+
+const WS_ID = '00000000-0000-4000-8000-000000000001';
+const PROJECT_ID = '00000000-0000-4000-8000-000000000002';
+const TASK_ID = '00000000-0000-4000-8000-000000000003';
+const USER = mocks.sessionUser;
+
+function request(body = JSON.stringify({ taskId: TASK_ID })) {
+  return new NextRequest(
+    `http://localhost/api/v1/workspaces/${WS_ID}/task-projects/${PROJECT_ID}/tasks`,
+    { body, method: 'POST' }
+  );
+}
+
+const context = {
+  params: Promise.resolve({ projectId: PROJECT_ID, wsId: WS_ID }),
+};
+
+function adminClient() {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'task_projects') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { ws_id: WS_ID },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+      if (table === 'tasks') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  closed_at: null,
+                  completed: false,
+                  completed_at: null,
+                  id: TASK_ID,
+                  name: 'Task',
+                  priority: null,
+                  task_lists: {
+                    name: 'List',
+                    status: 'active',
+                    workspace_boards: { ws_id: WS_ID },
+                  },
+                },
+              }),
+            })),
+          })),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+    rpc: mocks.rpc,
+  };
+}
+
+describe('POST project task link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.normalizeWorkspaceId.mockResolvedValue(WS_ID);
+    mocks.verifyWorkspaceMembershipType.mockResolvedValue({ ok: true });
+    mocks.getPermissions.mockResolvedValue({
+      containsPermission: (permission: string) =>
+        permission === 'manage_projects',
+    });
+    mocks.createAdminClient.mockResolvedValue(adminClient());
+    mocks.rpc.mockResolvedValue({ error: null });
+  });
+
+  it('returns 500 when membership lookup fails', async () => {
+    mocks.verifyWorkspaceMembershipType.mockResolvedValue({
+      error: 'membership_lookup_failed',
+      ok: false,
+    });
+
+    const response = await POST(request(), context);
+
+    expect(response.status).toBe(500);
+    expect(mocks.getPermissions).not.toHaveBeenCalled();
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects nonmembers before permission lookup', async () => {
+    mocks.verifyWorkspaceMembershipType.mockResolvedValue({
+      error: 'membership_missing',
+      ok: false,
+    });
+
+    const response = await POST(request(), context);
+
+    expect(response.status).toBe(403);
+    expect(mocks.getPermissions).not.toHaveBeenCalled();
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects members without manage_projects before parsing or admin work', async () => {
+    mocks.getPermissions.mockResolvedValue({
+      containsPermission: () => false,
+    });
+
+    const response = await POST(request('{'), context);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "You don't have permission to perform this operation",
+    });
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when permissions cannot be resolved', async () => {
+    mocks.getPermissions.mockResolvedValue(null);
+
+    const response = await POST(request('{'), context);
+
+    expect(response.status).toBe(403);
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('uses the resolved app-session actor for permission lookup and linking', async () => {
+    const response = await POST(request(), context);
+
+    expect(response.status).toBe(200);
+    expect(mocks.getPermissions).toHaveBeenCalledWith({
+      user: USER,
+      wsId: WS_ID,
+    });
+    expect(mocks.rpc).toHaveBeenCalledWith('link_task_project_with_actor', {
+      p_actor_user_id: USER.id,
+      p_project_id: PROJECT_ID,
+      p_task_id: TASK_ID,
+    });
+  });
+
+  it('preserves duplicate-link conflicts', async () => {
+    mocks.rpc.mockResolvedValue({ error: { code: '23505' } });
+
+    const response = await POST(request(), context);
+
+    expect(response.status).toBe(409);
+  });
+});

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/route.test.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/route.test.ts
@@ -161,12 +161,15 @@ describe('POST project task link', () => {
     expect(mocks.createAdminClient).not.toHaveBeenCalled();
   });
 
-  it('fails closed when permissions cannot be resolved', async () => {
+  it('surfaces permission-resolution failures', async () => {
     mocks.getPermissions.mockResolvedValue(null);
 
     const response = await POST(request('{'), context);
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to resolve workspace permissions',
+    });
     expect(mocks.createAdminClient).not.toHaveBeenCalled();
   });
 

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/route.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/route.ts
@@ -4,6 +4,7 @@ import type { TaskActorRpcArgs } from '@tuturuuu/types/db';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import type { TaskList } from '@tuturuuu/types/primitives/TaskList';
 import {
+  getPermissions,
   normalizeWorkspaceId,
   verifyWorkspaceMembershipType,
 } from '@tuturuuu/utils/workspace-helper';
@@ -290,6 +291,17 @@ export const POST = withSessionAuth<RouteParams>(
 
       if (!membership.ok) {
         return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+
+      const permissions = await getPermissions({
+        user,
+        wsId: normalizedWorkspaceId,
+      });
+      if (!permissions?.containsPermission('manage_projects')) {
+        return NextResponse.json(
+          { error: "You don't have permission to perform this operation" },
+          { status: 403 }
+        );
       }
 
       const body = await request.json();

--- a/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/route.ts
+++ b/apps/tasks/src/app/api/v1/workspaces/[wsId]/task-projects/[projectId]/tasks/route.ts
@@ -297,7 +297,15 @@ export const POST = withSessionAuth<RouteParams>(
         user,
         wsId: normalizedWorkspaceId,
       });
-      if (!permissions?.containsPermission('manage_projects')) {
+      if (!permissions) {
+        console.error('Failed to resolve workspace permissions');
+        return NextResponse.json(
+          { error: 'Failed to resolve workspace permissions' },
+          { status: 500 }
+        );
+      }
+
+      if (!permissions.containsPermission('manage_projects')) {
         return NextResponse.json(
           { error: "You don't have permission to perform this operation" },
           { status: 403 }


### PR DESCRIPTION
## Summary
- require `manage_projects` before linking or unlinking tasks and projects
- preserve current Tasks app-session actor attribution and route wrappers
- enforce the same permission at the RLS/RPC boundary
- add focused POST/DELETE route tests and pgTAP coverage

## Validation
- focused Tasks route tests: 12 passed
- Tasks type-check: passed
- Tasks production build: passed, 88/88 prerender targets
- `bun check`: passed all checks
- local database stack remained unavailable; database CI is the canonical migration gate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires the `manage_projects` workspace permission before linking or unlinking tasks and projects. Previously any workspace member could do this; now both the Tasks API routes and the `task_project_tasks` RLS policies reject callers without that permission, and failed permission resolution returns a 500 before any admin work.

<sup>Written for commit 2205ab27f9bd973175ad331d7fe564d9ca968bf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

