### PR TITLE
chore(ci): pause TanStack and Rust E2E

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -167,7 +167,9 @@ jobs:
       - name: Build and publish E2E image bundle
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: node scripts/ci/e2e-image-bundle.js publish
+        # The TanStack/Rust migration is paused. Build only the live Next.js
+        # frontend bundle needed by the maintained Playwright matrix.
+        run: node scripts/ci/e2e-image-bundle.js publish --frontend next
 
       - name: Remove Turbo BuildKit secret files
         if: always()
@@ -653,7 +655,9 @@ jobs:
   migration-e2e:
     name: Migration E2E (${{ matrix.mode }})
     needs: [prepare-e2e-images]
-    if: ${{ always() && github.ref != 'refs/heads/production' }}
+    # Preserve the matrix for an intentional future restart, but do not spend
+    # CI capacity on the paused TanStack/Rust migration.
+    if: ${{ false }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:

--- a/apps/docs/build/devops/github-actions-runbook.mdx
+++ b/apps/docs/build/devops/github-actions-runbook.mdx
@@ -236,6 +236,11 @@ shared `ci-check.yml` switchboard will leave the expensive Rust/TanStack jobs
 skipped. Re-enable them only when active maintenance resumes and the full
 workflow is again an intentional delivery gate.
 
+The shared `e2e-tests.yaml` workflow also keeps `migration-e2e` disabled and
+publishes only the `next` image bundle. Maintained Next.js Playwright coverage
+continues to run; the retained TanStack dual-stack and comparison matrix is a
+manual source reference until migration work resumes.
+
 ### TanStack/Rust Cloudflare deployment
 
 `rust-backend.yml` is also the manually dispatched Cloudflare preview deployment

--- a/apps/docs/build/devops/overview.mdx
+++ b/apps/docs/build/devops/overview.mdx
@@ -41,7 +41,7 @@ released, or recovered.
   `scripts/check-discord-python.js`.
 - Vercel handles hosted satellite web deployments, platform preview build validation, and the hosted platform production deploy. Automatic TanStack production builds are disabled while that migration is paused. Supabase migrations run as separate workflows; `main` drives staging schema promotion and `production` drives production schema promotion.
 - Self-hosted web deployment is Docker-based, and blue/green rollout is the supported rebuild-before-restart path.
-- The TanStack/Rust migration is paused. Its source remains available for local or explicitly approved manual work, but automatic Rust/TanStack CI, Cloudflare workflow jobs, and TanStack production builds stay disabled in `tuturuuu.ts` until maintenance resumes. `apps/web` remains the production source of truth.
+- The TanStack/Rust migration is paused. Its source remains available for local or explicitly approved manual work, but automatic Rust/TanStack CI, Cloudflare workflow jobs, TanStack production builds, and the migration E2E matrix stay disabled until maintenance resumes. The shared E2E bundle now builds only the maintained Next.js frontend, and `apps/web` remains the production source of truth.
 - Secrets live in GitHub Actions secrets/variables or local env files such as `apps/web/.env.local`. They do not belong in the repo.
 
 ## Vercel Cost Controls

--- a/apps/docs/platform/architecture/tanstack-rust-migration.mdx
+++ b/apps/docs/platform/architecture/tanstack-rust-migration.mdx
@@ -15,10 +15,11 @@ contracts documented in `apps/backend/api/openapi.yaml`.
 <Warning>
   Active development of `apps/tanstack-web` and `apps/backend` is paused. Their
   combined `rust-backend.yml` CI/Cloudflare workflow and automatic TanStack
-  Vercel production builds are disabled in `tuturuuu.ts`. `apps/backend` is not
-  deployed and receives no production traffic; `apps/web` remains the live API
-  runtime. A route marked `migrated` below records implemented source work, not
-  a production cutover or a currently maintained migration target.
+  Vercel production builds are disabled in `tuturuuu.ts`, and the shared E2E
+  workflow skips its migration matrix and TanStack image build. `apps/backend`
+  is not deployed and receives no production traffic; `apps/web` remains the
+  live API runtime. A route marked `migrated` below records implemented source
+  work, not a production cutover or a currently maintained migration target.
 </Warning>
 
 The crate can run as a native container and keeps a Cloudflare Workers Rust

--- a/scripts/ci/check-workflow-config.test.js
+++ b/scripts/ci/check-workflow-config.test.js
@@ -849,13 +849,13 @@ test('secretless Turbo fallback caches are task-scoped and trusted-write only', 
   assert.doesNotMatch(setupAction, /TURBO_TOKEN|TURBO_TEAM|node_modules/);
 });
 
