### PR TITLE
fix(nova): authorize role management

### DIFF
--- a/apps/nova/src/app/[locale]/(dashboard)/(admin)/(role-management)/users/columns.tsx
+++ b/apps/nova/src/app/[locale]/(dashboard)/(admin)/(role-management)/users/columns.tsx
@@ -75,7 +75,6 @@ export const getUserColumns = ({
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          userId,
           enabled,
           allow_challenge_management,
           allow_manage_all_challenges,

--- a/apps/nova/src/app/api/v1/nova/users/[userId]/route.test.ts
+++ b/apps/nova/src/app/api/v1/nova/users/[userId]/route.test.ts
@@ -12,16 +12,10 @@ const VALID_ROLE_FLAGS = {
 
 const mocks = vi.hoisted(() => ({
   authorizeNovaRoleManager: vi.fn(),
-  createAdminClient: vi.fn(),
-  directAdminFrom: vi.fn(),
 }));
 
 vi.mock('@/lib/nova-team-api-auth', () => ({
   authorizeNovaRoleManager: mocks.authorizeNovaRoleManager,
-}));
-
-vi.mock('@tuturuuu/supabase/next/server', () => ({
-  createAdminClient: mocks.createAdminClient,
 }));
 
 function routeParams(userId?: string) {
@@ -97,7 +91,6 @@ describe('Nova user role route', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    mocks.createAdminClient.mockResolvedValue({ from: mocks.directAdminFrom });
   });
 
   it('rejects anonymous PUT requests before parsing or querying', async () => {
@@ -109,8 +102,6 @@ describe('Nova user role route', () => {
 
     expect(response.status).toBe(401);
     expect(request.json).not.toHaveBeenCalled();
-    expect(mocks.createAdminClient).not.toHaveBeenCalled();
-    expect(mocks.directAdminFrom).not.toHaveBeenCalled();
   });
 
   it('rejects enabled users without role management before parsing or querying', async () => {
@@ -122,8 +113,6 @@ describe('Nova user role route', () => {
 
     expect(response.status).toBe(403);
     expect(request.json).not.toHaveBeenCalled();
-    expect(mocks.createAdminClient).not.toHaveBeenCalled();
-    expect(mocks.directAdminFrom).not.toHaveBeenCalled();
   });
 
   it('rejects disabled role managers before resolving params or querying', async () => {
@@ -132,14 +121,18 @@ describe('Nova user role route', () => {
     const params = new Promise<{ userId: string }>((resolve) => {
       resolveParams = resolve;
     });
+    let paramsSettled = false;
+    void params.then(() => {
+      paramsSettled = true;
+    });
 
     const { DELETE } = await import('./route');
     const response = await DELETE({} as never, { params });
 
     expect(response.status).toBe(403);
-    expect(resolveParams).toBeTypeOf('function');
-    expect(mocks.createAdminClient).not.toHaveBeenCalled();
-    expect(mocks.directAdminFrom).not.toHaveBeenCalled();
+    expect(paramsSettled).toBe(false);
+    resolveParams?.({ userId: TARGET_USER_ID });
+    await params;
   });
 
   it('updates exactly the route-targeted user for an authorized manager', async () => {

--- a/apps/nova/src/app/api/v1/nova/users/[userId]/route.test.ts
+++ b/apps/nova/src/app/api/v1/nova/users/[userId]/route.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TARGET_USER_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_USER_ID = '22222222-2222-4222-8222-222222222222';
+
+const VALID_ROLE_FLAGS = {
+  allow_challenge_management: true,
+  allow_manage_all_challenges: false,
+  allow_role_management: true,
+  enabled: true,
+};
+
+const mocks = vi.hoisted(() => ({
+  authorizeNovaRoleManager: vi.fn(),
+  createAdminClient: vi.fn(),
+  directAdminFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/nova-team-api-auth', () => ({
+  authorizeNovaRoleManager: mocks.authorizeNovaRoleManager,
+}));
+
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: mocks.createAdminClient,
+}));
+
+function routeParams(userId?: string) {
+  return {
+    params: Promise.resolve(userId === undefined ? {} : { userId }),
+  } as never;
+}
+
+function putRequest(body: unknown) {
+  return new Request(`http://localhost/api/v1/nova/users/${TARGET_USER_ID}`, {
+    body: JSON.stringify(body),
+    method: 'PUT',
+  }) as never;
+}
+
+function createRoleClient({
+  deleteError = null,
+  updateError = null,
+}: {
+  deleteError?: { message: string } | null;
+  updateError?: { message: string } | null;
+} = {}) {
+  const updateEq = vi.fn().mockResolvedValue({ error: updateError });
+  const update = vi.fn(() => ({ eq: updateEq }));
+  const deleteEq = vi.fn().mockResolvedValue({ error: deleteError });
+  const deleteRoles = vi.fn(() => ({ eq: deleteEq }));
+  const from = vi.fn(() => ({ delete: deleteRoles, update }));
+  const sbAdmin = { from };
+
+  return {
+    deleteEq,
+    deleteError,
+    deleteRoles,
+    from,
+    sbAdmin,
+    update,
+    updateEq,
+    updateError,
+  };
+}
+
+function authorize(options?: Parameters<typeof createRoleClient>[0]) {
+  const client = createRoleClient(options);
+  mocks.authorizeNovaRoleManager.mockResolvedValue({
+    ok: true,
+    value: {
+      privateDb: {},
+      role: {
+        allow_challenge_management: false,
+        allow_manage_all_challenges: false,
+        allow_role_management: true,
+        enabled: true,
+      },
+      sbAdmin: client.sbAdmin,
+      user: { id: 'manager-id' },
+    },
+  });
+
+  return client;
+}
+
+function deny(status: 401 | 403) {
+  mocks.authorizeNovaRoleManager.mockResolvedValue({
+    ok: false,
+    response: Response.json(
+      { error: status === 401 ? 'Unauthorized' : 'Forbidden' },
+      { status }
+    ),
+  });
+}
+
+describe('Nova user role route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.createAdminClient.mockResolvedValue({ from: mocks.directAdminFrom });
+  });
+
+  it('rejects anonymous PUT requests before parsing or querying', async () => {
+    deny(401);
+    const request = { json: vi.fn() };
+
+    const { PUT } = await import('./route');
+    const response = await PUT(request as never, routeParams(TARGET_USER_ID));
+
+    expect(response.status).toBe(401);
+    expect(request.json).not.toHaveBeenCalled();
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+    expect(mocks.directAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it('rejects enabled users without role management before parsing or querying', async () => {
+    deny(403);
+    const request = { json: vi.fn() };
+
+    const { PUT } = await import('./route');
+    const response = await PUT(request as never, routeParams(TARGET_USER_ID));
+
+    expect(response.status).toBe(403);
+    expect(request.json).not.toHaveBeenCalled();
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+    expect(mocks.directAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it('rejects disabled role managers before resolving params or querying', async () => {
+    deny(403);
+    let resolveParams: ((value: { userId: string }) => void) | undefined;
+    const params = new Promise<{ userId: string }>((resolve) => {
+      resolveParams = resolve;
+    });
+
+    const { DELETE } = await import('./route');
+    const response = await DELETE({} as never, { params });
+
+    expect(response.status).toBe(403);
+    expect(resolveParams).toBeTypeOf('function');
+    expect(mocks.createAdminClient).not.toHaveBeenCalled();
+    expect(mocks.directAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it('updates exactly the route-targeted user for an authorized manager', async () => {
+    const client = authorize();
+
+    const { PUT } = await import('./route');
+    const response = await PUT(
+      putRequest(VALID_ROLE_FLAGS),
+      routeParams(TARGET_USER_ID)
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(client.from).toHaveBeenCalledWith('platform_user_roles');
+    expect(client.update).toHaveBeenCalledWith(VALID_ROLE_FLAGS);
+    expect(client.updateEq).toHaveBeenCalledWith('user_id', TARGET_USER_ID);
+  });
+
+  it('rejects malformed JSON before querying', async () => {
+    const client = authorize();
+    const request = new Request(
+      `http://localhost/api/v1/nova/users/${TARGET_USER_ID}`,
+      { body: '{', method: 'PUT' }
+    );
+
+    const { PUT } = await import('./route');
+    const response = await PUT(request as never, routeParams(TARGET_USER_ID));
+
+    expect(response.status).toBe(400);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['PUT', 'not-a-uuid'],
+    ['PUT', undefined],
+    ['DELETE', 'not-a-uuid'],
+    ['DELETE', undefined],
+  ] as const)(
+    'rejects an invalid or missing %s route user ID',
+    async (method, userId) => {
+      const client = authorize();
+      const request: Record<string, unknown> =
+        method === 'PUT'
+          ? { json: vi.fn().mockResolvedValue(VALID_ROLE_FLAGS) }
+          : {};
+      const route = await import('./route');
+
+      const response = await route[method](
+        request as never,
+        routeParams(userId)
+      );
+
+      expect(response.status).toBe(400);
+      expect(client.from).not.toHaveBeenCalled();
+      if (method === 'PUT')
+        expect(request.json as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    [
+      'a body userId that differs from the path',
+      { ...VALID_ROLE_FLAGS, userId: OTHER_USER_ID },
+    ],
+    [
+      'a body userId that matches the path',
+      { ...VALID_ROLE_FLAGS, userId: TARGET_USER_ID },
+    ],
+    ['an unknown field', { ...VALID_ROLE_FLAGS, unexpected: true }],
+    [
+      'a missing role flag',
+      {
+        allow_challenge_management: true,
+        allow_manage_all_challenges: false,
+        enabled: true,
+      },
+    ],
+    ['a wrongly typed role flag', { ...VALID_ROLE_FLAGS, enabled: 'true' }],
+  ])('rejects %s before querying', async (_, body) => {
+    const client = authorize();
+
+    const { PUT } = await import('./route');
+    const response = await PUT(putRequest(body), routeParams(TARGET_USER_ID));
+
+    expect(response.status).toBe(400);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes role update database failures', async () => {
+    const client = authorize({ updateError: { message: 'private detail' } });
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const { PUT } = await import('./route');
+    const response = await PUT(
+      putRequest(VALID_ROLE_FLAGS),
+      routeParams(TARGET_USER_ID)
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Error updating user permissions',
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to update Nova user permissions',
+      client.updateError
+    );
+  });
+
+  it('deletes exactly the route-targeted user for an authorized manager', async () => {
+    const client = authorize();
+
+    const { DELETE } = await import('./route');
+    const response = await DELETE({} as never, routeParams(TARGET_USER_ID));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(client.from).toHaveBeenCalledWith('platform_user_roles');
+    expect(client.deleteRoles).toHaveBeenCalledOnce();
+    expect(client.deleteEq).toHaveBeenCalledWith('user_id', TARGET_USER_ID);
+  });
+
+  it('sanitizes role deletion database failures', async () => {
+    const client = authorize({ deleteError: { message: 'private detail' } });
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const { DELETE } = await import('./route');
+    const response = await DELETE({} as never, routeParams(TARGET_USER_ID));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Error deleting user permissions',
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to delete Nova user permissions',
+      client.deleteError
+    );
+  });
+});

--- a/apps/nova/src/app/api/v1/nova/users/[userId]/route.ts
+++ b/apps/nova/src/app/api/v1/nova/users/[userId]/route.ts
@@ -1,46 +1,52 @@
-import { createAdminClient } from '@tuturuuu/supabase/next/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authorizeNovaRoleManager } from '@/lib/nova-team-api-auth';
 
-export async function PUT(req: NextRequest) {
-  const {
-    userId,
-    enabled,
-    allow_challenge_management,
-    allow_manage_all_challenges,
-    allow_role_management,
-  } = (await req.json()) as {
-    userId: string;
-    enabled: boolean;
-    allow_challenge_management: boolean;
-    allow_manage_all_challenges: boolean;
-    allow_role_management: boolean;
-  };
+const userIdSchema = z.string().uuid();
 
-  if (!userId) {
-    return NextResponse.json(
-      { message: 'User Id is required' },
-      { status: 400 }
-    );
+const roleUpdateSchema = z
+  .object({
+    allow_challenge_management: z.boolean(),
+    allow_manage_all_challenges: z.boolean(),
+    allow_role_management: z.boolean(),
+    enabled: z.boolean(),
+  })
+  .strict();
+
+type RouteContext = {
+  params: Promise<{ userId?: string }>;
+};
+
+function invalidRequest() {
+  return NextResponse.json({ message: 'Invalid request' }, { status: 400 });
+}
+
+export async function PUT(request: NextRequest, { params }: RouteContext) {
+  const authorization = await authorizeNovaRoleManager(request);
+  if (!authorization.ok) return authorization.response;
+
+  const parsedUserId = userIdSchema.safeParse((await params).userId);
+  if (!parsedUserId.success) return invalidRequest();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return invalidRequest();
   }
 
-  const sbAdmin = await createAdminClient();
+  const parsedBody = roleUpdateSchema.safeParse(body);
+  if (!parsedBody.success) return invalidRequest();
 
-  const updateData = {
-    enabled: enabled ?? false,
-    allow_challenge_management: allow_challenge_management ?? false,
-    allow_manage_all_challenges: allow_manage_all_challenges ?? false,
-    allow_role_management: allow_role_management ?? false,
-  };
-
-  const { error } = await sbAdmin
+  const { error } = await authorization.value.sbAdmin
     .from('platform_user_roles')
-    .update(updateData)
-    .eq('user_id', userId);
+    .update(parsedBody.data)
+    .eq('user_id', parsedUserId.data);
 
   if (error) {
-    console.error('Error updating user roles:', error);
+    console.error('Failed to update Nova user permissions', error);
     return NextResponse.json(
-      { message: 'Error updating user permissions', error: error.message },
+      { message: 'Error updating user permissions' },
       { status: 500 }
     );
   }
@@ -48,30 +54,22 @@ export async function PUT(req: NextRequest) {
   return NextResponse.json({ success: true }, { status: 200 });
 }
 
-export async function DELETE(
-  _: NextRequest,
-  { params }: { params: Promise<{ userId: string }> }
-) {
-  const { userId } = await params;
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  const authorization = await authorizeNovaRoleManager(request);
+  if (!authorization.ok) return authorization.response;
 
-  if (!userId) {
-    return NextResponse.json(
-      { message: 'User Id is required' },
-      { status: 400 }
-    );
-  }
+  const parsedUserId = userIdSchema.safeParse((await params).userId);
+  if (!parsedUserId.success) return invalidRequest();
 
-  const sbAdmin = await createAdminClient();
-
-  const { error } = await sbAdmin
+  const { error } = await authorization.value.sbAdmin
     .from('platform_user_roles')
     .delete()
-    .eq('user_id', userId);
+    .eq('user_id', parsedUserId.data);
 
   if (error) {
-    console.log(error);
+    console.error('Failed to delete Nova user permissions', error);
     return NextResponse.json(
-      { message: 'Error fetching AI Models' },
+      { message: 'Error deleting user permissions' },
       { status: 500 }
     );
   }


### PR DESCRIPTION
Enforces workspace authorization for Nova role management. Validated with 17 focused tests, Nova type-check, and bun check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Nova workspace authorization on role management so only authorized Nova role managers can update or delete user permissions. The `PUT` and `DELETE` handlers previously used an admin client without checking the caller; they now return 401/403 before parsing the request or querying the database. The handlers also validate the route `userId` and role payload, and sanitize database errors.

<sup>Written for commit 1aad68f5486714c4a64ecc43361f0f395d23b4ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

