### PR TITLE
perf(tasks): defer My Tasks filter catalogs

### DIFF
--- a/packages/tasks-ui/src/tu-do/my-tasks/__tests__/label-project-filter.test.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/__tests__/label-project-filter.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LabelProjectFilter } from '../label-project-filter';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe('LabelProjectFilter catalog demand', () => {
+  function renderFilter() {
+    const onLabelsRequested = vi.fn();
+    const onProjectsRequested = vi.fn();
+    render(
+      <LabelProjectFilter
+        labels={[]}
+        projects={[]}
+        selectedLabelIds={[]}
+        selectedProjectIds={[]}
+        onSelectedLabelIdsChange={vi.fn()}
+        onSelectedProjectIdsChange={vi.fn()}
+        onLabelsRequested={onLabelsRequested}
+        onProjectsRequested={onProjectsRequested}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    return { onLabelsRequested, onProjectsRequested };
+  }
+
+  it('requests labels only when the label selector opens', () => {
+    const { onLabelsRequested, onProjectsRequested } = renderFilter();
+
+    fireEvent.click(screen.getByText('filter_labels'));
+
+    expect(onLabelsRequested).toHaveBeenCalledOnce();
+    expect(onProjectsRequested).not.toHaveBeenCalled();
+  });
+
+  it('requests projects only when the project selector opens', () => {
+    const { onLabelsRequested, onProjectsRequested } = renderFilter();
+
+    fireEvent.click(screen.getByText('filter_projects'));
+
+    expect(onProjectsRequested).toHaveBeenCalledOnce();
+    expect(onLabelsRequested).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tasks-ui/src/tu-do/my-tasks/__tests__/my-tasks-content.test.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/__tests__/my-tasks-content.test.tsx
@@ -2,14 +2,21 @@ import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
-const { mockUseMyTasksState, mockUseQueryClient, mockUseUserConfig } =
-  vi.hoisted(() => ({
-    mockUseMyTasksState: vi.fn(),
-    mockUseQueryClient: vi.fn(() => ({
-      invalidateQueries: vi.fn(),
-    })),
-    mockUseUserConfig: vi.fn(() => ({ data: 'enter' })),
-  }));
+const {
+  mockCommandBar,
+  mockMyTasksFilters,
+  mockUseMyTasksState,
+  mockUseQueryClient,
+  mockUseUserConfig,
+} = vi.hoisted(() => ({
+  mockCommandBar: vi.fn((_props: any) => undefined),
+  mockMyTasksFilters: vi.fn((_props: any) => undefined),
+  mockUseMyTasksState: vi.fn(),
+  mockUseQueryClient: vi.fn(() => ({
+    invalidateQueries: vi.fn(),
+  })),
+  mockUseUserConfig: vi.fn(() => ({ data: 'enter' })),
+}));
 
 // Mock the state hook
 vi.mock('../use-my-tasks-state', () => ({
@@ -44,9 +51,10 @@ vi.mock('../my-tasks-header', () => ({
 }));
 
 vi.mock('../command-bar', () => ({
-  CommandBar: (props: any) => (
-    <div data-testid="command-bar" data-loading={props.isLoading} />
-  ),
+  CommandBar: (props: any) => {
+    mockCommandBar(props);
+    return <div data-testid="command-bar" data-loading={props.isLoading} />;
+  },
 }));
 
 vi.mock('../ai-credit-indicator', () => ({
@@ -54,9 +62,12 @@ vi.mock('../ai-credit-indicator', () => ({
 }));
 
 vi.mock('../my-tasks-filters', () => ({
-  MyTasksFilters: (props: any) => (
-    <div data-testid="my-tasks-filters" data-props={JSON.stringify(props)} />
-  ),
+  MyTasksFilters: (props: any) => {
+    mockMyTasksFilters(props);
+    return (
+      <div data-testid="my-tasks-filters" data-props={JSON.stringify(props)} />
+    );
+  },
 }));
 
 vi.mock('../task-list', () => ({
@@ -239,6 +250,8 @@ function createDefaultState(overrides?: Record<string, any>) {
     handleProjectFilterChange: vi.fn(),
     handleCreateNewLabel: vi.fn(),
     handleCreateNewProject: vi.fn(),
+    requestLabelCatalog: vi.fn(),
+    requestProjectCatalog: vi.fn(),
 
     ...overrides,
   };
@@ -329,6 +342,29 @@ describe('MyTasksContent', () => {
 
   // ── Prop threading ───────────────────────────────────────────────────────
   describe('prop threading', () => {
+    it('threads catalog demand callbacks to task creation and filter controls', () => {
+      const requestLabelCatalog = vi.fn();
+      const requestProjectCatalog = vi.fn();
+      mockUseMyTasksState.mockReturnValue(
+        createDefaultState({ requestLabelCatalog, requestProjectCatalog })
+      );
+
+      render(<MyTasksContent wsId="ws-1" userId="user-1" isPersonal={true} />);
+
+      expect(mockCommandBar).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onLabelsRequested: requestLabelCatalog,
+          onProjectsRequested: requestProjectCatalog,
+        })
+      );
+      expect(mockMyTasksFilters).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onLabelsRequested: requestLabelCatalog,
+          onProjectsRequested: requestProjectCatalog,
+        })
+      );
+    });
+
     it('passes task counts from filteredTasks to MyTasksHeader', () => {
       mockUseMyTasksState.mockReturnValue(
         createDefaultState({

--- a/packages/tasks-ui/src/tu-do/my-tasks/__tests__/use-my-tasks-state.test.ts
+++ b/packages/tasks-ui/src/tu-do/my-tasks/__tests__/use-my-tasks-state.test.ts
@@ -4,6 +4,7 @@ import { LABEL_COLOR_PRESETS } from '../../utils/label-colors';
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
 const {
+  MockInternalApiError,
   mockCreateWorkspaceLabel,
   mockCreateWorkspaceTaskProject,
   mockListWorkspaceLabels,
@@ -29,6 +30,14 @@ const {
   mockCreateTaskFn,
   mockFetch,
 } = vi.hoisted(() => ({
+  MockInternalApiError: class MockInternalApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number
+    ) {
+      super(message);
+    }
+  },
   mockCreateWorkspaceLabel: vi.fn(),
   mockCreateWorkspaceTaskProject: vi.fn(),
   mockListWorkspaceLabels: vi.fn(),
@@ -64,6 +73,7 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 
 vi.mock('@tuturuuu/internal-api', () => ({
+  InternalApiError: MockInternalApiError,
   createWorkspaceLabel: mockCreateWorkspaceLabel,
   createWorkspaceTaskBoard: vi.fn(),
   createWorkspaceTaskProject: mockCreateWorkspaceTaskProject,
@@ -308,8 +318,43 @@ describe('useMyTasksState', () => {
 
       await expect(boardQuery?.queryFn()).resolves.toHaveLength(200);
       expect(mockListWorkspaceTaskBoards.mock.calls).toEqual([
-        ['ws-a', { page: 1, pageSize: 200 }],
-        ['ws-a', { page: 2, pageSize: 200 }],
+        ['ws-a', { page: 1, pageSize: 200, status: 'all' }],
+        ['ws-a', { page: 2, pageSize: 200, status: 'all' }],
+      ]);
+    });
+
+    it('keeps accessible boards when another workspace rejects catalog access', async () => {
+      const workspaces = [
+        { id: 'ws-allowed', name: 'Allowed', personal: false },
+        { id: 'ws-forbidden', name: 'Forbidden', personal: false },
+      ];
+      setupPersonalQueries(workspaces);
+      mockListWorkspaces.mockResolvedValue(workspaces);
+      mockListWorkspaceTaskBoards.mockImplementation(async (workspaceId) => {
+        if (workspaceId === 'ws-forbidden') {
+          throw new MockInternalApiError('Forbidden', 403);
+        }
+        return {
+          boards: [
+            {
+              deleted_at: null,
+              id: 'board-allowed',
+              name: 'Allowed board',
+              ws_id: 'ws-allowed',
+            },
+          ],
+        };
+      });
+
+      renderHook(() => useMyTasksState({ ...DEFAULT_PROPS, isPersonal: true }));
+      const boardQuery = findQueryOptions('all-user-boards');
+
+      await expect(boardQuery?.queryFn()).resolves.toEqual([
+        {
+          id: 'board-allowed',
+          name: 'Allowed board',
+          ws_id: 'ws-allowed',
+        },
       ]);
     });
 

--- a/packages/tasks-ui/src/tu-do/my-tasks/__tests__/use-my-tasks-state.test.ts
+++ b/packages/tasks-ui/src/tu-do/my-tasks/__tests__/use-my-tasks-state.test.ts
@@ -6,8 +6,8 @@ import { LABEL_COLOR_PRESETS } from '../../utils/label-colors';
 const {
   mockCreateWorkspaceLabel,
   mockCreateWorkspaceTaskProject,
-  mockListCurrentUserTaskBoards,
   mockListWorkspaceLabels,
+  mockListWorkspaceTaskBoards,
   mockListWorkspaceTaskProjects,
   mockListWorkspaces,
   mockInvalidateQueries,
@@ -31,8 +31,8 @@ const {
 } = vi.hoisted(() => ({
   mockCreateWorkspaceLabel: vi.fn(),
   mockCreateWorkspaceTaskProject: vi.fn(),
-  mockListCurrentUserTaskBoards: vi.fn(),
   mockListWorkspaceLabels: vi.fn(),
+  mockListWorkspaceTaskBoards: vi.fn(),
   mockListWorkspaceTaskProjects: vi.fn(),
   mockListWorkspaces: vi.fn(),
   mockInvalidateQueries: vi.fn(),
@@ -67,12 +67,11 @@ vi.mock('@tuturuuu/internal-api', () => ({
   createWorkspaceLabel: mockCreateWorkspaceLabel,
   createWorkspaceTaskBoard: vi.fn(),
   createWorkspaceTaskProject: mockCreateWorkspaceTaskProject,
-  listCurrentUserTaskBoards: mockListCurrentUserTaskBoards,
   listWorkspaceBoardsWithLists: vi.fn(),
   listWorkspaceLabels: mockListWorkspaceLabels,
   listWorkspaceMembers: vi.fn(),
   listWorkspaces: mockListWorkspaces,
-  listWorkspaceTaskBoards: vi.fn(),
+  listWorkspaceTaskBoards: mockListWorkspaceTaskBoards,
   listWorkspaceTaskLists: vi.fn(),
   listWorkspaceTaskProjects: mockListWorkspaceTaskProjects,
   updateWorkspaceTaskList: vi.fn(),
@@ -243,28 +242,28 @@ describe('useMyTasksState', () => {
         ],
       },
     ])(
-      'uses one workspace query and one board summary for $name workspaces',
+      'loads complete board catalogs for $name workspaces',
       async ({ workspaces }) => {
         setupPersonalQueries(workspaces);
         mockListWorkspaces.mockResolvedValue(workspaces);
-        mockListCurrentUserTaskBoards.mockResolvedValue({
-          boards: [
-            {
-              access_type: 'guest',
-              deleted_at: null,
-              id: 'guest-board',
-              name: 'Guest board',
-              ws_id: 'ws-guest',
-            },
-            {
-              access_type: 'member',
-              deleted_at: '2026-01-01T00:00:00.000Z',
-              id: 'deleted-board',
-              name: 'Deleted board',
-              ws_id: 'ws-a',
-            },
-          ],
-        });
+        mockListWorkspaceTaskBoards.mockImplementation(
+          async (workspaceId: string) => ({
+            boards: [
+              {
+                deleted_at: null,
+                id: `board-${workspaceId}`,
+                name: `Board ${workspaceId}`,
+                ws_id: workspaceId,
+              },
+              {
+                deleted_at: '2026-01-01T00:00:00.000Z',
+                id: `deleted-${workspaceId}`,
+                name: 'Deleted board',
+                ws_id: workspaceId,
+              },
+            ],
+          })
+        );
 
         renderHook(() =>
           useMyTasksState({ ...DEFAULT_PROPS, isPersonal: true })
@@ -273,19 +272,46 @@ describe('useMyTasksState', () => {
         const workspaceQuery = findQueryOptions('user-workspaces');
         const boardQuery = findQueryOptions('all-user-boards');
         await expect(workspaceQuery?.queryFn()).resolves.toEqual(workspaces);
-        await expect(boardQuery?.queryFn()).resolves.toEqual([
-          {
-            id: 'guest-board',
-            name: 'Guest board',
-            ws_id: 'ws-guest',
-          },
-        ]);
-        expect(mockListWorkspaces).toHaveBeenCalledOnce();
-        expect(mockListCurrentUserTaskBoards).toHaveBeenCalledOnce();
+        await expect(boardQuery?.queryFn()).resolves.toEqual(
+          workspaces.map((workspace) => ({
+            id: `board-${workspace.id}`,
+            name: `Board ${workspace.id}`,
+            ws_id: workspace.id,
+          }))
+        );
+        expect(mockListWorkspaces).toHaveBeenCalledTimes(2);
+        expect(mockListWorkspaceTaskBoards).toHaveBeenCalledTimes(
+          workspaces.length
+        );
         expect(findQueryOptions('workspaceLabels')?.enabled).toBe(false);
         expect(findQueryOptions('workspaceProjects')?.enabled).toBe(false);
       }
     );
+
+    it('paginates every workspace board catalog until a short page', async () => {
+      setupPersonalQueries([{ id: 'ws-a', name: 'A', personal: false }]);
+      mockListWorkspaces.mockResolvedValue([
+        { id: 'ws-a', name: 'A', personal: false },
+      ]);
+      const firstPage = Array.from({ length: 200 }, (_, index) => ({
+        deleted_at: null,
+        id: `board-${index}`,
+        name: `Board ${index}`,
+        ws_id: 'ws-a',
+      }));
+      mockListWorkspaceTaskBoards
+        .mockResolvedValueOnce({ boards: firstPage })
+        .mockResolvedValueOnce({ boards: [] });
+
+      renderHook(() => useMyTasksState({ ...DEFAULT_PROPS, isPersonal: true }));
+      const boardQuery = findQueryOptions('all-user-boards');
+
+      await expect(boardQuery?.queryFn()).resolves.toHaveLength(200);
+      expect(mockListWorkspaceTaskBoards.mock.calls).toEqual([
+        ['ws-a', { page: 1, pageSize: 200 }],
+        ['ws-a', { page: 2, pageSize: 200 }],
+      ]);
+    });
 
     it('loads each workspace label catalog only after demand and keeps a stable key', async () => {
       setupPersonalQueries([
@@ -305,6 +331,7 @@ describe('useMyTasksState', () => {
 
       const requestedQuery = findQueryOptions('workspaceLabels');
       expect(requestedQuery?.enabled).toBe(true);
+      expect(requestedQuery?.staleTime).toBe(5 * 60 * 1000);
       expect(requestedQuery?.queryKey).toEqual([
         'workspaceLabels',
         'ws-a',
@@ -328,10 +355,31 @@ describe('useMyTasksState', () => {
       expect(findQueryOptions('workspaceProjects')?.enabled).toBe(false);
       act(() => result.current.requestProjectCatalog());
       expect(findQueryOptions('workspaceProjects')?.enabled).toBe(true);
+      expect(findQueryOptions('workspaceProjects')?.staleTime).toBe(
+        5 * 60 * 1000
+      );
 
       act(() => result.current.handleLabelFilterChange(['label-persisted']));
       expect(findQueryOptions('workspaceLabels')?.enabled).toBe(true);
       expect(result.current.taskFilters.labelIds).toEqual(['label-persisted']);
+    });
+
+    it('loads the current workspace catalogs on demand outside personal mode', () => {
+      const { result } = renderHook(() =>
+        useMyTasksState({ ...DEFAULT_PROPS, isPersonal: false })
+      );
+
+      act(() => result.current.requestProjectCatalog());
+      expect(findQueryOptions('workspaceProjects')).toMatchObject({
+        enabled: true,
+        queryKey: ['workspaceProjects', 'ws-1'],
+      });
+
+      act(() => result.current.requestLabelCatalog());
+      expect(findQueryOptions('workspaceLabels')).toMatchObject({
+        enabled: true,
+        queryKey: ['workspaceLabels', 'ws-1'],
+      });
     });
   });
 

--- a/packages/tasks-ui/src/tu-do/my-tasks/__tests__/use-my-tasks-state.test.ts
+++ b/packages/tasks-ui/src/tu-do/my-tasks/__tests__/use-my-tasks-state.test.ts
@@ -6,6 +6,10 @@ import { LABEL_COLOR_PRESETS } from '../../utils/label-colors';
 const {
   mockCreateWorkspaceLabel,
   mockCreateWorkspaceTaskProject,
+  mockListCurrentUserTaskBoards,
+  mockListWorkspaceLabels,
+  mockListWorkspaceTaskProjects,
+  mockListWorkspaces,
   mockInvalidateQueries,
   mockUseQuery,
   mockUseMutation,
@@ -27,6 +31,10 @@ const {
 } = vi.hoisted(() => ({
   mockCreateWorkspaceLabel: vi.fn(),
   mockCreateWorkspaceTaskProject: vi.fn(),
+  mockListCurrentUserTaskBoards: vi.fn(),
+  mockListWorkspaceLabels: vi.fn(),
+  mockListWorkspaceTaskProjects: vi.fn(),
+  mockListWorkspaces: vi.fn(),
   mockInvalidateQueries: vi.fn(),
   mockUseQuery: vi.fn(),
   mockUseMutation: vi.fn(),
@@ -59,13 +67,14 @@ vi.mock('@tuturuuu/internal-api', () => ({
   createWorkspaceLabel: mockCreateWorkspaceLabel,
   createWorkspaceTaskBoard: vi.fn(),
   createWorkspaceTaskProject: mockCreateWorkspaceTaskProject,
+  listCurrentUserTaskBoards: mockListCurrentUserTaskBoards,
   listWorkspaceBoardsWithLists: vi.fn(),
-  listWorkspaceLabels: vi.fn(),
+  listWorkspaceLabels: mockListWorkspaceLabels,
   listWorkspaceMembers: vi.fn(),
-  listWorkspaces: vi.fn(),
+  listWorkspaces: mockListWorkspaces,
   listWorkspaceTaskBoards: vi.fn(),
   listWorkspaceTaskLists: vi.fn(),
-  listWorkspaceTaskProjects: vi.fn(),
+  listWorkspaceTaskProjects: mockListWorkspaceTaskProjects,
   updateWorkspaceTaskList: vi.fn(),
 }));
 
@@ -176,6 +185,13 @@ function setupSupabaseMocks() {
   });
 }
 
+function findQueryOptions(queryKey: string) {
+  return [...mockUseQuery.mock.calls]
+    .reverse()
+    .map(([options]) => options as Record<string, any>)
+    .find((options) => options.queryKey?.[0] === queryKey);
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 describe('useMyTasksState', () => {
   beforeEach(() => {
@@ -183,6 +199,140 @@ describe('useMyTasksState', () => {
     setupDefaultMocks();
     setupInternalApiMocks();
     setupSupabaseMocks();
+  });
+
+  describe('personal workspace catalog loading', () => {
+    function setupPersonalQueries(
+      workspaces: Array<{ id: string; name: string; personal: boolean }>
+    ) {
+      mockUseQuery.mockImplementation((opts: Record<string, any>) => {
+        if (opts.queryKey?.[0] === 'my-tasks') {
+          return {
+            data: {
+              overdue: [],
+              today: [],
+              upcoming: [],
+              completed: [],
+              totalActiveTasks: 0,
+              totalCompletedTasks: 0,
+              hasMoreCompleted: false,
+              completedPage: 0,
+            },
+            isLoading: false,
+          };
+        }
+        if (opts.queryKey?.[0] === 'user-workspaces') {
+          return { data: workspaces, isLoading: false };
+        }
+        return { data: undefined, isLoading: false };
+      });
+    }
+
+    it.each([
+      { name: 'zero', workspaces: [] },
+      {
+        name: 'one',
+        workspaces: [{ id: 'ws-a', name: 'A', personal: false }],
+      },
+      {
+        name: 'many',
+        workspaces: [
+          { id: 'ws-b', name: 'B', personal: false },
+          { id: 'ws-a', name: 'A', personal: false },
+          { id: 'ws-c', name: 'C', personal: false },
+        ],
+      },
+    ])(
+      'uses one workspace query and one board summary for $name workspaces',
+      async ({ workspaces }) => {
+        setupPersonalQueries(workspaces);
+        mockListWorkspaces.mockResolvedValue(workspaces);
+        mockListCurrentUserTaskBoards.mockResolvedValue({
+          boards: [
+            {
+              access_type: 'guest',
+              deleted_at: null,
+              id: 'guest-board',
+              name: 'Guest board',
+              ws_id: 'ws-guest',
+            },
+            {
+              access_type: 'member',
+              deleted_at: '2026-01-01T00:00:00.000Z',
+              id: 'deleted-board',
+              name: 'Deleted board',
+              ws_id: 'ws-a',
+            },
+          ],
+        });
+
+        renderHook(() =>
+          useMyTasksState({ ...DEFAULT_PROPS, isPersonal: true })
+        );
+
+        const workspaceQuery = findQueryOptions('user-workspaces');
+        const boardQuery = findQueryOptions('all-user-boards');
+        await expect(workspaceQuery?.queryFn()).resolves.toEqual(workspaces);
+        await expect(boardQuery?.queryFn()).resolves.toEqual([
+          {
+            id: 'guest-board',
+            name: 'Guest board',
+            ws_id: 'ws-guest',
+          },
+        ]);
+        expect(mockListWorkspaces).toHaveBeenCalledOnce();
+        expect(mockListCurrentUserTaskBoards).toHaveBeenCalledOnce();
+        expect(findQueryOptions('workspaceLabels')?.enabled).toBe(false);
+        expect(findQueryOptions('workspaceProjects')?.enabled).toBe(false);
+      }
+    );
+
+    it('loads each workspace label catalog only after demand and keeps a stable key', async () => {
+      setupPersonalQueries([
+        { id: 'ws-b', name: 'B', personal: false },
+        { id: 'ws-a', name: 'A', personal: false },
+      ]);
+      mockListWorkspaceLabels
+        .mockResolvedValueOnce([{ id: 'label-a', name: 'A' }])
+        .mockResolvedValueOnce([{ id: 'label-b', name: 'B' }]);
+
+      const { result } = renderHook(() =>
+        useMyTasksState({ ...DEFAULT_PROPS, isPersonal: true })
+      );
+      expect(findQueryOptions('workspaceLabels')?.enabled).toBe(false);
+
+      act(() => result.current.requestLabelCatalog());
+
+      const requestedQuery = findQueryOptions('workspaceLabels');
+      expect(requestedQuery?.enabled).toBe(true);
+      expect(requestedQuery?.queryKey).toEqual([
+        'workspaceLabels',
+        'ws-a',
+        'ws-b',
+      ]);
+      await requestedQuery?.queryFn();
+      expect(mockListWorkspaceLabels.mock.calls).toEqual([['ws-a'], ['ws-b']]);
+
+      act(() => result.current.requestLabelCatalog());
+      expect(findQueryOptions('workspaceLabels')?.queryKey).toEqual(
+        requestedQuery?.queryKey
+      );
+    });
+
+    it('loads projects on demand and resolves persisted selections while closed', () => {
+      setupPersonalQueries([{ id: 'ws-a', name: 'A', personal: false }]);
+      const { result } = renderHook(() =>
+        useMyTasksState({ ...DEFAULT_PROPS, isPersonal: true })
+      );
+
+      expect(findQueryOptions('workspaceProjects')?.enabled).toBe(false);
+      act(() => result.current.requestProjectCatalog());
+      expect(findQueryOptions('workspaceProjects')?.enabled).toBe(true);
+
+      act(() => result.current.handleLabelFilterChange(['label-persisted']));
+      expect(findQueryOptions('workspaceLabels')?.enabled).toBe(true);
+      expect(result.current.taskFilters.labelIds).toEqual(['label-persisted']);
+    });
   });
 
   // ── Initial state ────────────────────────────────────────────────────────

--- a/packages/tasks-ui/src/tu-do/my-tasks/command-bar.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/command-bar.tsx
@@ -103,6 +103,8 @@ interface CommandBarProps {
   wsId?: string;
   onCreateNewLabel?: () => void;
   onCreateNewProject?: () => void;
+  onLabelsRequested?: () => void;
+  onProjectsRequested?: () => void;
   value: string;
   onValueChange: (value: string) => void;
   aiCreditsExhausted?: boolean;
@@ -130,6 +132,8 @@ export function CommandBar({
   workspaceEstimationConfig = null,
   onCreateNewLabel,
   onCreateNewProject,
+  onLabelsRequested,
+  onProjectsRequested,
   value,
   onValueChange,
   aiCreditsExhausted = false,
@@ -587,49 +591,49 @@ export function CommandBar({
                                 </button>
                               )}
 
-                            {workspaceProjects.length > 0 && (
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  setActiveSettingsView('projects')
-                                }
-                                className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted"
-                              >
-                                <div className="flex items-center gap-2">
-                                  <Box className="h-4 w-4 text-dynamic-sky" />
-                                  <span>{t('cmd_projects')}</span>
-                                </div>
-                                <div className="flex items-center gap-2">
-                                  {selectedProjectIds.length > 0 && (
-                                    <span className="font-medium text-muted-foreground text-xs">
-                                      {selectedProjectIds.length}
-                                    </span>
-                                  )}
-                                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                                </div>
-                              </button>
-                            )}
+                            <button
+                              type="button"
+                              onClick={() => {
+                                onProjectsRequested?.();
+                                setActiveSettingsView('projects');
+                              }}
+                              className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted"
+                            >
+                              <div className="flex items-center gap-2">
+                                <Box className="h-4 w-4 text-dynamic-sky" />
+                                <span>{t('cmd_projects')}</span>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                {selectedProjectIds.length > 0 && (
+                                  <span className="font-medium text-muted-foreground text-xs">
+                                    {selectedProjectIds.length}
+                                  </span>
+                                )}
+                                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                              </div>
+                            </button>
 
-                            {workspaceLabels.length > 0 && (
-                              <button
-                                type="button"
-                                onClick={() => setActiveSettingsView('labels')}
-                                className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted"
-                              >
-                                <div className="flex items-center gap-2">
-                                  <Tag className="h-4 w-4 text-dynamic-cyan" />
-                                  <span>{t('cmd_labels')}</span>
-                                </div>
-                                <div className="flex items-center gap-2">
-                                  {selectedLabelIds.length > 0 && (
-                                    <span className="font-medium text-muted-foreground text-xs">
-                                      {selectedLabelIds.length}
-                                    </span>
-                                  )}
-                                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                                </div>
-                              </button>
-                            )}
+                            <button
+                              type="button"
+                              onClick={() => {
+                                onLabelsRequested?.();
+                                setActiveSettingsView('labels');
+                              }}
+                              className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted"
+                            >
+                              <div className="flex items-center gap-2">
+                                <Tag className="h-4 w-4 text-dynamic-cyan" />
+                                <span>{t('cmd_labels')}</span>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                {selectedLabelIds.length > 0 && (
+                                  <span className="font-medium text-muted-foreground text-xs">
+                                    {selectedLabelIds.length}
+                                  </span>
+                                )}
+                                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                              </div>
+                            </button>
 
                             {workspaceMembers.length > 0 && (
                               <button

--- a/packages/tasks-ui/src/tu-do/my-tasks/label-project-filter.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/label-project-filter.tsx
@@ -31,6 +31,8 @@ interface LabelProjectFilterProps {
   selectedProjectIds: string[];
   onSelectedLabelIdsChange: (ids: string[]) => void;
   onSelectedProjectIdsChange: (ids: string[]) => void;
+  onLabelsRequested?: () => void;
+  onProjectsRequested?: () => void;
 }
 
 type ViewType = 'main' | 'labels' | 'projects';
@@ -42,6 +44,8 @@ export function LabelProjectFilter({
   selectedProjectIds,
   onSelectedLabelIdsChange,
   onSelectedProjectIdsChange,
+  onLabelsRequested,
+  onProjectsRequested,
 }: LabelProjectFilterProps) {
   const t = useTranslations('ws-tasks');
   const [open, setOpen] = useState(false);
@@ -90,7 +94,10 @@ export function LabelProjectFilter({
             <div className="p-2">
               <button
                 type="button"
-                onClick={() => setView('labels')}
+                onClick={() => {
+                  onLabelsRequested?.();
+                  setView('labels');
+                }}
                 className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted"
               >
                 <div className="flex items-center gap-2">
@@ -103,7 +110,10 @@ export function LabelProjectFilter({
               </button>
               <button
                 type="button"
-                onClick={() => setView('projects')}
+                onClick={() => {
+                  onProjectsRequested?.();
+                  setView('projects');
+                }}
                 className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted"
               >
                 <div className="flex items-center gap-2">

--- a/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-content.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-content.tsx
@@ -121,6 +121,8 @@ export default function MyTasksContent({
           wsId={wsId}
           onCreateNewLabel={() => state.setNewLabelDialogOpen(true)}
           onCreateNewProject={() => state.setNewProjectDialogOpen(true)}
+          onLabelsRequested={state.requestLabelCatalog}
+          onProjectsRequested={state.requestProjectCatalog}
           aiCreditsExhausted={aiCreditsExhausted}
           aiCreditsTooltip={
             aiCreditsExhausted ? t('ai_credits_exhausted_tooltip') : undefined
@@ -155,6 +157,8 @@ export default function MyTasksContent({
             state.setNewBoardName('');
             state.setNewBoardDialogOpen(true);
           }}
+          onLabelsRequested={state.requestLabelCatalog}
+          onProjectsRequested={state.requestProjectCatalog}
         />
       )}
 

--- a/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-filters.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-filters.tsx
@@ -38,6 +38,8 @@ interface MyTasksFiltersProps {
   onLabelFilterChange: (ids: string[]) => void;
   onProjectFilterChange: (ids: string[]) => void;
   onCreateNewBoard: () => void;
+  onLabelsRequested?: () => void;
+  onProjectsRequested?: () => void;
 }
 
 export function MyTasksFilters({
@@ -53,6 +55,8 @@ export function MyTasksFilters({
   onLabelFilterChange,
   onProjectFilterChange,
   onCreateNewBoard,
+  onLabelsRequested,
+  onProjectsRequested,
 }: MyTasksFiltersProps) {
   const t = useTranslations();
   const hasActiveFilters =
@@ -83,6 +87,8 @@ export function MyTasksFilters({
           selectedProjectIds={taskFilters.projectIds}
           onSelectedLabelIdsChange={onLabelFilterChange}
           onSelectedProjectIdsChange={onProjectFilterChange}
+          onLabelsRequested={onLabelsRequested}
+          onProjectsRequested={onProjectsRequested}
         />
 
         <Button

--- a/packages/tasks-ui/src/tu-do/my-tasks/use-my-tasks-state.ts
+++ b/packages/tasks-ui/src/tu-do/my-tasks/use-my-tasks-state.ts
@@ -5,6 +5,7 @@ import {
   createWorkspaceLabel,
   createWorkspaceTaskBoard,
   createWorkspaceTaskProject,
+  listCurrentUserTaskBoards,
   listWorkspaceBoardsWithLists,
   listWorkspaceLabels,
   listWorkspaceMembers,
@@ -85,6 +86,16 @@ export function useMyTasksState({
     projectIds: [],
     selfManagedOnly: false,
   });
+  const [labelCatalogRequested, setLabelCatalogRequested] = useState(false);
+  const [projectCatalogRequested, setProjectCatalogRequested] = useState(false);
+  const requestLabelCatalog = useCallback(
+    () => setLabelCatalogRequested(true),
+    []
+  );
+  const requestProjectCatalog = useCallback(
+    () => setProjectCatalogRequested(true),
+    []
+  );
 
   // Fetch tasks via TanStack Query (filters applied server-side)
   const { data: queryData, isLoading: queryLoading } = useMyTasksQuery(
@@ -164,7 +175,17 @@ export function useMyTasksState({
   >([]);
 
   // Preview state
-  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewOpen, setPreviewOpenState] = useState(false);
+  const setPreviewOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        requestLabelCatalog();
+        requestProjectCatalog();
+      }
+      setPreviewOpenState(open);
+    },
+    [requestLabelCatalog, requestProjectCatalog]
+  );
   const [previewEntry, setPreviewEntry] = useState<string | null>(null);
   const [lastResult, setLastResult] = useState<any | null>(null);
   const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([]);
@@ -185,17 +206,28 @@ export function useMyTasksState({
     getRandomNewLabelColor()
   );
   const [creatingLabel, setCreatingLabel] = useState(false);
-  const setNewLabelDialogOpen = useCallback((open: boolean) => {
-    if (open) {
-      setNewLabelColor((previousColor) =>
-        getRandomNewLabelColor(previousColor)
-      );
-    }
-    setNewLabelDialogOpenState(open);
-  }, []);
+  const setNewLabelDialogOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        requestLabelCatalog();
+        setNewLabelColor((previousColor) =>
+          getRandomNewLabelColor(previousColor)
+        );
+      }
+      setNewLabelDialogOpenState(open);
+    },
+    [requestLabelCatalog]
+  );
 
   // Project creation dialog state
-  const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false);
+  const [newProjectDialogOpen, setNewProjectDialogOpenState] = useState(false);
+  const setNewProjectDialogOpen = useCallback(
+    (open: boolean) => {
+      if (open) requestProjectCatalog();
+      setNewProjectDialogOpenState(open);
+    },
+    [requestProjectCatalog]
+  );
   const [newProjectName, setNewProjectName] = useState('');
   const [creatingProject, setCreatingProject] = useState(false);
 
@@ -246,41 +278,8 @@ export function useMyTasksState({
   const { data: allBoardsData = [] } = useQuery({
     queryKey: ['all-user-boards'],
     queryFn: async () => {
-      const workspaces = await listWorkspaces();
-      const workspaceIds = workspaces.map((workspace) => workspace.id);
-      if (workspaceIds.length === 0) return [];
-
-      const fetchAllWorkspaceBoards = async (workspaceId: string) => {
-        const pageSize = 200;
-        const boards: Awaited<
-          ReturnType<typeof listWorkspaceTaskBoards>
-        >['boards'] = [];
-        let page = 1;
-
-        while (true) {
-          const payload = await listWorkspaceTaskBoards(workspaceId, {
-            page,
-            pageSize,
-          });
-          const pageBoards = payload.boards ?? [];
-          boards.push(...pageBoards);
-
-          if (pageBoards.length < pageSize) {
-            break;
-          }
-
-          page += 1;
-        }
-
-        return boards;
-      };
-
-      const boardGroups = await Promise.all(
-        workspaceIds.map((workspaceId) => fetchAllWorkspaceBoards(workspaceId))
-      );
-
-      return boardGroups
-        .flat()
+      const payload = await listCurrentUserTaskBoards();
+      return (payload.boards ?? [])
         .filter((board) => !board.deleted_at)
         .map((board) => ({
           id: board.id,
@@ -394,25 +393,29 @@ export function useMyTasksState({
     : ((boardsDataRaw as any)?.boards ?? []);
 
   const allWorkspaceIds = useMemo(
-    () => workspacesData?.map((ws) => ws.id) || [],
+    () => (workspacesData?.map((ws) => ws.id) || []).toSorted(),
     [workspacesData]
   );
 
   // Fetch workspace labels
   const { data: workspaceLabels = [] } = useQuery({
-    queryKey: ['workspaceLabels', JSON.stringify(allWorkspaceIds)],
+    queryKey: ['workspaceLabels', ...allWorkspaceIds],
     queryFn: async () => {
       if (allWorkspaceIds.length === 0) return [];
       const promises = allWorkspaceIds.map((id) => listWorkspaceLabels(id));
       const results = await Promise.all(promises);
       return results.flat().filter(Boolean);
     },
-    enabled: isPersonal && allWorkspaceIds.length > 0,
+    staleTime: Number.POSITIVE_INFINITY,
+    enabled:
+      isPersonal &&
+      allWorkspaceIds.length > 0 &&
+      (labelCatalogRequested || taskFilters.labelIds.length > 0),
   });
 
   // Fetch workspace projects
   const { data: workspaceProjects = [] } = useQuery({
-    queryKey: ['workspaceProjects', JSON.stringify(allWorkspaceIds)],
+    queryKey: ['workspaceProjects', ...allWorkspaceIds],
     queryFn: async () => {
       if (allWorkspaceIds.length === 0) return [];
       const projectGroups = await Promise.all(
@@ -428,7 +431,11 @@ export function useMyTasksState({
 
       return projectGroups.flat().sort((a, b) => a.name.localeCompare(b.name));
     },
-    enabled: isPersonal && allWorkspaceIds.length > 0,
+    staleTime: Number.POSITIVE_INFINITY,
+    enabled:
+      isPersonal &&
+      allWorkspaceIds.length > 0 &&
+      (projectCatalogRequested || taskFilters.projectIds.length > 0),
   });
 
   // Fetch workspace members
@@ -1004,6 +1011,8 @@ export function useMyTasksState({
     boardsLoading,
     workspaceLabels,
     workspaceProjects,
+    requestLabelCatalog,
+    requestProjectCatalog,
     workspaceMembers,
     boardConfig,
     availableLists,

--- a/packages/tasks-ui/src/tu-do/my-tasks/use-my-tasks-state.ts
+++ b/packages/tasks-ui/src/tu-do/my-tasks/use-my-tasks-state.ts
@@ -5,7 +5,6 @@ import {
   createWorkspaceLabel,
   createWorkspaceTaskBoard,
   createWorkspaceTaskProject,
-  listCurrentUserTaskBoards,
   listWorkspaceBoardsWithLists,
   listWorkspaceLabels,
   listWorkspaceMembers,
@@ -278,8 +277,33 @@ export function useMyTasksState({
   const { data: allBoardsData = [] } = useQuery({
     queryKey: ['all-user-boards'],
     queryFn: async () => {
-      const payload = await listCurrentUserTaskBoards();
-      return (payload.boards ?? [])
+      const workspaces = await listWorkspaces();
+      const fetchAllWorkspaceBoards = async (workspaceId: string) => {
+        const pageSize = 200;
+        const boards: Awaited<
+          ReturnType<typeof listWorkspaceTaskBoards>
+        >['boards'] = [];
+        let page = 1;
+
+        while (true) {
+          const payload = await listWorkspaceTaskBoards(workspaceId, {
+            page,
+            pageSize,
+          });
+          const pageBoards = payload.boards ?? [];
+          boards.push(...pageBoards);
+          if (pageBoards.length < pageSize) break;
+          page += 1;
+        }
+
+        return boards;
+      };
+      const boardGroups = await Promise.all(
+        workspaces.map((workspace) => fetchAllWorkspaceBoards(workspace.id))
+      );
+
+      return boardGroups
+        .flat()
         .filter((board) => !board.deleted_at)
         .map((board) => ({
           id: board.id,
@@ -393,8 +417,12 @@ export function useMyTasksState({
     : ((boardsDataRaw as any)?.boards ?? []);
 
   const allWorkspaceIds = useMemo(
-    () => (workspacesData?.map((ws) => ws.id) || []).toSorted(),
-    [workspacesData]
+    () =>
+      (isPersonal
+        ? workspacesData?.map((ws) => ws.id) || []
+        : [wsId]
+      ).toSorted(),
+    [isPersonal, workspacesData, wsId]
   );
 
   // Fetch workspace labels
@@ -406,9 +434,8 @@ export function useMyTasksState({
       const results = await Promise.all(promises);
       return results.flat().filter(Boolean);
     },
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: 5 * 60 * 1000,
     enabled:
-      isPersonal &&
       allWorkspaceIds.length > 0 &&
       (labelCatalogRequested || taskFilters.labelIds.length > 0),
   });
@@ -431,9 +458,8 @@ export function useMyTasksState({
 
       return projectGroups.flat().sort((a, b) => a.name.localeCompare(b.name));
     },
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: 5 * 60 * 1000,
     enabled:
-      isPersonal &&
       allWorkspaceIds.length > 0 &&
       (projectCatalogRequested || taskFilters.projectIds.length > 0),
   });

--- a/packages/tasks-ui/src/tu-do/my-tasks/use-my-tasks-state.ts
+++ b/packages/tasks-ui/src/tu-do/my-tasks/use-my-tasks-state.ts
@@ -5,6 +5,7 @@ import {
   createWorkspaceLabel,
   createWorkspaceTaskBoard,
   createWorkspaceTaskProject,
+  InternalApiError,
   listWorkspaceBoardsWithLists,
   listWorkspaceLabels,
   listWorkspaceMembers,
@@ -285,15 +286,23 @@ export function useMyTasksState({
         >['boards'] = [];
         let page = 1;
 
-        while (true) {
-          const payload = await listWorkspaceTaskBoards(workspaceId, {
-            page,
-            pageSize,
-          });
-          const pageBoards = payload.boards ?? [];
-          boards.push(...pageBoards);
-          if (pageBoards.length < pageSize) break;
-          page += 1;
+        try {
+          while (true) {
+            const payload = await listWorkspaceTaskBoards(workspaceId, {
+              page,
+              pageSize,
+              status: 'all',
+            });
+            const pageBoards = payload.boards ?? [];
+            boards.push(...pageBoards);
+            if (pageBoards.length < pageSize) break;
+            page += 1;
+          }
+        } catch (error) {
+          if (error instanceof InternalApiError && error.status === 403) {
+            return [];
+          }
+          throw error;
         }
 
         return boards;


### PR DESCRIPTION
Defers expensive My Tasks filter catalogs until they are needed. Validated with 70 focused tests, Tasks type-check, and bun check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers My Tasks label and project catalog loading until they are needed, avoiding eager catalog requests during the initial render.

- Loads catalogs when a filter menu, command menu, creation dialog, or task preview needs them, or when a persisted filter references them.
- Caches each catalog for 5 minutes and uses stable keys for personal workspace catalogs.
- Paginates personal My Tasks boards completely and skips inaccessible workspaces while keeping boards from accessible workspaces.
- Keeps the Projects and Labels command menu entries visible before their catalogs load.

<sup>Written for commit d7fa0045a8eaf80c8c754d376332c52101a88898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

