### PR TITLE
fix(meet): identify media publishing failures safely

### DIFF
--- a/apps/docs/platform/features/meet-calls.mdx
+++ b/apps/docs/platform/features/meet-calls.mdx
@@ -398,3 +398,15 @@ AudioWorklet check, and the disposable database runner with
 The disposable runner copies Git-tracked files; new migrations and tests must be
 tracked before running it. Run the Meet Cloudflare build before deployment and
 verify a signed-in live transcript plus persisted notes against Gemini afterward.
+
+### Diagnosing media on another device
+
+A working local camera preview proves capture succeeded, but does not prove other
+participants can receive it. If enabling a device shows a transmission warning,
+record its diagnostic code and the action that triggered it. `SFU_HTTP_*` identifies
+an upstream SFU rejection; `SIGNALING_*` identifies the signaling connection or
+request timeout; `RTC_*` identifies a browser peer-connection failure. The code
+contains no raw provider message, SDP, credential, or meeting content. A successful
+retry clears the previous warning for that device. Reproduce on the affected device
+before changing transport settings; synthetic sources in another browser do not
+establish physical-device compatibility.

--- a/apps/meet/messages/en.json
+++ b/apps/meet/messages/en.json
@@ -3840,6 +3840,7 @@
       "lobby_waiting_hint": "Waiting for the host to let you in.",
       "lower_hand": "Lower hand",
       "media_device_busy": "The device could not start. Check whether another app is using it, then try again.",
+      "media_error_code": "Diagnostic code: {code}",
       "media_failed": "Could not start or transmit media. Try again, or leave and rejoin the call.",
       "media_permission_denied": "Access was blocked. Allow this site to use the device in your browser and system privacy settings, then try again.",
       "meeting_code": "Meeting code",

--- a/apps/meet/messages/vi.json
+++ b/apps/meet/messages/vi.json
@@ -3840,6 +3840,7 @@
       "lobby_waiting_hint": "Đang chờ chủ phòng cho vào.",
       "lower_hand": "Hạ tay",
       "media_device_busy": "Không thể khởi động thiết bị. Hãy kiểm tra xem ứng dụng khác có đang sử dụng thiết bị không rồi thử lại.",
+      "media_error_code": "Mã chẩn đoán: {code}",
       "media_failed": "Không thể khởi động hoặc truyền âm thanh, hình ảnh. Hãy thử lại hoặc rời và tham gia lại cuộc gọi.",
       "media_permission_denied": "Quyền truy cập bị chặn. Hãy cho phép trang web sử dụng thiết bị trong trình duyệt và cài đặt quyền riêng tư của hệ thống rồi thử lại.",
       "meeting_code": "Mã cuộc họp",

--- a/apps/meet/src/features/call/components/call-shell.tsx
+++ b/apps/meet/src/features/call/components/call-shell.tsx
@@ -17,7 +17,7 @@ import {
   selectOthers,
   selectSelf,
 } from '../lib/call-state';
-import { getMediaErrorKey } from '../lib/media-error';
+import { getMediaErrorDiagnostic, getMediaErrorKey } from '../lib/media-error';
 import { type CallPanel, ControlBar } from './control-bar';
 import { CopyInvite } from './copy-invite';
 import { Lobby } from './lobby';
