### PR TITLE
perf(infrastructure): paginate GitHub branch sync

### DIFF
--- a/apps/infrastructure/src/app/api/v1/infrastructure/projects/[projectId]/sync/route.test.ts
+++ b/apps/infrastructure/src/app/api/v1/infrastructure/projects/[projectId]/sync/route.test.ts
@@ -10,8 +10,7 @@ vi.mock('@/lib/infrastructure/projects', () => ({
 }));
 
 vi.mock('../../_shared', () => ({
-  handleInfrastructureProjectRequest:
-    mocks.handleInfrastructureProjectRequest,
+  handleInfrastructureProjectRequest: mocks.handleInfrastructureProjectRequest,
 }));
 
 import { POST } from './route';
@@ -20,8 +19,7 @@ describe('POST infrastructure project sync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.handleInfrastructureProjectRequest.mockImplementation(
-      async (_request, _route, handler) =>
-        Response.json(await handler())
+      async (_request, _route, handler) => Response.json(await handler())
     );
   });
 

--- a/apps/infrastructure/src/app/api/v1/infrastructure/projects/[projectId]/sync/route.test.ts
+++ b/apps/infrastructure/src/app/api/v1/infrastructure/projects/[projectId]/sync/route.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  handleInfrastructureProjectRequest: vi.fn(),
+  syncInfrastructureProject: vi.fn(),
+}));
+
+vi.mock('@/lib/infrastructure/projects', () => ({
+  syncInfrastructureProject: mocks.syncInfrastructureProject,
+}));
+
+vi.mock('../../_shared', () => ({
+  handleInfrastructureProjectRequest:
+    mocks.handleInfrastructureProjectRequest,
+}));
+
+import { POST } from './route';
+
+describe('POST infrastructure project sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.handleInfrastructureProjectRequest.mockImplementation(
+      async (_request, _route, handler) =>
+        Response.json(await handler())
+    );
+  });
+
+  it('preserves the project response envelope and route boundary', async () => {
+    const project = {
+      branches: [{ name: 'main' }, { name: 'release' }],
+      id: 'project-1',
+      selectedBranch: 'release',
+    };
+    mocks.syncInfrastructureProject.mockResolvedValue(project);
+    const request = new Request(
+      'https://example.test/api/v1/infrastructure/projects/project-1/sync',
+      { method: 'POST' }
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ projectId: 'project-1' }),
+    });
+
+    expect(await response.json()).toEqual({ project });
+    expect(mocks.syncInfrastructureProject).toHaveBeenCalledWith('project-1');
+    expect(mocks.handleInfrastructureProjectRequest).toHaveBeenCalledWith(
+      request,
+      '/api/v1/infrastructure/projects/project-1/sync',
+      expect.any(Function)
+    );
+  });
+});

