### PR TITLE
fix(planning): authenticate embedded task dependencies

### DIFF
--- a/apps/calendar/src/lib/task-api-rewrites.test.ts
+++ b/apps/calendar/src/lib/task-api-rewrites.test.ts
@@ -39,4 +39,11 @@ describe('task API ownership', () => {
       false
     );
   });
+  it('keeps workspace task preferences on the Tasks API owner', () => {
+    const source = '/api/v1/users/me/workspaces/:wsId/configs/:path*';
+    expect(createTaskApiRewrites('https://tasks.example.com')).toContainEqual({
+      source,
+      destination: `https://tasks.example.com${source}`,
+    });
+  });
 });

--- a/apps/calendar/src/lib/task-api-rewrites.ts
+++ b/apps/calendar/src/lib/task-api-rewrites.ts
@@ -27,6 +27,7 @@ export function createTaskApiRewrites(origin: string) {
     ),
     '/api/v1/users/me/tasks/:path*',
     '/api/v1/users/me/task-boards/:path*',
+    '/api/v1/users/me/workspaces/:wsId/configs/:path*',
     '/api/v1/users/task-settings',
     '/api/v1/task-board-status-templates/:path*',
     '/api/v1/task-projects/resolve-workspace',

--- a/apps/docs/platform/applications/calendar.mdx
+++ b/apps/docs/platform/applications/calendar.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Calendar"
 description: "Shared Calendar product surface across apps/web and apps/calendar."
-updatedAt: "2026-08-10"
+updatedAt: "2026-09-06"
 ---
 
 ## Tasks and Calendar planning

--- a/apps/docs/platform/applications/calendar.mdx
+++ b/apps/docs/platform/applications/calendar.mdx
@@ -14,6 +14,12 @@ Calendar routes explicitly accept Calendar and Tasks audiences while retaining
 workspace membership and permission checks. Do not route these APIs through Web:
 Web no longer owns the Calendar events or Tasks endpoints.
 
+Tasks' session verifier also accepts Calendar for routes that explicitly accept
+Tasks, including labels, projects, task detail dependencies, and workspace task
+preferences. It preserves required scopes and does not widen unrelated app
+audiences. Calendar forwards `/api/v1/users/me/workspaces/:wsId/configs/*` to
+Tasks so those preferences use the verified planning actor and membership guard.
+
 Collection rewrites must have an exact path before their `/:path*` variant.
 Vercel can retain a trailing slash when the wildcard is empty, causing the owning
 app to return a 308 to the same browser URL and loop. Verify both collection and

--- a/apps/tasks/src/lib/api-auth.ts
+++ b/apps/tasks/src/lib/api-auth.ts
@@ -40,6 +40,7 @@ import {
   resolveWebAbuseDecision,
 } from './abuse-risk';
 import { setLogDrainUserContext } from './infrastructure/log-drain';
+import { withPlanningSessionAudience } from './planning-session-audience';
 import { checkRateLimit, type RateLimitConfig } from './rate-limit';
 
 export type AuthorizedRequest = {
@@ -173,10 +174,6 @@ export async function authorize(
   }
   return { user, error: null };
 }
