### PR TITLE
fix(git): surface repository toggle failures

### DIFF
--- a/apps/git/src/app/[locale]/-/[wsId]/admin-actions.ts
+++ b/apps/git/src/app/[locale]/-/[wsId]/admin-actions.ts
@@ -209,28 +209,38 @@ export async function toggleRepositoryAction(
 ) {
   const admin = await requireGitAdmin();
   if (!admin) redirect('/login');
-  const { data, error } = await privateDb(admin.db)
-    .from('git_repositories')
-    .update({
-      enabled,
-      updated_at: new Date().toISOString(),
-      updated_by: admin.user.id,
-    })
-    .eq('id', repositoryId)
-    .select('id,name,owner_login')
-    .single();
 
-  if (!error && data) {
+  let destination = adminPath(wsId, 'repositories', {
+    error: 'Unable to update repository',
+  });
+
+  try {
+    const { data, error } = await privateDb(admin.db)
+      .from('git_repositories')
+      .update({
+        enabled,
+        updated_at: new Date().toISOString(),
+        updated_by: admin.user.id,
+      })
+      .eq('id', repositoryId)
+      .select('id,name,owner_login')
+      .single();
+
+    if (error || !data) throw new Error('Repository update failed');
+
     await recordGitAuditEvent({
       eventType: enabled ? 'repository.enabled' : 'repository.disabled',
-      repositoryId,
+      repositoryId: data.id,
       userId: admin.user.id,
-    });
+    }).catch(() => undefined);
     revalidateTag(
       `git:${String(data.owner_login).toLowerCase()}/${String(data.name).toLowerCase()}`,
       'max'
     );
+    destination = adminPath(wsId, 'repositories', { updated: '1' });
+  } catch {
+    console.error('Failed to update Git repository state');
   }
 
-  redirect(adminPath(wsId, 'repositories', { updated: '1' }));
+  redirect(destination);
 }