--- a/apps/infrastructure/src/lib/infrastructure/project-github-sync.test.ts
+++ b/apps/infrastructure/src/lib/infrastructure/project-github-sync.test.ts
@@ -181,7 +181,10 @@ describe('Infrastructure GitHub project sync', () => {
       new Map([
         [
           1,
-          [branch('main', 'first-sha', false), branch('main', 'other-sha', true)],
+          [
+            branch('main', 'first-sha', false),
+            branch('main', 'other-sha', true),
+          ],
         ],
       ])
     );

--- a/apps/infrastructure/src/lib/infrastructure/project-github-sync.test.ts
+++ b/apps/infrastructure/src/lib/infrastructure/project-github-sync.test.ts
@@ -1,0 +1,257 @@
+import type { InfrastructureProject } from '@tuturuuu/internal-api/infrastructure/monitoring';
+import type { Sql } from 'postgres';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchCompleteGitHubBranchSnapshot,
+  parsePublicGitHubRepoUrl,
+  reconcileInfrastructureProjectGitHub,
+} from './project-github-sync';
+
+const parsedRepository = parsePublicGitHubRepoUrl(
+  'https://github.com/tutur3u/platform'
+);
+
+function branch(name: string, sha = `${name}-sha`, protectedBranch = false) {
+  return {
+    commit: { sha },
+    name,
+    protected: protectedBranch,
+  };
+}
+
+function branchPage(prefix: string, count: number, offset = 0) {
+  return Array.from({ length: count }, (_, index) =>
+    branch(`${prefix}-${index + offset}`)
+  );
+}
+
+function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    headers: { 'content-type': 'application/json' },
+    status,
+  });
+}
+
+function repositoryResponse() {
+  return {
+    default_branch: 'main',
+    full_name: 'tutur3u/platform',
+    html_url: 'https://github.com/tutur3u/platform',
+    name: 'platform',
+    owner: { login: 'tutur3u' },
+    private: false,
+  };
+}
+
+interface RecordedQuery {
+  text: string;
+  values: unknown[];
+}
+
+function createSqlRecorder() {
+  const transactionQueries: RecordedQuery[] = [];
+  let beginCount = 0;
+  const transaction = ((
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => {
+    transactionQueries.push({
+      text: strings.join(' ? ').replace(/\s+/g, ' ').trim(),
+      values,
+    });
+    return Promise.resolve([]);
+  }) as unknown as Sql;
+  const sql = (() => Promise.resolve([])) as unknown as Sql;
+  Object.assign(sql, {
+    begin: async (callback: (client: Sql) => Promise<unknown>) => {
+      beginCount += 1;
+      return callback(transaction);
+    },
+  });
+
+  return {
+    get beginCount() {
+      return beginCount;
+    },
+    sql,
+    transactionQueries,
+  };
+}
+
+function createSyncFetch(
+  pages: Map<number, unknown>,
+  options: { commitResponse?: Response } = {}
+) {
+  return vi.fn<typeof fetch>(async (input) => {
+    const url = String(input);
+    if (url.endsWith('/repos/tutur3u/platform')) {
+      return jsonResponse(repositoryResponse());
+    }
+    if (url.includes('/branches?')) {
+      const page = Number(new URL(url).searchParams.get('page'));
+      const value = pages.get(page);
+      if (value instanceof Response) {
+        return value;
+      }
+      return jsonResponse(value);
+    }
+    if (url.includes('/commits/')) {
+      return options.commitResponse ?? jsonResponse({ sha: 'selected-sha' });
+    }
+    throw new Error(`Unexpected test URL: ${url}`);
+  });
+}
+
+function syncOptions(fetchImpl: typeof fetch, sql: Sql) {
+  const project = { id: 'project-1' } as InfrastructureProject;
+  return {
+    fetchImpl,
+    project: {
+      repo_url: 'https://github.com/tutur3u/platform',
+      selected_branch: 'main',
+    },
+    projectId: 'project-1',
+    reloadProject: vi.fn(async () => project),
+    sql,
+  };
+}
+
+describe('Infrastructure GitHub project sync', () => {
+  it('fetches 150 branches with fixed sequential page URLs', async () => {
+    const fetchImpl = createSyncFetch(
+      new Map([
+        [1, branchPage('branch', 100)],
+        [2, branchPage('branch', 50, 100)],
+      ])
+    );
+
+    const result = await fetchCompleteGitHubBranchSnapshot(
+      parsedRepository,
+      fetchImpl
+    );
+
+    expect(result).toHaveLength(150);
+    expect(fetchImpl.mock.calls.map(([input]) => String(input))).toEqual([
+      'https://api.github.com/repos/tutur3u/platform/branches?per_page=100&page=1',
+      'https://api.github.com/repos/tutur3u/platform/branches?per_page=100&page=2',
+    ]);
+  });
+
+  it('rejects a full page 100 at the 10,000 branch ceiling', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const page = Number(new URL(String(input)).searchParams.get('page'));
+      return jsonResponse(branchPage(`page-${page}`, 100));
+    });
+
+    await expect(
+      fetchCompleteGitHubBranchSnapshot(parsedRepository, fetchImpl)
+    ).rejects.toThrow(
+      'GitHub branch snapshot exceeds the 10,000 branch safety limit.'
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(100);
+  });
+
+  it.each([
+    ['invalid', { invalid: true }],
+    ['failed', new Response(null, { status: 503 })],
+  ])(
+    'performs zero writes when a later branch page is %s',
+    async (_label, secondPage) => {
+      const recorder = createSqlRecorder();
+      const fetchImpl = createSyncFetch(
+        new Map<number, unknown>([
+          [1, branchPage('branch', 100)],
+          [2, secondPage],
+        ])
+      );
+
+      await expect(
+        reconcileInfrastructureProjectGitHub(
+          syncOptions(fetchImpl, recorder.sql)
+        )
+      ).rejects.toThrow();
+      expect(recorder.beginCount).toBe(0);
+      expect(recorder.transactionQueries).toHaveLength(0);
+    }
+  );
+
+  it('rejects conflicting duplicate branch metadata before persistence', async () => {
+    const recorder = createSqlRecorder();
+    const fetchImpl = createSyncFetch(
+      new Map([
+        [
+          1,
+          [branch('main', 'first-sha', false), branch('main', 'other-sha', true)],
+        ],
+      ])
+    );
+
+    await expect(
+      reconcileInfrastructureProjectGitHub(syncOptions(fetchImpl, recorder.sql))
+    ).rejects.toThrow('GitHub returned conflicting duplicate branch data.');
+    expect(recorder.beginCount).toBe(0);
+  });
+
+  it('treats a successful empty snapshot as authoritative', async () => {
+    const recorder = createSqlRecorder();
+    const fetchImpl = createSyncFetch(new Map([[1, []]]));
+
+    await reconcileInfrastructureProjectGitHub(
+      syncOptions(fetchImpl, recorder.sql)
+    );
+
+    expect(recorder.beginCount).toBe(1);
+    expect(recorder.transactionQueries).toHaveLength(3);
+    expect(recorder.transactionQueries[1]?.text).toContain(
+      'INSERT INTO infrastructure_project_branches'
+    );
+    expect(recorder.transactionQueries[1]?.values).toContain('[]');
+    expect(recorder.transactionQueries[2]?.text).toContain(
+      'DELETE FROM infrastructure_project_branches'
+    );
+    expect(recorder.transactionQueries[2]?.values).toContain('[]');
+  });
+
+  it('uses a complete snapshot for selected-branch fallback and stale deletion', async () => {
+    const recorder = createSqlRecorder();
+    const pages = new Map<number, unknown>([
+      [1, branchPage('branch', 100)],
+      [2, [branch('release', 'release-sha', true)]],
+    ]);
+    const fetchImpl = createSyncFetch(pages, {
+      commitResponse: new Response(null, { status: 404 }),
+    });
+    const options = syncOptions(fetchImpl, recorder.sql);
+    options.project.selected_branch = 'release';
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await reconcileInfrastructureProjectGitHub(options);
+
+    expect(result).toBe(await options.reloadProject.mock.results[0]?.value);
+    expect(recorder.transactionQueries).toHaveLength(3);
+    expect(recorder.transactionQueries[0]?.values).toContain('release-sha');
+    expect(recorder.transactionQueries[1]?.values).toContainEqual(
+      expect.stringContaining('"name":"release"')
+    );
+    expect(recorder.transactionQueries[2]?.text).toContain('NOT EXISTS');
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+
+  it('uses a constant three reconciliation statements for 150 branches', async () => {
+    const recorder = createSqlRecorder();
+    const fetchImpl = createSyncFetch(
+      new Map([
+        [1, branchPage('branch', 100)],
+        [2, branchPage('branch', 50, 100)],
+      ])
+    );
+
+    await reconcileInfrastructureProjectGitHub(
+      syncOptions(fetchImpl, recorder.sql)
+    );
+
+    expect(recorder.beginCount).toBe(1);
+    expect(recorder.transactionQueries).toHaveLength(3);
+  });
+});

--- a/apps/infrastructure/src/lib/infrastructure/project-github-sync.test.ts
+++ b/apps/infrastructure/src/lib/infrastructure/project-github-sync.test.ts
@@ -170,8 +170,11 @@ describe('Infrastructure GitHub project sync', () => {
           syncOptions(fetchImpl, recorder.sql)
         )
       ).rejects.toThrow();
-      expect(recorder.beginCount).toBe(0);
-      expect(recorder.transactionQueries).toHaveLength(0);
+      expect(recorder.beginCount).toBe(1);
+      expect(recorder.transactionQueries).toHaveLength(1);
+      expect(recorder.transactionQueries[0]?.text).toContain(
+        'pg_advisory_xact_lock'
+      );
     }
   );
 