-
-// ---------------------------------------------------------------------------
-// withSessionAuth — rate-limited session-auth wrapper
-// ---------------------------------------------------------------------------
 
 export interface SessionAuthContext {
   user: SupabaseUser;
@@ -345,8 +342,10 @@ function verifyConfiguredAppSessionRequest(
     request,
     allowAppSessionAuth
   )) {
-    const verification = verifyAppSessionRequest(request, verificationOptions);
-
+    const verification = verifyAppSessionRequest(
+      request,
+      withPlanningSessionAudience(verificationOptions)
+    );
     if (verification.ok) {
       return verification;
     }

--- a/apps/tasks/src/lib/planning-session-audience.test.ts
+++ b/apps/tasks/src/lib/planning-session-audience.test.ts
@@ -1,0 +1,102 @@
+import {
+  createAppSessionToken,
+  verifyAppSessionRequest,
+} from '@tuturuuu/auth/app-session';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveSessionAuthContext } from './api-auth';
+import { withPlanningSessionAudience } from './planning-session-audience';
+
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: vi.fn(async () => ({ auth: {} })),
+  createClient: vi.fn(() => {
+    throw new Error('Calendar actor must not fall back to Supabase cookies');
+  }),
+}));
+vi.mock('@tuturuuu/utils/abuse-protection/edge-trust', () => ({
+  writeVerifiedSessionCacheForSubjects: vi.fn(),
+}));
+vi.mock('./infrastructure/log-drain', () => ({
+  setLogDrainUserContext: vi.fn(),
+}));
+
+describe('embedded planning session audiences', () => {
+  beforeEach(() => {
+    vi.stubEnv('APP_COORDINATION_TOKEN_SECRET', 'planning-test-secret');
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  function requestFor(targetApp: string, scopes = ['internal-app:session']) {
+    const { token } = createAppSessionToken({
+      userId: 'planning-user',
+      targetApp,
+      scopes,
+    });
+    return { headers: new Headers({ authorization: `Bearer ${token}` }) };
+  }
+
+  it.each(['tasks', 'calendar'])(
+    'verifies the signed %s actor for Tasks-owned routes',
+    (app) => {
+      const result = verifyAppSessionRequest(
+        requestFor(app),
+        withPlanningSessionAudience({ targetApp: 'tasks' })
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.claims.sub).toBe('planning-user');
+    }
+  );
+
+  it('does not accept unrelated app sessions', () => {
+    expect(
+      verifyAppSessionRequest(
+        requestFor('mail'),
+        withPlanningSessionAudience({ targetApp: ['platform', 'tasks'] })
+      ).ok
+    ).toBe(false);
+  });
+
+  it('preserves the route scope requirement', () => {
+    expect(
+      verifyAppSessionRequest(
+        requestFor('calendar'),
+        withPlanningSessionAudience({
+          targetApp: 'tasks',
+          requiredScope: 'tasks:write',
+        })
+      ).ok
+    ).toBe(false);
+  });
+
+  it('leaves unrelated and already shared audiences unchanged', () => {
+    for (const targetApp of [undefined, 'platform', ['calendar', 'tasks']]) {
+      const options = { targetApp };
+      expect(withPlanningSessionAudience(options)).toBe(options);
+    }
+  });
+
+  it('does not mutate an explicit CLI and Tasks audience list', () => {
+    const options = { targetApp: ['platform', 'tasks'] as const };
+    expect(withPlanningSessionAudience(options).targetApp).toEqual([
+      'platform',
+      'tasks',
+      'calendar',
+    ]);
+    expect(options.targetApp).toEqual(['platform', 'tasks']);
+  });
+
+  it('resolves the Calendar actor through the real Tasks session wrapper', async () => {
+    const result = await resolveSessionAuthContext(
+      {
+        ...requestFor('calendar'),
+        url: 'https://tasks.example.com/api/v1/workspaces/workspace-1/labels',
+      },
+      { allowAppSessionAuth: { targetApp: ['platform', 'tasks'] } }
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.user.id).toBe('planning-user');
+      const { data } = await result.supabase.auth.getUser();
+      expect(data.user?.id).toBe('planning-user');
+    }
+  });
+});

--- a/apps/tasks/src/lib/planning-session-audience.ts
+++ b/apps/tasks/src/lib/planning-session-audience.ts
@@ -1,0 +1,21 @@
+import type { verifyAppSessionRequest } from '@tuturuuu/auth/app-session';
+
+type SessionOptions = NonNullable<
+  Parameters<typeof verifyAppSessionRequest>[1]
+>;
+
+/** Calendar embeds the Tasks UI and uses its own signed session for Tasks APIs. */
+export function withPlanningSessionAudience(
+  options: SessionOptions
+): SessionOptions {
+  const targets =
+    typeof options.targetApp === 'string'
+      ? [options.targetApp]
+      : options.targetApp;
+
+  if (!targets?.includes('tasks') || targets.includes('calendar')) {
+    return options;
+  }
+
+  return { ...options, targetApp: [...targets, 'calendar'] };
+}


### PR DESCRIPTION
Calendar task boards could load task collections but still rejected labels, projects, and workspace task preferences. Tasks now recognizes signed Calendar sessions on routes that explicitly accept Tasks, preserving required scopes and membership guards. Calendar forwards workspace preferences to their Tasks API owner.

Validation: signed-token and real session-resolver regression tests pass, including unrelated-audience and missing-scope rejection. Calendar rewrite tests pass. Both Tasks and Calendar production builds pass. `bun check --run-all` passes tests and all guards; only previously identified generated Tasks API route signature errors remain in local type-check. No database changes.

Live verification on the preceding deployment confirmed task collections return 200 with no redirect loop and board cards populate after refresh. This follow-up addresses the remaining 401/403 dependencies; final authenticated verification follows deployment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Tasks rejecting Calendar-signed sessions for labels, projects, and workspace task preferences, so embedded calendar task boards fully authenticate their dependencies.

- Adds `withPlanningSessionAudience` so Tasks routes that explicitly accept Tasks also accept Calendar sessions while preserving the required scopes.
- Calendar now forwards `/api/v1/users/me/workspaces/:wsId/configs/*` to Tasks so workspace preferences use the verified planning actor.
- Adds tests for Calendar and Tasks audience acceptance, unrelated-audience rejection, and scope preservation, and refreshes the Calendar docs guidance date.

<sup>Written for commit d8dbfc60fa8ba87cb68cbb5fdc7e220f657da936. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

