### PR TITLE
fix(discord): prevent interaction replay

### DIFF
--- a/apps/database/supabase/migrations/20260810051643_discord_interaction_replay_claims.sql
+++ b/apps/database/supabase/migrations/20260810051643_discord_interaction_replay_claims.sql
@@ -1,0 +1,112 @@
+create table private.discord_interaction_claims (
+  interaction_id text primary key,
+  interaction_type smallint not null,
+  claimed_at timestamptz not null default clock_timestamp(),
+  expires_at timestamptz not null,
+  constraint discord_interaction_claims_id_valid
+    check (interaction_id ~ '^[0-9]{1,32}$'),
+  constraint discord_interaction_claims_type_valid
+    check (interaction_type in (1, 2, 3, 5)),
+  constraint discord_interaction_claims_expiry_valid
+    check (expires_at > claimed_at)
+);
+
+alter table private.discord_interaction_claims enable row level security;
+alter table private.discord_interaction_claims force row level security;
+
+create index discord_interaction_claims_expires_at_idx
+  on private.discord_interaction_claims (expires_at);
+
+revoke all on table private.discord_interaction_claims from public, anon, authenticated;
+grant select, insert, delete on table private.discord_interaction_claims to service_role;
+
+create or replace function private.claim_discord_interaction(
+  p_interaction_id text,
+  p_interaction_type smallint,
+  p_retention_seconds integer default 86400
+)
+returns boolean
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_claimed boolean;
+begin
+  if p_interaction_id is null
+    or p_interaction_id !~ '^[0-9]{1,32}$'
+    or p_interaction_type not in (1, 2, 3, 5)
+    or p_retention_seconds < 300
+    or p_retention_seconds > 604800
+  then
+    raise exception 'invalid Discord interaction claim';
+  end if;
+
+  delete from private.discord_interaction_claims
+  where interaction_id in (
+    select interaction_id
+    from private.discord_interaction_claims
+    where expires_at <= clock_timestamp()
+    order by expires_at
+    limit 100
+  );
+
+  insert into private.discord_interaction_claims (
+    interaction_id,
+    interaction_type,
+    expires_at
+  )
+  values (
+    p_interaction_id,
+    p_interaction_type,
+    clock_timestamp() + make_interval(secs => p_retention_seconds)
+  )
+  on conflict (interaction_id) do nothing
+  returning true into v_claimed;
+
+  return coalesce(v_claimed, false);
+end;
+$$;
+
+revoke all on function private.claim_discord_interaction(text, smallint, integer)
+  from public, anon, authenticated;
+grant execute on function private.claim_discord_interaction(text, smallint, integer)
+  to service_role;
+
+create or replace function private.prune_discord_interaction_claims(
+  p_limit integer default 1000
+)
+returns bigint
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_deleted bigint;
+begin
+  if p_limit < 1 or p_limit > 10000 then
+    raise exception 'invalid Discord interaction prune limit';
+  end if;
+
+  with expired as (
+    select interaction_id
+    from private.discord_interaction_claims
+    where expires_at <= clock_timestamp()
+    order by expires_at
+    limit p_limit
+  ), deleted as (
+    delete from private.discord_interaction_claims claims
+    using expired
+    where claims.interaction_id = expired.interaction_id
+    returning 1
+  )
+  select count(*) into v_deleted from deleted;
+
+  return v_deleted;
+end;
+$$;
+
+revoke all on function private.prune_discord_interaction_claims(integer)
+  from public, anon, authenticated;
+grant execute on function private.prune_discord_interaction_claims(integer)
+  to service_role;

--- a/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
+++ b/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
@@ -143,16 +143,19 @@ language sql
 security invoker
 set search_path = ''
 as $$
