### PR TITLE
fix(planning): prevent collection redirect loops

### DIFF
--- a/apps/calendar/src/lib/task-api-rewrites.test.ts
+++ b/apps/calendar/src/lib/task-api-rewrites.test.ts
@@ -14,6 +14,22 @@ describe('task API ownership', () => {
       });
     }
   );
+  it.each([
+    '/api/v1/workspaces/:wsId/tasks',
+    '/api/v1/workspaces/:wsId/labels',
+    '/api/v1/users/me/tasks',
+  ])('preserves the collection path %s before wildcard matching', (source) => {
+    const rewrites = createTaskApiRewrites('https://owner.example.com');
+    const exact = rewrites.findIndex((route) => route.source === source);
+    const nested = rewrites.findIndex(
+      (route) => route.source === `${source}/:path*`
+    );
+    expect(exact).toBeGreaterThanOrEqual(0);
+    expect(exact).toBeLessThan(nested);
+    expect(rewrites[exact]?.destination).toBe(
+      `https://owner.example.com${source}`
+    );
+  });
   it('does not redirect host-local authentication or unrelated workspace APIs', () => {
     const rewrites = createTaskApiRewrites('https://task.example.com');
     expect(rewrites.some((route) => route.source.startsWith('/api/auth'))).toBe(

--- a/apps/calendar/src/lib/task-api-rewrites.ts
+++ b/apps/calendar/src/lib/task-api-rewrites.ts
@@ -34,5 +34,11 @@ export function createTaskApiRewrites(origin: string) {
     '/api/v1/shared/tasks/:path*',
     '/api/v1/mira/tasks/:path*',
     '/api/:wsId/task/:path*',
-  ].map((source) => ({ source, destination: `${base}${source}` }));
+  ]
+    .flatMap((source) =>
+      source.endsWith('/:path*')
+        ? [source.replace(/\/:path\*$/u, ''), source]
+        : [source]
+    )
+    .map((source) => ({ source, destination: `${base}${source}` }));
 }

--- a/apps/docs/platform/applications/calendar.mdx
+++ b/apps/docs/platform/applications/calendar.mdx
@@ -14,6 +14,11 @@ Calendar routes explicitly accept Calendar and Tasks audiences while retaining
 workspace membership and permission checks. Do not route these APIs through Web:
 Web no longer owns the Calendar events or Tasks endpoints.
 
+Collection rewrites must have an exact path before their `/:path*` variant.
+Vercel can retain a trailing slash when the wildcard is empty, causing the owning
+app to return a 308 to the same browser URL and loop. Verify both collection and
+nested resource requests on the deployed host.
+
 Both satellite apps expose local planning views without changing workspace or
 requiring a cross-app login handoff:
 

--- a/apps/tasks/src/lib/calendar-api-rewrites.test.ts
+++ b/apps/tasks/src/lib/calendar-api-rewrites.test.ts
@@ -23,6 +23,21 @@ describe('calendar API ownership', () => {
         'https://calendar.example.com/api/v1/workspaces/:wsId/calendar-settings',
     });
   });
+  it.each(['/api/v1/calendar', '/api/v1/workspaces/:wsId/calendars'])(
+    'preserves the collection path %s before wildcard matching',
+    (source) => {
+      const rewrites = createCalendarApiRewrites('https://owner.example.com');
+      const exact = rewrites.findIndex((route) => route.source === source);
+      const nested = rewrites.findIndex(
+        (route) => route.source === `${source}/:path*`
+      );
+      expect(exact).toBeGreaterThanOrEqual(0);
+      expect(exact).toBeLessThan(nested);
+      expect(rewrites[exact]?.destination).toBe(
+        `https://owner.example.com${source}`
+      );
+    }
+  );
   it('does not redirect host-local authentication or unrelated workspace APIs', () => {
     const rewrites = createCalendarApiRewrites('https://calendar.example.com');
     expect(rewrites.some((route) => route.source.startsWith('/api/auth'))).toBe(

--- a/apps/tasks/src/lib/calendar-api-rewrites.ts
+++ b/apps/tasks/src/lib/calendar-api-rewrites.ts
@@ -9,5 +9,11 @@ export function createCalendarApiRewrites(origin: string) {
     '/api/v1/workspaces/:wsId/calendar-hours/:path*',
     '/api/v1/workspaces/:wsId/calendar-settings',
     '/api/v1/workspaces/:wsId/calendars/:path*',
-  ].map((source) => ({ source, destination: `${base}${source}` }));
+  ]
+    .flatMap((source) =>
+      source.endsWith('/:path*')
+        ? [source.replace(/\/:path\*$/u, ''), source]
+        : [source]
+    )
+    .map((source) => ({ source, destination: `${base}${source}` }));
 }

--- a/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-header.test.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-header.test.tsx
@@ -1,7 +1,7 @@
 import { act } from 'react';
 import { hydrateRoot, type Root } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MyTasksHeader } from './my-tasks-header';
 
 vi.mock('next-intl', () => ({
@@ -10,7 +10,11 @@ vi.mock('next-intl', () => ({
 }));
 
 describe('task greeting hydration', () => {
-  afterEach(() => vi.useRealTimers());
+  beforeEach(() => vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true));
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
 
   it('keeps server markup independent of server timezone', () => {
     const html = renderToString(

--- a/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-header.test.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-header.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { hydrateRoot, type Root } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MyTasksHeader } from './my-tasks-header';
@@ -21,10 +22,26 @@ describe('task greeting hydration', () => {
 
   it('shows the local greeting after hydration', () => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 6, 8));
+    const container = document.createElement('div');
+    const header = (
+      <MyTasksHeader overdueCount={0} todayCount={0} upcomingCount={0} />
+    );
+    container.innerHTML = renderToString(header);
+    expect(container.querySelector('h1')?.textContent).toBe(
+      'sidebar_tabs.tasks'
+    );
+
     vi.setSystemTime(new Date(2026, 8, 6, 15));
-    render(<MyTasksHeader overdueCount={0} todayCount={0} upcomingCount={0} />);
-    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(
+    const onRecoverableError = vi.fn();
+    let root: Root | undefined;
+    act(() => {
+      root = hydrateRoot(container, header, { onRecoverableError });
+    });
+    expect(container.querySelector('h1')?.textContent).toBe(
       'ws-tasks.good_afternoon'
     );
+    expect(onRecoverableError).not.toHaveBeenCalled();
+    act(() => root?.unmount());
   });
 });

--- a/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-header.test.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-header.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MyTasksHeader } from './my-tasks-header';
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (key: string) => key,
+}));
+
+describe('task greeting hydration', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('keeps server markup independent of server timezone', () => {
+    const html = renderToString(
+      <MyTasksHeader overdueCount={0} todayCount={0} upcomingCount={0} />
+    );
+    expect(html).toContain('sidebar_tabs.tasks');
+    expect(html).not.toContain('ws-tasks.good_');
+  });
+
+  it('shows the local greeting after hydration', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 6, 15));
+    render(<MyTasksHeader overdueCount={0} todayCount={0} upcomingCount={0} />);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(
+      'ws-tasks.good_afternoon'
+    );
+  });
+});

