### PR TITLE
fix(ai): restore whitelist runtime access

### DIFF
--- a/apps/web/src/lib/ai-whitelist/email-repository.test.ts
+++ b/apps/web/src/lib/ai-whitelist/email-repository.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: mocks.createAdminClient,
+}));
+vi.mock('server-only', () => ({}));
+
+import { isAIWhitelistEmailEnabled } from './email-repository';
+
+function mockWhitelistLookup(result: {
+  data: { enabled: boolean } | null;
+  error: Error | null;
+}) {
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const eq = vi.fn().mockReturnValue({ maybeSingle });
+  const select = vi.fn().mockReturnValue({ eq });
+  const from = vi.fn().mockReturnValue({ select });
+  const schema = vi.fn().mockReturnValue({ from });
+
+  mocks.createAdminClient.mockResolvedValue({ schema });
+
+  return { eq, from, maybeSingle, schema, select };
+}
+
+describe('isAIWhitelistEmailEnabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { enabled: true, expected: true },
+    { enabled: false, expected: false },
+  ])(
+    'returns $expected when enabled is $enabled',
+    async ({ enabled, expected }) => {
+      const query = mockWhitelistLookup({ data: { enabled }, error: null });
+
+      await expect(
+        isAIWhitelistEmailEnabled('learner@example.com')
+      ).resolves.toBe(expected);
+
+      expect(mocks.createAdminClient).toHaveBeenCalledWith({ noCookie: true });
+      expect(query.schema).toHaveBeenCalledWith('private');
+      expect(query.from).toHaveBeenCalledWith('ai_whitelisted_emails');
+      expect(query.select).toHaveBeenCalledWith('enabled');
+      expect(query.eq).toHaveBeenCalledWith('email', 'learner@example.com');
+      expect(query.maybeSingle).toHaveBeenCalledOnce();
+    }
+  );
+
+  it('fails closed when no whitelist row exists', async () => {
+    mockWhitelistLookup({ data: null, error: null });
+
+    await expect(
+      isAIWhitelistEmailEnabled('missing@example.com')
+    ).resolves.toBe(false);
+  });
+
+  it('surfaces database errors instead of granting access', async () => {
+    const error = new Error('private schema unavailable');
+    mockWhitelistLookup({ data: null, error });
+
+    await expect(isAIWhitelistEmailEnabled('learner@example.com')).rejects.toBe(
+      error
+    );
+  });
+});

--- a/apps/web/src/lib/ai-whitelist/email-repository.ts
+++ b/apps/web/src/lib/ai-whitelist/email-repository.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
+import { createAdminClient } from '@tuturuuu/supabase/next/server';
 import type { AIWhitelistEmail } from '@tuturuuu/types';
