### PR TITLE
fix(meet): deliver room snapshots after guest admission

### DIFF
--- a/packages/realtime/src/meet/room.test.ts
+++ b/packages/realtime/src/meet/room.test.ts
@@ -116,6 +116,81 @@ describe('meet room admission', () => {
     ]);
   });
 
+  it('sends existing tracks only to the guest after approval', () => {
+    const host = token();
+    const joined = admitOrHold(createMeetRoomSnapshot(), host, NOW).state;
+    const published = run(
+      joined,
+      {
+        type: 'sfu.tracks.publish',
+        sessionId: 'host-session',
+        sessionDescription: { type: 'offer', sdp: 'v=0' },
+        tracks: [{ kind: 'audio', mid: '0', trackName: 'host-audio' }],
+      },
+      host
+    ).state;
+    const held = admitOrHold(
+      published,
+      token({ admission: 'lobby', role: 'speaker' }),
+      NOW
+    );
+    expect(held.reply.some((entry) => entry.type === 'track.published')).toBe(
+      false
+    );
+    const admitted = run(
+      held.state,
+      {
+        admit: true,
+        type: 'admission.decide',
+        userId: GUEST_ID,
+      },
+      host
+    );
+    expect(admitted.direct[0]?.message.type).toBe('admission.result');
+    expect(admitted.direct[1]).toMatchObject({
+      userId: GUEST_ID,
+      message: {
+        type: 'track.published',
+        userId: HOST_ID,
+        sessionId: 'host-session',
+        tracks: [{ trackName: 'host-audio' }],
+      },
+    });
+    const denied = run(
+      held.state,
+      {
+        admit: false,
+        type: 'admission.decide',
+        userId: GUEST_ID,
+      },
+      host
+    );
+    expect(
+      denied.direct.some((entry) => entry.message.type === 'track.published')
+    ).toBe(false);
+  });
+
+  it('shows existing waiting guests to a host who connects later', () => {
+    const held = admitOrHold(
+      createMeetRoomSnapshot(),
+      token({ admission: 'lobby', role: 'speaker' }),
+      NOW
+    ).state;
+    const host = admitOrHold(held, token(), NOW);
+    expect(host.reply).toContainEqual({
+      type: 'admission.pending',
+      participants: [held.waiting[GUEST_ID]],
+    });
+    const speaker = admitOrHold(
+      held,
+      token({ role: 'speaker', userId: SPEAKER_ID }),
+      NOW
+    );
+    expect(
+      speaker.reply.some((entry) => entry.type === 'admission.pending')
+    ).toBe(false);
+  });
+
   it('disconnects a denied guest without adding them to presence', () => {
     const held = admitOrHold(
       createMeetRoomSnapshot(),

--- a/packages/realtime/src/meet/room.ts
+++ b/packages/realtime/src/meet/room.ts
@@ -213,7 +213,12 @@ export function admitOrHold(
 
   return outcome(next, {
     broadcast: [meetPresenceMessage(next, token.roomId)],
-    reply: [buildReady(next, token, 'admitted')],
+    reply: [
+      buildReady(next, token, 'admitted'),
+      ...(canMeetRealtimeManageParticipants(token)
+        ? [meetAdmissionPendingMessage(next)]
+        : []),
+    ],
   });
 }
 
@@ -448,6 +453,15 @@ export function applyMeetRoomCommand(
             },
             userId: message.userId,
           },
+          ...remoteMeetTracks(next, message.userId).map((track) => ({
+            userId: message.userId,
+            message: {
+              type: 'track.published' as const,
+              sessionId: track.sessionId,
+              tracks: [track],
+              userId: track.userId,
+            },
+          })),
         ],
         toManagers: [meetAdmissionPendingMessage(next)],
       });


### PR DESCRIPTION
Guests admitted from the lobby did not receive tracks published before they connected, and hosts connecting after a join request did not receive the existing waiting list. Send the waiting snapshot to newly connected managers and replay existing remote tracks directly after guest approval.

Validation: 45 realtime tests and package type-check pass, including regressions for late host arrival, approved guest track replay, and denial without replay. The broader intermittent media failure remains under investigation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes meet room admission so approved guests receive tracks published before they connected, and hosts who connect later see the existing waiting list.

**Bug Fixes**
- On approval, the guest receives a `track.published` replay for each existing remote track; denial does not trigger replay.
- Newly connected managers receive an `admission.pending` snapshot of the waiting list; other roles do not.

<sup>Written for commit 753d93503a8920f6bd20aa2aaf7f549d3b6b35c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