@@ -192,7 +195,10 @@ describe('Infrastructure GitHub project sync', () => {
     await expect(
       reconcileInfrastructureProjectGitHub(syncOptions(fetchImpl, recorder.sql))
     ).rejects.toThrow('GitHub returned conflicting duplicate branch data.');
-    expect(recorder.beginCount).toBe(0);
+    expect(recorder.beginCount).toBe(1);
+    expect(recorder.transactionQueries[0]?.text).toContain(
+      'pg_advisory_xact_lock'
+    );
   });
 
   it('treats a successful empty snapshot as authoritative', async () => {
@@ -204,15 +210,15 @@ describe('Infrastructure GitHub project sync', () => {
     );
 
     expect(recorder.beginCount).toBe(1);
-    expect(recorder.transactionQueries).toHaveLength(3);
-    expect(recorder.transactionQueries[1]?.text).toContain(
+    expect(recorder.transactionQueries).toHaveLength(4);
+    expect(recorder.transactionQueries[2]?.text).toContain(
       'INSERT INTO infrastructure_project_branches'
     );
-    expect(recorder.transactionQueries[1]?.values).toContain('[]');
-    expect(recorder.transactionQueries[2]?.text).toContain(
+    expect(recorder.transactionQueries[2]?.values).toContain('[]');
+    expect(recorder.transactionQueries[3]?.text).toContain(
       'DELETE FROM infrastructure_project_branches'
     );
-    expect(recorder.transactionQueries[2]?.values).toContain('[]');
+    expect(recorder.transactionQueries[3]?.values).toContain('[]');
   });
 
   it('uses a complete snapshot for selected-branch fallback and stale deletion', async () => {
@@ -231,12 +237,12 @@ describe('Infrastructure GitHub project sync', () => {
     const result = await reconcileInfrastructureProjectGitHub(options);
 
     expect(result).toBe(await options.reloadProject.mock.results[0]?.value);
-    expect(recorder.transactionQueries).toHaveLength(3);
-    expect(recorder.transactionQueries[0]?.values).toContain('release-sha');
-    expect(recorder.transactionQueries[1]?.values).toContainEqual(
+    expect(recorder.transactionQueries).toHaveLength(4);
+    expect(recorder.transactionQueries[1]?.values).toContain('release-sha');
+    expect(recorder.transactionQueries[2]?.values).toContainEqual(
       expect.stringContaining('"name":"release"')
     );
-    expect(recorder.transactionQueries[2]?.text).toContain('NOT EXISTS');
+    expect(recorder.transactionQueries[3]?.text).toContain('NOT EXISTS');
     expect(warning).toHaveBeenCalledOnce();
     warning.mockRestore();
   });
@@ -255,6 +261,12 @@ describe('Infrastructure GitHub project sync', () => {
     );
 
     expect(recorder.beginCount).toBe(1);
-    expect(recorder.transactionQueries).toHaveLength(3);
+    expect(recorder.transactionQueries).toHaveLength(4);
+    expect(recorder.transactionQueries[0]?.text).toContain(
+      'pg_advisory_xact_lock'
+    );
+    expect(recorder.transactionQueries[2]?.text).toContain(
+      'EXCLUDED.commit_hash IS DISTINCT FROM infrastructure_project_branches.commit_hash'
+    );
   });
 });

--- a/apps/infrastructure/src/lib/infrastructure/project-github-sync.ts
+++ b/apps/infrastructure/src/lib/infrastructure/project-github-sync.ts
@@ -309,41 +309,46 @@ export async function reconcileInfrastructureProjectGitHub({
   sql,
 }: ReconcileInfrastructureProjectGitHubOptions) {
   const parsed = parsePublicGitHubRepoUrl(project.repo_url);
-  const [repository, branches] = await Promise.all([
-    fetchGitHubRepository(parsed, fetchImpl),
-    fetchCompleteGitHubBranchSnapshot(parsed, fetchImpl),
-  ]);
-  const selectedBranch = normalizeBranch(
-    project.selected_branch,
-    repository.defaultBranch
-  );
-  const selectedCommit = await fetchGitHubCommit(
-    parsed,
-    selectedBranch,
-    fetchImpl
-  );
-  const selectedHash =
-    selectedCommit?.sha ??
-    branches.find((branch) => branch.name === selectedBranch)?.commitSha ??
-    null;
-  const selectedSubject = firstLine(selectedCommit?.commit?.message);
-  const branchSnapshot = JSON.stringify(
-    branches.map((branch) => {
-      const commit = branch.name === selectedBranch ? selectedCommit : null;
-      const commitHash = branch.commitSha || commit?.sha || null;
-      return {
-        commit_hash: commitHash,
-        commit_short_hash: shortHash(commitHash),
-        commit_subject: firstLine(commit?.commit?.message),
-        committed_at: commit?.commit?.author?.date ?? null,
-        default_branch: branch.name === repository.defaultBranch,
-        name: branch.name,
-        protected: branch.protected,
-      };
-    })
-  );
 
   await sql.begin(async (transaction) => {
+    await transaction`
+      SELECT pg_advisory_xact_lock(hashtextextended(${projectId}::text, 0))
+    `;
+
+    const [repository, branches] = await Promise.all([
+      fetchGitHubRepository(parsed, fetchImpl),
+      fetchCompleteGitHubBranchSnapshot(parsed, fetchImpl),
+    ]);
+    const selectedBranch = normalizeBranch(
+      project.selected_branch,
+      repository.defaultBranch
+    );
+    const selectedCommit = await fetchGitHubCommit(
+      parsed,
+      selectedBranch,
+      fetchImpl
+    );
+    const selectedHash =
+      selectedCommit?.sha ??
+      branches.find((branch) => branch.name === selectedBranch)?.commitSha ??
+      null;
+    const selectedSubject = firstLine(selectedCommit?.commit?.message);
+    const branchSnapshot = JSON.stringify(
+      branches.map((branch) => {
+        const commit = branch.name === selectedBranch ? selectedCommit : null;
+        const commitHash = branch.commitSha || commit?.sha || null;
+        return {
+          commit_hash: commitHash,
+          commit_short_hash: shortHash(commitHash),
+          commit_subject: firstLine(commit?.commit?.message),
+          committed_at: commit?.commit?.author?.date ?? null,
+          default_branch: branch.name === repository.defaultBranch,
+          name: branch.name,
+          protected: branch.protected,
+        };
+      })
+    );
+
     await transaction`
       UPDATE infrastructure_projects
       SET
@@ -393,8 +398,16 @@ export async function reconcileInfrastructureProjectGitHub({
       ON CONFLICT (project_id, name) DO UPDATE SET
         commit_hash = EXCLUDED.commit_hash,
         commit_short_hash = EXCLUDED.commit_short_hash,
-        commit_subject = COALESCE(EXCLUDED.commit_subject, infrastructure_project_branches.commit_subject),
-        committed_at = COALESCE(EXCLUDED.committed_at, infrastructure_project_branches.committed_at),
+        commit_subject = CASE
+          WHEN EXCLUDED.commit_hash IS DISTINCT FROM infrastructure_project_branches.commit_hash
+            THEN EXCLUDED.commit_subject
+          ELSE COALESCE(EXCLUDED.commit_subject, infrastructure_project_branches.commit_subject)
+        END,
+        committed_at = CASE
+          WHEN EXCLUDED.commit_hash IS DISTINCT FROM infrastructure_project_branches.commit_hash
+            THEN EXCLUDED.committed_at
+          ELSE COALESCE(EXCLUDED.committed_at, infrastructure_project_branches.committed_at)
+        END,
         protected = EXCLUDED.protected,
         default_branch = EXCLUDED.default_branch,
         last_synced_at = EXCLUDED.last_synced_at

--- a/apps/infrastructure/src/lib/infrastructure/project-github-sync.ts
+++ b/apps/infrastructure/src/lib/infrastructure/project-github-sync.ts
@@ -1,0 +1,420 @@
+import type { InfrastructureProject } from '@tuturuuu/internal-api/infrastructure/monitoring';
+import type { Sql } from 'postgres';
+
+const GITHUB_API_ROOT = 'https://api.github.com';
+const GITHUB_BRANCH_PAGE_SIZE = 100;
+const GITHUB_BRANCH_PAGE_LIMIT = 100;
+const GITHUB_REQUEST_TIMEOUT_MS = 10_000;
+const BRANCH_LIMIT_ERROR =
+  'GitHub branch snapshot exceeds the 10,000 branch safety limit.';
+
+export interface ParsedGitHubRepository {
+  owner: string;
+  repo: string;
+  repoUrl: string;
+}
+
+interface GitHubRepositoryResponse {
+  default_branch?: string;
+  full_name?: string;
+  html_url?: string;
+  name?: string;
+  owner?: {
+    login?: string;
+  };
+  private?: boolean;
+}
+
+interface GitHubCommitResponse {
+  commit?: {
+    author?: {
+      date?: string;
+    };
+    message?: string;
+  };
+  sha?: string;
+}
+
+export interface GitHubBranchSnapshotEntry {
+  commitSha: string;
+  name: string;
+  protected: boolean;
+}
+
+export interface InfrastructureProjectGitHubSyncRow {
+  repo_url: string;
+  selected_branch: string;
+}
+
+interface ReconcileInfrastructureProjectGitHubOptions {
+  fetchImpl?: typeof fetch;
+  project: InfrastructureProjectGitHubSyncRow;
+  projectId: string;
+  reloadProject: (projectId: string) => Promise<InfrastructureProject | null>;
+  sql: Sql;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function optionalString(value: unknown) {
+  return value == null || typeof value === 'string';
+}
+
+function isGitHubRepositoryResponse(
+  value: unknown
+): value is GitHubRepositoryResponse {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  return (
+    optionalString(value.default_branch) &&
+    optionalString(value.full_name) &&
+    optionalString(value.html_url) &&
+    optionalString(value.name) &&
+    (value.private == null || typeof value.private === 'boolean') &&
+    (value.owner == null ||
+      (isObject(value.owner) && optionalString(value.owner.login)))
+  );
+}
+
+function parseGitHubBranchPage(value: unknown): GitHubBranchSnapshotEntry[] {
+  if (!Array.isArray(value)) {
+    throw new Error('GitHub returned an invalid branch response.');
+  }
+
+  return value.map((branch) => {
+    if (
+      !isObject(branch) ||
+      typeof branch.name !== 'string' ||
+      branch.name.length === 0 ||
+      !isObject(branch.commit) ||
+      typeof branch.commit.sha !== 'string' ||
+      branch.commit.sha.length === 0 ||
+      typeof branch.protected !== 'boolean'
+    ) {
+      throw new Error('GitHub returned an invalid branch response.');
+    }
+
+    return {
+      commitSha: branch.commit.sha,
+      name: branch.name,
+      protected: branch.protected,
+    };
+  });
+}
+
+function isGitHubCommitResponse(value: unknown): value is GitHubCommitResponse {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  return (
+    optionalString(value.sha) &&
+    (value.commit == null ||
+      (isObject(value.commit) &&
+        optionalString(value.commit.message) &&
+        (value.commit.author == null ||
+          (isObject(value.commit.author) &&
+            optionalString(value.commit.author.date)))))
+  );
+}
+
+export function parsePublicGitHubRepoUrl(
+  rawUrl: string
+): ParsedGitHubRepository {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    throw new Error('GitHub repository URL is required.');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error('Enter a valid GitHub repository URL.');
+  }
+
+  if (parsed.protocol !== 'https:' || parsed.hostname !== 'github.com') {
+    throw new Error(
+      'Only public https://github.com repositories are supported.'
+    );
+  }
+
+  const [owner, repoSegment, ...rest] = parsed.pathname
+    .split('/')
+    .filter(Boolean);
+  if (!owner || !repoSegment || rest.length > 0) {
+    throw new Error('Use a repository URL like https://github.com/owner/repo.');
+  }
+
+  const repo = repoSegment.replace(/\.git$/i, '');
+  if (!repo || repo.includes('/')) {
+    throw new Error('Use a repository URL like https://github.com/owner/repo.');
+  }
+
+  return {
+    owner,
+    repo,
+    repoUrl: `https://github.com/${owner}/${repo}`,
+  };
+}
+
+function getGitHubHeaders() {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'Tuturuuu-Platform',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  const token = process.env.GITHUB_TOKEN?.trim();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+async function fetchGitHubJson(
+  url: string,
+  fetchImpl: typeof fetch
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      headers: getGitHubHeaders(),
+      next: { revalidate: 0 },
+      signal: AbortSignal.timeout(GITHUB_REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    throw new Error('GitHub request failed.');
+  }
+
+  if (!response.ok) {
+    throw new Error(`GitHub returned ${response.status}.`);
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    throw new Error('GitHub returned invalid JSON.');
+  }
+}
+
+export async function fetchGitHubRepository(
+  repo: ParsedGitHubRepository,
+  fetchImpl: typeof fetch = fetch
+) {
+  const value = await fetchGitHubJson(
+    `${GITHUB_API_ROOT}/repos/${repo.owner}/${repo.repo}`,
+    fetchImpl
+  );
+  if (!isGitHubRepositoryResponse(value)) {
+    throw new Error('GitHub returned an invalid repository response.');
+  }
+  if (value.private) {
+    throw new Error('Private GitHub repositories are not supported in v1.');
+  }
+
+  const owner = value.owner?.login ?? repo.owner;
+  const repoName = value.name ?? repo.repo;
+
+  return {
+    defaultBranch: value.default_branch || 'main',
+    name: value.full_name ?? `${owner}/${repoName}`,
+    owner,
+    repo: repoName,
+    repoUrl: value.html_url ?? repo.repoUrl,
+  };
+}
+
+export async function fetchCompleteGitHubBranchSnapshot(
+  repo: ParsedGitHubRepository,
+  fetchImpl: typeof fetch = fetch
+) {
+  const branches = new Map<string, GitHubBranchSnapshotEntry>();
+
+  for (let page = 1; page <= GITHUB_BRANCH_PAGE_LIMIT; page += 1) {
+    const value = await fetchGitHubJson(
+      `${GITHUB_API_ROOT}/repos/${repo.owner}/${repo.repo}/branches?per_page=${GITHUB_BRANCH_PAGE_SIZE}&page=${page}`,
+      fetchImpl
+    );
+    const pageBranches = parseGitHubBranchPage(value);
+
+    for (const branch of pageBranches) {
+      const existing = branches.get(branch.name);
+      if (
+        existing &&
+        (existing.commitSha !== branch.commitSha ||
+          existing.protected !== branch.protected)
+      ) {
+        throw new Error('GitHub returned conflicting duplicate branch data.');
+      }
+      branches.set(branch.name, branch);
+    }
+
+    if (pageBranches.length < GITHUB_BRANCH_PAGE_SIZE) {
+      return [...branches.values()];
+    }
+    if (page === GITHUB_BRANCH_PAGE_LIMIT) {
+      throw new Error(BRANCH_LIMIT_ERROR);
+    }
+  }
+
+  throw new Error(BRANCH_LIMIT_ERROR);
+}
+
+async function fetchGitHubCommit(
+  repo: ParsedGitHubRepository,
+  ref: string,
+  fetchImpl: typeof fetch
+): Promise<GitHubCommitResponse | null> {
+  try {
+    const value = await fetchGitHubJson(
+      `${GITHUB_API_ROOT}/repos/${repo.owner}/${repo.repo}/commits/${encodeURIComponent(ref)}`,
+      fetchImpl
+    );
+    if (!isGitHubCommitResponse(value)) {
+      throw new Error('GitHub returned an invalid commit response.');
+    }
+    return value;
+  } catch (error) {
+    console.warn('Unable to sync GitHub commit metadata', {
+      error: error instanceof Error ? error.message : String(error),
+      ref,
+      repo: repo.repoUrl,
+    });
+    return null;
+  }
+}
+
+function normalizeBranch(value: string | null | undefined, fallback: string) {
+  return (value ?? '').trim() || fallback;
+}
+
+function firstLine(value: string | null | undefined) {
+  return value?.split('\n')[0]?.trim() || null;
+}
+
+function shortHash(value: string | null | undefined) {
+  return value ? value.slice(0, 10) : null;
+}
+
+export async function reconcileInfrastructureProjectGitHub({
+  fetchImpl = fetch,
+  project,
+  projectId,
+  reloadProject,
+  sql,
+}: ReconcileInfrastructureProjectGitHubOptions) {
+  const parsed = parsePublicGitHubRepoUrl(project.repo_url);
+  const [repository, branches] = await Promise.all([
+    fetchGitHubRepository(parsed, fetchImpl),
+    fetchCompleteGitHubBranchSnapshot(parsed, fetchImpl),
+  ]);
+  const selectedBranch = normalizeBranch(
+    project.selected_branch,
+    repository.defaultBranch
+  );
+  const selectedCommit = await fetchGitHubCommit(
+    parsed,
+    selectedBranch,
+    fetchImpl
+  );
+  const selectedHash =
+    selectedCommit?.sha ??
+    branches.find((branch) => branch.name === selectedBranch)?.commitSha ??
+    null;
+  const selectedSubject = firstLine(selectedCommit?.commit?.message);
+  const branchSnapshot = JSON.stringify(
+    branches.map((branch) => {
+      const commit = branch.name === selectedBranch ? selectedCommit : null;
+      const commitHash = branch.commitSha || commit?.sha || null;
+      return {
+        commit_hash: commitHash,
+        commit_short_hash: shortHash(commitHash),
+        commit_subject: firstLine(commit?.commit?.message),
+        committed_at: commit?.commit?.author?.date ?? null,
+        default_branch: branch.name === repository.defaultBranch,
+        name: branch.name,
+        protected: branch.protected,
+      };
+    })
+  );
+
+  await sql.begin(async (transaction) => {
+    await transaction`
+      UPDATE infrastructure_projects
+      SET
+        name = ${repository.name},
+        repo_url = ${repository.repoUrl},
+        github_owner = ${repository.owner},
+        github_repo = ${repository.repo},
+        latest_commit_hash = ${selectedHash},
+        latest_commit_short_hash = ${shortHash(selectedHash)},
+        latest_commit_subject = ${selectedSubject},
+        latest_synced_at = now(),
+        updated_at = now()
+      WHERE id = ${projectId}
+    `;
+
+    await transaction`
+      INSERT INTO infrastructure_project_branches (
+        project_id,
+        name,
+        commit_hash,
+        commit_short_hash,
+        commit_subject,
+        committed_at,
+        protected,
+        default_branch,
+        last_synced_at
+      )
+      SELECT
+        ${projectId},
+        branch.name,
+        branch.commit_hash,
+        branch.commit_short_hash,
+        branch.commit_subject,
+        branch.committed_at,
+        branch.protected,
+        branch.default_branch,
+        now()
+      FROM jsonb_to_recordset(${branchSnapshot}::jsonb) AS branch(
+        name TEXT,
+        commit_hash TEXT,
+        commit_short_hash TEXT,
+        commit_subject TEXT,
+        committed_at TIMESTAMPTZ,
+        protected BOOLEAN,
+        default_branch BOOLEAN
+      )
+      ON CONFLICT (project_id, name) DO UPDATE SET
+        commit_hash = EXCLUDED.commit_hash,
+        commit_short_hash = EXCLUDED.commit_short_hash,
+        commit_subject = COALESCE(EXCLUDED.commit_subject, infrastructure_project_branches.commit_subject),
+        committed_at = COALESCE(EXCLUDED.committed_at, infrastructure_project_branches.committed_at),
+        protected = EXCLUDED.protected,
+        default_branch = EXCLUDED.default_branch,
+        last_synced_at = EXCLUDED.last_synced_at
+    `;
+
+    await transaction`
+      DELETE FROM infrastructure_project_branches AS persisted
+      WHERE persisted.project_id = ${projectId}
+        AND NOT EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset(${branchSnapshot}::jsonb) AS snapshot(name TEXT)
+          WHERE snapshot.name = persisted.name
+        )
+    `;
+  });
+
+  const synced = await reloadProject(projectId);
+  if (!synced) {
+    throw new Error('Project was synced but could not be reloaded.');
+  }
+
+  return synced;
+}

--- a/apps/infrastructure/src/lib/infrastructure/projects.ts
+++ b/apps/infrastructure/src/lib/infrastructure/projects.ts
@@ -5,41 +5,14 @@ import type {
 } from '@tuturuuu/internal-api/infrastructure/monitoring';
 import { readBlueGreenMonitoringSnapshot } from './blue-green-monitoring';
 import { ensureLogDrainSchema, getLogDrainSqlClient } from './log-drain';
+import {
+  fetchGitHubRepository,
+  parsePublicGitHubRepoUrl,
+  reconcileInfrastructureProjectGitHub,
+} from './project-github-sync';
 
-export interface ParsedGitHubRepository {
-  owner: string;
-  repo: string;
-  repoUrl: string;
-}
-
-interface GitHubRepositoryResponse {
-  default_branch?: string;
-  full_name?: string;
-  html_url?: string;
-  name?: string;
-  owner?: {
-    login?: string;
-  };
-  private?: boolean;
-}
-
-interface GitHubBranchResponse {
-  commit?: {
-    sha?: string;
-  };
-  name?: string;
-  protected?: boolean;
-}
-
-interface GitHubCommitResponse {
-  commit?: {
-    author?: {
-      date?: string;
-    };
-    message?: string;
-  };
-  sha?: string;
-}
+export { parsePublicGitHubRepoUrl } from './project-github-sync';
+export type { ParsedGitHubRepository } from './project-github-sync';
 
 interface ProjectRow {
   app_root: string;
@@ -132,46 +105,6 @@ export interface UpdateInfrastructureProjectInput {
   name?: string;
   redisEnabled?: boolean;
   selectedBranch?: string;
-}
-
-export function parsePublicGitHubRepoUrl(
-  rawUrl: string
-): ParsedGitHubRepository {
-  const trimmed = rawUrl.trim();
-  if (!trimmed) {
-    throw new Error('GitHub repository URL is required.');
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch {
-    throw new Error('Enter a valid GitHub repository URL.');
-  }
-
-  if (parsed.protocol !== 'https:' || parsed.hostname !== 'github.com') {
-    throw new Error(
-      'Only public https://github.com repositories are supported.'
-    );
-  }
-
-  const [owner, repoSegment, ...rest] = parsed.pathname
-    .split('/')
-    .filter(Boolean);
-  if (!owner || !repoSegment || rest.length > 0) {
-    throw new Error('Use a repository URL like https://github.com/owner/repo.');
-  }
-
-  const repo = repoSegment.replace(/\.git$/i, '');
-  if (!repo || repo.includes('/')) {
-    throw new Error('Use a repository URL like https://github.com/owner/repo.');
-  }
-
-  return {
-    owner,
-    repo,
-    repoUrl: `https://github.com/${owner}/${repo}`,
-  };
 }
 
 function normalizeHostname(hostname: string) {
@@ -289,82 +222,6 @@ async function getSql() {
   }
 
   return sql;
-}
-
-function getGitHubHeaders() {
-  const headers: Record<string, string> = {
-    Accept: 'application/vnd.github+json',
-    'User-Agent': 'Tuturuuu-Platform',
-    'X-GitHub-Api-Version': '2022-11-28',
-  };
-  const token = process.env.GITHUB_TOKEN?.trim();
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
-  return headers;
-}
-
-async function fetchGitHubJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
-    headers: getGitHubHeaders(),
-    next: { revalidate: 0 },
-  });
-
-  if (!response.ok) {
-    throw new Error(`GitHub returned ${response.status} for ${url}.`);
-  }
-
-  return response.json() as Promise<T>;
-}
-
-async function fetchGitHubRepository(repo: ParsedGitHubRepository) {
-  const repository = await fetchGitHubJson<GitHubRepositoryResponse>(
-    `https://api.github.com/repos/${repo.owner}/${repo.repo}`
-  );
-
-  if (repository.private) {
-    throw new Error('Private GitHub repositories are not supported in v1.');
-  }
-
-  const owner = repository.owner?.login ?? repo.owner;
-  const repoName = repository.name ?? repo.repo;
-
-  return {
-    defaultBranch: repository.default_branch || 'main',
-    name: repository.full_name ?? `${owner}/${repoName}`,
-    owner,
-    repo: repoName,
-    repoUrl: repository.html_url ?? repo.repoUrl,
-  };
-}
-
-async function fetchGitHubBranches(repo: ParsedGitHubRepository) {
-  return fetchGitHubJson<GitHubBranchResponse[]>(
-    `https://api.github.com/repos/${repo.owner}/${repo.repo}/branches?per_page=100`
-  );
-}
-
-async function fetchGitHubCommit(
-  repo: ParsedGitHubRepository,
-  ref: string
-): Promise<GitHubCommitResponse | null> {
-  try {
-    return await fetchGitHubJson<GitHubCommitResponse>(
-      `https://api.github.com/repos/${repo.owner}/${repo.repo}/commits/${encodeURIComponent(ref)}`
-    );
-  } catch (error) {
-    console.warn('Unable to sync GitHub commit metadata', {
-      error: error instanceof Error ? error.message : String(error),
-      ref,
-      repo: repo.repoUrl,
-    });
-    return null;
-  }
-}
-
-function firstLine(value: string | null | undefined) {
-  return value?.split('\n')[0]?.trim() || null;
 }
 
 function shortHash(value: string | null | undefined) {
@@ -564,10 +421,8 @@ export async function createInfrastructureProject(
 ) {
   const parsed = parsePublicGitHubRepoUrl(input.repoUrl);
   const repository = await fetchGitHubRepository(parsed);
-  const selectedBranch = normalizeBranch(
-    input.selectedBranch,
-    repository.defaultBranch
-  );
+  const selectedBranch =
+    input.selectedBranch?.trim() || repository.defaultBranch;
   const projectId = makeProjectId(
     repository.owner,
     repository.repo,
@@ -714,86 +569,12 @@ export async function syncInfrastructureProject(projectId: string) {
     throw new Error('Project not found.');
   }
 
-  const parsed = parsePublicGitHubRepoUrl(project.repo_url);
-  const [repository, branches] = await Promise.all([
-    fetchGitHubRepository(parsed),
-    fetchGitHubBranches(parsed),
-  ]);
-  const selectedBranch = normalizeBranch(
-    project.selected_branch,
-    repository.defaultBranch
-  );
-  const selectedCommit = await fetchGitHubCommit(parsed, selectedBranch);
-  const selectedHash =
-    selectedCommit?.sha ??
-    branches.find((branch) => branch.name === selectedBranch)?.commit?.sha ??
-    null;
-  const selectedSubject = firstLine(selectedCommit?.commit?.message);
-
-  await sql.begin(async (transaction) => {
-    await transaction`
-      UPDATE infrastructure_projects
-      SET
-        name = ${repository.name},
-        repo_url = ${repository.repoUrl},
-        github_owner = ${repository.owner},
-        github_repo = ${repository.repo},
-        latest_commit_hash = ${selectedHash},
-        latest_commit_short_hash = ${shortHash(selectedHash)},
-        latest_commit_subject = ${selectedSubject},
-        latest_synced_at = now(),
-        updated_at = now()
-      WHERE id = ${projectId}
-    `;
-
-    for (const branch of branches) {
-      if (!branch.name) {
-        continue;
-      }
-
-      const commit = branch.name === selectedBranch ? selectedCommit : null;
-      const commitHash = branch.commit?.sha ?? commit?.sha ?? null;
-      await transaction`
-        INSERT INTO infrastructure_project_branches (
-          project_id,
-          name,
-          commit_hash,
-          commit_short_hash,
-          commit_subject,
-          committed_at,
-          protected,
-          default_branch,
-          last_synced_at
-        )
-        VALUES (
-          ${projectId},
-          ${branch.name},
-          ${commitHash},
-          ${shortHash(commitHash)},
-          ${firstLine(commit?.commit?.message)},
-          ${commit?.commit?.author?.date ? new Date(commit.commit.author.date) : null},
-          ${branch.protected ?? false},
-          ${branch.name === repository.defaultBranch},
-          now()
-        )
-        ON CONFLICT (project_id, name) DO UPDATE SET
-          commit_hash = EXCLUDED.commit_hash,
-          commit_short_hash = EXCLUDED.commit_short_hash,
-          commit_subject = COALESCE(EXCLUDED.commit_subject, infrastructure_project_branches.commit_subject),
-          committed_at = COALESCE(EXCLUDED.committed_at, infrastructure_project_branches.committed_at),
-          protected = EXCLUDED.protected,
-          default_branch = EXCLUDED.default_branch,
-          last_synced_at = EXCLUDED.last_synced_at
-      `;
-    }
+  return reconcileInfrastructureProjectGitHub({
+    project,
+    projectId,
+    reloadProject: getInfrastructureProject,
+    sql,
   });
-
-  const synced = await getInfrastructureProject(projectId);
-  if (!synced) {
-    throw new Error('Project was synced but could not be reloaded.');
-  }
-
-  return synced;
 }
 
 export async function queueInfrastructureProjectDeployment(projectId: string) {

--- a/apps/infrastructure/src/lib/infrastructure/projects.ts
+++ b/apps/infrastructure/src/lib/infrastructure/projects.ts
@@ -11,8 +11,8 @@ import {
   reconcileInfrastructureProjectGitHub,
 } from './project-github-sync';
 
-export { parsePublicGitHubRepoUrl } from './project-github-sync';
 export type { ParsedGitHubRepository } from './project-github-sync';
+export { parsePublicGitHubRepoUrl } from './project-github-sync';
 
 interface ProjectRow {
   app_root: string;


### PR DESCRIPTION
Paginates GitHub branch synchronization so large repositories are complete. Validated with focused tests, Infrastructure type-check, and bun check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginates GitHub branch sync so repositories with more than 100 branches sync completely instead of only storing the first page. The old sync never removed branches deleted upstream; the new one deletes stale branch rows after a successful full snapshot.

**Changes**
- Extracts GitHub sync helpers from `projects.ts` into `project-github-sync.ts`.
- Fetches all branch pages up to a 10,000 branch safety limit and aborts before any writes if a page is invalid or duplicates conflict.
- Persists the full branch snapshot with one transaction containing three SQL statements.
- Adds tests for multi-page sync and the sync route.

<sup>Written for commit da04846b89736ee62c851da1d934611760ccc878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

