### PR TITLE
chore(deps): update OpenCode plugin lockfile

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,19 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.17.6"
+        "@opencode-ai/plugin": "1.18.27"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,19 +99,20 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.6.tgz",
-      "integrity": "sha512-xa7MBAP9mFch8yZvpNMo5O1TEITKv2Mvo6+IDiMIl+F0nswLBCE2K/45CLP1pB/p/jpFJd11ZrnnYkMYk0XNVg==",
+      "version": "1.18.27",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.27.tgz",
+      "integrity": "sha512-/sQbDUVz/VlfTPjEEQ+fZ70Z9AwtVVwOMKYuGEjjSOpRvlQEC16+jnC3GO4w05VeyffAlghDbM/3p38fMEAhfw==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.17.6",
-        "effect": "4.0.0-beta.74",
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.18.27",
+        "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.3.4",
-        "@opentui/keymap": ">=0.3.4",
-        "@opentui/solid": ">=0.3.4"
+        "@opentui/core": ">=0.4.5",
+        "@opentui/keymap": ">=0.4.5",
+        "@opentui/solid": ">=0.4.5"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -114,9 +127,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.6.tgz",
-      "integrity": "sha512-kCzdd9Git2sjDjXSHj4mMWuU1RXZ38d7gFEcq2rzlVz7XV6PPwNw8pelWsk99La2CtDkpfoW5lfHnpCaK6/oBQ==",
+      "version": "1.18.27",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.27.tgz",
+      "integrity": "sha512-VTfAB9SWaGiMtI2L9rf2xl+0fTYDMHB2pHYKCquWG5OIX3rHvth9oM915d9Z38IuPZUZkmdNMVz2iAdxG4IR+A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -153,9 +166,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.74",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
-      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -171,9 +184,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
-      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
       "funding": [
         {
           "type": "individual",
@@ -213,6 +226,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
@@ -220,9 +239,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
-      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.1.0.tgz",
+      "integrity": "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ==",
       "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.4"
@@ -251,9 +270,9 @@
       }
     },
     "node_modules/multipasta": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
-      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
       "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -281,9 +300,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
       "funding": [
         {
           "type": "individual",
@@ -318,18 +337,18 @@
       }
     },
     "node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"


### PR DESCRIPTION
## Summary
- update the standalone OpenCode lockfile from `@opencode-ai/plugin` 1.17.6 to 1.18.27
- refresh transitive dependencies, including `toml` from vulnerable 4.1.1 to 4.3.0
- clear Dependabot alerts 140 and 141 (patched in toml 4.1.2)

## Validation
- `bun check`
- lockfile assertion: plugin 1.18.27, toml 4.3.0

## Notes
- `.opencode/package-lock.json` is a standalone tracked lockfile without a tracked package manifest; it was regenerated through a temporary manifest and the manifest was removed before commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the standalone OpenCode lockfile to pull in `@opencode-ai/plugin` 1.18.27 and refreshed transitive dependencies, including `toml` 4.3.0, which patches two Dependabot alerts.

The lockfile was regenerated from a temporary manifest because `.opencode/package-lock.json` has no tracked package manifest; `bun check` passes.

<sup>Written for commit 02993f168bba72f74a04c5e68fc6b8b2da58e72b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