--- a/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-header.tsx
+++ b/packages/tasks-ui/src/tu-do/my-tasks/my-tasks-header.tsx
@@ -3,7 +3,11 @@
 import { Calendar, Clock, Flag } from '@tuturuuu/icons';
 import { cn } from '@tuturuuu/utils/format';
 import { useLocale, useTranslations } from 'next-intl';
-import { useMemo } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
+
+const subscribeToHydration = () => () => {};
+const clientHydrationSnapshot = () => true;
+const serverHydrationSnapshot = () => false;
 
 interface MyTasksHeaderProps {
   overdueCount: number;
@@ -18,8 +22,16 @@ export function MyTasksHeader({
 }: MyTasksHeaderProps) {
   const t = useTranslations();
   const locale = useLocale();
+  const hydrated = useSyncExternalStore(
+    subscribeToHydration,
+    clientHydrationSnapshot,
+    serverHydrationSnapshot
+  );
 
   const { greetingMessage, formattedDate } = useMemo(() => {
+    if (!hydrated) {
+      return { greetingMessage: t('sidebar_tabs.tasks'), formattedDate: '' };
+    }
     const now = new Date();
     const hour = now.getHours();
     let greeting: string;
@@ -36,7 +48,7 @@ export function MyTasksHeader({
         day: 'numeric',
       }),
     };
-  }, [t, locale]);
+  }, [t, locale, hydrated]);
 
   const cards = [
     {
@@ -78,7 +90,7 @@ export function MyTasksHeader({
         <h1 className="font-bold text-2xl tracking-tight md:text-3xl">
           {greetingMessage}
         </h1>
-        <p className="text-muted-foreground text-sm">{formattedDate}</p>
+        <p className="min-h-5 text-muted-foreground text-sm">{formattedDate}</p>
       </div>
 
       {/* Summary Cards */}


### PR DESCRIPTION
Calendar task collections were repeatedly returning HTTP 308 to the same URL through the deployed wildcard rewrite, leaving boards empty. Add exact collection rewrites before nested paths in both planning apps, and make the task greeting hydrate independently of the server timezone.

Validation: 17 focused regression tests passed; Tasks and Calendar production builds passed. `bun check --run-all` passed tests and all repository guards; post-build Tasks type-check remains blocked by pre-existing optional route contexts and exported helper functions in unchanged API routes. The preceding release passed clean-runner TypeScript CI.

Live tracing confirmed the same-URL 308 loop. Fresh signed-in board and mobile verification will follow deployment; Chrome disconnected during the mobile check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes calendar and task collection redirect loops by adding exact collection rewrites before nested wildcard paths, and makes the task greeting hydrate client-side to avoid server timezone mismatches. A new test exercises real hydration to verify no server/client mismatch.

- Adds exact rewrite routes for collection paths in both `apps/calendar` and `apps/tasks`, so requests like `/api/v1/workspaces/:wsId/tasks` no longer hit the wildcard that caused a same-URL 308 loop.
- Documents the rewrite ordering requirement in `apps/docs/platform/applications/calendar.mdx`.
- `MyTasksHeader` renders a static heading on the server and shows the timezone-based greeting only after hydration; a new hydration test confirms the date area stays stable and no recoverable errors are reported.

<sup>Written for commit 4be0938ab68ede56f5c64f6f6210479da8937f59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

