### PR TITLE
test(inventory): avoid storefront hydration probe mismatch

### DIFF
--- a/apps/inventory/e2e/storefront-cache-invalidation.spec.ts
+++ b/apps/inventory/e2e/storefront-cache-invalidation.spec.ts
@@ -66,15 +66,14 @@ test('invalidates cached availability and preserves the shared storefront shell'
     ).toBeVisible();
     const storefrontShell = page.locator('[data-storefront-shell]');
     await storefrontShell.evaluate((element) => {
-      element.dataset.navigationProbe = 'persistent';
+      Reflect.set(element, '__storefrontNavigationProbe', 'persistent');
     });
     await instant(page, async () => {
       await page.getByRole('link', { name: 'Browse' }).click();
-      await expect(
-        page.locator(
-          '[data-storefront-shell][data-navigation-probe="persistent"]'
-        )
-      ).toBeVisible();
+      await expect(storefrontShell).toHaveJSProperty(
+        '__storefrontNavigationProbe',
+        'persistent'
+      );
       await expect(page.locator('main[aria-busy="true"]')).toBeVisible();
     });
     await expect(page).toHaveURL(new RegExp(`/${fixture.slug}/?$`, 'u'));


### PR DESCRIPTION
## Summary
- keep the storefront shell persistence probe out of server-rendered DOM attributes
- store the sentinel as a JavaScript property and assert it survives navigation
- avoid introducing a test-created hydration mismatch while preserving the cache-shell contract

## Validation
- `bunx biome check apps/inventory/e2e/storefront-cache-invalidation.spec.ts`
- `bun check`
- canonical Inventory / Storefront cache-contract E2E is required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the storefront cache-invalidation test to store its navigation probe as a JavaScript property instead of a data attribute, preventing a test-created hydration mismatch while still asserting the cached shell survives navigation.

<sup>Written for commit 8b28bdf1fcb283bc4614501da5c957f910320683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

