### PR TITLE
fix(tasks-ui): restore dynamic time tracker colors

### DIFF
--- a/packages/tasks-ui/src/calendar/components/time-tracker/components/active-session-card.tsx
+++ b/packages/tasks-ui/src/calendar/components/time-tracker/components/active-session-card.tsx
@@ -31,14 +31,14 @@ export function ActiveSessionCard({
 
   return (
     <div className="space-y-4 text-center">
-      <div className="relative overflow-hidden rounded-lg bg-linear-to-br from-red-50 to-red-100 @lg:p-6 p-4 dark:from-red-950/20 dark:to-red-900/20">
-        <div className="absolute inset-0 animate-pulse bg-linear-to-r from-red-500/10 to-transparent opacity-30" />
+      <div className="relative overflow-hidden rounded-lg bg-linear-to-br from-dynamic-red/10 to-dynamic-red/20 @lg:p-6 p-4">
+        <div className="absolute inset-0 animate-pulse bg-linear-to-r from-dynamic-red/10 to-transparent opacity-30" />
         <div className="relative">
-          <div className="font-bold font-mono @lg:text-4xl text-3xl text-red-600 transition-all duration-300 dark:text-red-400">
+          <div className="font-bold font-mono @lg:text-4xl text-3xl text-dynamic-red transition-all duration-300">
             {formatTime(elapsedTime)}
           </div>
-          <div className="mt-2 flex items-center gap-2 @lg:text-sm text-red-600 text-xs dark:text-red-400">
-            <div className="h-2 w-2 animate-pulse rounded-full bg-red-500" />
+          <div className="mt-2 flex items-center gap-2 @lg:text-sm text-dynamic-red/70 text-xs">
+            <div className="h-2 w-2 animate-pulse rounded-full bg-dynamic-red" />
             Started at {new Date(session.start_time).toLocaleTimeString()}
           </div>
         </div>

--- a/packages/tasks-ui/src/calendar/components/time-tracker/components/new-session-support.tsx
+++ b/packages/tasks-ui/src/calendar/components/time-tracker/components/new-session-support.tsx
@@ -240,10 +240,10 @@ export function CompletionCelebration({
     <div className="fade-in fixed inset-0 z-50 flex animate-in items-center justify-center bg-black/20 backdrop-blur-sm duration-300">
       <div className="zoom-in animate-in rounded-lg border bg-background p-6 shadow-xl duration-300">
         <div className="text-center">
-          <CheckCircle className="mx-auto mb-4 h-12 w-12 animate-pulse text-green-500" />
+          <CheckCircle className="mx-auto mb-4 h-12 w-12 animate-pulse text-dynamic-green" />
           <h3 className="mb-2 font-semibold text-lg">Session Completed!</h3>
           <p className="mb-1 text-muted-foreground">{session.title}</p>
-          <p className="font-medium text-green-600 text-sm dark:text-green-400">
+          <p className="font-medium text-dynamic-green text-sm">
             {formatDuration(session.duration_seconds || 0)} tracked
           </p>
         </div>

--- a/packages/tasks-ui/src/calendar/components/time-tracker/components/session-card.tsx
+++ b/packages/tasks-ui/src/calendar/components/time-tracker/components/session-card.tsx
@@ -52,7 +52,7 @@ export function SessionCard({
       className={cn(
         'group relative rounded-lg border @lg:p-4 p-3 transition-all hover:bg-accent/50 hover:shadow-sm',
         isHighlighted &&
-          'slide-in-from-top animate-in bg-green-50 ring-2 ring-green-500 duration-500 dark:bg-green-950/20'
+          'slide-in-from-top animate-in bg-dynamic-green/10 ring-2 ring-dynamic-green duration-500'
       )}
     >
       <div className="flex items-start justify-between gap-3">

--- a/packages/tasks-ui/src/calendar/components/time-tracker/theme-token-contract.test.ts
+++ b/packages/tasks-ui/src/calendar/components/time-tracker/theme-token-contract.test.ts
@@ -9,7 +9,7 @@ const COMPONENT_FILES = [
 ] as const;
 
 const FIXED_CHROMATIC_TOKEN =
-  /(?:bg|text|border|ring|from|via|to|fill|stroke)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}/;
+  /(?:bg|text|border|ring|from|via|to|fill|stroke|accent|caret|decoration|divide|outline|placeholder|shadow)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}/;
 
 async function readComponent(relativePath: (typeof COMPONENT_FILES)[number]) {
   return readFile(

--- a/packages/tasks-ui/src/calendar/components/time-tracker/theme-token-contract.test.ts
+++ b/packages/tasks-ui/src/calendar/components/time-tracker/theme-token-contract.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const COMPONENT_FILES = [
+  'components/active-session-card.tsx',
+  'components/new-session-support.tsx',
+  'components/session-card.tsx',
+] as const;
+
+const FIXED_CHROMATIC_TOKEN =
+  /(?:bg|text|border|ring|from|via|to|fill|stroke)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}/;
+
+async function readComponent(relativePath: (typeof COMPONENT_FILES)[number]) {
+  return readFile(
+    resolve(
+      process.cwd(),
+      'src/calendar/components/time-tracker',
+      relativePath
+    ),
+    'utf8'
+  );
+}
+
+describe('time tracker theme token contract', () => {
+  it.each(COMPONENT_FILES)(
+    'keeps %s free of fixed chromatic palette classes',
+    async (relativePath) => {
+      const source = await readComponent(relativePath);
+
+      expect(source).not.toMatch(FIXED_CHROMATIC_TOKEN);
+    }
+  );
+
+  it('uses dynamic theme colors for running and completed session states', async () => {
+    const [activeSession, completion, session] = await Promise.all(
+      COMPONENT_FILES.map(readComponent)
+    );
+
+    expect(activeSession).toContain('from-dynamic-red/10');
+    expect(activeSession).toContain('text-dynamic-red');
+    expect(completion).toContain('text-dynamic-green');
+    expect(session).toContain('bg-dynamic-green/10');
+    expect(session).toContain('ring-dynamic-green');
+  });
+});


### PR DESCRIPTION
## Summary
- restore dynamic red tokens for the active timer state
- restore dynamic green tokens for completion and recently-created session states
- add a source-level theme contract that rejects fixed numbered chromatic palette classes in the affected components

## Regression
Commit c7eff4b5abef08fd5e6a23bdb86cc6575271c047 introduced 16 fixed palette classes across these three extracted components.

## Validation
- focused time-tracker tests: 16 passed
- tasks-ui type-check: passed
- repo check: focused changes, type-check, and Biome passed; the only failures were two unrelated web Docker request-tracker tests unable to bind 127.0.0.1 in the sandbox (EPERM)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores dynamic theme colors in the time tracker UI after a regression replaced them with fixed palette classes. Active timer, completion, and recently-created session states now use `dynamic-red` and `dynamic-green` tokens again.

- Adds a source-level test that rejects fixed numbered chromatic palette classes in the affected components.
- Focused time-tracker tests and tasks-ui type-check pass; two unrelated web Docker tests fail in the sandbox due to EPERM.

<sup>Written for commit 7f55769214b8ed60910de463a7940b65fa4c4dea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