--- a/apps/git/src/app/[locale]/-/[wsId]/admin-actions.ts
+++ b/apps/git/src/app/[locale]/-/[wsId]/admin-actions.ts
@@ -226,7 +226,8 @@ export async function toggleRepositoryAction(
       .select('id,name,owner_login')
       .single();
 
-    if (error || !data) throw new Error('Repository update failed');
+    if (error) throw error;
+    if (!data) throw new Error('Repository update failed');
 
     await recordGitAuditEvent({
       eventType: enabled ? 'repository.enabled' : 'repository.disabled',
@@ -238,8 +239,8 @@ export async function toggleRepositoryAction(
       'max'
     );
     destination = adminPath(wsId, 'repositories', { updated: '1' });
-  } catch {
-    console.error('Failed to update Git repository state');
+  } catch (error) {
+    console.error('Failed to update Git repository state', error);
   }
 
   redirect(destination);

--- a/apps/git/src/app/[locale]/-/[wsId]/repositories/page.tsx
+++ b/apps/git/src/app/[locale]/-/[wsId]/repositories/page.tsx
@@ -46,7 +46,7 @@ export default async function RepositoriesPage({
       </header>
       {query.error && (
         <Alert variant="destructive">
-          <AlertTitle>Repository was not added</AlertTitle>
+          <AlertTitle>Repository operation failed</AlertTitle>
           <AlertDescription>{query.error}</AlertDescription>
         </Alert>
       )}

--- a/apps/git/src/app/[locale]/-/[wsId]/repository-toggle.test.ts
+++ b/apps/git/src/app/[locale]/-/[wsId]/repository-toggle.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const REDIRECT_SENTINEL = new Error('NEXT_REDIRECT');
+
+const mocks = vi.hoisted(() => ({
+  privateDb: vi.fn(),
+  recordGitAuditEvent: vi.fn(),
+  redirect: vi.fn(),
+  revalidateTag: vi.fn(),
+  requireGitAdmin: vi.fn(),
+}));
+
+vi.mock('@/constants/common', () => ({
+  GITHUB_API_VERSION: 'test-version',
+}));
+
+vi.mock('next/cache', () => ({
+  revalidateTag: mocks.revalidateTag,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: mocks.redirect,
+}));
+
+vi.mock('@/lib/admin-access', () => ({
+  requireGitAdmin: mocks.requireGitAdmin,
+}));
+
+vi.mock('@/lib/github/credentials', () => ({
+  getGitAppConfigurationStatus: vi.fn(),
+  getInstallationToken: vi.fn(),
+  recordGitAuditEvent: mocks.recordGitAuditEvent,
+  saveGitAppConfiguration: vi.fn(),
+  updateGitAppValidation: vi.fn(),
+}));
+
+vi.mock('@/lib/github/errors', () => ({
+  getSafeGitHubErrorMessage: vi.fn(() => 'safe error'),
+}));
+
+vi.mock('@/lib/github/private-db', () => ({
+  privateDb: mocks.privateDb,
+}));
+
+vi.mock('@/lib/github/repository-input', () => ({
+  normalizeRepositoryInput: vi.fn(),
+}));
+
+import { toggleRepositoryAction } from './admin-actions';
+
+function createRepositoryUpdate(result: {
+  data: { id: string; name: string; owner_login: string } | null;
+  error: unknown;
+}) {
+  const query = {
+    eq: vi.fn(() => query),
+    select: vi.fn(() => query),
+    single: vi.fn().mockResolvedValue(result),
+    update: vi.fn(() => query),
+  };
+  const from = vi.fn(() => query);
+  mocks.privateDb.mockReturnValue({ from });
+  return { from, query };
+}
+
+async function expectRedirect(
+  operation: Promise<unknown>,
+  destination: string
+) {
+  await expect(operation).rejects.toBe(REDIRECT_SENTINEL);
+  expect(mocks.redirect).toHaveBeenLastCalledWith(destination);
+}
+
+describe('toggleRepositoryAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mocks.redirect.mockImplementation(() => {
+      throw REDIRECT_SENTINEL;
+    });
+    mocks.requireGitAdmin.mockResolvedValue({
+      db: { schema: vi.fn() },
+      user: { id: 'admin-1' },
+    });
+    mocks.recordGitAuditEvent.mockResolvedValue(undefined);
+  });
+
+  it('redirects unauthorized callers before accessing the registry', async () => {
+    mocks.requireGitAdmin.mockResolvedValue(null);
+
+    await expectRedirect(
+      toggleRepositoryAction('workspace-1', 'repository-1', true),
+      '/login'
+    );
+
+    expect(mocks.privateDb).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { enabled: true, eventType: 'repository.enabled' },
+    { enabled: false, eventType: 'repository.disabled' },
+  ])('records and revalidates $eventType', async ({ enabled, eventType }) => {
+    const { query } = createRepositoryUpdate({
+      data: {
+        id: 'repository-1',
+        name: 'Platform',
+        owner_login: 'Tutur3u',
+      },
+      error: null,
+    });
+
+    await expectRedirect(
+      toggleRepositoryAction('workspace-1', 'repository-1', enabled),
+      '/-/workspace-1/repositories?updated=1'
+    );
+
+    expect(query.update).toHaveBeenCalledWith({
+      enabled,
+      updated_at: expect.any(String),
+      updated_by: 'admin-1',
+    });
+    expect(query.eq).toHaveBeenCalledWith('id', 'repository-1');
+    expect(mocks.recordGitAuditEvent).toHaveBeenCalledWith({
+      eventType,
+      repositoryId: 'repository-1',
+      userId: 'admin-1',
+    });
+    expect(mocks.revalidateTag).toHaveBeenCalledWith(
+      'git:tutur3u/platform',
+      'max'
+    );
+  });
+
+  it.each([
+    [{ message: 'private detail' }, null],
+    [null, null],
+  ])(
+    'surfaces a sanitized failure for an unsuccessful update',
+    async (error, data) => {
+      createRepositoryUpdate({ data, error });
+
+      await expectRedirect(
+        toggleRepositoryAction('workspace-1', 'repository-1', true),
+        '/-/workspace-1/repositories?error=Unable+to+update+repository'
+      );
+
+      expect(mocks.recordGitAuditEvent).not.toHaveBeenCalled();
+      expect(mocks.revalidateTag).not.toHaveBeenCalled();
+    }
+  );
+
+  it('keeps a successful toggle successful when audit recording fails', async () => {
+    createRepositoryUpdate({
+      data: {
+        id: 'repository-1',
+        name: 'platform',
+        owner_login: 'tutur3u',
+      },
+      error: null,
+    });
+    mocks.recordGitAuditEvent.mockRejectedValue(new Error('audit unavailable'));
+
+    await expectRedirect(
+      toggleRepositoryAction('workspace-1', 'repository-1', true),
+      '/-/workspace-1/repositories?updated=1'
+    );
+
+    expect(mocks.revalidateTag).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/git/src/app/[locale]/-/[wsId]/repository-toggle.test.ts
+++ b/apps/git/src/app/[locale]/-/[wsId]/repository-toggle.test.ts
@@ -146,6 +146,10 @@ describe('toggleRepositoryAction', () => {
 
       expect(mocks.recordGitAuditEvent).not.toHaveBeenCalled();
       expect(mocks.revalidateTag).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to update Git repository state',
+        error ?? expect.any(Error)
+      );
     }
   );
 


### PR DESCRIPTION
Shows repository activation/deactivation failures instead of leaving optimistic UI stale. Validated with 13 focused tests, Git type-check, and bun check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Git repository enable/disable toggle so failed updates no longer redirect with the `updated=1` success state. Failed toggles now redirect to an `error=Unable to update repository` state, and the page alert is generalized from "Repository was not added" to "Repository operation failed."

- Audit event recording failures are ignored, so a successful toggle stays successful even if auditing is unavailable.
- The underlying error is logged server-side for diagnostics while users see a generic message.
- Adds tests for unauthorized callers, successful toggles, failed updates, and audit-recording failures.

<sup>Written for commit 15883eb954f9525c4fcf2ec66839d17a3e2456ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