-test('TanStack migration E2E workflow keeps dual-stack and compare coverage', () => {
+test('paused TanStack migration E2E retains its restartable matrix', () => {
   const workflow = readWorkflowYaml('e2e-tests.yaml');
   const job = workflow.jobs?.['migration-e2e'];
 
   assert.ok(job, 'e2e-tests.yaml must define the migration-e2e job');
   assert.deepEqual(job.needs, ['prepare-e2e-images']);
-  assert.match(job.if, /always\(\)/u);
+  assert.equal(job.if, githubExpression('false'));
   assert.equal(job['timeout-minutes'], 60);
   assert.equal(job.strategy?.['fail-fast'], false);
 
@@ -1036,7 +1036,7 @@ test('E2E image bundle completes before private, bounded, optional consumers', (
   assert.deepEqual(e2e.needs, ['prepare-e2e-images']);
   assert.deepEqual(migration.needs, ['prepare-e2e-images']);
   assert.match(e2e.if, /always\(\)/u);
-  assert.match(migration.if, /always\(\)/u);
+  assert.equal(migration.if, githubExpression('false'));
   assert.equal(producer['continue-on-error'], true);
   assert.equal(producer.permissions?.contents, 'read');
   assert.equal(producer.permissions?.packages, 'write');
@@ -1108,7 +1108,7 @@ test('E2E image bundle completes before private, bounded, optional consumers', (
     producer.steps.some(
       (step) =>
         step.name === 'Build and publish E2E image bundle' &&
-        step.run === 'node scripts/ci/e2e-image-bundle.js publish'
+        step.run.endsWith('publish --frontend next')
     )
   );
 });

--- a/scripts/ci/e2e-image-bundle.js
+++ b/scripts/ci/e2e-image-bundle.js
@@ -357,6 +357,7 @@ async function publishBundle(
   });
   const manifest = createBundleManifest({
     env: buildEnv,
+    frontend: options.frontend,
     producerProject: options.producerProject,
     repository: options.repository,
     tagPrefix: options.tagPrefix,

--- a/scripts/ci/e2e-image-bundle.js
+++ b/scripts/ci/e2e-image-bundle.js
@@ -184,7 +184,7 @@ function parseArgs(argv = process.argv.slice(2), env = process.env) {
           )
         : null,
     frontend:
-      command === 'pull'
+      command === 'pull' || command === 'publish'
         ? validateBundleFrontend(
             getOptionValue(
               argv,

--- a/scripts/ci/e2e-image-bundle.test.js
+++ b/scripts/ci/e2e-image-bundle.test.js
@@ -81,6 +81,14 @@ test('parseArgs resolves CI interfaces and rejects missing command inputs', () =
     }).frontend,
     'tanstack'
   );
+  assert.equal(
+    parseArgs(['publish', '--frontend', 'next'], {
+      E2E_IMAGE_BUNDLE_REPOSITORY: REPOSITORY,
+      E2E_IMAGE_BUNDLE_TAG_PREFIX: TAG_PREFIX,
+      GITHUB_RUN_ID: '12345',
+    }).frontend,
+    'next'
+  );
   assert.throws(() => parseArgs(['publish'], {}));
   assert.throws(() => parseArgs(['unknown'], {}));
 });

--- a/scripts/ci/e2e-image-bundle.test.js
+++ b/scripts/ci/e2e-image-bundle.test.js
@@ -186,6 +186,7 @@ test('publish builds the planned services once and pushes the ready marker last'
 
   await publishBundle(
     {
+      frontend: 'next',
       producerProject: 'producer',
       repository: REPOSITORY,
       tagPrefix: TAG_PREFIX,
@@ -209,7 +210,7 @@ test('publish builds the planned services once and pushes the ready marker last'
 
   assert.deepEqual(
     buildOptions.services,
-    getBundleServices({}).filter((service) => service !== 'web-blue')
+    getBundleServices({}, 'next').filter((service) => service !== 'web-blue')
   );
   assert.equal(buildOptions.buildStrategy, 'bake');
   assert.match(buildOptions.bakeFile, /registry-output\.json$/u);
@@ -232,7 +233,7 @@ test('publish builds the planned services once and pushes the ready marker last'
     calls.filter(
       ([, args]) => args.slice(0, 3).join(' ') === 'buildx imagetools create'
     ).length,
-    getBundleServices({}).length + 2
+    getBundleServices({}, 'next').length + 2
   );
   const sentinelIndex = calls.findIndex(([, args]) =>
     args.includes(`${REPOSITORY}:${SENTINEL_TAG}`)
@@ -242,13 +243,18 @@ test('publish builds the planned services once and pushes the ready marker last'
   );
   assert.ok(sentinelIndex >= 0);
   assert.ok(firstBundleIndex > sentinelIndex);
-  for (const service of getBundleServices({})) {
+  for (const service of getBundleServices({}, 'next')) {
     assert.ok(
       calls.some(([, args]) =>
         args.includes(`${REPOSITORY}:${TAG_PREFIX}-${service}`)
       )
     );
   }
+  assert.ok(
+    !calls.some(([, args]) =>
+      args.includes(`${REPOSITORY}:${TAG_PREFIX}-tanstack-web-blue`)
+    )
+  );
   assert.ok(calls.at(-1)[1].includes(`${REPOSITORY}:${TAG_PREFIX}-ready`));
 });
 

--- a/scripts/ci/paused-migration-workflows.test.js
+++ b/scripts/ci/paused-migration-workflows.test.js
@@ -1,7 +1,5 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
 const {
   assertWorkflowDecision,
   createFixtureRoot,
@@ -24,17 +22,4 @@ test('paused TanStack and Rust workflows remain disabled', () => {
 
     assert.match(decision.output, /disabled in tuturuuu\.ts/);
   }
-});
-
-test('shared E2E avoids paused TanStack and Rust work', () => {
-  const workflow = fs.readFileSync(
-    path.join(__dirname, '..', '..', '.github', 'workflows', 'e2e-tests.yaml'),
-    'utf8'
-  );
-
-  assert.match(workflow, /e2e-image-bundle\.js publish --frontend next/u);
-  assert.match(
-    workflow,
-    /migration-e2e:\n(?:.|\n)*?\n {4}if: \$\{\{ false \}\}/u
-  );
 });

--- a/scripts/ci/paused-migration-workflows.test.js
+++ b/scripts/ci/paused-migration-workflows.test.js
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const {
   assertWorkflowDecision,
   createFixtureRoot,
@@ -22,4 +24,17 @@ test('paused TanStack and Rust workflows remain disabled', () => {
 
     assert.match(decision.output, /disabled in tuturuuu\.ts/);
   }
+});
+
+test('shared E2E avoids paused TanStack and Rust work', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '..', '.github', 'workflows', 'e2e-tests.yaml'),
+    'utf8'
+  );
+
+  assert.match(workflow, /e2e-image-bundle\.js publish --frontend next/u);
+  assert.match(
+    workflow,
+    /migration-e2e:\n(?:.|\n)*?\n {4}if: \$\{\{ false \}\}/u
+  );
 });

--- a/scripts/ci/release-workflows.test.js
+++ b/scripts/ci/release-workflows.test.js
@@ -1194,7 +1194,7 @@ test('E2E workflow frees runner disk before loading cached Docker images', () =>
   assert.doesNotMatch(e2eJob, /name: test-results-/u);
 });
 
-test('E2E workflow runs TanStack migration dual-stack and compare smoke jobs', () => {
+test('E2E workflow retains the paused migration restart contract', () => {
   const workflow = fs.readFileSync(
     path.join(repoRoot, '.github', 'workflows', 'e2e-tests.yaml'),
     'utf8'
@@ -1211,8 +1211,8 @@ test('E2E workflow runs TanStack migration dual-stack and compare smoke jobs', (
 
   assert.match(workflow, /\n {2}workflow_dispatch:\n/u);
   assert.match(migrationJob, /needs: \[prepare-e2e-images\]/u);
-  assert.match(migrationJob, /if: \$\{\{ always\(\)/u);
-  assert.match(migrationJob, /github\.ref != 'refs\/heads\/production'/u);
+  assert.match(migrationJob, /if: \$\{\{ false \}\}/u);
+  assert.doesNotMatch(migrationJob, /refs\/heads\/production/u);
   assert.match(migrationJob, /mode: tanstack-dual-stack/u);
   assert.match(
     migrationJob,


### PR DESCRIPTION
## Summary
- skip the retained TanStack/Rust migration E2E matrix while that migration is paused
- publish only the maintained Next.js E2E image bundle
- make the bundle publisher honor its frontend selection
- document and test the paused state so it cannot silently regress

## Verification
- `node --test scripts/ci/e2e-image-bundle.test.js scripts/ci/paused-migration-workflows.test.js scripts/ci/check-workflow-config.test.js scripts/ci/release-workflows.test.js` (81 passed)
- `bun check:source-size`
- `bun check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pauses the TanStack/Rust migration E2E matrix while that migration is paused. The `migration-e2e` job in `e2e-tests.yaml` is disabled with `if: false` but retained for a future restart, and the workflow now publishes only the maintained Next.js image bundle. Documentation and CI tests record the paused state so it cannot silently regress.

**Bug Fixes**
- The image bundle publisher now honors the `--frontend` selection for `publish`, so it no longer builds the TanStack frontend.

<sup>Written for commit 01251abe9c8fc99045c347e509e5e847666545cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