-import { getPlatformSql } from '@/lib/database/platform-sql';
 
 interface ListAIWhitelistEmailsOptions {
   page?: string;
@@ -24,48 +24,25 @@ export async function listAIWhitelistEmails({
   page,
   pageSize,
 }: ListAIWhitelistEmailsOptions = {}) {
-  const sql = getPlatformSql();
+  const db = (await createAdminClient({ noCookie: true })).schema('private');
   const limit = parsePositiveInteger(pageSize, 10);
   const offset = (parsePositiveInteger(page, 1) - 1) * limit;
   const search = normalizeEmailSearch(q);
 
-  const rows = search
-    ? await sql<AIWhitelistEmail[]>`
-        select
-          email,
-          enabled,
-          created_at::text as created_at
-        from private.ai_whitelisted_emails
-        where email ilike ${search}
-        order by created_at desc
-        limit ${limit}
-        offset ${offset}
-      `
-    : await sql<AIWhitelistEmail[]>`
-        select
-          email,
-          enabled,
-          created_at::text as created_at
-        from private.ai_whitelisted_emails
-        order by created_at desc
-        limit ${limit}
-        offset ${offset}
-      `;
+  let query = db
+    .from('ai_whitelisted_emails')
+    .select('email, enabled, created_at', { count: 'exact' })
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
 
-  const [countRow] = search
-    ? await sql<{ count: number }[]>`
-        select count(*)::int as count
-        from private.ai_whitelisted_emails
-        where email ilike ${search}
-      `
-    : await sql<{ count: number }[]>`
-        select count(*)::int as count
-        from private.ai_whitelisted_emails
-      `;
+  if (search) query = query.ilike('email', search);
+
+  const { data, error, count } = await query;
+  if (error) throw error;
 
   return {
-    data: rows,
-    count: countRow?.count ?? 0,
+    data: data ?? [],
+    count: count ?? 0,
   };
 }
 
@@ -73,57 +50,50 @@ export async function addAIWhitelistEmail({
   email,
   enabled,
 }: Pick<AIWhitelistEmail, 'email' | 'enabled'>) {
-  const sql = getPlatformSql();
+  const db = (await createAdminClient({ noCookie: true })).schema('private');
+  const { data, error } = await db
+    .from('ai_whitelisted_emails')
+    .insert({ email, enabled })
+    .select('email, enabled, created_at')
+    .single();
 
-  const [row] = await sql<AIWhitelistEmail[]>`
-    insert into private.ai_whitelisted_emails (
-      email,
-      enabled
-    )
-    values (
-      ${email},
-      ${enabled}
-    )
-    returning
-      email,
-      enabled,
-      created_at::text as created_at
-  `;
+  if (error) throw error;
 
-  return row;
+  return data;
 }
 
 export async function updateAIWhitelistEmailEnabled(
   email: string,
   enabled: boolean
 ) {
-  const sql = getPlatformSql();
+  const db = (await createAdminClient({ noCookie: true })).schema('private');
+  const { error } = await db
+    .from('ai_whitelisted_emails')
+    .update({ enabled })
+    .eq('email', email);
 
-  await sql`
-    update private.ai_whitelisted_emails
-    set enabled = ${enabled}
-    where email = ${email}
-  `;
+  if (error) throw error;
 }
 
 export async function deleteAIWhitelistEmail(email: string) {
-  const sql = getPlatformSql();
+  const db = (await createAdminClient({ noCookie: true })).schema('private');
+  const { error } = await db
+    .from('ai_whitelisted_emails')
+    .delete()
+    .eq('email', email);
 
-  await sql`
-    delete from private.ai_whitelisted_emails
-    where email = ${email}
-  `;
+  if (error) throw error;
 }
 
 export async function isAIWhitelistEmailEnabled(email: string) {
-  const sql = getPlatformSql();
+  const db = (await createAdminClient({ noCookie: true })).schema('private');
+  const { data, error } = await db
+    .from('ai_whitelisted_emails')
+    .select('enabled')
+    .eq('email', email)
+    .maybeSingle();
 
-  const [row] = await sql<{ enabled: boolean }[]>`
-    select enabled
-    from private.ai_whitelisted_emails
-    where email = ${email}
-    limit 1
-  `;
+  if (error) throw error;
 
-  return row?.enabled ?? false;
+  return data?.enabled ?? false;
 }


### PR DESCRIPTION
## Summary
- replace the AI whitelist repository deployment-specific direct Postgres client with the existing service-role private-schema client
- preserve fail-closed behavior for missing rows and database errors
- add focused coverage for enabled, disabled, missing-row, and query-error outcomes

## Production incident
Rewise /personal/new error reference 240937868 was traced in Vercel runtime logs to /api/v1/ai/whitelist/me returning 500 because no private database connection URL was configured. This removes that unnecessary runtime dependency.

## Validation
- focused email-repository Vitest: 4 passed
- web type-check: passed
- repo check reached all tests; focused changes, type-check, and Biome passed, while two unrelated SDK browser-opener timing tests failed in packages/sdk/src/cli/auth.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the AI whitelist repository's deployment-specific direct Postgres client with the existing service-role private-schema client, restoring `/api/v1/ai/whitelist/me` which was returning 500 in production because no private database connection URL was configured.

- All whitelist reads and writes now use `createAdminClient({ noCookie: true }).schema('private')` instead of `getPlatformSql()`.
- Missing whitelist rows still resolve to `false`, and database errors are thrown rather than granting access.
- Adds Vitest coverage for enabled, disabled, missing-row, and query-error outcomes.
- Focused tests, type-check, and Biome pass; two unrelated SDK browser-opener timing tests fail in `packages/sdk/src/cli/auth.test.ts`.

<sup>Written for commit 31f4ece575d8ae92d7e179dd551ec8924f4c8674. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