@@ -53,15 +53,24 @@ export function CallShell({
 }) {
   const t = useTranslations('meet.call');
   const aiT = useTranslations('meet.ai');
-  const runMediaAction = (
+  const runMediaAction = async (
     action: () => Promise<void>,
     device: 'microphone' | 'camera' | 'screen'
   ) => {
-    void action().catch((error: unknown) =>
-      toast.error(t(getMediaErrorKey(error, device)), {
-        id: `meet-media-${device}`,
-      })
-    );
+    const id = `meet-media-${device}`;
+    try {
+      await action();
+      toast.dismiss(id);
+    } catch (error) {
+      const key = getMediaErrorKey(error, device);
+      toast.error(t(key), {
+        id,
+        description:
+          key === 'media_failed'
+            ? t('media_error_code', { code: getMediaErrorDiagnostic(error) })
+            : undefined,
+      });
+    }
   };
   const router = useRouter();
   const room = useMeetRoom({ meetingId, realtimeUrl, token, wsId });
@@ -128,24 +137,9 @@ export function CallShell({
         meetingName={meetingName}
         onJoin={async ({ audioEnabled, videoEnabled }) => {
           setJoined(true);
-          if (audioEnabled) {
-            try {
-              await room.toggleMicrophone();
-            } catch (error) {
-              toast.error(t(getMediaErrorKey(error, 'microphone')), {
-                id: 'meet-media-microphone',
-              });
-            }
-          }
-          if (videoEnabled) {
-            try {
-              await room.toggleCamera();
-            } catch (error) {
-              toast.error(t(getMediaErrorKey(error, 'camera')), {
-                id: 'meet-media-camera',
-              });
-            }
-          }
+          if (audioEnabled)
+            await runMediaAction(room.toggleMicrophone, 'microphone');
+          if (videoEnabled) await runMediaAction(room.toggleCamera, 'camera');
         }}
         waiting={state.admission === 'waiting'}
       />

--- a/apps/meet/src/features/call/lib/media-error.test.ts
+++ b/apps/meet/src/features/call/lib/media-error.test.ts
@@ -19,3 +19,27 @@ it('distinguishes missing input devices from permissions and transmission', () =
     'media_failed'
   );
 });
+
+it('reports useful transmission codes without exposing sensitive error text', async () => {
+  const { getMediaErrorDiagnostic } = await import('./media-error');
+  expect(
+    getMediaErrorDiagnostic(
+      new Error('cloudflare_sfu_request_failed:406 private SDP and credentials')
+    )
+  ).toBe('SFU_HTTP_406');
+  expect(getMediaErrorDiagnostic(new Error('signaling_timeout'))).toBe(
+    'SIGNALING_TIMEOUT'
+  );
+  expect(
+    getMediaErrorDiagnostic(new DOMException('private SDP', 'OperationError'))
+  ).toBe('RTC_OPERATION_FAILED');
+  for (const error of [
+    new Error('https://private.example/?token=secret'),
+    new Error('constructor'),
+    { name: 'secret', message: 'secret' },
+    'secret',
+    null,
+  ]) {
+    expect(getMediaErrorDiagnostic(error)).toBe('MEDIA_UNKNOWN');
+  }
+});

--- a/apps/meet/src/features/call/lib/media-error.ts
+++ b/apps/meet/src/features/call/lib/media-error.ts
@@ -15,3 +15,36 @@ export function getMediaErrorKey(
     return 'media_device_busy';
   return 'media_failed';
 }
+
+/** Never expose raw provider errors: they may contain SDP, URLs, or tokens. */
+export function getMediaErrorDiagnostic(error: unknown): string {
+  const message = error instanceof Error ? error.message : '';
+  const sfuStatus = /^cloudflare_sfu_request_failed:([45]\d{2})(?:\s|$)/.exec(
+    message
+  );
+  if (sfuStatus) return `SFU_HTTP_${sfuStatus[1]}`;
+
+  const knownErrors: Record<string, string> = {
+    signaling_closed: 'SIGNALING_CLOSED',
+    signaling_timeout: 'SIGNALING_TIMEOUT',
+    sfu_session_failed: 'SFU_SESSION_FAILED',
+    sfu_session_replaced: 'SFU_SESSION_REPLACED',
+    publish_not_allowed: 'PUBLISH_NOT_ALLOWED',
+    permission_denied: 'CALL_PERMISSION_DENIED',
+    not_admitted: 'NOT_ADMITTED',
+  };
+  if (Object.hasOwn(knownErrors, message)) return knownErrors[message]!;
+
+  const name = error instanceof Error ? error.name : '';
+  const browserErrors: Record<string, string> = {
+    InvalidStateError: 'RTC_INVALID_STATE',
+    InvalidModificationError: 'RTC_INVALID_MODIFICATION',
+    OperationError: 'RTC_OPERATION_FAILED',
+    NotSupportedError: 'RTC_NOT_SUPPORTED',
+    TypeError: 'MEDIA_TYPE_ERROR',
+    AbortError: 'MEDIA_ABORTED',
+  };
+  return Object.hasOwn(browserErrors, name)
+    ? browserErrors[name]!
+    : 'MEDIA_UNKNOWN';
+}


### PR DESCRIPTION
When microphone or camera capture succeeds but call publishing fails, Meet currently shows only a generic warning. The warning now includes a safe diagnostic code for SFU HTTP rejection, signaling failure, or browser WebRTC failure, so a report from another device can identify the failing boundary. Raw provider messages, SDP, URLs, and credentials are excluded. Successful retries dismiss the previous device warning, and lobby joins use the same error handling as in-call controls.

Validation: 146 Meet tests pass, including sensitive-error redaction. Full `bun check` and the real OpenNext Cloudflare production build both pass. This adds diagnostic evidence; the reported physical-device transmission failure is not yet claimed fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the generic media-failure warning with safe diagnostic codes (`SFU_HTTP_*`, `SIGNALING_*`, `RTC_*`) so users can report the failing boundary from another device. Capture success but publish failure now shows a code instead of a generic message; raw provider messages, SDP, URLs, and credentials stay hidden. Successful retries dismiss the previous device warning, and lobby joins use the same error handling as in-call controls.

**Validation and docs**
- Adds `apps/docs` guidance for diagnosing media on another device.
- Passes 146 Meet tests including sensitive-error redaction; `bun check` and the OpenNext production build pass.
- Adds diagnostics only; the reported physical-device transmission issue is not yet fixed.

<sup>Written for commit cf6ae8ba91c68b4cd20a9f7e17f1cf35929f9826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

