### PR TITLE
fix(git): preserve locale in repository views

### DIFF
--- a/apps/git/src/app/[locale]/[owner]/[repo]/[[...view]]/page.tsx
+++ b/apps/git/src/app/[locale]/[owner]/[repo]/[[...view]]/page.tsx
@@ -82,7 +82,7 @@ export default async function RepositoryPage({
   params,
   searchParams,
 }: PageProps) {
-  const { owner, repo, view = [] } = await params;
+  const { locale, owner, repo, view = [] } = await params;
   const query = await searchParams;
   const activeView = resolveActiveView(view);
 


### PR DESCRIPTION
## Summary
- restore the locale value when destructuring repository page params
- unblock the exact-main TypeScript gate after #5199

## Verification
- `cd apps/git && bun run type-check`
- `cd apps/git && bun run test` (71 passed)
- `bun check`: type-check and Biome passed; the only failure was the known sandbox-only `listen EPERM 127.0.0.1` in `apps/web/docker/request-tracker.test.js` (2 timeouts; 2,886 other web tests passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the git repository page so the `locale` param is preserved when destructuring page params, unblocking the exact-main TypeScript check.

<sup>Written for commit c812bfc0c417451c6eba8bdedc5f3b93e7818fc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

