### PR TITLE
fix(hive): confirm browser state recovery

### DIFF
--- a/apps/hive/messages/en.json
+++ b/apps/hive/messages/en.json
@@ -41,6 +41,12 @@
     "water": "Water",
     "worldState": "World state"
   },
+  "browserStateRecovery": {
+    "button": "Reset browser state",
+    "description": "This clears cached Hive browser data and signs you out. Continue only if Hive is not loading correctly.",
+    "forbidden": "Browser state reset requires same-origin confirmation.",
+    "title": "Reset browser state"
+  },
   "chat": {
     "first_activity": "First activity",
     "last_activity": "Last activity",

--- a/apps/hive/messages/vi.json
+++ b/apps/hive/messages/vi.json
@@ -41,6 +41,12 @@
     "water": "Nước",
     "worldState": "Trạng thái thế giới"
   },
+  "browserStateRecovery": {
+    "button": "Đặt lại trạng thái trình duyệt",
+    "description": "Thao tác này xóa dữ liệu Hive được lưu trong trình duyệt và đăng xuất bạn. Chỉ tiếp tục nếu Hive không tải đúng cách.",
+    "forbidden": "Việc đặt lại trạng thái trình duyệt yêu cầu xác nhận từ cùng nguồn.",
+    "title": "Đặt lại trạng thái trình duyệt"
+  },
   "chat": {
     "first_activity": "Hoạt động đầu tiên",
     "last_activity": "Hoạt động gần nhất",

--- a/apps/hive/src/app/~recover-browser-state/route.test.ts
+++ b/apps/hive/src/app/~recover-browser-state/route.test.ts
@@ -1,14 +1,82 @@
 import { NextRequest } from 'next/server';
-import { describe, expect, it } from 'vitest';
-import { GET } from './route';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getTranslations: vi.fn(),
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: mocks.getTranslations,
+}));
+
+import { GET, POST } from './route';
+
+const translations: Record<string, string> = {
+  button: 'Reset <state>',
+  description: 'Clear cached data & sign out.',
+  forbidden: 'Same-origin confirmation required.',
+  title: 'Reset "browser" state',
+};
 
 describe('Hive browser state recovery route', () => {
-  it('redirects to login and clears browser storage headers', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getTranslations.mockResolvedValue(
+      (key: string) => translations[key] ?? key
+    );
+  });
+
+  it('serves a localized no-store confirmation page without clearing browser state on GET', async () => {
     const response = await GET(
+      new NextRequest('https://hive.tuturuuu.com/~recover-browser-state', {
+        headers: {
+          cookie: 'NEXT_LOCALE=vi; sb-resolved-kingfish-21146-auth-token=stale',
+        },
+      })
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.headers.get('cache-control')).toContain('no-store');
+    expect(response.headers.get('clear-site-data')).toBeNull();
+    expect(response.headers.get('location')).toBeNull();
+    expect(
+      response.cookies.get('sb-resolved-kingfish-21146-auth-token')
+    ).toBeUndefined();
+    expect(body).toContain('<html lang="vi">');
+    expect(body).toContain(
+      '<form method="post" action="/~recover-browser-state">'
+    );
+    expect(body).toContain('Reset &quot;browser&quot; state');
+    expect(body).toContain('Clear cached data &amp; sign out.');
+    expect(body).toContain('Reset &lt;state&gt;');
+    expect(mocks.getTranslations).toHaveBeenCalledWith({
+      locale: 'vi',
+      namespace: 'browserStateRecovery',
+    });
+  });
+
+  it('falls back to the default locale for an unsupported cookie', async () => {
+    await GET(
+      new NextRequest('https://hive.tuturuuu.com/~recover-browser-state', {
+        headers: { cookie: 'NEXT_LOCALE=fr' },
+      })
+    );
+
+    expect(mocks.getTranslations).toHaveBeenCalledWith({
+      locale: 'en',
+      namespace: 'browserStateRecovery',
+    });
+  });
+
+  it('clears Hive site data and only Supabase auth cookies after same-origin Origin confirmation', async () => {
+    const response = await POST(
       new NextRequest('https://hive.tuturuuu.com/~recover-browser-state', {
         headers: {
           cookie:
             'sb-resolved-kingfish-21146-auth-token=stale; sb-resolved-kingfish-21146-auth-token.0=chunk; unrelated=value',
+          origin: 'https://hive.tuturuuu.com',
         },
       })
     );
@@ -17,12 +85,11 @@ describe('Hive browser state recovery route', () => {
     expect(response.headers.get('location')).toBe(
       'https://hive.tuturuuu.com/login?browserStateReset=1'
     );
-    expect(response.headers.get('cache-control')).toBe(
-      'no-store, no-cache, must-revalidate'
-    );
+    expect(response.headers.get('cache-control')).toContain('no-store');
     expect(response.headers.get('clear-site-data')).toBe(
       '"cache", "storage", "executionContexts"'
     );
+    expect(response.headers.get('clear-site-data')).not.toContain('cookies');
     expect(
       response.cookies.get('sb-resolved-kingfish-21146-auth-token')?.value
     ).toBe('');
@@ -32,13 +99,48 @@ describe('Hive browser state recovery route', () => {
     expect(response.cookies.get('unrelated')).toBeUndefined();
   });
 
-  it('does not redirect browser-state recovery to the internal listener origin', async () => {
-    const response = await GET(
-      new NextRequest('http://0.0.0.0:7814/~recover-browser-state')
+  it('accepts same-origin Referer fallback and preserves the Hive public redirect', async () => {
+    const response = await POST(
+      new NextRequest('http://0.0.0.0:7814/~recover-browser-state', {
+        headers: {
+          referer: 'http://0.0.0.0:7814/settings',
+        },
+      })
     );
 
+    expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe(
       'https://hive.tuturuuu.localhost/login?browserStateReset=1'
     );
+    expect(response.headers.get('clear-site-data')).toBe(
+      '"cache", "storage", "executionContexts"'
+    );
+  });
+
+  it.each([
+    ['cross-origin Origin', { origin: 'https://attacker.example' }],
+    [
+      'malformed Origin even with a same-origin Referer',
+      { origin: 'not a url', referer: 'https://hive.tuturuuu.com/settings' },
+    ],
+    ['missing Origin and Referer', {}],
+    ['malformed Referer fallback', { referer: 'not a url' }],
+  ])('rejects %s without clearing browser state', async (_name, headers) => {
+    const response = await POST(
+      new NextRequest('https://hive.tuturuuu.com/~recover-browser-state', {
+        headers: {
+          cookie: 'sb-resolved-kingfish-21146-auth-token=stale',
+          ...headers,
+        },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('cache-control')).toContain('no-store');
+    expect(response.headers.get('clear-site-data')).toBeNull();
+    expect(response.headers.get('location')).toBeNull();
+    expect(
+      response.cookies.get('sb-resolved-kingfish-21146-auth-token')
+    ).toBeUndefined();
   });
 });

--- a/apps/hive/src/app/~recover-browser-state/route.ts
+++ b/apps/hive/src/app/~recover-browser-state/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { getTranslations } from 'next-intl/server';
+import { type Locale, routing } from '@/i18n/routing';
 import { createHivePublicUrl } from '@/lib/hive-public-url';
 
 const SUPABASE_AUTH_COOKIE_PATTERN = /^sb-[A-Za-z0-9-]+-auth-token(?:\.\d+)?$/u;
@@ -11,20 +13,120 @@ function getAuthCookieNames(request: NextRequest): string[] {
     .filter((cookieName) => SUPABASE_AUTH_COOKIE_PATTERN.test(cookieName));
 }
 
+function getRequestLocale(request: NextRequest): Locale {
+  const locale = request.cookies.get('NEXT_LOCALE')?.value;
+
+  return locale && routing.locales.includes(locale as Locale)
+    ? (locale as Locale)
+    : routing.defaultLocale;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/gu,
+    (character) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[character] ?? character
+  );
+}
+
 function applyNoStoreHeaders(response: NextResponse) {
   response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate');
   response.headers.set('CDN-Cache-Control', 'no-store');
+}
+
+function applyClearSiteDataHeaders(response: NextResponse) {
+  applyNoStoreHeaders(response);
   response.headers.set('Clear-Site-Data', CLEAR_SITE_DATA_VALUE);
 }
 
+function isSameOriginRecoveryRequest(request: NextRequest) {
+  const origin = request.headers.get('origin');
+  if (origin) {
+    try {
+      return new URL(origin).origin === request.nextUrl.origin;
+    } catch {
+      return false;
+    }
+  }
+
+  const referer = request.headers.get('referer');
+  if (!referer) {
+    return false;
+  }
+
+  try {
+    return new URL(referer).origin === request.nextUrl.origin;
+  } catch {
+    return false;
+  }
+}
+
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  const locale = getRequestLocale(request);
+  const t = await getTranslations({
+    locale,
+    namespace: 'browserStateRecovery',
+  });
+  const title = escapeHtml(t('title'));
+  const description = escapeHtml(t('description'));
+  const button = escapeHtml(t('button'));
+  const response = new NextResponse(
+    `<!doctype html>
+<html lang="${escapeHtml(locale)}">
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+  </head>
+  <body>
+    <main>
+      <h1>${title}</h1>
+      <p>${description}</p>
+      <form method="post" action="/~recover-browser-state">
+        <button type="submit">${button}</button>
+      </form>
+    </main>
+  </body>
+</html>`,
+    {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+      },
+      status: 200,
+    }
+  );
+
+  applyNoStoreHeaders(response);
+  return response;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isSameOriginRecoveryRequest(request)) {
+    const locale = getRequestLocale(request);
+    const t = await getTranslations({
+      locale,
+      namespace: 'browserStateRecovery',
+    });
+    const response = NextResponse.json(
+      { error: t('forbidden') },
+      { status: 403 }
+    );
+    applyNoStoreHeaders(response);
+    return response;
+  }
+
   const redirectUrl = createHivePublicUrl(
     '/login?browserStateReset=1',
     request
   );
   const response = NextResponse.redirect(redirectUrl);
 
-  applyNoStoreHeaders(response);
+  applyClearSiteDataHeaders(response);
 
   for (const cookieName of getAuthCookieNames(request)) {
     response.cookies.set(cookieName, '', {


### PR DESCRIPTION
Makes destructive browser-state recovery explicit, same-origin protected, and localized. Validated with 8 focused tests, Hive type-check, and bun check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes browser state recovery require explicit user confirmation and same-origin validation. The route now serves a localized confirmation page on GET and only clears browser data on POST; previously a GET immediately cleared it.

- Adds `en` and `vi` translations for the confirmation page and the forbidden response.
- Rejects POST requests whose `Origin` or `Referer` does not match the request origin with a 403.
- Keeps `Clear-Site-Data` for cache, storage, and execution contexts but stops clearing cookies; Supabase auth cookies are cleared explicitly.
- Expands tests to cover localized GET, locale fallback, same-origin acceptance, and rejected cross-origin or malformed requests.

<sup>Written for commit 1a5e0072790b0b57e9be3f0eae91b919a919ff44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