-  update private.discord_interaction_claims
-  set
-    completed_at = clock_timestamp(),
-    response_payload = p_response_payload,
-    lease_expires_at = expires_at
-  where interaction_id = p_interaction_id
-    and interaction_type = p_interaction_type
-    and claim_token = p_claim_token
-    and response_payload is null
-  returning true;
+  with completed as (
+    update private.discord_interaction_claims
+    set
+      completed_at = clock_timestamp(),
+      response_payload = p_response_payload,
+      lease_expires_at = expires_at
+    where interaction_id = p_interaction_id
+      and interaction_type = p_interaction_type
+      and claim_token = p_claim_token
+      and response_payload is null
+    returning 1
+  )
+  select exists(select 1 from completed);
 $$;
 
 create or replace function private.release_discord_interaction(

--- a/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
+++ b/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
@@ -6,7 +6,7 @@ create table private.discord_interaction_claims (
   constraint discord_interaction_claims_id_valid
     check (interaction_id ~ '^[0-9]{1,32}$'),
   constraint discord_interaction_claims_type_valid
-    check (interaction_type in (1, 2, 3, 5)),
+    check (interaction_type in (2, 3, 5)),
   constraint discord_interaction_claims_expiry_valid
     check (expires_at > claimed_at)
 );
@@ -35,7 +35,7 @@ declare
 begin
   if p_interaction_id is null
     or p_interaction_id !~ '^[0-9]{1,32}$'
-    or p_interaction_type not in (1, 2, 3, 5)
+    or p_interaction_type not in (2, 3, 5)
     or p_retention_seconds < 300
     or p_retention_seconds > 604800
   then

--- a/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
+++ b/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
@@ -2,13 +2,20 @@ create table private.discord_interaction_claims (
   interaction_id text primary key,
   interaction_type smallint not null,
   claimed_at timestamptz not null default clock_timestamp(),
+  lease_expires_at timestamptz not null,
+  completed_at timestamptz,
+  response_payload jsonb,
   expires_at timestamptz not null,
   constraint discord_interaction_claims_id_valid
     check (interaction_id ~ '^[0-9]{1,32}$'),
   constraint discord_interaction_claims_type_valid
     check (interaction_type in (2, 3, 5)),
   constraint discord_interaction_claims_expiry_valid
-    check (expires_at > claimed_at)
+    check (expires_at > claimed_at),
+  constraint discord_interaction_claims_lease_valid
+    check (lease_expires_at > claimed_at and lease_expires_at <= expires_at),
+  constraint discord_interaction_claims_completion_valid
+    check ((completed_at is null) = (response_payload is null))
 );
 
 alter table private.discord_interaction_claims enable row level security;
@@ -18,20 +25,21 @@ create index discord_interaction_claims_expires_at_idx
   on private.discord_interaction_claims (expires_at);
 
 revoke all on table private.discord_interaction_claims from public, anon, authenticated;
-grant select, insert, delete on table private.discord_interaction_claims to service_role;
+grant select, insert, update, delete on table private.discord_interaction_claims to service_role;
 
 create or replace function private.claim_discord_interaction(
   p_interaction_id text,
   p_interaction_type smallint,
   p_retention_seconds integer default 86400
 )
-returns boolean
+returns jsonb
 language plpgsql
 security invoker
 set search_path = ''
 as $$
 declare
   v_claimed boolean;
+  v_existing private.discord_interaction_claims%rowtype;
 begin
   if p_interaction_id is null
     or p_interaction_id !~ '^[0-9]{1,32}$'
@@ -54,23 +62,98 @@ begin
   insert into private.discord_interaction_claims (
     interaction_id,
     interaction_type,
+    lease_expires_at,
     expires_at
   )
   values (
     p_interaction_id,
     p_interaction_type,
+    clock_timestamp() + interval '1 minute',
     clock_timestamp() + make_interval(secs => p_retention_seconds)
   )
   on conflict (interaction_id) do nothing
   returning true into v_claimed;
 
-  return coalesce(v_claimed, false);
+  if coalesce(v_claimed, false) then
+    return jsonb_build_object('state', 'claimed');
+  end if;
+
+  select * into v_existing
+  from private.discord_interaction_claims
+  where interaction_id = p_interaction_id;
+
+  if v_existing.response_payload is not null then
+    return jsonb_build_object(
+      'state', 'completed',
+      'response', v_existing.response_payload
+    );
+  end if;
+
+  update private.discord_interaction_claims
+  set
+    interaction_type = p_interaction_type,
+    claimed_at = clock_timestamp(),
+    lease_expires_at = clock_timestamp() + interval '1 minute',
+    expires_at = clock_timestamp() + make_interval(secs => p_retention_seconds)
+  where interaction_id = p_interaction_id
+    and response_payload is null
+    and lease_expires_at <= clock_timestamp()
+  returning true into v_claimed;
+
+  return jsonb_build_object(
+    'state', case when coalesce(v_claimed, false) then 'claimed' else 'processing' end
+  );
 end;
 $$;
 
 revoke all on function private.claim_discord_interaction(text, smallint, integer)
   from public, anon, authenticated;
 grant execute on function private.claim_discord_interaction(text, smallint, integer)
+  to service_role;
+
+create or replace function private.complete_discord_interaction(
+  p_interaction_id text,
+  p_interaction_type smallint,
+  p_response_payload jsonb
+)
+returns boolean
+language sql
+security invoker
+set search_path = ''
+as $$
+  update private.discord_interaction_claims
+  set
+    completed_at = clock_timestamp(),
+    response_payload = p_response_payload,
+    lease_expires_at = expires_at
+  where interaction_id = p_interaction_id
+    and interaction_type = p_interaction_type
+    and response_payload is null
+  returning true;
+$$;
+
+create or replace function private.release_discord_interaction(
+  p_interaction_id text,
+  p_interaction_type smallint
+)
+returns void
+language sql
+security invoker
+set search_path = ''
+as $$
+  delete from private.discord_interaction_claims
+  where interaction_id = p_interaction_id
+    and interaction_type = p_interaction_type
+    and response_payload is null;
+$$;
+
+revoke all on function private.complete_discord_interaction(text, smallint, jsonb)
+  from public, anon, authenticated;
+grant execute on function private.complete_discord_interaction(text, smallint, jsonb)
+  to service_role;
+revoke all on function private.release_discord_interaction(text, smallint)
+  from public, anon, authenticated;
+grant execute on function private.release_discord_interaction(text, smallint)
   to service_role;
 
 create or replace function private.prune_discord_interaction_claims(
@@ -84,7 +167,7 @@ as $$
 declare
   v_deleted bigint;
 begin
-  if p_limit < 1 or p_limit > 10000 then
+  if p_limit is null or p_limit < 1 or p_limit > 10000 then
     raise exception 'invalid Discord interaction prune limit';
   end if;
 

--- a/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
+++ b/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
@@ -132,6 +132,44 @@ revoke all on function private.claim_discord_interaction(text, smallint, integer
 grant execute on function private.claim_discord_interaction(text, smallint, integer)
   to service_role;
 
+create or replace function private.renew_discord_interaction_claim(
+  p_interaction_id text,
+  p_interaction_type smallint,
+  p_claim_token uuid,
+  p_lease_seconds integer default 60
+)
+returns boolean
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if p_lease_seconds is null or p_lease_seconds < 15 or p_lease_seconds > 300 then
+    raise exception 'invalid Discord interaction lease duration';
+  end if;
+
+  update private.discord_interaction_claims
+  set lease_expires_at = least(
+    clock_timestamp() + make_interval(secs => p_lease_seconds),
+    expires_at
+  )
+  where interaction_id = p_interaction_id
+    and interaction_type = p_interaction_type
+    and claim_token = p_claim_token
+    and response_payload is null
+    and expires_at > clock_timestamp();
+
+  return found;
+end;
+$$;
+
+revoke all on function private.renew_discord_interaction_claim(
+  text, smallint, uuid, integer
+) from public, anon, authenticated;
+grant execute on function private.renew_discord_interaction_claim(
+  text, smallint, uuid, integer
+) to service_role;
+
 create or replace function private.complete_discord_interaction(
   p_interaction_id text,
   p_interaction_type smallint,

--- a/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
+++ b/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
@@ -1,6 +1,7 @@
 create table private.discord_interaction_claims (
   interaction_id text primary key,
   interaction_type smallint not null,
+  claim_token uuid not null default gen_random_uuid(),
   claimed_at timestamptz not null default clock_timestamp(),
   lease_expires_at timestamptz not null,
   completed_at timestamptz,
@@ -39,6 +40,7 @@ set search_path = ''
 as $$
 declare
   v_claimed boolean;
+  v_claim_token uuid;
   v_existing private.discord_interaction_claims%rowtype;
 begin
   if p_interaction_id is null
@@ -59,50 +61,69 @@ begin
     limit 100
   );
 
-  insert into private.discord_interaction_claims (
-    interaction_id,
-    interaction_type,
-    lease_expires_at,
-    expires_at
-  )
-  values (
-    p_interaction_id,
-    p_interaction_type,
-    clock_timestamp() + interval '1 minute',
-    clock_timestamp() + make_interval(secs => p_retention_seconds)
-  )
-  on conflict (interaction_id) do nothing
-  returning true into v_claimed;
+  loop
+    v_claimed := false;
+    v_claim_token := null;
 
-  if coalesce(v_claimed, false) then
-    return jsonb_build_object('state', 'claimed');
-  end if;
+    insert into private.discord_interaction_claims (
+      interaction_id,
+      interaction_type,
+      lease_expires_at,
+      expires_at
+    )
+    values (
+      p_interaction_id,
+      p_interaction_type,
+      clock_timestamp() + interval '1 minute',
+      clock_timestamp() + make_interval(secs => p_retention_seconds)
+    )
+    on conflict (interaction_id) do nothing
+    returning true, claim_token into v_claimed, v_claim_token;
 
-  select * into v_existing
-  from private.discord_interaction_claims
-  where interaction_id = p_interaction_id;
+    if coalesce(v_claimed, false) then
+      return jsonb_build_object(
+        'state', 'claimed',
+        'claimToken', v_claim_token
+      );
+    end if;
 
-  if v_existing.response_payload is not null then
-    return jsonb_build_object(
-      'state', 'completed',
-      'response', v_existing.response_payload
-    );
-  end if;
+    select * into v_existing
+    from private.discord_interaction_claims
+    where interaction_id = p_interaction_id
+    for update;
 
-  update private.discord_interaction_claims
-  set
-    interaction_type = p_interaction_type,
-    claimed_at = clock_timestamp(),
-    lease_expires_at = clock_timestamp() + interval '1 minute',
-    expires_at = clock_timestamp() + make_interval(secs => p_retention_seconds)
-  where interaction_id = p_interaction_id
-    and response_payload is null
-    and lease_expires_at <= clock_timestamp()
-  returning true into v_claimed;
+    if not found then
+      continue;
+    end if;
 
-  return jsonb_build_object(
-    'state', case when coalesce(v_claimed, false) then 'claimed' else 'processing' end
-  );
+    if v_existing.response_payload is not null then
+      return jsonb_build_object(
+        'state', 'completed',
+        'response', v_existing.response_payload
+      );
+    end if;
+
+    update private.discord_interaction_claims
+    set
+      interaction_type = p_interaction_type,
+      claim_token = gen_random_uuid(),
+      claimed_at = clock_timestamp(),
+      lease_expires_at = clock_timestamp() + interval '1 minute',
+      expires_at = clock_timestamp() + make_interval(secs => p_retention_seconds)
+    where interaction_id = p_interaction_id
+      and response_payload is null
+      and lease_expires_at <= clock_timestamp()
+    returning claim_token into v_claim_token;
+
+    if v_claim_token is not null then
+      return jsonb_build_object(
+        'state', 'claimed',
+        'claimToken', v_claim_token
+      );
+    end if;
+
+    return jsonb_build_object('state', 'processing');
+  end loop;
 end;
 $$;
 
@@ -114,6 +135,7 @@ grant execute on function private.claim_discord_interaction(text, smallint, inte
 create or replace function private.complete_discord_interaction(
   p_interaction_id text,
   p_interaction_type smallint,
+  p_claim_token uuid,
   p_response_payload jsonb
 )
 returns boolean
@@ -128,13 +150,15 @@ as $$
     lease_expires_at = expires_at
   where interaction_id = p_interaction_id
     and interaction_type = p_interaction_type
+    and claim_token = p_claim_token
     and response_payload is null
   returning true;
 $$;
 
 create or replace function private.release_discord_interaction(
   p_interaction_id text,
-  p_interaction_type smallint
+  p_interaction_type smallint,
+  p_claim_token uuid
 )
 returns void
 language sql
@@ -144,16 +168,17 @@ as $$
   delete from private.discord_interaction_claims
   where interaction_id = p_interaction_id
     and interaction_type = p_interaction_type
+    and claim_token = p_claim_token
     and response_payload is null;
 $$;
 
-revoke all on function private.complete_discord_interaction(text, smallint, jsonb)
+revoke all on function private.complete_discord_interaction(text, smallint, uuid, jsonb)
   from public, anon, authenticated;
-grant execute on function private.complete_discord_interaction(text, smallint, jsonb)
+grant execute on function private.complete_discord_interaction(text, smallint, uuid, jsonb)
   to service_role;
-revoke all on function private.release_discord_interaction(text, smallint)
+revoke all on function private.release_discord_interaction(text, smallint, uuid)
   from public, anon, authenticated;
-grant execute on function private.release_discord_interaction(text, smallint)
+grant execute on function private.release_discord_interaction(text, smallint, uuid)
   to service_role;
 
 create or replace function private.prune_discord_interaction_claims(

--- a/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
+++ b/apps/database/supabase/migrations/20260903090000_discord_interaction_replay_claims.sql
@@ -157,6 +157,7 @@ begin
     and interaction_type = p_interaction_type
     and claim_token = p_claim_token
     and response_payload is null
+    and lease_expires_at > clock_timestamp()
     and expires_at > clock_timestamp();
 
   return found;

--- a/apps/database/supabase/tests/discord-interaction-replay.sql
+++ b/apps/database/supabase/tests/discord-interaction-replay.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(22);
+select plan(26);
 
 select has_table(
   'private',
@@ -17,6 +17,7 @@ select columns_are(
   array[
     'interaction_id',
     'interaction_type',
+    'claim_token',
     'claimed_at',
     'lease_expires_at',
     'completed_at',
@@ -98,29 +99,54 @@ select ok(
 select ok(
   not has_function_privilege(
     'anon',
-    'private.complete_discord_interaction(text,smallint,jsonb)',
+    'private.complete_discord_interaction(text,smallint,uuid,jsonb)',
+    'execute'
+  )
+  and not has_function_privilege(
+    'anon',
+    'private.release_discord_interaction(text,smallint,uuid)',
     'execute'
   )
   and not has_function_privilege(
     'authenticated',
-    'private.release_discord_interaction(text,smallint)',
+    'private.complete_discord_interaction(text,smallint,uuid,jsonb)',
+    'execute'
+  )
+  and not has_function_privilege(
+    'authenticated',
+    'private.release_discord_interaction(text,smallint,uuid)',
+    'execute'
+  )
+  and not has_function_privilege(
+    'anon',
+    'private.prune_discord_interaction_claims(integer)',
+    'execute'
+  )
+  and not has_function_privilege(
+    'authenticated',
+    'private.prune_discord_interaction_claims(integer)',
     'execute'
   ),
-  'non-service roles cannot complete or release Discord interactions'
+  'non-service roles cannot complete, release, or prune Discord interactions'
 );
 
 select ok(
   has_function_privilege(
     'service_role',
-    'private.complete_discord_interaction(text,smallint,jsonb)',
+    'private.complete_discord_interaction(text,smallint,uuid,jsonb)',
     'execute'
   )
   and has_function_privilege(
     'service_role',
-    'private.release_discord_interaction(text,smallint)',
+    'private.release_discord_interaction(text,smallint,uuid)',
+    'execute'
+  )
+  and has_function_privilege(
+    'service_role',
+    'private.prune_discord_interaction_claims(integer)',
     'execute'
   ),
-  'service role can complete and release Discord interactions'
+  'service role can complete, release, and prune Discord interactions'
 );
 
 select is(
@@ -153,6 +179,7 @@ select ok(
   private.complete_discord_interaction(
     '100000000000000001',
     2,
+    (select claim_token from first_claim_snapshot),
     '{"type": 9, "data": {"title": "Ticket"}}'::jsonb
   ),
   'a claimed interaction can persist its callback response'
@@ -170,8 +197,16 @@ select is(
   'a second interaction can be claimed before a failed dispatch'
 );
 
+create temporary table second_claim_snapshot as
+select *
+from private.discord_interaction_claims
+where interaction_id = '100000000000000003';
+
 select lives_ok(
-  $$select private.release_discord_interaction('100000000000000003', 5)$$,
+  format(
+    $$select private.release_discord_interaction('100000000000000003', 5, %L::uuid)$$,
+    (select claim_token from second_claim_snapshot)
+  ),
   'an unfinished interaction claim can be released'
 );
 
@@ -179,6 +214,46 @@ select is(
   private.claim_discord_interaction('100000000000000003', 5, 86400)->>'state',
   'claimed',
   'a released interaction can be claimed by a retry'
+);
+
+create temporary table retried_claim_snapshot as
+select *
+from private.discord_interaction_claims
+where interaction_id = '100000000000000003';
+
+select isnt(
+  (select claim_token from retried_claim_snapshot),
+  (select claim_token from second_claim_snapshot),
+  'a retried interaction receives a fresh ownership token'
+);
+
+select is(
+  private.complete_discord_interaction(
+    '100000000000000003',
+    5,
+    (select claim_token from second_claim_snapshot),
+    '{"type": 5}'::jsonb
+  ),
+  false,
+  'a stale owner cannot complete a newer interaction claim'
+);
+
+select lives_ok(
+  format(
+    $$select private.release_discord_interaction('100000000000000003', 5, %L::uuid)$$,
+    (select claim_token from second_claim_snapshot)
+  ),
+  'a stale release is safely ignored'
+);
+
+select is(
+  (
+    select count(*)
+    from private.discord_interaction_claims
+    where interaction_id = '100000000000000003'
+  ),
+  1::bigint,
+  'a stale owner cannot release a newer interaction claim'
 );
 
 select throws_ok(

--- a/apps/database/supabase/tests/discord-interaction-replay.sql
+++ b/apps/database/supabase/tests/discord-interaction-replay.sql
@@ -1,0 +1,128 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = public, extensions;
+
+select plan(14);
+
+select has_table(
+  'private',
+  'discord_interaction_claims',
+  'Discord interaction claims are stored privately'
+);
+
+select columns_are(
+  'private',
+  'discord_interaction_claims',
+  array['interaction_id', 'interaction_type', 'claimed_at', 'expires_at'],
+  'claim rows contain only the opaque id, type, and retention timestamps'
+);
+
+select has_pk(
+  'private',
+  'discord_interaction_claims',
+  'interaction ids are uniquely claimable'
+);
+
+select has_index(
+  'private',
+  'discord_interaction_claims',
+  'discord_interaction_claims_expires_at_idx',
+  'expired claims have a cleanup index'
+);
+
+select ok(
+  not exists (
+    select 1
+    from unnest(array['select', 'insert', 'update', 'delete']) privilege
+    where has_table_privilege(
+      'anon', 'private.discord_interaction_claims', privilege
+    )
+  ),
+  'anon cannot read or mutate Discord interaction claims'
+);
+
+select ok(
+  not exists (
+    select 1
+    from unnest(array['select', 'insert', 'update', 'delete']) privilege
+    where has_table_privilege(
+      'authenticated', 'private.discord_interaction_claims', privilege
+    )
+  ),
+  'authenticated users cannot read or mutate Discord interaction claims'
+);
+
+select ok(
+  has_table_privilege(
+    'service_role', 'private.discord_interaction_claims', 'select,insert,delete'
+  ),
+  'service role has only the table privileges required by claim and cleanup RPCs'
+);
+
+select ok(
+  not has_function_privilege(
+    'anon', 'private.claim_discord_interaction(text,smallint,integer)', 'execute'
+  ),
+  'anon cannot claim Discord interactions'
+);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    'private.claim_discord_interaction(text,smallint,integer)',
+    'execute'
+  ),
+  'authenticated users cannot claim Discord interactions'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'private.claim_discord_interaction(text,smallint,integer)',
+    'execute'
+  ),
+  'service role can atomically claim Discord interactions'
+);
+
+select ok(
+  private.claim_discord_interaction('100000000000000001', 2, 86400),
+  'the first interaction claim succeeds'
+);
+
+select ok(
+  not private.claim_discord_interaction('100000000000000001', 2, 86400),
+  'a duplicate interaction claim loses without replacing the first row'
+);
+
+insert into private.discord_interaction_claims (
+  interaction_id,
+  interaction_type,
+  claimed_at,
+  expires_at
+)
+values (
+  '100000000000000002',
+  3,
+  clock_timestamp() - interval '2 hours',
+  clock_timestamp() - interval '1 hour'
+);
+
+select is(
+  private.prune_discord_interaction_claims(1000),
+  1::bigint,
+  'bounded cleanup prunes expired claims'
+);
+
+select is(
+  (
+    select count(*)
+    from private.discord_interaction_claims
+    where interaction_id = '100000000000000002'
+  ),
+  0::bigint,
+  'expired claim data is removed'
+);
+
+select * from finish();
+rollback;

--- a/apps/database/supabase/tests/discord-interaction-replay.sql
+++ b/apps/database/supabase/tests/discord-interaction-replay.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(14);
+select plan(22);
 
 select has_table(
   'private',
@@ -14,8 +14,16 @@ select has_table(
 select columns_are(
   'private',
   'discord_interaction_claims',
-  array['interaction_id', 'interaction_type', 'claimed_at', 'expires_at'],
-  'claim rows contain only the opaque id, type, and retention timestamps'
+  array[
+    'interaction_id',
+    'interaction_type',
+    'claimed_at',
+    'lease_expires_at',
+    'completed_at',
+    'response_payload',
+    'expires_at'
+  ],
+  'claim rows contain only dispatch lifecycle data'
 );
 
 select has_pk(
@@ -55,9 +63,11 @@ select ok(
 
 select ok(
   has_table_privilege(
-    'service_role', 'private.discord_interaction_claims', 'select,insert,delete'
+    'service_role',
+    'private.discord_interaction_claims',
+    'select,insert,update,delete'
   ),
-  'service role has only the table privileges required by claim and cleanup RPCs'
+  'service role has the table privileges required by lifecycle RPCs'
 );
 
 select ok(
@@ -86,25 +96,110 @@ select ok(
 );
 
 select ok(
-  private.claim_discord_interaction('100000000000000001', 2, 86400),
-  'the first interaction claim succeeds'
+  not has_function_privilege(
+    'anon',
+    'private.complete_discord_interaction(text,smallint,jsonb)',
+    'execute'
+  )
+  and not has_function_privilege(
+    'authenticated',
+    'private.release_discord_interaction(text,smallint)',
+    'execute'
+  ),
+  'non-service roles cannot complete or release Discord interactions'
 );
 
 select ok(
-  not private.claim_discord_interaction('100000000000000001', 2, 86400),
-  'a duplicate interaction claim loses without replacing the first row'
+  has_function_privilege(
+    'service_role',
+    'private.complete_discord_interaction(text,smallint,jsonb)',
+    'execute'
+  )
+  and has_function_privilege(
+    'service_role',
+    'private.release_discord_interaction(text,smallint)',
+    'execute'
+  ),
+  'service role can complete and release Discord interactions'
+);
+
+select is(
+  private.claim_discord_interaction('100000000000000001', 2, 86400)->>'state',
+  'claimed',
+  'the first interaction claim succeeds'
+);
+
+create temporary table first_claim_snapshot as
+select *
+from private.discord_interaction_claims
+where interaction_id = '100000000000000001';
+
+select ok(
+  private.claim_discord_interaction('100000000000000001', 2, 86400)->>'state'
+    = 'processing'
+  and exists (
+    select 1
+    from private.discord_interaction_claims current_claim
+    join first_claim_snapshot original_claim using (interaction_id)
+    where current_claim.interaction_type = original_claim.interaction_type
+      and current_claim.claimed_at = original_claim.claimed_at
+      and current_claim.lease_expires_at = original_claim.lease_expires_at
+      and current_claim.expires_at = original_claim.expires_at
+  ),
+  'an active duplicate loses without replacing the first lease'
+);
+
+select ok(
+  private.complete_discord_interaction(
+    '100000000000000001',
+    2,
+    '{"type": 9, "data": {"title": "Ticket"}}'::jsonb
+  ),
+  'a claimed interaction can persist its callback response'
+);
+
+select is(
+  private.claim_discord_interaction('100000000000000001', 2, 86400)->'response',
+  '{"type": 9, "data": {"title": "Ticket"}}'::jsonb,
+  'a completed duplicate replays the original callback response'
+);
+
+select is(
+  private.claim_discord_interaction('100000000000000003', 5, 86400)->>'state',
+  'claimed',
+  'a second interaction can be claimed before a failed dispatch'
+);
+
+select lives_ok(
+  $$select private.release_discord_interaction('100000000000000003', 5)$$,
+  'an unfinished interaction claim can be released'
+);
+
+select is(
+  private.claim_discord_interaction('100000000000000003', 5, 86400)->>'state',
+  'claimed',
+  'a released interaction can be claimed by a retry'
+);
+
+select throws_ok(
+  $$select private.prune_discord_interaction_claims(null)$$,
+  'P0001',
+  'invalid Discord interaction prune limit',
+  'an explicit null prune limit is rejected'
 );
 
 insert into private.discord_interaction_claims (
   interaction_id,
   interaction_type,
   claimed_at,
+  lease_expires_at,
   expires_at
 )
 values (
   '100000000000000002',
   3,
   clock_timestamp() - interval '2 hours',
+  clock_timestamp() - interval '90 minutes',
   clock_timestamp() - interval '1 hour'
 );
 

--- a/apps/database/supabase/tests/discord-interaction-replay.sql
+++ b/apps/database/supabase/tests/discord-interaction-replay.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(26);
+select plan(28);
 
 select has_table(
   'private',
@@ -119,6 +119,16 @@ select ok(
   )
   and not has_function_privilege(
     'anon',
+    'private.renew_discord_interaction_claim(text,smallint,uuid,integer)',
+    'execute'
+  )
+  and not has_function_privilege(
+    'authenticated',
+    'private.renew_discord_interaction_claim(text,smallint,uuid,integer)',
+    'execute'
+  )
+  and not has_function_privilege(
+    'anon',
     'private.prune_discord_interaction_claims(integer)',
     'execute'
   )
@@ -143,6 +153,11 @@ select ok(
   )
   and has_function_privilege(
     'service_role',
+    'private.renew_discord_interaction_claim(text,smallint,uuid,integer)',
+    'execute'
+  )
+  and has_function_privilege(
+    'service_role',
     'private.prune_discord_interaction_claims(integer)',
     'execute'
   ),
@@ -159,6 +174,27 @@ create temporary table first_claim_snapshot as
 select *
 from private.discord_interaction_claims
 where interaction_id = '100000000000000001';
+
+select ok(
+  private.renew_discord_interaction_claim(
+    '100000000000000001',
+    2,
+    (select claim_token from first_claim_snapshot),
+    120
+  ),
+  'the claim owner can renew its completion lease'
+);
+
+select is(
+  private.renew_discord_interaction_claim(
+    '100000000000000001',
+    2,
+    gen_random_uuid(),
+    120
+  ),
+  false,
+  'a stale owner cannot renew another claim lease'
+);
 
 select ok(
   private.claim_discord_interaction('100000000000000001', 2, 86400)->>'state'

--- a/apps/database/supabase/tests/discord-interaction-replay.sql
+++ b/apps/database/supabase/tests/discord-interaction-replay.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(28);
+select plan(29);
 
 select has_table(
   'private',
@@ -196,6 +196,12 @@ select is(
   'a stale owner cannot renew another claim lease'
 );
 
+truncate first_claim_snapshot;
+insert into first_claim_snapshot
+select *
+from private.discord_interaction_claims
+where interaction_id = '100000000000000001';
+
 select ok(
   private.claim_discord_interaction('100000000000000001', 2, 86400)->>'state'
     = 'processing'
@@ -209,6 +215,28 @@ select ok(
       and current_claim.expires_at = original_claim.expires_at
   ),
   'an active duplicate loses without replacing the first lease'
+);
+
+create temporary table expired_claim_snapshot as
+select private.claim_discord_interaction(
+  '100000000000000004', 3, 86400
+) as claim;
+
+update private.discord_interaction_claims
+set
+  claimed_at = clock_timestamp() - interval '2 minutes',
+  lease_expires_at = clock_timestamp() - interval '1 minute'
+where interaction_id = '100000000000000004';
+
+select is(
+  private.renew_discord_interaction_claim(
+    '100000000000000004',
+    3,
+    ((select claim from expired_claim_snapshot)->>'claimToken')::uuid,
+    120
+  ),
+  false,
+  'an owner cannot renew an already expired lease'
 );
 
 select ok(

--- a/apps/discord/app.py
+++ b/apps/discord/app.py
@@ -1,18 +1,15 @@
 """Main Discord bot application."""
 
-import json
 import logging
 import os
 import traceback
-from typing import cast
 
 import modal
 import requests
 
-from auth import DiscordAuth
+import interaction_replay
 from commands import CommandHandler
 from config import DiscordInteractionType, DiscordResponseType
-from interaction_replay import prepare_interaction_dispatch
 from markitdown_service import handle_markitdown
 from utils import get_supabase_client
 
@@ -35,6 +32,7 @@ image = (
         "commands",
         "config",
         "discord_client",
+        "interaction_replay",
         "link_shortener",
         "markitdown_service",
         "utils",
@@ -900,13 +898,14 @@ def web_app():
         return bool(query_secret and query_secret.strip() == secret)
 
     @web_app.post("/api")
+    @interaction_replay.with_discord_interaction_replay
     async def get_api(request: Request):
         """Handle Discord interactions."""
-        body = await request.body()
-        DiscordAuth.verify_request(cast(dict, request.headers), body)
-
-        data = json.loads(body.decode())
-        interaction_type, duplicate_response = prepare_interaction_dispatch(data)
+        (
+            data,
+            interaction_type,
+            duplicate_response,
+        ) = await interaction_replay.prepare_interaction_dispatch(request)
         if duplicate_response is not None:
             return duplicate_response
 

--- a/apps/discord/app.py
+++ b/apps/discord/app.py
@@ -12,17 +12,11 @@ import requests
 from auth import DiscordAuth
 from commands import CommandHandler
 from config import DiscordInteractionType, DiscordResponseType
+from interaction_replay import prepare_interaction_dispatch
 from markitdown_service import handle_markitdown
-from utils import claim_discord_interaction, get_supabase_client
+from utils import get_supabase_client
 
 logger = logging.getLogger(__name__)
-
-
-def _duplicate_interaction_response(interaction_type: int) -> dict[str, int]:
-    """Return a protocol-valid acknowledgement without repeating side effects."""
-    if interaction_type == DiscordInteractionType.PING:
-        return {"type": DiscordResponseType.PONG}
-    return {"type": DiscordResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE}
 
 image = (
     modal.Image.debian_slim(python_version="3.13")
@@ -909,52 +903,14 @@ def web_app():
     async def get_api(request: Request):
         """Handle Discord interactions."""
         body = await request.body()
-
-        # confirm this is a request from Discord
         DiscordAuth.verify_request(cast(dict, request.headers), body)
 
-        print("🤖: parsing request")
         data = json.loads(body.decode())
-
-        if not isinstance(data, dict):
-            raise HTTPException(status_code=400, detail="Bad request")
-
-        interaction_id = data.get("id")
-        interaction_type = data.get("type")
-        supported_interaction_types = {
-            DiscordInteractionType.PING,
-            DiscordInteractionType.APPLICATION_COMMAND,
-            DiscordInteractionType.MESSAGE_COMPONENT,
-            DiscordInteractionType.MODAL_SUBMIT,
-        }
-        if (
-            not isinstance(interaction_id, str)
-            or not interaction_id.isdigit()
-            or not isinstance(interaction_type, int)
-            or interaction_type not in supported_interaction_types
-        ):
-            raise HTTPException(status_code=400, detail="Bad request")
-
-        try:
-            claimed = claim_discord_interaction(interaction_id, interaction_type)
-        except Exception as error:
-            logger.exception(
-                "Failed to claim Discord interaction",
-                extra={"interaction_type": interaction_type},
-            )
-            raise HTTPException(
-                status_code=503, detail="Interaction claim unavailable"
-            ) from error
-
-        if not claimed:
-            logger.info(
-                "Acknowledging duplicate Discord interaction",
-                extra={"interaction_type": interaction_type},
-            )
-            return _duplicate_interaction_response(interaction_type)
+        interaction_type, duplicate_response = prepare_interaction_dispatch(data)
+        if duplicate_response is not None:
+            return duplicate_response
 
         if interaction_type == DiscordInteractionType.PING:
-            print("🤖: acking PING from Discord during auth check")
             return {"type": DiscordResponseType.PONG}
 
         if interaction_type == DiscordInteractionType.APPLICATION_COMMAND:

--- a/apps/discord/app.py
+++ b/apps/discord/app.py
@@ -13,9 +13,16 @@ from auth import DiscordAuth
 from commands import CommandHandler
 from config import DiscordInteractionType, DiscordResponseType
 from markitdown_service import handle_markitdown
-from utils import get_supabase_client
+from utils import claim_discord_interaction, get_supabase_client
 
 logger = logging.getLogger(__name__)
+
+
+def _duplicate_interaction_response(interaction_type: int) -> dict[str, int]:
+    """Return a protocol-valid acknowledgement without repeating side effects."""
+    if interaction_type == DiscordInteractionType.PING:
+        return {"type": DiscordResponseType.PONG}
+    return {"type": DiscordResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE}
 
 image = (
     modal.Image.debian_slim(python_version="3.13")
@@ -909,11 +916,48 @@ def web_app():
         print("🤖: parsing request")
         data = json.loads(body.decode())
 
-        if data.get("type") == DiscordInteractionType.PING:
+        if not isinstance(data, dict):
+            raise HTTPException(status_code=400, detail="Bad request")
+
+        interaction_id = data.get("id")
+        interaction_type = data.get("type")
+        supported_interaction_types = {
+            DiscordInteractionType.PING,
+            DiscordInteractionType.APPLICATION_COMMAND,
+            DiscordInteractionType.MESSAGE_COMPONENT,
+            DiscordInteractionType.MODAL_SUBMIT,
+        }
+        if (
+            not isinstance(interaction_id, str)
+            or not interaction_id.isdigit()
+            or not isinstance(interaction_type, int)
+            or interaction_type not in supported_interaction_types
+        ):
+            raise HTTPException(status_code=400, detail="Bad request")
+
+        try:
+            claimed = claim_discord_interaction(interaction_id, interaction_type)
+        except Exception as error:
+            logger.exception(
+                "Failed to claim Discord interaction",
+                extra={"interaction_type": interaction_type},
+            )
+            raise HTTPException(
+                status_code=503, detail="Interaction claim unavailable"
+            ) from error
+
+        if not claimed:
+            logger.info(
+                "Acknowledging duplicate Discord interaction",
+                extra={"interaction_type": interaction_type},
+            )
+            return _duplicate_interaction_response(interaction_type)
+
+        if interaction_type == DiscordInteractionType.PING:
             print("🤖: acking PING from Discord during auth check")
             return {"type": DiscordResponseType.PONG}
 
-        if data.get("type") == DiscordInteractionType.APPLICATION_COMMAND:
+        if interaction_type == DiscordInteractionType.APPLICATION_COMMAND:
             print("🤖: handling slash command")
             app_id = data["application_id"]
             interaction_token = data["token"]
@@ -999,7 +1043,7 @@ def web_app():
             # respond immediately with defer message
             return {"type": DiscordResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE}
 
-        if data.get("type") == DiscordInteractionType.MESSAGE_COMPONENT:
+        if interaction_type == DiscordInteractionType.MESSAGE_COMPONENT:
             print("🤖: handling component interaction")
             app_id = data["application_id"]
             interaction_token = data["token"]
@@ -1076,7 +1120,7 @@ def web_app():
 
             return {"type": DiscordResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE}
 
-        if data.get("type") == DiscordInteractionType.MODAL_SUBMIT:
+        if interaction_type == DiscordInteractionType.MODAL_SUBMIT:
             print("🤖: handling modal submission")
             app_id = data["application_id"]
             interaction_token = data["token"]

--- a/apps/discord/auth.py
+++ b/apps/discord/auth.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from fastapi.exceptions import HTTPException
 from nacl.exceptions import BadSignatureError
@@ -22,7 +22,7 @@ class DiscordAuth:
 
     @staticmethod
     def verify_request(
-        headers: dict,
+        headers: Mapping[str, str],
         body: bytes,
         *,
         clock: Callable[[], float] = time.time,

--- a/apps/discord/auth.py
+++ b/apps/discord/auth.py
@@ -1,19 +1,34 @@
 """Authentication and request verification for Discord interactions."""
 
+import logging
 import os
+import time
+from collections.abc import Callable
 
 from fastapi.exceptions import HTTPException
 from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
+
+logger = logging.getLogger(__name__)
+
+# Discord requires the timestamp header to be included in signature verification
+# but does not publish a numeric replay tolerance. Five minutes allows ordinary
+# delivery jitter while sharply bounding the useful lifetime of a captured request.
+DISCORD_SIGNATURE_FRESHNESS_SECONDS = 300
 
 
 class DiscordAuth:
     """Handles Discord request authentication."""
 
     @staticmethod
-    def verify_request(headers: dict, body: bytes) -> None:
+    def verify_request(
+        headers: dict,
+        body: bytes,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
         """Verify that the request is from Discord using their public key."""
-        print("🤖: authenticating request")
+        logger.debug("Authenticating Discord interaction request")
 
         # Get Discord public key from environment
         public_key = os.getenv("DISCORD_PUBLIC_KEY")
@@ -31,11 +46,20 @@ class DiscordAuth:
         if not signature or not timestamp:
             raise HTTPException(status_code=401, detail="Missing signature headers")
 
+        try:
+            timestamp_seconds = int(timestamp)
+        except (TypeError, ValueError) as error:
+            raise HTTPException(status_code=401, detail="Invalid request") from error
+
         # Create message for verification
         message = timestamp.encode() + body
 
         try:
             verify_key.verify(message, bytes.fromhex(signature))
-        except BadSignatureError as error:
+        except (BadSignatureError, ValueError) as error:
             # Either an unauthorized request or Discord's "negative control" check
             raise HTTPException(status_code=401, detail="Invalid request") from error
+
+        age_seconds = clock() - timestamp_seconds
+        if abs(age_seconds) > DISCORD_SIGNATURE_FRESHNESS_SECONDS:
+            raise HTTPException(status_code=401, detail="Invalid request")

--- a/apps/discord/interaction_replay.py
+++ b/apps/discord/interaction_replay.py
@@ -1,11 +1,22 @@
 """Validation and replay protection for Discord interaction dispatch."""
 
+import json
 import logging
+import re
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import Any
 
 from fastapi.exceptions import HTTPException
+from fastapi.requests import Request
 
+from auth import DiscordAuth
 from config import DiscordInteractionType, DiscordResponseType
-from utils import claim_discord_interaction
+from utils import (
+    claim_discord_interaction,
+    complete_discord_interaction,
+    release_discord_interaction,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -15,10 +26,19 @@ SUPPORTED_INTERACTION_TYPES = {
     DiscordInteractionType.MESSAGE_COMPONENT,
     DiscordInteractionType.MODAL_SUBMIT,
 }
+INTERACTION_ID_PATTERN = re.compile(r"^[0-9]{1,32}$")
+CLAIM_ID_STATE_KEY = "discord_interaction_claim_id"
+CLAIM_TYPE_STATE_KEY = "discord_interaction_claim_type"
 
 
-def prepare_interaction_dispatch(data: object) -> tuple[int, dict[str, int] | None]:
-    """Validate an interaction and claim side-effecting deliveries once."""
+async def prepare_interaction_dispatch(
+    request: Request,
+) -> tuple[dict, int, dict[str, Any] | None]:
+    """Verify, parse, validate, and claim an interaction for dispatch."""
+    body = await request.body()
+    DiscordAuth.verify_request(request.headers, body)
+    data = json.loads(body.decode())
+
     if not isinstance(data, dict):
         raise HTTPException(status_code=400, detail="Bad request")
 
@@ -29,14 +49,14 @@ def prepare_interaction_dispatch(data: object) -> tuple[int, dict[str, int] | No
     # PING is a side-effect-free endpoint handshake. Keeping it independent of
     # claim storage avoids turning database availability into endpoint downtime.
     if interaction_type == DiscordInteractionType.PING:
-        return interaction_type, None
+        return data, interaction_type, None
 
     interaction_id = data.get("id")
-    if not isinstance(interaction_id, str) or not interaction_id.isdigit():
+    if not isinstance(interaction_id, str) or not INTERACTION_ID_PATTERN.fullmatch(interaction_id):
         raise HTTPException(status_code=400, detail="Bad request")
 
     try:
-        claimed = claim_discord_interaction(interaction_id, interaction_type)
+        claim = claim_discord_interaction(interaction_id, interaction_type)
     except Exception as error:
         logger.exception(
             "Failed to claim Discord interaction",
@@ -44,11 +64,65 @@ def prepare_interaction_dispatch(data: object) -> tuple[int, dict[str, int] | No
         )
         raise HTTPException(status_code=503, detail="Interaction claim unavailable") from error
 
-    if claimed:
-        return interaction_type, None
+    state = claim.get("state")
+    if state == "claimed":
+        setattr(request.state, CLAIM_ID_STATE_KEY, interaction_id)
+        setattr(request.state, CLAIM_TYPE_STATE_KEY, interaction_type)
+        return data, interaction_type, None
+
+    if state == "completed" and isinstance(claim.get("response"), dict):
+        return data, interaction_type, claim["response"]
+
+    if state != "processing":
+        raise HTTPException(status_code=503, detail="Interaction claim unavailable")
 
     logger.info(
         "Acknowledging duplicate Discord interaction",
         extra={"interaction_type": interaction_type},
     )
-    return interaction_type, {"type": DiscordResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE}
+    return (
+        data,
+        interaction_type,
+        {"type": DiscordResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE},
+    )
+
+
+def with_discord_interaction_replay(
+    handler: Callable[..., Awaitable[dict[str, Any]]],
+) -> Callable[..., Awaitable[dict[str, Any]]]:
+    """Release failed dispatches and cache successful protocol responses."""
+
+    @wraps(handler)
+    async def guarded(request: Request, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        try:
+            response = await handler(request, *args, **kwargs)
+        except BaseException:
+            interaction_id = getattr(request.state, CLAIM_ID_STATE_KEY, None)
+            interaction_type = getattr(request.state, CLAIM_TYPE_STATE_KEY, None)
+            if isinstance(interaction_id, str) and isinstance(interaction_type, int):
+                try:
+                    release_discord_interaction(interaction_id, interaction_type)
+                except Exception:
+                    logger.exception(
+                        "Failed to release Discord interaction claim",
+                        extra={"interaction_type": interaction_type},
+                    )
+            raise
+
+        interaction_id = getattr(request.state, CLAIM_ID_STATE_KEY, None)
+        interaction_type = getattr(request.state, CLAIM_TYPE_STATE_KEY, None)
+        if isinstance(interaction_id, str) and isinstance(interaction_type, int):
+            try:
+                complete_discord_interaction(interaction_id, interaction_type, response)
+            except Exception as error:
+                logger.exception(
+                    "Failed to complete Discord interaction claim",
+                    extra={"interaction_type": interaction_type},
+                )
+                raise HTTPException(
+                    status_code=503, detail="Interaction completion unavailable"
+                ) from error
+
+        return response
+
+    return guarded

--- a/apps/discord/interaction_replay.py
+++ b/apps/discord/interaction_replay.py
@@ -1,0 +1,54 @@
+"""Validation and replay protection for Discord interaction dispatch."""
+
+import logging
+
+from fastapi.exceptions import HTTPException
+
+from config import DiscordInteractionType, DiscordResponseType
+from utils import claim_discord_interaction
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_INTERACTION_TYPES = {
+    DiscordInteractionType.PING,
+    DiscordInteractionType.APPLICATION_COMMAND,
+    DiscordInteractionType.MESSAGE_COMPONENT,
+    DiscordInteractionType.MODAL_SUBMIT,
+}
+
+
+def prepare_interaction_dispatch(data: object) -> tuple[int, dict[str, int] | None]:
+    """Validate an interaction and claim side-effecting deliveries once."""
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="Bad request")
+
+    interaction_type = data.get("type")
+    if not isinstance(interaction_type, int) or interaction_type not in SUPPORTED_INTERACTION_TYPES:
+        raise HTTPException(status_code=400, detail="Bad request")
+
+    # PING is a side-effect-free endpoint handshake. Keeping it independent of
+    # claim storage avoids turning database availability into endpoint downtime.
+    if interaction_type == DiscordInteractionType.PING:
+        return interaction_type, None
+
+    interaction_id = data.get("id")
+    if not isinstance(interaction_id, str) or not interaction_id.isdigit():
+        raise HTTPException(status_code=400, detail="Bad request")
+
+    try:
+        claimed = claim_discord_interaction(interaction_id, interaction_type)
+    except Exception as error:
+        logger.exception(
+            "Failed to claim Discord interaction",
+            extra={"interaction_type": interaction_type},
+        )
+        raise HTTPException(status_code=503, detail="Interaction claim unavailable") from error
+
+    if claimed:
+        return interaction_type, None
+
+    logger.info(
+        "Acknowledging duplicate Discord interaction",
+        extra={"interaction_type": interaction_type},
+    )
+    return interaction_type, {"type": DiscordResponseType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE}

--- a/apps/discord/interaction_replay.py
+++ b/apps/discord/interaction_replay.py
@@ -176,7 +176,7 @@ def with_discord_interaction_replay(
                     claim_token,
                     response,
                 )
-            except BaseException as error:
+            except (Exception, asyncio.CancelledError) as error:
                 logger.exception(
                     "Failed to complete Discord interaction claim",
                     extra={"interaction_type": interaction_type},

--- a/apps/discord/interaction_replay.py
+++ b/apps/discord/interaction_replay.py
@@ -17,6 +17,7 @@ from utils import (
     claim_discord_interaction,
     complete_discord_interaction,
     release_discord_interaction,
+    renew_discord_interaction_claim,
 )
 
 logger = logging.getLogger(__name__)
@@ -61,8 +62,31 @@ async def prepare_interaction_dispatch(
     if not isinstance(interaction_id, str) or not INTERACTION_ID_PATTERN.fullmatch(interaction_id):
         raise HTTPException(status_code=400, detail="Bad request")
 
+    claim_task = asyncio.create_task(
+        asyncio.to_thread(claim_discord_interaction, interaction_id, interaction_type)
+    )
     try:
-        claim = await asyncio.to_thread(claim_discord_interaction, interaction_id, interaction_type)
+        claim = await asyncio.shield(claim_task)
+    except asyncio.CancelledError:
+        # Cancelling an await does not stop its worker thread. Wait for the
+        # claim result and release any late ownership before propagating the
+        # request cancellation, otherwise retries remain fenced until expiry.
+        try:
+            late_claim = await claim_task
+            late_token = late_claim.get("claimToken")
+            if late_claim.get("state") == "claimed" and isinstance(late_token, str):
+                await asyncio.to_thread(
+                    release_discord_interaction,
+                    interaction_id,
+                    interaction_type,
+                    late_token,
+                )
+        except Exception:
+            logger.exception(
+                "Failed to clean up canceled Discord interaction claim",
+                extra={"interaction_type": interaction_type},
+            )
+        raise
     except Exception as error:
         logger.exception(
             "Failed to claim Discord interaction",
@@ -139,20 +163,26 @@ def with_discord_interaction_replay(
             and isinstance(interaction_type, int)
         ):
             try:
-                await asyncio.to_thread(
+                await _run_blocking_to_completion(
+                    renew_discord_interaction_claim,
+                    interaction_id,
+                    interaction_type,
+                    claim_token,
+                )
+                await _run_blocking_to_completion(
                     complete_discord_interaction,
                     interaction_id,
                     interaction_type,
                     claim_token,
                     response,
                 )
-            except Exception as error:
+            except BaseException as error:
                 logger.exception(
                     "Failed to complete Discord interaction claim",
                     extra={"interaction_type": interaction_type},
                 )
                 try:
-                    await asyncio.to_thread(
+                    await _run_blocking_to_completion(
                         release_discord_interaction,
                         interaction_id,
                         interaction_type,
@@ -163,6 +193,8 @@ def with_discord_interaction_replay(
                         "Failed to release Discord interaction claim",
                         extra={"interaction_type": interaction_type},
                     )
+                if isinstance(error, asyncio.CancelledError):
+                    raise
                 raise HTTPException(
                     status_code=503, detail="Interaction completion unavailable"
                 ) from error
@@ -170,3 +202,16 @@ def with_discord_interaction_replay(
         return response
 
     return guarded
+
+
+async def _run_blocking_to_completion(function: Callable[..., Any], *args: Any) -> Any:
+    """Let an ownership-changing RPC finish even if its request is canceled."""
+    task = asyncio.create_task(asyncio.to_thread(function, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        try:
+            await task
+        except Exception:
+            logger.exception("Canceled Discord interaction RPC failed")
+        raise

--- a/apps/discord/interaction_replay.py
+++ b/apps/discord/interaction_replay.py
@@ -28,6 +28,7 @@ SUPPORTED_INTERACTION_TYPES = {
 }
 INTERACTION_ID_PATTERN = re.compile(r"^[0-9]{1,32}$")
 CLAIM_ID_STATE_KEY = "discord_interaction_claim_id"
+CLAIM_OWNERSHIP_STATE_KEY = "discord_interaction_claim_ownership"
 CLAIM_TYPE_STATE_KEY = "discord_interaction_claim_type"
 
 
@@ -37,7 +38,10 @@ async def prepare_interaction_dispatch(
     """Verify, parse, validate, and claim an interaction for dispatch."""
     body = await request.body()
     DiscordAuth.verify_request(request.headers, body)
-    data = json.loads(body.decode())
+    try:
+        data = json.loads(body.decode())
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise HTTPException(status_code=400, detail="Bad request") from error
 
     if not isinstance(data, dict):
         raise HTTPException(status_code=400, detail="Bad request")
@@ -65,8 +69,10 @@ async def prepare_interaction_dispatch(
         raise HTTPException(status_code=503, detail="Interaction claim unavailable") from error
 
     state = claim.get("state")
-    if state == "claimed":
+    claim_token = claim.get("claimToken")
+    if state == "claimed" and isinstance(claim_token, str):
         setattr(request.state, CLAIM_ID_STATE_KEY, interaction_id)
+        setattr(request.state, CLAIM_OWNERSHIP_STATE_KEY, claim_token)
         setattr(request.state, CLAIM_TYPE_STATE_KEY, interaction_type)
         return data, interaction_type, None
 
@@ -98,10 +104,15 @@ def with_discord_interaction_replay(
             response = await handler(request, *args, **kwargs)
         except BaseException:
             interaction_id = getattr(request.state, CLAIM_ID_STATE_KEY, None)
+            claim_token = getattr(request.state, CLAIM_OWNERSHIP_STATE_KEY, None)
             interaction_type = getattr(request.state, CLAIM_TYPE_STATE_KEY, None)
-            if isinstance(interaction_id, str) and isinstance(interaction_type, int):
+            if (
+                isinstance(interaction_id, str)
+                and isinstance(claim_token, str)
+                and isinstance(interaction_type, int)
+            ):
                 try:
-                    release_discord_interaction(interaction_id, interaction_type)
+                    release_discord_interaction(interaction_id, interaction_type, claim_token)
                 except Exception:
                     logger.exception(
                         "Failed to release Discord interaction claim",
@@ -110,15 +121,29 @@ def with_discord_interaction_replay(
             raise
 
         interaction_id = getattr(request.state, CLAIM_ID_STATE_KEY, None)
+        claim_token = getattr(request.state, CLAIM_OWNERSHIP_STATE_KEY, None)
         interaction_type = getattr(request.state, CLAIM_TYPE_STATE_KEY, None)
-        if isinstance(interaction_id, str) and isinstance(interaction_type, int):
+        if (
+            isinstance(interaction_id, str)
+            and isinstance(claim_token, str)
+            and isinstance(interaction_type, int)
+        ):
             try:
-                complete_discord_interaction(interaction_id, interaction_type, response)
+                complete_discord_interaction(
+                    interaction_id, interaction_type, claim_token, response
+                )
             except Exception as error:
                 logger.exception(
                     "Failed to complete Discord interaction claim",
                     extra={"interaction_type": interaction_type},
                 )
+                try:
+                    release_discord_interaction(interaction_id, interaction_type, claim_token)
+                except Exception:
+                    logger.exception(
+                        "Failed to release Discord interaction claim",
+                        extra={"interaction_type": interaction_type},
+                    )
                 raise HTTPException(
                     status_code=503, detail="Interaction completion unavailable"
                 ) from error

--- a/apps/discord/interaction_replay.py
+++ b/apps/discord/interaction_replay.py
@@ -62,9 +62,7 @@ async def prepare_interaction_dispatch(
         raise HTTPException(status_code=400, detail="Bad request")
 
     try:
-        claim = await asyncio.to_thread(
-            claim_discord_interaction, interaction_id, interaction_type
-        )
+        claim = await asyncio.to_thread(claim_discord_interaction, interaction_id, interaction_type)
     except Exception as error:
         logger.exception(
             "Failed to claim Discord interaction",

--- a/apps/discord/interaction_replay.py
+++ b/apps/discord/interaction_replay.py
@@ -1,5 +1,6 @@
 """Validation and replay protection for Discord interaction dispatch."""
 
+import asyncio
 import json
 import logging
 import re
@@ -30,6 +31,7 @@ INTERACTION_ID_PATTERN = re.compile(r"^[0-9]{1,32}$")
 CLAIM_ID_STATE_KEY = "discord_interaction_claim_id"
 CLAIM_OWNERSHIP_STATE_KEY = "discord_interaction_claim_ownership"
 CLAIM_TYPE_STATE_KEY = "discord_interaction_claim_type"
+DISPATCH_TIMEOUT_SECONDS = 45
 
 
 async def prepare_interaction_dispatch(
@@ -60,7 +62,9 @@ async def prepare_interaction_dispatch(
         raise HTTPException(status_code=400, detail="Bad request")
 
     try:
-        claim = claim_discord_interaction(interaction_id, interaction_type)
+        claim = await asyncio.to_thread(
+            claim_discord_interaction, interaction_id, interaction_type
+        )
     except Exception as error:
         logger.exception(
             "Failed to claim Discord interaction",
@@ -101,7 +105,10 @@ def with_discord_interaction_replay(
     @wraps(handler)
     async def guarded(request: Request, *args: Any, **kwargs: Any) -> dict[str, Any]:
         try:
-            response = await handler(request, *args, **kwargs)
+            response = await asyncio.wait_for(
+                handler(request, *args, **kwargs),
+                timeout=DISPATCH_TIMEOUT_SECONDS,
+            )
         except BaseException:
             interaction_id = getattr(request.state, CLAIM_ID_STATE_KEY, None)
             claim_token = getattr(request.state, CLAIM_OWNERSHIP_STATE_KEY, None)
@@ -112,7 +119,12 @@ def with_discord_interaction_replay(
                 and isinstance(interaction_type, int)
             ):
                 try:
-                    release_discord_interaction(interaction_id, interaction_type, claim_token)
+                    await asyncio.to_thread(
+                        release_discord_interaction,
+                        interaction_id,
+                        interaction_type,
+                        claim_token,
+                    )
                 except Exception:
                     logger.exception(
                         "Failed to release Discord interaction claim",
@@ -129,8 +141,12 @@ def with_discord_interaction_replay(
             and isinstance(interaction_type, int)
         ):
             try:
-                complete_discord_interaction(
-                    interaction_id, interaction_type, claim_token, response
+                await asyncio.to_thread(
+                    complete_discord_interaction,
+                    interaction_id,
+                    interaction_type,
+                    claim_token,
+                    response,
                 )
             except Exception as error:
                 logger.exception(
@@ -138,7 +154,12 @@ def with_discord_interaction_replay(
                     extra={"interaction_type": interaction_type},
                 )
                 try:
-                    release_discord_interaction(interaction_id, interaction_type, claim_token)
+                    await asyncio.to_thread(
+                        release_discord_interaction,
+                        interaction_id,
+                        interaction_type,
+                        claim_token,
+                    )
                 except Exception:
                     logger.exception(
                         "Failed to release Discord interaction claim",

--- a/apps/discord/tests/test_interaction_replay.py
+++ b/apps/discord/tests/test_interaction_replay.py
@@ -3,6 +3,7 @@ import json
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -457,7 +458,7 @@ def test_canceled_completion_waits_then_releases_owned_claim(
 
     async def run() -> None:
         guarded = interaction_replay.with_discord_interaction_replay(handler)
-        task = asyncio.create_task(guarded(request))
+        task: asyncio.Task[dict[str, Any]] = asyncio.create_task(guarded(request))
         await asyncio.to_thread(completion_started.wait, 1)
         task.cancel()
         finish_completion.set()

--- a/apps/discord/tests/test_interaction_replay.py
+++ b/apps/discord/tests/test_interaction_replay.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import threading
 import time
@@ -6,6 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 from fastapi.exceptions import HTTPException
+from fastapi.requests import Request
 from fastapi.testclient import TestClient
 from nacl.signing import SigningKey
 
@@ -359,3 +361,31 @@ def test_completion_failure_releases_the_owned_claim_for_retry(
     interaction_lifecycle["release"].assert_called_once_with(
         "623456789012345678", 2, CLAIM_OWNERSHIP_ID
     )
+
+
+def test_dispatch_timeout_releases_claim_before_lease_expiry(
+    interaction_lifecycle: dict[str, Mock], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(interaction_replay, "DISPATCH_TIMEOUT_SECONDS", 0.01)
+
+    async def slow_dispatch(_request: Request) -> dict[str, int]:
+        await asyncio.sleep(0.05)
+        return {"type": 5}
+
+    request = Request({"type": "http", "method": "POST", "path": "/"})
+    setattr(request.state, interaction_replay.CLAIM_ID_STATE_KEY, "723456789012345678")
+    setattr(
+        request.state,
+        interaction_replay.CLAIM_OWNERSHIP_STATE_KEY,
+        CLAIM_OWNERSHIP_ID,
+    )
+    setattr(request.state, interaction_replay.CLAIM_TYPE_STATE_KEY, 2)
+
+    guarded = interaction_replay.with_discord_interaction_replay(slow_dispatch)
+    with pytest.raises(TimeoutError):
+        asyncio.run(guarded(request))
+
+    interaction_lifecycle["release"].assert_called_once_with(
+        "723456789012345678", 2, CLAIM_OWNERSHIP_ID
+    )
+    interaction_lifecycle["complete"].assert_not_called()

--- a/apps/discord/tests/test_interaction_replay.py
+++ b/apps/discord/tests/test_interaction_replay.py
@@ -38,9 +38,11 @@ def signing_key(monkeypatch: pytest.MonkeyPatch) -> SigningKey:
 def interaction_lifecycle(monkeypatch: pytest.MonkeyPatch) -> dict[str, Mock]:
     complete = Mock()
     release = Mock()
+    renew = Mock()
     monkeypatch.setattr(interaction_replay, "complete_discord_interaction", complete)
     monkeypatch.setattr(interaction_replay, "release_discord_interaction", release)
-    return {"complete": complete, "release": release}
+    monkeypatch.setattr(interaction_replay, "renew_discord_interaction_claim", renew)
+    return {"complete": complete, "release": release, "renew": renew}
 
 
 @pytest.mark.parametrize(
@@ -160,6 +162,9 @@ def test_duplicate_delivery_is_acknowledged_without_spawning(
     spawn.assert_called_once()
     interaction_lifecycle["complete"].assert_called_once_with(
         "123456789012345678", 2, CLAIM_OWNERSHIP_ID, response_payload
+    )
+    interaction_lifecycle["renew"].assert_called_once_with(
+        "123456789012345678", 2, CLAIM_OWNERSHIP_ID
     )
 
 
@@ -389,3 +394,77 @@ def test_dispatch_timeout_releases_claim_before_lease_expiry(
         "723456789012345678", 2, CLAIM_OWNERSHIP_ID
     )
     interaction_lifecycle["complete"].assert_not_called()
+
+
+def test_canceled_claim_releases_late_ownership(monkeypatch: pytest.MonkeyPatch) -> None:
+    claim_started = threading.Event()
+    finish_claim = threading.Event()
+
+    def delayed_claim(*_args: object) -> dict[str, str]:
+        claim_started.set()
+        finish_claim.wait(timeout=1)
+        return {"state": "claimed", "claimToken": CLAIM_OWNERSHIP_ID}
+
+    monkeypatch.setattr(interaction_replay.DiscordAuth, "verify_request", Mock())
+    monkeypatch.setattr(interaction_replay, "claim_discord_interaction", delayed_claim)
+    release = Mock()
+    monkeypatch.setattr(interaction_replay, "release_discord_interaction", release)
+
+    async def run() -> None:
+        body = json.dumps(command_payload("823456789012345678")).encode()
+
+        async def receive() -> dict[str, object]:
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        request = Request(
+            {"type": "http", "method": "POST", "path": "/", "headers": []},
+            receive,
+        )
+        task = asyncio.create_task(interaction_replay.prepare_interaction_dispatch(request))
+        await asyncio.to_thread(claim_started.wait, 1)
+        task.cancel()
+        finish_claim.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())
+    release.assert_called_once_with("823456789012345678", 2, CLAIM_OWNERSHIP_ID)
+
+
+def test_canceled_completion_waits_then_releases_owned_claim(
+    interaction_lifecycle: dict[str, Mock],
+) -> None:
+    completion_started = threading.Event()
+    finish_completion = threading.Event()
+
+    def delayed_completion(*_args: object) -> None:
+        completion_started.set()
+        finish_completion.wait(timeout=1)
+
+    interaction_lifecycle["complete"].side_effect = delayed_completion
+
+    async def handler(_request: Request) -> dict[str, int]:
+        return {"type": 5}
+
+    request = Request({"type": "http", "method": "POST", "path": "/"})
+    setattr(request.state, interaction_replay.CLAIM_ID_STATE_KEY, "923456789012345678")
+    setattr(
+        request.state,
+        interaction_replay.CLAIM_OWNERSHIP_STATE_KEY,
+        CLAIM_OWNERSHIP_ID,
+    )
+    setattr(request.state, interaction_replay.CLAIM_TYPE_STATE_KEY, 2)
+
+    async def run() -> None:
+        guarded = interaction_replay.with_discord_interaction_replay(handler)
+        task = asyncio.create_task(guarded(request))
+        await asyncio.to_thread(completion_started.wait, 1)
+        task.cancel()
+        finish_completion.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())
+    interaction_lifecycle["release"].assert_called_once_with(
+        "923456789012345678", 2, CLAIM_OWNERSHIP_ID
+    )

--- a/apps/discord/tests/test_interaction_replay.py
+++ b/apps/discord/tests/test_interaction_replay.py
@@ -13,6 +13,8 @@ import app
 import interaction_replay
 from auth import DISCORD_SIGNATURE_FRESHNESS_SECONDS, DiscordAuth
 
+CLAIM_OWNERSHIP_ID = "11111111-1111-4111-8111-111111111111"
+
 
 def signed_headers(signing_key: SigningKey, timestamp: int, body: bytes) -> dict[str, str]:
     timestamp_text = str(timestamp)
@@ -133,7 +135,7 @@ def test_duplicate_delivery_is_acknowledged_without_spawning(
     response_payload = {"type": 5}
     claims = iter(
         [
-            {"state": "claimed"},
+            {"state": "claimed", "claimToken": CLAIM_OWNERSHIP_ID},
             {"state": "completed", "response": response_payload},
         ]
     )
@@ -155,7 +157,7 @@ def test_duplicate_delivery_is_acknowledged_without_spawning(
     assert claim.call_count == 2
     spawn.assert_called_once()
     interaction_lifecycle["complete"].assert_called_once_with(
-        "123456789012345678", 2, response_payload
+        "123456789012345678", 2, CLAIM_OWNERSHIP_ID, response_payload
     )
 
 
@@ -171,7 +173,7 @@ def test_concurrent_duplicate_delivery_spawns_once(
             if interaction_id in claimed_ids:
                 return {"state": "processing"}
             claimed_ids.add(interaction_id)
-            return {"state": "claimed"}
+            return {"state": "claimed", "claimToken": CLAIM_OWNERSHIP_ID}
 
     def send_delivery(_: int):
         with TestClient(app.web_app.get_raw_f()()) as client:
@@ -222,7 +224,7 @@ def test_failed_dispatch_releases_the_claim_for_retry(
     monkeypatch.setattr(
         interaction_replay,
         "claim_discord_interaction",
-        Mock(return_value={"state": "claimed"}),
+        Mock(return_value={"state": "claimed", "claimToken": CLAIM_OWNERSHIP_ID}),
     )
     monkeypatch.setattr(
         app.reply_ticket,
@@ -239,7 +241,9 @@ def test_failed_dispatch_releases_the_claim_for_retry(
     )
 
     assert response.status_code == 500
-    interaction_lifecycle["release"].assert_called_once_with("423456789012345678", 2)
+    interaction_lifecycle["release"].assert_called_once_with(
+        "423456789012345678", 2, CLAIM_OWNERSHIP_ID
+    )
     interaction_lifecycle["complete"].assert_not_called()
 
 
@@ -307,3 +311,51 @@ def test_ping_does_not_depend_on_claim_storage(
     assert response.status_code == 200
     assert response.json() == {"type": 1}
     claim.assert_not_called()
+
+
+@pytest.mark.parametrize("body", [b"\xff", b"{"])
+def test_signed_malformed_payload_is_a_bad_request(
+    body: bytes,
+    monkeypatch: pytest.MonkeyPatch,
+    signing_key: SigningKey,
+) -> None:
+    claim = Mock()
+    monkeypatch.setattr(interaction_replay, "claim_discord_interaction", claim)
+    timestamp = int(time.time())
+    client = TestClient(app.web_app.get_raw_f()())
+
+    response = client.post(
+        "/api",
+        content=body,
+        headers=signed_headers(signing_key, timestamp, body),
+    )
+
+    assert response.status_code == 400
+    claim.assert_not_called()
+
+
+def test_completion_failure_releases_the_owned_claim_for_retry(
+    interaction_lifecycle: dict[str, Mock],
+    monkeypatch: pytest.MonkeyPatch,
+    signing_key: SigningKey,
+) -> None:
+    interaction_lifecycle["complete"].side_effect = RuntimeError("completion unavailable")
+    monkeypatch.setattr(
+        interaction_replay,
+        "claim_discord_interaction",
+        Mock(return_value={"state": "claimed", "claimToken": CLAIM_OWNERSHIP_ID}),
+    )
+    monkeypatch.setattr(app.reply_ticket, "spawn", Mock())
+    client = TestClient(app.web_app.get_raw_f()())
+
+    response = post_signed(
+        client,
+        signing_key,
+        command_payload("623456789012345678"),
+        int(time.time()),
+    )
+
+    assert response.status_code == 503
+    interaction_lifecycle["release"].assert_called_once_with(
+        "623456789012345678", 2, CLAIM_OWNERSHIP_ID
+    )

--- a/apps/discord/tests/test_interaction_replay.py
+++ b/apps/discord/tests/test_interaction_replay.py
@@ -30,6 +30,15 @@ def signing_key(monkeypatch: pytest.MonkeyPatch) -> SigningKey:
     return key
 
 
+@pytest.fixture(autouse=True)
+def interaction_lifecycle(monkeypatch: pytest.MonkeyPatch) -> dict[str, Mock]:
+    complete = Mock()
+    release = Mock()
+    monkeypatch.setattr(interaction_replay, "complete_discord_interaction", complete)
+    monkeypatch.setattr(interaction_replay, "release_discord_interaction", release)
+    return {"complete": complete, "release": release}
+
+
 @pytest.mark.parametrize(
     "offset",
     [-DISCORD_SIGNATURE_FRESHNESS_SECONDS, DISCORD_SIGNATURE_FRESHNESS_SECONDS],
@@ -117,9 +126,17 @@ def post_signed(client: TestClient, signing_key: SigningKey, payload: dict, time
 
 
 def test_duplicate_delivery_is_acknowledged_without_spawning(
-    monkeypatch: pytest.MonkeyPatch, signing_key: SigningKey
+    interaction_lifecycle: dict[str, Mock],
+    monkeypatch: pytest.MonkeyPatch,
+    signing_key: SigningKey,
 ) -> None:
-    claims = iter([True, False])
+    response_payload = {"type": 5}
+    claims = iter(
+        [
+            {"state": "claimed"},
+            {"state": "completed", "response": response_payload},
+        ]
+    )
     claim = Mock(side_effect=lambda *_args: next(claims))
     spawn = Mock()
     monkeypatch.setattr(interaction_replay, "claim_discord_interaction", claim)
@@ -137,6 +154,9 @@ def test_duplicate_delivery_is_acknowledged_without_spawning(
     assert second.json() == {"type": 5}
     assert claim.call_count == 2
     spawn.assert_called_once()
+    interaction_lifecycle["complete"].assert_called_once_with(
+        "123456789012345678", 2, response_payload
+    )
 
 
 def test_concurrent_duplicate_delivery_spawns_once(
@@ -144,27 +164,27 @@ def test_concurrent_duplicate_delivery_spawns_once(
 ) -> None:
     claimed_ids: set[str] = set()
     claim_lock = threading.Lock()
+    request_barrier = threading.Barrier(2)
 
-    def claim_once(interaction_id: str, _interaction_type: int) -> bool:
+    def claim_once(interaction_id: str, _interaction_type: int) -> dict[str, str]:
         with claim_lock:
             if interaction_id in claimed_ids:
-                return False
+                return {"state": "processing"}
             claimed_ids.add(interaction_id)
-            return True
+            return {"state": "claimed"}
+
+    def send_delivery(_: int):
+        with TestClient(app.web_app.get_raw_f()()) as client:
+            request_barrier.wait()
+            return post_signed(client, signing_key, payload, int(time.time()))
 
     spawn = Mock()
     monkeypatch.setattr(interaction_replay, "claim_discord_interaction", claim_once)
     monkeypatch.setattr(app.reply_ticket, "spawn", spawn)
-    client = TestClient(app.web_app.get_raw_f()())
     payload = command_payload("223456789012345678")
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        responses = list(
-            executor.map(
-                lambda _: post_signed(client, signing_key, payload, int(time.time())),
-                range(2),
-            )
-        )
+        responses = list(executor.map(send_delivery, range(2)))
 
     assert [response.status_code for response in responses] == [200, 200]
     assert [response.json() for response in responses] == [{"type": 5}, {"type": 5}]
@@ -192,6 +212,87 @@ def test_claim_store_failure_fails_closed_before_spawn(
 
     assert response.status_code == 503
     spawn.assert_not_called()
+
+
+def test_failed_dispatch_releases_the_claim_for_retry(
+    interaction_lifecycle: dict[str, Mock],
+    monkeypatch: pytest.MonkeyPatch,
+    signing_key: SigningKey,
+) -> None:
+    monkeypatch.setattr(
+        interaction_replay,
+        "claim_discord_interaction",
+        Mock(return_value={"state": "claimed"}),
+    )
+    monkeypatch.setattr(
+        app.reply_ticket,
+        "spawn",
+        Mock(side_effect=RuntimeError("dispatch failed")),
+    )
+    client = TestClient(app.web_app.get_raw_f()(), raise_server_exceptions=False)
+
+    response = post_signed(
+        client,
+        signing_key,
+        command_payload("423456789012345678"),
+        int(time.time()),
+    )
+
+    assert response.status_code == 500
+    interaction_lifecycle["release"].assert_called_once_with("423456789012345678", 2)
+    interaction_lifecycle["complete"].assert_not_called()
+
+
+def test_completed_component_delivery_replays_the_original_modal(
+    interaction_lifecycle: dict[str, Mock],
+    monkeypatch: pytest.MonkeyPatch,
+    signing_key: SigningKey,
+) -> None:
+    modal_response = {
+        "type": 9,
+        "data": {"custom_id": "ticket_form|board|list", "title": "Ticket"},
+    }
+    monkeypatch.setattr(
+        interaction_replay,
+        "claim_discord_interaction",
+        Mock(return_value={"state": "completed", "response": modal_response}),
+    )
+    client = TestClient(app.web_app.get_raw_f()())
+
+    response = post_signed(
+        client,
+        signing_key,
+        {"id": "523456789012345678", "type": 3},
+        int(time.time()),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == modal_response
+    interaction_lifecycle["complete"].assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "interaction_id",
+    ["1" * 33, "\uff11\uff12\uff13", "123-not-numeric"],
+)
+def test_invalid_interaction_ids_are_bad_requests_before_claim(
+    interaction_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+    signing_key: SigningKey,
+) -> None:
+    claim = Mock()
+    monkeypatch.setattr(interaction_replay, "claim_discord_interaction", claim)
+    client = TestClient(app.web_app.get_raw_f()())
+
+    response = post_signed(
+        client,
+        signing_key,
+        command_payload(interaction_id),
+        int(time.time()),
+    )
+
+    assert response.status_code == 400
+    claim.assert_not_called()
 
 
 def test_ping_does_not_depend_on_claim_storage(

--- a/apps/discord/tests/test_interaction_replay.py
+++ b/apps/discord/tests/test_interaction_replay.py
@@ -1,0 +1,199 @@
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
+
+import pytest
+from fastapi.exceptions import HTTPException
+from fastapi.testclient import TestClient
+from nacl.signing import SigningKey
+
+import app
+from auth import DISCORD_SIGNATURE_FRESHNESS_SECONDS, DiscordAuth
+
+
+def signed_headers(signing_key: SigningKey, timestamp: int, body: bytes) -> dict[str, str]:
+    timestamp_text = str(timestamp)
+    signature = signing_key.sign(timestamp_text.encode() + body).signature.hex()
+    return {
+        "X-Signature-Ed25519": signature,
+        "X-Signature-Timestamp": timestamp_text,
+    }
+
+
+@pytest.fixture
+def signing_key(monkeypatch: pytest.MonkeyPatch) -> SigningKey:
+    key = SigningKey.generate()
+    monkeypatch.setenv("DISCORD_PUBLIC_KEY", key.verify_key.encode().hex())
+    return key
+
+
+@pytest.mark.parametrize(
+    "offset",
+    [-DISCORD_SIGNATURE_FRESHNESS_SECONDS, DISCORD_SIGNATURE_FRESHNESS_SECONDS],
+)
+def test_signature_freshness_accepts_exact_boundaries(
+    signing_key: SigningKey, offset: int
+) -> None:
+    now = 2_000_000_000
+    body = b'{"id":"1","type":1}'
+    timestamp = now + offset
+
+    DiscordAuth.verify_request(
+        signed_headers(signing_key, timestamp, body), body, clock=lambda: now
+    )
+
+
+@pytest.mark.parametrize(
+    "offset",
+    [
+        -DISCORD_SIGNATURE_FRESHNESS_SECONDS - 1,
+        DISCORD_SIGNATURE_FRESHNESS_SECONDS + 1,
+    ],
+)
+def test_signature_freshness_rejects_outside_boundaries(
+    signing_key: SigningKey, offset: int
+) -> None:
+    now = 2_000_000_000
+    body = b'{"id":"1","type":1}'
+    timestamp = now + offset
+
+    with pytest.raises(HTTPException) as exc_info:
+        DiscordAuth.verify_request(
+            signed_headers(signing_key, timestamp, body), body, clock=lambda: now
+        )
+
+    assert exc_info.value.status_code == 401
+
+
+def test_signature_freshness_rejects_malformed_timestamp(
+    signing_key: SigningKey,
+) -> None:
+    body = b'{"id":"1","type":1}'
+    timestamp = "not-a-timestamp"
+    signature = signing_key.sign(timestamp.encode() + body).signature.hex()
+
+    with pytest.raises(HTTPException) as exc_info:
+        DiscordAuth.verify_request(
+            {
+                "X-Signature-Ed25519": signature,
+                "X-Signature-Timestamp": timestamp,
+            },
+            body,
+            clock=lambda: 2_000_000_000,
+        )
+
+    assert exc_info.value.status_code == 401
+
+
+def test_signature_freshness_rejects_invalid_signature(
+    signing_key: SigningKey,
+) -> None:
+    now = 2_000_000_000
+    body = b'{"id":"1","type":1}'
+    headers = signed_headers(signing_key, now, body)
+    headers["X-Signature-Ed25519"] = "00" * 64
+
+    with pytest.raises(HTTPException) as exc_info:
+        DiscordAuth.verify_request(headers, body, clock=lambda: now)
+
+    assert exc_info.value.status_code == 401
+
+
+def command_payload(interaction_id: str) -> dict:
+    return {
+        "application_id": "application-1",
+        "data": {"name": "ticket"},
+        "id": interaction_id,
+        "member": {"user": {"id": "user-1"}},
+        "token": "interaction-token",
+        "type": 2,
+    }
+
+
+def post_signed(
+    client: TestClient, signing_key: SigningKey, payload: dict, timestamp: int
+):
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    return client.post(
+        "/api", content=body, headers=signed_headers(signing_key, timestamp, body)
+    )
+
+
+def test_duplicate_delivery_is_acknowledged_without_spawning(
+    monkeypatch: pytest.MonkeyPatch, signing_key: SigningKey
+) -> None:
+    claims = iter([True, False])
+    claim = Mock(side_effect=lambda *_args: next(claims))
+    spawn = Mock()
+    monkeypatch.setattr(app, "claim_discord_interaction", claim)
+    monkeypatch.setattr(app.reply_ticket, "spawn", spawn)
+    client = TestClient(app.web_app.get_raw_f()())
+    payload = command_payload("123456789012345678")
+    timestamp = int(time.time())
+
+    first = post_signed(client, signing_key, payload, timestamp)
+    second = post_signed(client, signing_key, payload, timestamp)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == {"type": 5}
+    assert second.json() == {"type": 5}
+    assert claim.call_count == 2
+    spawn.assert_called_once()
+
+
+def test_concurrent_duplicate_delivery_spawns_once(
+    monkeypatch: pytest.MonkeyPatch, signing_key: SigningKey
+) -> None:
+    claimed_ids: set[str] = set()
+    claim_lock = threading.Lock()
+
+    def claim_once(interaction_id: str, _interaction_type: int) -> bool:
+        with claim_lock:
+            if interaction_id in claimed_ids:
+                return False
+            claimed_ids.add(interaction_id)
+            return True
+
+    spawn = Mock()
+    monkeypatch.setattr(app, "claim_discord_interaction", claim_once)
+    monkeypatch.setattr(app.reply_ticket, "spawn", spawn)
+    client = TestClient(app.web_app.get_raw_f()())
+    payload = command_payload("223456789012345678")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        responses = list(
+            executor.map(
+                lambda _: post_signed(client, signing_key, payload, int(time.time())),
+                range(2),
+            )
+        )
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert [response.json() for response in responses] == [{"type": 5}, {"type": 5}]
+    spawn.assert_called_once()
+
+
+def test_claim_store_failure_fails_closed_before_spawn(
+    monkeypatch: pytest.MonkeyPatch, signing_key: SigningKey
+) -> None:
+    spawn = Mock()
+    monkeypatch.setattr(
+        app,
+        "claim_discord_interaction",
+        Mock(side_effect=RuntimeError("claim unavailable")),
+    )
+    monkeypatch.setattr(app.reply_ticket, "spawn", spawn)
+    client = TestClient(app.web_app.get_raw_f()())
+
+    response = post_signed(
+        client,
+        signing_key,
+        command_payload("323456789012345678"),
+        int(time.time()),
+    )
+
+    assert response.status_code == 503
+    spawn.assert_not_called()

--- a/apps/discord/tests/test_interaction_replay.py
+++ b/apps/discord/tests/test_interaction_replay.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from nacl.signing import SigningKey
 
 import app
+import interaction_replay
 from auth import DISCORD_SIGNATURE_FRESHNESS_SECONDS, DiscordAuth
 
 
@@ -33,9 +34,7 @@ def signing_key(monkeypatch: pytest.MonkeyPatch) -> SigningKey:
     "offset",
     [-DISCORD_SIGNATURE_FRESHNESS_SECONDS, DISCORD_SIGNATURE_FRESHNESS_SECONDS],
 )
-def test_signature_freshness_accepts_exact_boundaries(
-    signing_key: SigningKey, offset: int
-) -> None:
+def test_signature_freshness_accepts_exact_boundaries(signing_key: SigningKey, offset: int) -> None:
     now = 2_000_000_000
     body = b'{"id":"1","type":1}'
     timestamp = now + offset
@@ -112,13 +111,9 @@ def command_payload(interaction_id: str) -> dict:
     }
 
 
-def post_signed(
-    client: TestClient, signing_key: SigningKey, payload: dict, timestamp: int
-):
+def post_signed(client: TestClient, signing_key: SigningKey, payload: dict, timestamp: int):
     body = json.dumps(payload, separators=(",", ":")).encode()
-    return client.post(
-        "/api", content=body, headers=signed_headers(signing_key, timestamp, body)
-    )
+    return client.post("/api", content=body, headers=signed_headers(signing_key, timestamp, body))
 
 
 def test_duplicate_delivery_is_acknowledged_without_spawning(
@@ -127,7 +122,7 @@ def test_duplicate_delivery_is_acknowledged_without_spawning(
     claims = iter([True, False])
     claim = Mock(side_effect=lambda *_args: next(claims))
     spawn = Mock()
-    monkeypatch.setattr(app, "claim_discord_interaction", claim)
+    monkeypatch.setattr(interaction_replay, "claim_discord_interaction", claim)
     monkeypatch.setattr(app.reply_ticket, "spawn", spawn)
     client = TestClient(app.web_app.get_raw_f()())
     payload = command_payload("123456789012345678")
@@ -158,7 +153,7 @@ def test_concurrent_duplicate_delivery_spawns_once(
             return True
 
     spawn = Mock()
-    monkeypatch.setattr(app, "claim_discord_interaction", claim_once)
+    monkeypatch.setattr(interaction_replay, "claim_discord_interaction", claim_once)
     monkeypatch.setattr(app.reply_ticket, "spawn", spawn)
     client = TestClient(app.web_app.get_raw_f()())
     payload = command_payload("223456789012345678")
@@ -181,7 +176,7 @@ def test_claim_store_failure_fails_closed_before_spawn(
 ) -> None:
     spawn = Mock()
     monkeypatch.setattr(
-        app,
+        interaction_replay,
         "claim_discord_interaction",
         Mock(side_effect=RuntimeError("claim unavailable")),
     )
@@ -197,3 +192,17 @@ def test_claim_store_failure_fails_closed_before_spawn(
 
     assert response.status_code == 503
     spawn.assert_not_called()
+
+
+def test_ping_does_not_depend_on_claim_storage(
+    monkeypatch: pytest.MonkeyPatch, signing_key: SigningKey
+) -> None:
+    claim = Mock(side_effect=RuntimeError("claim unavailable"))
+    monkeypatch.setattr(interaction_replay, "claim_discord_interaction", claim)
+    client = TestClient(app.web_app.get_raw_f()())
+
+    response = post_signed(client, signing_key, {"type": 1}, int(time.time()))
+
+    assert response.status_code == 200
+    assert response.json() == {"type": 1}
+    claim.assert_not_called()

--- a/apps/discord/utils.py
+++ b/apps/discord/utils.py
@@ -65,10 +65,7 @@ def claim_discord_interaction(interaction_id: str, interaction_type: int) -> boo
         "p_retention_seconds": DISCORD_INTERACTION_RETENTION_SECONDS,
     }
     response = (
-        get_supabase_client()
-        .schema("private")
-        .rpc("claim_discord_interaction", params)
-        .execute()
+        get_supabase_client().schema("private").rpc("claim_discord_interaction", params).execute()
     )
     return response.data is True
 

--- a/apps/discord/utils.py
+++ b/apps/discord/utils.py
@@ -10,6 +10,8 @@ from supabase import Client, create_client
 
 from config import DEFAULT_SLUG_LENGTH, MAX_SLUG_LENGTH
 
+DISCORD_INTERACTION_RETENTION_SECONDS = 86400
+
 
 def is_valid_url(url: str) -> bool:
     """Validate URL format."""
@@ -53,6 +55,22 @@ def get_supabase_client() -> Client:
         raise Exception("Supabase credentials not found in environment variables")
 
     return create_client(supabase_url, supabase_key)
+
+
+def claim_discord_interaction(interaction_id: str, interaction_type: int) -> bool:
+    """Atomically claim an opaque Discord interaction id for dispatch."""
+    params: dict[str, Any] = {
+        "p_interaction_id": interaction_id,
+        "p_interaction_type": interaction_type,
+        "p_retention_seconds": DISCORD_INTERACTION_RETENTION_SECONDS,
+    }
+    response = (
+        get_supabase_client()
+        .schema("private")
+        .rpc("claim_discord_interaction", params)
+        .execute()
+    )
+    return response.data is True
 
 
 def is_user_authorized_for_guild(discord_user_id: str, guild_id: str) -> bool:

--- a/apps/discord/utils.py
+++ b/apps/discord/utils.py
@@ -95,6 +95,26 @@ def complete_discord_interaction(
         raise RuntimeError("Discord interaction completion was not recorded")
 
 
+def renew_discord_interaction_claim(
+    interaction_id: str, interaction_type: int, claim_token: str
+) -> None:
+    """Extend an owned claim before persisting its dispatched response."""
+    params: dict[str, Any] = {
+        "p_interaction_id": interaction_id,
+        "p_interaction_type": interaction_type,
+        "p_claim_token": claim_token,
+        "p_lease_seconds": 60,
+    }
+    response = (
+        get_supabase_client()
+        .schema("private")
+        .rpc("renew_discord_interaction_claim", params)
+        .execute()
+    )
+    if response.data is not True:
+        raise RuntimeError("Discord interaction claim lease was not renewed")
+
+
 def release_discord_interaction(
     interaction_id: str, interaction_type: int, claim_token: str
 ) -> None:

--- a/apps/discord/utils.py
+++ b/apps/discord/utils.py
@@ -73,12 +73,16 @@ def claim_discord_interaction(interaction_id: str, interaction_type: int) -> dic
 
 
 def complete_discord_interaction(
-    interaction_id: str, interaction_type: int, response_payload: dict
+    interaction_id: str,
+    interaction_type: int,
+    claim_token: str,
+    response_payload: dict,
 ) -> None:
     """Persist a protocol response after dispatch has completed successfully."""
     params: dict[str, Any] = {
         "p_interaction_id": interaction_id,
         "p_interaction_type": interaction_type,
+        "p_claim_token": claim_token,
         "p_response_payload": response_payload,
     }
     response = (
@@ -91,11 +95,14 @@ def complete_discord_interaction(
         raise RuntimeError("Discord interaction completion was not recorded")
 
 
-def release_discord_interaction(interaction_id: str, interaction_type: int) -> None:
+def release_discord_interaction(
+    interaction_id: str, interaction_type: int, claim_token: str
+) -> None:
     """Release an unfinished claim so a delivery retry can dispatch it."""
     params: dict[str, Any] = {
         "p_interaction_id": interaction_id,
         "p_interaction_type": interaction_type,
+        "p_claim_token": claim_token,
     }
     get_supabase_client().schema("private").rpc("release_discord_interaction", params).execute()
 

--- a/apps/discord/utils.py
+++ b/apps/discord/utils.py
@@ -57,8 +57,8 @@ def get_supabase_client() -> Client:
     return create_client(supabase_url, supabase_key)
 
 
-def claim_discord_interaction(interaction_id: str, interaction_type: int) -> bool:
-    """Atomically claim an opaque Discord interaction id for dispatch."""
+def claim_discord_interaction(interaction_id: str, interaction_type: int) -> dict:
+    """Claim an interaction or retrieve its previously completed response."""
     params: dict[str, Any] = {
         "p_interaction_id": interaction_id,
         "p_interaction_type": interaction_type,
@@ -67,7 +67,37 @@ def claim_discord_interaction(interaction_id: str, interaction_type: int) -> boo
     response = (
         get_supabase_client().schema("private").rpc("claim_discord_interaction", params).execute()
     )
-    return response.data is True
+    if not isinstance(response.data, dict):
+        raise RuntimeError("Invalid Discord interaction claim response")
+    return response.data
+
+
+def complete_discord_interaction(
+    interaction_id: str, interaction_type: int, response_payload: dict
+) -> None:
+    """Persist a protocol response after dispatch has completed successfully."""
+    params: dict[str, Any] = {
+        "p_interaction_id": interaction_id,
+        "p_interaction_type": interaction_type,
+        "p_response_payload": response_payload,
+    }
+    response = (
+        get_supabase_client()
+        .schema("private")
+        .rpc("complete_discord_interaction", params)
+        .execute()
+    )
+    if response.data is not True:
+        raise RuntimeError("Discord interaction completion was not recorded")
+
+
+def release_discord_interaction(interaction_id: str, interaction_type: int) -> None:
+    """Release an unfinished claim so a delivery retry can dispatch it."""
+    params: dict[str, Any] = {
+        "p_interaction_id": interaction_id,
+        "p_interaction_type": interaction_type,
+    }
+    get_supabase_client().schema("private").rpc("release_discord_interaction", params).execute()
 
 
 def is_user_authorized_for_guild(discord_user_id: str, guild_id: str) -> bool:


### PR DESCRIPTION
## Summary
- reject stale or future-skewed Discord signatures outside a bounded freshness window
- atomically claim side-effecting Discord interactions in a private service-role-only table
- acknowledge duplicate deliveries without repeating command, component, or modal side effects
- keep side-effect-free PING handshakes independent of claim-store availability
- isolate replay dispatch from the grandfathered oversized app module

## Validation
- `uv run pytest tests/test_interaction_replay.py -q` (10 passed)
- `uv run ruff check app.py auth.py interaction_replay.py utils.py tests/test_interaction_replay.py`
- `bun check`

## Database note
- local Supabase was unavailable; migration application and pgTAP execution are delegated to canonical CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Discord interaction replay so a captured request can no longer trigger duplicate command, component, or modal side effects. Requests are now rejected outside a five-minute signature freshness window, and side-effecting interactions are claimed exactly once before dispatch; each claim is fenced by a fresh ownership token so only the current owner can renew, complete, or release it, and expired leases cannot be renewed. PING handshakes stay independent of claim-store availability, and a claim-store failure fails the request closed with a 503. Failed dispatches, process control interruptions, and 45-second dispatch timeouts release their claim so a retry can take over, and completed interactions store their callback so duplicates replay the original response.

**Migration**
- Adds `private.discord_interaction_claims` with RLS and service-role-only grants, plus `claim_discord_interaction`, `renew_discord_interaction_claim`, `complete_discord_interaction`, `release_discord_interaction`, and `prune_discord_interaction_claims` RPCs.
- Migration application and pgTAP tests run in canonical CI because local Supabase was unavailable.

<sup>Written for commit 19a7e85866956296a6cecb17a25dbbfa323024db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

