### PR TITLE
feat(mail): import Google Takeout history

### DIFF
--- a/apps/docs/platform/applications/mail.mdx
+++ b/apps/docs/platform/applications/mail.mdx
@@ -305,6 +305,34 @@ The live Cloudflare webhook imports new inbound deliveries; it is not a
 historical Gmail importer and must not be used to silently flatten sent mail,
 drafts, or labels into the inbox.
 
+Use the resumable Google Takeout importer after extracting only each account's
+`Takeout/Mail` directory into one directory per email address. Run it without
+`--apply` first and reconcile its report with an independent MBOX inventory:
+
+```bash
+bun --env-file=/path/to/mail-production.env \
+  apps/mail/scripts/import-google-takeout.ts \
+  --root=/path/to/mail-data \
+  --report=/path/to/import-dry-run-report.json
+```
+
+The production operator can then repeat the command with `--apply`. The
+importer writes raw MIME and attachments to the configured Mail R2 bucket,
+uses deterministic IDs, and skips existing provider or Internet Message-ID
+records so an interrupted run can resume safely. It processes Deleted MBOX
+files first so duplicates retain their trash state. It preserves Gmail thread
+IDs, original timestamps, sent/draft/spam/trash/read/star/archive state, system
+labels, and custom labels. State rows may be recorded for a suspended user's
+existing profile, but the importer does not activate a mailbox or create a
+mailbox membership.
+
+After the apply run, compare its report with counts from
+`private.mail_messages`, `private.mail_raw_messages`,
+`private.mail_attachments`, and `private.mail_stored_objects`. Re-run the
+importer with the same arguments to verify that every message is reported as
+already present. Keep the source export until database counts, R2 objects, and
+an authenticated Mail reader sample all agree.
+
 Onboard Cloudflare **Email Sending** separately from **Email Routing**. Sending
 uses its bounce subdomain and DKIM records and can be prepared while the apex
 MX remains on Google. Verify the existing DMARC policy and reporting addresses

--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -1,0 +1,405 @@
+import { createAdminClient } from '@tuturuuu/supabase/next/server';
+import type { Address, Email } from 'postal-mime';
+import {
+  createSnippet,
+  sanitizeMailHtml,
+  stripHtml,
+} from '../src/lib/mail/html';
+import {
+  deterministicUuid,
+  flattenAddresses,
+  mailboxAddress,
+} from '../src/lib/mail/import/google-takeout';
+
+type AnyRecord = Record<string, any>;
+
+export type StoredObjectRow = {
+  bucket_name: string;
+  content_id?: string | null;
+  content_disposition?: string | null;
+  content_type: string;
+  filename?: string | null;
+  id: string;
+  mailbox_id: string;
+  message_id: string | null;
+  object_key: string;
+  object_kind: 'attachment' | 'raw_mime';
+  provider: 'r2';
+  provider_metadata: AnyRecord;
+  sha256: string;
+  size_bytes: number;
+};
+
+export type PreparedImportMessage = {
+  account: string;
+  attachmentRows: AnyRecord[];
+  customLabels: string[];
+  date: string;
+  direction: 'inbound' | 'outbound';
+  email: Email;
+  gmailLabels: string[];
+  gmailThreadId: string | null;
+  isArchived: boolean;
+  isRead: boolean;
+  isStarred: boolean;
+  isTrashed: boolean;
+  mailboxId: string;
+  messageId: string;
+  providerMessageId: string;
+  rawMessageId: string;
+  rawSha256: string;
+  status: 'draft' | 'quarantined' | 'received' | 'sent';
+  storedObjects: StoredObjectRow[];
+  systemLabelSlugs: string[];
+  threadId: string;
+};
+
+export type ThreadSummary = {
+  firstMessageAt: string;
+  id: string;
+  lastMessageAt: string;
+  messageCount: number;
+  normalizedSubject: string;
+  status: 'active' | 'archived' | 'spam' | 'trash';
+  subject: string;
+  unreadCount: number;
+};
+
+function table(admin: AnyRecord, name: string) {
+  return admin.schema('private').from(name);
+}
+
+export async function createImportAdmin() {
+  return createAdminClient({ noCookie: true }) as AnyRecord;
+}
+
+export async function loadImportMailbox(admin: AnyRecord, address: string) {
+  const { data, error } = await table(admin, 'mail_mailboxes')
+    .select('id,address,status,type,created_by')
+    .eq('address', address)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) throw new Error(`No Tuturuuu mailbox exists for ${address}`);
+  let stateUserId = data.created_by as string | null;
+  if (!stateUserId) {
+    const { data: user, error: userError } = await admin
+      .from('user_private_details')
+      .select('user_id')
+      .ilike('email', address)
+      .maybeSingle();
+    if (userError) throw userError;
+    stateUserId = user?.user_id ?? null;
+  }
+  return {
+    ...data,
+    state_user_id: stateUserId,
+  } as {
+    address: string;
+    created_by: string | null;
+    id: string;
+    state_user_id: string | null;
+    status: string;
+    type: string;
+  };
+}
+
+async function loadPagedRows(
+  build: (start: number, end: number) => PromiseLike<AnyRecord>,
+  pageSize = 1000
+) {
+  const rows: AnyRecord[] = [];
+  for (let start = 0; ; start += pageSize) {
+    const { data, error } = await build(start, start + pageSize - 1);
+    if (error) throw error;
+    rows.push(...(data ?? []));
+    if ((data ?? []).length < pageSize) return rows;
+  }
+}
+
+export async function loadExistingMessageKeys(
+  admin: AnyRecord,
+  mailboxId: string
+) {
+  const rows = await loadPagedRows((start, end) =>
+    table(admin, 'mail_messages')
+      .select('provider_message_id,internet_message_id')
+      .eq('mailbox_id', mailboxId)
+      .range(start, end)
+  );
+  return {
+    internetMessageIds: new Set(
+      rows.flatMap((row) =>
+        row.internet_message_id ? [String(row.internet_message_id)] : []
+      )
+    ),
+    providerMessageIds: new Set(
+      rows.flatMap((row) =>
+        row.provider_message_id ? [String(row.provider_message_id)] : []
+      )
+    ),
+  };
+}
+
+export async function ensureImportLabels({
+  admin,
+  customLabels,
+  mailboxId,
+}: {
+  admin: AnyRecord;
+  customLabels: Map<string, string>;
+  mailboxId: string;
+}) {
+  const system = [
+    ['Inbox', 'inbox'],
+    ['Sent', 'sent'],
+    ['Drafts', 'drafts'],
+    ['Archive', 'archive'],
+    ['Trash', 'trash'],
+    ['Starred', 'starred'],
+    ['Spam', 'spam'],
+  ].map(([name, slug]) => ({
+    kind: 'system',
+    mailbox_id: mailboxId,
+    name,
+    slug,
+  }));
+  const custom = [...customLabels].map(([slug, name]) => ({
+    kind: 'custom',
+    mailbox_id: mailboxId,
+    name,
+    slug,
+  }));
+  const { error } = await table(admin, 'mail_labels').upsert(
+    [...system, ...custom],
+    { onConflict: 'mailbox_id,slug' }
+  );
+  if (error) throw error;
+  const { data, error: loadError } = await table(admin, 'mail_labels')
+    .select('id,slug')
+    .eq('mailbox_id', mailboxId);
+  if (loadError) throw loadError;
+  return new Map(
+    (data ?? []).map((row: AnyRecord) => [String(row.slug), String(row.id)])
+  );
+}
+
+function validMailbox(address: { address?: string; name?: string }) {
+  const value = address.address?.trim().toLowerCase();
+  return value?.includes('@')
+    ? { address: value, display_name: address.name?.trim() || null }
+    : null;
+}
+
+function recipientRows(message: PreparedImportMessage) {
+  const rows: AnyRecord[] = [];
+  const add = (kind: string, addresses: Address[]) => {
+    for (const [index, address] of flattenAddresses(addresses).entries()) {
+      const normalized = validMailbox(address);
+      if (!normalized) continue;
+      rows.push({
+        ...normalized,
+        id: deterministicUuid(
+          'google-takeout-recipient',
+          `${message.messageId}:${kind}:${index}:${normalized.address}`
+        ),
+        kind,
+        message_id: message.messageId,
+      });
+    }
+  };
+  const from = mailboxAddress(message.email.from);
+  if (from) add('from', [from]);
+  add('to', message.email.to ?? []);
+  add('cc', message.email.cc ?? []);
+  add('bcc', message.email.bcc ?? []);
+  add('reply_to', message.email.replyTo ?? []);
+  return rows;
+}
+
+function headerRecord(email: Email) {
+  const headers: Record<string, string> = {};
+  for (const header of email.headers) {
+    headers[header.key] = headers[header.key]
+      ? `${headers[header.key]}, ${header.value}`
+      : header.value;
+  }
+  return headers;
+}
+
+export async function persistImportBatch({
+  admin,
+  labelIds,
+  mailboxOwnerId,
+  messages,
+  threadRows,
+}: {
+  admin: AnyRecord;
+  labelIds: Map<string, string>;
+  mailboxOwnerId: string | null;
+  messages: PreparedImportMessage[];
+  threadRows: AnyRecord[];
+}) {
+  if (messages.length === 0) return;
+  const initialObjects = messages.flatMap((message) =>
+    message.storedObjects.map((object) => ({ ...object, message_id: null }))
+  );
+  let result = await table(admin, 'mail_stored_objects').upsert(
+    initialObjects,
+    {
+      onConflict: 'id',
+    }
+  );
+  if (result.error) throw result.error;
+
+  result = await table(admin, 'mail_raw_messages').upsert(
+    messages.map((message) => ({
+      id: message.rawMessageId,
+      provider: 'google_takeout',
+      provider_message_id: message.providerMessageId,
+      provider_payload: {
+        account: message.account,
+        gmailLabels: message.gmailLabels,
+        gmailThreadId: message.gmailThreadId,
+        source: 'google_workspace_export',
+      },
+      raw_headers: headerRecord(message.email),
+      sha256: message.rawSha256,
+      size_bytes: message.raw.byteLength,
+      status: 'imported',
+      stored_object_id: message.storedObjects[0]?.id ?? null,
+      created_at: message.date,
+    })),
+    { onConflict: 'id' }
+  );
+  if (result.error) throw result.error;
+
+  result = await table(admin, 'mail_threads').upsert(threadRows, {
+    ignoreDuplicates: true,
+    onConflict: 'id',
+  });
+  if (result.error) throw result.error;
+
+  result = await table(admin, 'mail_messages').upsert(
+    messages.map((message) => {
+      const from = mailboxAddress(message.email.from);
+      const sanitizedHtml = message.email.html
+        ? sanitizeMailHtml(message.email.html)
+        : null;
+      const bodyText =
+        message.email.text ?? (sanitizedHtml ? stripHtml(sanitizedHtml) : null);
+      return {
+        body_html: message.email.html ?? null,
+        body_text: bodyText,
+        created_at: message.date,
+        direction: message.direction,
+        from_address:
+          from?.address?.trim().toLowerCase() ?? 'unknown@example.invalid',
+        from_name: from?.name?.trim() || null,
+        has_attachments: message.attachmentRows.length > 0,
+        id: message.messageId,
+        in_reply_to: message.email.inReplyTo ?? null,
+        internet_message_id: message.email.messageId ?? null,
+        mailbox_id: message.mailboxId,
+        metadata: {
+          googleTakeout: {
+            gmailLabels: message.gmailLabels,
+            gmailThreadId: message.gmailThreadId,
+            rawSha256: message.rawSha256,
+          },
+        },
+        provider: 'google_takeout',
+        provider_message_id: message.providerMessageId,
+        raw_message_id: message.rawMessageId,
+        received_at: message.direction === 'inbound' ? message.date : null,
+        references_headers:
+          message.email.references?.split(/\s+/u).filter(Boolean) ?? [],
+        sanitized_html: sanitizedHtml,
+        sent_at: message.direction === 'outbound' ? message.date : null,
+        size_bytes: message.raw.byteLength,
+        snippet: createSnippet({ html: sanitizedHtml, text: bodyText }),
+        status: message.status,
+        subject: message.email.subject?.trim() || '(no subject)',
+        thread_id: message.threadId,
+        updated_at: message.date,
+      };
+    }),
+    { onConflict: 'id' }
+  );
+  if (result.error) throw result.error;
+
+  const recipients = messages.flatMap(recipientRows);
+  if (recipients.length) {
+    result = await table(admin, 'mail_recipients').upsert(recipients, {
+      onConflict: 'id',
+    });
+    if (result.error) throw result.error;
+  }
+  const attachments = messages.flatMap((message) => message.attachmentRows);
+  if (attachments.length) {
+    result = await table(admin, 'mail_attachments').upsert(attachments, {
+      onConflict: 'id',
+    });
+    if (result.error) throw result.error;
+  }
+  const messageLabels = messages.flatMap((message) =>
+    [...message.systemLabelSlugs, ...message.customLabels].flatMap((slug) => {
+      const labelId = labelIds.get(slug);
+      return labelId
+        ? [{ label_id: labelId, message_id: message.messageId }]
+        : [];
+    })
+  );
+  if (messageLabels.length) {
+    result = await table(admin, 'mail_message_labels').upsert(messageLabels, {
+      onConflict: 'message_id,label_id',
+    });
+    if (result.error) throw result.error;
+  }
+  if (mailboxOwnerId) {
+    result = await table(admin, 'mail_message_user_state').upsert(
+      messages.map((message) => ({
+        archived_at: message.isArchived ? message.date : null,
+        mailbox_id: message.mailboxId,
+        message_id: message.messageId,
+        read_at: message.isRead ? message.date : null,
+        starred_at: message.isStarred ? message.date : null,
+        trashed_at: message.isTrashed ? message.date : null,
+        user_id: mailboxOwnerId,
+      })),
+      { onConflict: 'message_id,user_id' }
+    );
+    if (result.error) throw result.error;
+  }
+  result = await table(admin, 'mail_stored_objects').upsert(
+    messages.flatMap((message) => message.storedObjects),
+    { onConflict: 'id' }
+  );
+  if (result.error) throw result.error;
+}
+
+export async function finalizeThreads({
+  admin,
+  mailboxId,
+  threads,
+}: {
+  admin: AnyRecord;
+  mailboxId: string;
+  threads: ThreadSummary[];
+}) {
+  const { error } = await table(admin, 'mail_threads').upsert(
+    threads.map((thread) => ({
+      created_at: thread.firstMessageAt,
+      id: thread.id,
+      last_message_at: thread.lastMessageAt,
+      mailbox_id: mailboxId,
+      message_count: thread.messageCount,
+      normalized_subject: thread.normalizedSubject,
+      status: thread.status,
+      subject: thread.subject,
+      unread_count: thread.unreadCount,
+      updated_at: thread.lastMessageAt,
+    })),
+    { onConflict: 'id' }
+  );
+  if (error) throw error;
+}

--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -123,6 +123,7 @@ export async function loadExistingMessageKeys(
     table(admin, 'mail_messages')
       .select('provider_message_id,internet_message_id')
       .eq('mailbox_id', mailboxId)
+      .order('id')
       .range(start, end)
   );
   return {

--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -84,7 +84,7 @@ export async function loadImportMailbox(admin: AnyRecord, address: string) {
     const { data: user, error: userError } = await admin
       .from('user_private_details')
       .select('user_id')
-      .ilike('email', address)
+      .eq('email', address)
       .maybeSingle();
     if (userError) throw userError;
     stateUserId = user?.user_id ?? null;

--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -10,8 +10,7 @@ import {
   flattenAddresses,
   mailboxAddress,
 } from '../src/lib/mail/import/google-takeout';
-
-type AnyRecord = Record<string, any>;
+import type { AnyRecord } from '../src/lib/mail/repository/shared';
 
 export type StoredObjectRow = {
   bucket_name: string;

--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -45,6 +45,7 @@ export type PreparedImportMessage = {
   mailboxId: string;
   messageId: string;
   providerMessageId: string;
+  raw: Uint8Array;
   rawMessageId: string;
   rawSha256: string;
   status: 'draft' | 'quarantined' | 'received' | 'sent';
@@ -68,6 +69,10 @@ function table(admin: AnyRecord, name: string) {
   return admin.schema('private').from(name);
 }
 
+export function escapeLikePattern(value: string) {
+  return value.replaceAll(/([\\%_])/gu, '\\$1');
+}
+
 export async function createImportAdmin() {
   return createAdminClient({ noCookie: true }) as AnyRecord;
 }
@@ -84,7 +89,7 @@ export async function loadImportMailbox(admin: AnyRecord, address: string) {
     const { data: user, error: userError } = await admin
       .from('user_private_details')
       .select('user_id')
-      .eq('email', address)
+      .ilike('email', escapeLikePattern(address))
       .maybeSingle();
     if (userError) throw userError;
     stateUserId = user?.user_id ?? null;
@@ -163,24 +168,48 @@ export async function ensureImportLabels({
     name,
     slug,
   }));
-  const custom = [...customLabels].map(([slug, name]) => ({
-    kind: 'custom',
-    mailbox_id: mailboxId,
-    name,
-    slug,
-  }));
+  const { data: existing, error: existingError } = await table(
+    admin,
+    'mail_labels'
+  )
+    .select('id,name,slug')
+    .eq('mailbox_id', mailboxId);
+  if (existingError) throw existingError;
+  const existingByName = new Map(
+    (existing ?? []).map((row: AnyRecord) => [String(row.name), row])
+  );
+  const custom = [...customLabels].flatMap(([slug, name]) =>
+    existingByName.has(name)
+      ? []
+      : [
+          {
+            kind: 'custom',
+            mailbox_id: mailboxId,
+            name,
+            slug,
+          },
+        ]
+  );
   const { error } = await table(admin, 'mail_labels').upsert(
     [...system, ...custom],
     { onConflict: 'mailbox_id,slug' }
   );
   if (error) throw error;
   const { data, error: loadError } = await table(admin, 'mail_labels')
-    .select('id,slug')
+    .select('id,name,slug')
     .eq('mailbox_id', mailboxId);
   if (loadError) throw loadError;
-  return new Map(
+  const labelIds = new Map(
     (data ?? []).map((row: AnyRecord) => [String(row.slug), String(row.id)])
   );
+  const importedByName = new Map(
+    (data ?? []).map((row: AnyRecord) => [String(row.name), String(row.id)])
+  );
+  for (const [generatedSlug, name] of customLabels) {
+    const id = importedByName.get(name);
+    if (id) labelIds.set(generatedSlug, id);
+  }
+  return labelIds;
 }
 
 function validMailbox(address: { address?: string; name?: string }) {
@@ -194,6 +223,7 @@ function recipientRows(message: PreparedImportMessage) {
   const rows: AnyRecord[] = [];
   const add = (kind: string, addresses: Address[]) => {
     for (const [index, address] of flattenAddresses(addresses).entries()) {
+      if (!address) continue;
       const normalized = validMailbox(address);
       if (!normalized) continue;
       rows.push({

--- a/apps/mail/scripts/google-takeout-r2.ts
+++ b/apps/mail/scripts/google-takeout-r2.ts
@@ -1,0 +1,174 @@
+import { createHash } from 'node:crypto';
+import {
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import type { Attachment } from 'postal-mime';
+import { deterministicUuid } from '../src/lib/mail/import/google-takeout';
+import type {
+  PreparedImportMessage,
+  StoredObjectRow,
+} from './google-takeout-db';
+
+function requiredEnv(name: string) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function bytes(value: Attachment['content']) {
+  if (typeof value === 'string') return Buffer.from(value, 'utf8');
+  return Buffer.from(value);
+}
+
+function sha256(value: Uint8Array) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function createR2Client() {
+  const accountId = requiredEnv('MAIL_R2_ACCOUNT_ID');
+  return new S3Client({
+    credentials: {
+      accessKeyId: requiredEnv('MAIL_R2_ACCESS_KEY_ID'),
+      secretAccessKey: requiredEnv('MAIL_R2_SECRET_ACCESS_KEY'),
+    },
+    endpoint:
+      process.env.MAIL_R2_ENDPOINT ??
+      `https://${accountId}.r2.cloudflarestorage.com`,
+    region: 'auto',
+  });
+}
+
+export function createTakeoutObjectStore() {
+  const client = createR2Client();
+  const bucketName =
+    process.env.MAIL_R2_BUCKET_NAME ?? requiredEnv('MAIL_R2_BUCKET');
+
+  async function put({
+    body,
+    contentType,
+    key,
+    hash,
+  }: {
+    body: Uint8Array;
+    contentType: string;
+    hash: string;
+    key: string;
+  }) {
+    try {
+      const existing = await client.send(
+        new HeadObjectCommand({ Bucket: bucketName, Key: key })
+      );
+      if (
+        existing.ContentLength === body.byteLength &&
+        existing.Metadata?.sha256 === hash
+      ) {
+        return;
+      }
+    } catch (error) {
+      const status = (error as { $metadata?: { httpStatusCode?: number } })
+        .$metadata?.httpStatusCode;
+      if (status !== 404) throw error;
+    }
+    await client.send(
+      new PutObjectCommand({
+        Body: body,
+        Bucket: bucketName,
+        ContentType: contentType,
+        Key: key,
+        Metadata: { sha256: hash },
+      })
+    );
+  }
+
+  return { bucketName, put };
+}
+
+export async function uploadTakeoutMessage({
+  account,
+  message,
+  objectStore,
+}: {
+  account: string;
+  message: Omit<PreparedImportMessage, 'attachmentRows' | 'storedObjects'>;
+  objectStore: ReturnType<typeof createTakeoutObjectStore>;
+}) {
+  const accountKey = encodeURIComponent(account);
+  const rawKey = `migration/google-takeout/v1/${accountKey}/raw/${message.rawSha256}.eml`;
+  const rawObjectId = deterministicUuid('mail-stored-object', rawKey);
+  await objectStore.put({
+    body: message.raw,
+    contentType: 'message/rfc822',
+    hash: message.rawSha256,
+    key: rawKey,
+  });
+  const storedObjects: StoredObjectRow[] = [
+    {
+      bucket_name: objectStore.bucketName,
+      content_type: 'message/rfc822',
+      filename: `${message.rawSha256}.eml`,
+      id: rawObjectId,
+      mailbox_id: message.mailboxId,
+      message_id: message.messageId,
+      object_key: rawKey,
+      object_kind: 'raw_mime',
+      provider: 'r2',
+      provider_metadata: {
+        import: 'google_takeout',
+        providerMessageId: message.providerMessageId,
+      },
+      sha256: message.rawSha256,
+      size_bytes: message.raw.byteLength,
+    },
+  ];
+  const attachmentRows = [];
+  for (const [index, attachment] of message.email.attachments.entries()) {
+    const content = bytes(attachment.content);
+    const hash = sha256(content);
+    const key = `migration/google-takeout/v1/${accountKey}/attachments/${message.rawSha256}/${index}-${hash}`;
+    const objectId = deterministicUuid('mail-stored-object', key);
+    const attachmentId = deterministicUuid(
+      'google-takeout-attachment',
+      `${message.messageId}:${index}:${hash}`
+    );
+    const disposition =
+      attachment.disposition === 'inline' ? 'inline' : 'attachment';
+    const filename = attachment.filename?.trim() || `attachment-${index + 1}`;
+    await objectStore.put({
+      body: content,
+      contentType: attachment.mimeType || 'application/octet-stream',
+      hash,
+      key,
+    });
+    storedObjects.push({
+      bucket_name: objectStore.bucketName,
+      content_id: attachment.contentId ?? null,
+      content_disposition: disposition,
+      content_type: attachment.mimeType || 'application/octet-stream',
+      filename,
+      id: objectId,
+      mailbox_id: message.mailboxId,
+      message_id: message.messageId,
+      object_key: key,
+      object_kind: 'attachment',
+      provider: 'r2',
+      provider_metadata: { import: 'google_takeout' },
+      sha256: hash,
+      size_bytes: content.byteLength,
+    });
+    attachmentRows.push({
+      content_id: attachment.contentId ?? null,
+      content_type: attachment.mimeType || 'application/octet-stream',
+      disposition,
+      filename,
+      id: attachmentId,
+      message_id: message.messageId,
+      raw_message_id: message.rawMessageId,
+      sha256: hash,
+      size_bytes: content.byteLength,
+      stored_object_id: objectId,
+    });
+  }
+  return { attachmentRows, storedObjects };
+}

--- a/apps/mail/scripts/import-google-takeout.ts
+++ b/apps/mail/scripts/import-google-takeout.ts
@@ -271,12 +271,6 @@ async function importMailbox({
         `${mailbox.id}:${threadKey}`
       );
       updateThread(threads, parsed, threadId);
-      if (providerExists) {
-        skippedExisting += 1;
-        seenProviderIds.add(parsed.providerMessageId);
-        if (internetId) seenInternetIds.add(internetId);
-        continue;
-      }
       seenProviderIds.add(parsed.providerMessageId);
       if (internetId) seenInternetIds.add(internetId);
       const labels = customLabels(parsed);
@@ -284,9 +278,13 @@ async function importMailbox({
         labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
       }
       for (const label of labels) labelNames.set(label.slug, label.name);
-      messages += 1;
-      attachments += parsed.email.attachments.length;
-      attachmentBytes += parsed.attachmentBytes;
+      if (providerExists) {
+        skippedExisting += 1;
+      } else {
+        messages += 1;
+        attachments += parsed.email.attachments.length;
+        attachmentBytes += parsed.attachmentBytes;
+      }
       if (args.apply) {
         const messageId = deterministicUuid(
           'google-takeout-message',

--- a/apps/mail/scripts/import-google-takeout.ts
+++ b/apps/mail/scripts/import-google-takeout.ts
@@ -1,0 +1,380 @@
+import { readdir, writeFile } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+import {
+  deterministicUuid,
+  parseTakeoutMessage,
+  readMboxMessages,
+  slugifyGoogleLabel,
+  type TakeoutMessage,
+} from '../src/lib/mail/import/google-takeout';
+import {
+  createImportAdmin,
+  ensureImportLabels,
+  finalizeThreads,
+  loadExistingMessageKeys,
+  loadImportMailbox,
+  type PreparedImportMessage,
+  persistImportBatch,
+  type ThreadSummary,
+} from './google-takeout-db';
+import {
+  createTakeoutObjectStore,
+  uploadTakeoutMessage,
+} from './google-takeout-r2';
+
+const NON_CUSTOM_LABELS = new Set([
+  'archived',
+  'draft',
+  'drafts',
+  'inbox',
+  'sent',
+  'spam',
+  'starred',
+  'trash',
+  'unread',
+]);
+
+type Args = {
+  apply: boolean;
+  batchSize: number;
+  mailbox: string | null;
+  report: string;
+  root: string;
+};
+
+type MailboxReport = {
+  attachmentBytes: number;
+  attachments: number;
+  duplicates: number;
+  labels: Record<string, number>;
+  messages: number;
+  skippedExisting: number;
+  threads: number;
+};
+
+function parseArgs(): Args {
+  const values = new Map<string, string>();
+  let apply = false;
+  for (const argument of process.argv.slice(2)) {
+    if (argument === '--apply') {
+      apply = true;
+      continue;
+    }
+    const separator = argument.indexOf('=');
+    if (!argument.startsWith('--') || separator < 3) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    values.set(argument.slice(2, separator), argument.slice(separator + 1));
+  }
+  const root = values.get('root');
+  if (!root) throw new Error('--root=/path/to/mail-data is required');
+  const batchSize = Number(values.get('batch-size') ?? 10);
+  if (!Number.isInteger(batchSize) || batchSize < 1 || batchSize > 50) {
+    throw new Error('--batch-size must be an integer from 1 to 50');
+  }
+  return {
+    apply,
+    batchSize,
+    mailbox: values.get('mailbox')?.trim().toLowerCase() || null,
+    report: resolve(
+      values.get('report') ?? join(root, '..', 'import-report.json')
+    ),
+    root: resolve(root),
+  };
+}
+
+function normalizeSubject(subject?: string) {
+  return (subject?.trim() || '(no subject)')
+    .replace(/^(?:(?:re|fw|fwd):\s*)+/iu, '')
+    .trim()
+    .toLowerCase();
+}
+
+function customLabels(message: TakeoutMessage) {
+  return message.gmailLabels.flatMap((name) => {
+    if (NON_CUSTOM_LABELS.has(name.toLowerCase())) return [];
+    const slug = slugifyGoogleLabel(name);
+    return slug ? [{ name, slug }] : [];
+  });
+}
+
+function threadStatus(message: TakeoutMessage): ThreadSummary['status'] {
+  if (message.isTrashed) return 'trash';
+  if (message.status === 'quarantined') return 'spam';
+  if (message.isArchived) return 'archived';
+  return 'active';
+}
+
+function updateThread(
+  threads: Map<string, ThreadSummary>,
+  message: TakeoutMessage,
+  threadId: string
+) {
+  const subject = message.email.subject?.trim() || '(no subject)';
+  const existing = threads.get(threadId);
+  const nextStatus = threadStatus(message);
+  if (!existing) {
+    threads.set(threadId, {
+      firstMessageAt: message.date,
+      id: threadId,
+      lastMessageAt: message.date,
+      messageCount: 1,
+      normalizedSubject: normalizeSubject(subject),
+      status: nextStatus,
+      subject,
+      unreadCount: Number(message.direction === 'inbound' && !message.isRead),
+    });
+    return;
+  }
+  existing.firstMessageAt =
+    existing.firstMessageAt < message.date
+      ? existing.firstMessageAt
+      : message.date;
+  if (message.date >= existing.lastMessageAt) {
+    existing.lastMessageAt = message.date;
+    existing.subject = subject;
+    existing.normalizedSubject = normalizeSubject(subject);
+  }
+  existing.messageCount += 1;
+  existing.unreadCount += Number(
+    message.direction === 'inbound' && !message.isRead
+  );
+  const rank = { active: 3, archived: 2, spam: 1, trash: 0 } as const;
+  if (rank[nextStatus] > rank[existing.status]) existing.status = nextStatus;
+}
+
+function initialThreadRow(mailboxId: string, summary: ThreadSummary) {
+  return {
+    created_at: summary.firstMessageAt,
+    id: summary.id,
+    last_message_at: summary.lastMessageAt,
+    mailbox_id: mailboxId,
+    message_count: 0,
+    normalized_subject: summary.normalizedSubject,
+    status: summary.status,
+    subject: summary.subject,
+    unread_count: 0,
+    updated_at: summary.lastMessageAt,
+  };
+}
+
+async function listMailboxDirectories(root: string, only: string | null) {
+  const entries = await readdir(root, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory() && entry.name.includes('@'))
+    .map((entry) => entry.name.toLowerCase())
+    .filter((address) => !only || address === only)
+    .sort();
+}
+
+async function listMboxes(root: string, account: string) {
+  const dir = join(root, account);
+  return (await readdir(dir))
+    .filter((name) => name.endsWith('.mbox'))
+    .sort((left, right) => {
+      const leftDeleted = left.toLowerCase().includes('deleted');
+      const rightDeleted = right.toLowerCase().includes('deleted');
+      return (
+        Number(rightDeleted) - Number(leftDeleted) || left.localeCompare(right)
+      );
+    })
+    .map((name) => join(dir, name));
+}
+
+async function importMailbox({
+  account,
+  args,
+}: {
+  account: string;
+  args: Args;
+}) {
+  const admin = args.apply ? await createImportAdmin() : null;
+  const mailbox = admin
+    ? await loadImportMailbox(admin, account)
+    : {
+        created_by: null,
+        id: deterministicUuid('dry-run-mailbox', account),
+        state_user_id: null,
+      };
+  const existing = admin
+    ? await loadExistingMessageKeys(admin, mailbox.id)
+    : {
+        internetMessageIds: new Set<string>(),
+        providerMessageIds: new Set<string>(),
+      };
+  const seenInternetIds = new Set<string>();
+  const seenProviderIds = new Set<string>();
+  const threads = new Map<string, ThreadSummary>();
+  const labelNames = new Map<string, string>();
+  const labelCounts = new Map<string, number>();
+  const pending: PreparedImportMessage[] = [];
+  const objectStore = args.apply ? createTakeoutObjectStore() : null;
+  let duplicates = 0;
+  let skippedExisting = 0;
+  let messages = 0;
+  let attachments = 0;
+  let attachmentBytes = 0;
+
+  const flush = async () => {
+    if (!(admin && objectStore) || pending.length === 0) return;
+    const labelIds = await ensureImportLabels({
+      admin,
+      customLabels: labelNames,
+      mailboxId: mailbox.id,
+    });
+    const ready = await Promise.all(
+      pending.map(async (message) => ({
+        ...message,
+        ...(await uploadTakeoutMessage({ account, message, objectStore })),
+      }))
+    );
+    const threadRows = [
+      ...new Map(
+        ready.map((message) => {
+          const summary = threads.get(message.threadId)!;
+          return [message.threadId, initialThreadRow(mailbox.id, summary)];
+        })
+      ).values(),
+    ];
+    await persistImportBatch({
+      admin,
+      labelIds,
+      mailboxOwnerId: mailbox.state_user_id,
+      messages: ready,
+      threadRows,
+    });
+    pending.length = 0;
+  };
+
+  for (const mboxPath of await listMboxes(args.root, account)) {
+    const deletedMbox = basename(mboxPath).toLowerCase().includes('deleted');
+    for await (const raw of readMboxMessages(mboxPath)) {
+      const parsed = await parseTakeoutMessage({ account, deletedMbox, raw });
+      const internetId = parsed.email.messageId?.trim() || null;
+      const providerExists = existing.providerMessageIds.has(
+        parsed.providerMessageId
+      );
+      if (
+        seenProviderIds.has(parsed.providerMessageId) ||
+        (internetId && seenInternetIds.has(internetId)) ||
+        (!providerExists &&
+          internetId &&
+          existing.internetMessageIds.has(internetId))
+      ) {
+        duplicates += 1;
+        continue;
+      }
+      const subjectKey = normalizeSubject(parsed.email.subject);
+      const threadKey = parsed.gmailThreadId ?? `subject:${subjectKey}`;
+      const threadId = deterministicUuid(
+        'google-takeout-thread',
+        `${mailbox.id}:${threadKey}`
+      );
+      updateThread(threads, parsed, threadId);
+      if (providerExists) {
+        skippedExisting += 1;
+        seenProviderIds.add(parsed.providerMessageId);
+        if (internetId) seenInternetIds.add(internetId);
+        continue;
+      }
+      seenProviderIds.add(parsed.providerMessageId);
+      if (internetId) seenInternetIds.add(internetId);
+      const labels = customLabels(parsed);
+      for (const label of parsed.gmailLabels) {
+        labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+      }
+      for (const label of labels) labelNames.set(label.slug, label.name);
+      messages += 1;
+      attachments += parsed.email.attachments.length;
+      attachmentBytes += parsed.attachmentBytes;
+      if (args.apply) {
+        const messageId = deterministicUuid(
+          'google-takeout-message',
+          `${mailbox.id}:${parsed.providerMessageId}`
+        );
+        pending.push({
+          account,
+          attachmentRows: [],
+          customLabels: labels.map((label) => label.slug),
+          ...parsed,
+          mailboxId: mailbox.id,
+          messageId,
+          rawMessageId: deterministicUuid(
+            'google-takeout-raw-message',
+            parsed.providerMessageId
+          ),
+          storedObjects: [],
+          threadId,
+        });
+        if (pending.length >= args.batchSize) await flush();
+      }
+      if ((messages + skippedExisting) % 250 === 0) {
+        console.log(
+          `${account}: processed ${messages + skippedExisting} messages`
+        );
+      }
+    }
+  }
+  await flush();
+  if (admin && threads.size) {
+    await finalizeThreads({
+      admin,
+      mailboxId: mailbox.id,
+      threads: [...threads.values()],
+    });
+  }
+  return {
+    attachmentBytes,
+    attachments,
+    duplicates,
+    labels: Object.fromEntries(
+      [...labelCounts].sort(([left], [right]) => left.localeCompare(right))
+    ),
+    messages,
+    skippedExisting,
+    threads: threads.size,
+  } satisfies MailboxReport;
+}
+
+async function main() {
+  const args = parseArgs();
+  const accounts = await listMailboxDirectories(args.root, args.mailbox);
+  if (accounts.length === 0)
+    throw new Error('No matching mailbox directories found');
+  console.log(
+    `${args.apply ? 'APPLY' : 'DRY RUN'}: ${accounts.length} Google mailboxes from ${args.root}`
+  );
+  const mailboxes: Record<string, MailboxReport> = {};
+  for (const account of accounts) {
+    mailboxes[account] = await importMailbox({ account, args });
+    console.log(`${account}:`, mailboxes[account]);
+  }
+  const report = {
+    applied: args.apply,
+    completedAt: new Date().toISOString(),
+    mailboxes,
+    totals: Object.values(mailboxes).reduce(
+      (total, mailbox) => ({
+        attachmentBytes: total.attachmentBytes + mailbox.attachmentBytes,
+        attachments: total.attachments + mailbox.attachments,
+        duplicates: total.duplicates + mailbox.duplicates,
+        messages: total.messages + mailbox.messages,
+        skippedExisting: total.skippedExisting + mailbox.skippedExisting,
+        threads: total.threads + mailbox.threads,
+      }),
+      {
+        attachmentBytes: 0,
+        attachments: 0,
+        duplicates: 0,
+        messages: 0,
+        skippedExisting: 0,
+        threads: 0,
+      }
+    ),
+  };
+  await writeFile(args.report, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`Report: ${args.report}`);
+  console.log('Totals:', report.totals);
+}
+
+await main();

--- a/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ensureImportLabels,
+  escapeLikePattern,
+} from '../../../../scripts/google-takeout-db';
+import type { AnyRecord } from '../repository/shared';
+
+describe('Google Takeout database helpers', () => {
+  it('escapes case-insensitive exact-match wildcard characters', () => {
+    expect(escapeLikePattern(String.raw`Name_%\\Box@Example.com`)).toBe(
+      String.raw`Name\_\%\\\\Box@Example.com`
+    );
+  });
+
+  it('reuses an existing label with the same display name', async () => {
+    const existing = [{ id: 'existing-id', name: 'Résumé', slug: 'resume' }];
+    let upserted: AnyRecord[] = [];
+    const admin = {
+      schema: () => ({
+        from: () => ({
+          select: () => ({
+            eq: async () => ({ data: existing, error: null }),
+          }),
+          upsert: async (rows: AnyRecord[]) => {
+            upserted = rows;
+            return { error: null };
+          },
+        }),
+      }),
+    } as AnyRecord;
+
+    const ids = await ensureImportLabels({
+      admin,
+      customLabels: new Map([['resume-generated-hash', 'Résumé']]),
+      mailboxId: 'mailbox-id',
+    });
+
+    expect(upserted).not.toContainEqual(
+      expect.objectContaining({ name: 'Résumé' })
+    );
+    expect(ids.get('resume-generated-hash')).toBe('existing-id');
+  });
+});

--- a/apps/mail/src/lib/mail/import/google-takeout.test.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout.test.ts
@@ -19,6 +19,7 @@ describe('Google Takeout mail import', () => {
         'From sender@example.com Sat Sep  5 11:11:11 +0000 2026\n',
         'Message-ID: <one@example.com>\n\n',
         '>From preserved body line\n',
+        '>>From already quoted body line\n',
         'From sender@example.com Sun Sep  6 12:12:12 2026\n',
         'Message-ID: <two@example.com>\n\nSecond\n',
       ].join('')
@@ -31,6 +32,7 @@ describe('Google Takeout mail import', () => {
 
     expect(messages).toHaveLength(2);
     expect(messages[0]).toContain('\nFrom preserved body line\n');
+    expect(messages[0]).toContain('\n>From already quoted body line\n');
     expect(messages[1]).toContain('<two@example.com>');
   });
 

--- a/apps/mail/src/lib/mail/import/google-takeout.test.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -7,33 +7,38 @@ import {
   normalizeGmailLabels,
   parseTakeoutMessage,
   readMboxMessages,
+  slugifyGoogleLabel,
 } from './google-takeout';
 
 describe('Google Takeout mail import', () => {
   it('streams mbox messages and restores mboxrd From lines', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'mail-takeout-'));
-    const path = join(dir, 'mail.mbox');
-    await writeFile(
-      path,
-      [
-        'From sender@example.com Sat Sep  5 11:11:11 +0000 2026\n',
-        'Message-ID: <one@example.com>\n\n',
-        '>From preserved body line\n',
-        '>>From already quoted body line\n',
-        'From sender@example.com Sun Sep  6 12:12:12 2026\n',
-        'Message-ID: <two@example.com>\n\nSecond\n',
-      ].join('')
-    );
+    try {
+      const path = join(dir, 'mail.mbox');
+      await writeFile(
+        path,
+        [
+          'From sender@example.com Sat Sep  5 11:11:11 +0000 2026\n',
+          'Message-ID: <one@example.com>\n\n',
+          '>From preserved body line\n',
+          '>>From already quoted body line\n',
+          'From sender@example.com Sun Sep  6 12:12:12 2026\n',
+          'Message-ID: <two@example.com>\n\nSecond\n',
+        ].join('')
+      );
 
-    const messages: string[] = [];
-    for await (const raw of readMboxMessages(path)) {
-      messages.push(raw.toString());
+      const messages: string[] = [];
+      for await (const raw of readMboxMessages(path)) {
+        messages.push(raw.toString());
+      }
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toContain('\nFrom preserved body line\n');
+      expect(messages[0]).toContain('\n>From already quoted body line\n');
+      expect(messages[1]).toContain('<two@example.com>');
+    } finally {
+      await rm(dir, { force: true, recursive: true });
     }
-
-    expect(messages).toHaveLength(2);
-    expect(messages[0]).toContain('\nFrom preserved body line\n');
-    expect(messages[0]).toContain('\n>From already quoted body line\n');
-    expect(messages[1]).toContain('<two@example.com>');
   });
 
   it('normalizes folded and repeated Gmail labels', () => {
@@ -91,5 +96,11 @@ describe('Google Takeout mail import', () => {
     expect(first).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u
     );
+  });
+
+  it('creates nonempty collision-safe slugs for international labels', () => {
+    expect(slugifyGoogleLabel('安全')).toMatch(/^label-[0-9a-f]{10}$/u);
+    expect(slugifyGoogleLabel('Résumé')).not.toBe(slugifyGoogleLabel('Resume'));
+    expect(slugifyGoogleLabel('Résumé')).toBe(slugifyGoogleLabel('Résumé'));
   });
 });

--- a/apps/mail/src/lib/mail/import/google-takeout.test.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout.test.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  deterministicUuid,
+  normalizeGmailLabels,
+  parseTakeoutMessage,
+  readMboxMessages,
+} from './google-takeout';
+
+describe('Google Takeout mail import', () => {
+  it('streams mbox messages and restores mboxrd From lines', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mail-takeout-'));
+    const path = join(dir, 'mail.mbox');
+    await writeFile(
+      path,
+      [
+        'From sender@example.com Sat Sep  5 11:11:11 +0000 2026\n',
+        'Message-ID: <one@example.com>\n\n',
+        '>From preserved body line\n',
+        'From sender@example.com Sun Sep  6 12:12:12 2026\n',
+        'Message-ID: <two@example.com>\n\nSecond\n',
+      ].join('')
+    );
+
+    const messages: string[] = [];
+    for await (const raw of readMboxMessages(path)) {
+      messages.push(raw.toString());
+    }
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toContain('\nFrom preserved body line\n');
+    expect(messages[1]).toContain('<two@example.com>');
+  });
+
+  it('normalizes folded and repeated Gmail labels', () => {
+    expect(
+      normalizeGmailLabels([
+        {
+          key: 'x-gmail-labels',
+          originalKey: 'X-Gmail-Labels',
+          value: 'Inbox,Category\r\n Updates',
+        },
+        {
+          key: 'x-gmail-labels',
+          originalKey: 'X-Gmail-Labels',
+          value: 'Starred, Inbox',
+        },
+      ])
+    ).toEqual(['Inbox', 'Category Updates', 'Starred']);
+  });
+
+  it('preserves Gmail state and classifies deleted messages as trash', async () => {
+    const raw = Buffer.from(
+      [
+        'From: Sender <sender@example.com>',
+        'To: phucvo@tuturuuu.com',
+        'Date: Sun, 6 Sep 2026 12:11:15 +0000',
+        'Message-ID: <test@example.com>',
+        'X-GM-THRID: 123456',
+        'X-Gmail-Labels: Sent,Starred,Unread',
+        'Content-Type: text/plain; charset=utf-8',
+        '',
+        'Hello',
+      ].join('\r\n')
+    );
+    const parsed = await parseTakeoutMessage({
+      account: 'phucvo@tuturuuu.com',
+      deletedMbox: true,
+      raw,
+    });
+
+    expect(parsed.gmailThreadId).toBe('123456');
+    expect(parsed.direction).toBe('outbound');
+    expect(parsed.status).toBe('sent');
+    expect(parsed.isRead).toBe(false);
+    expect(parsed.isStarred).toBe(true);
+    expect(parsed.isTrashed).toBe(true);
+    expect(parsed.systemLabelSlugs).toEqual(
+      expect.arrayContaining(['sent', 'starred', 'trash'])
+    );
+  });
+
+  it('creates stable RFC 4122 version 5-shaped IDs', () => {
+    const first = deterministicUuid('message', 'same');
+    expect(first).toBe(deterministicUuid('message', 'same'));
+    expect(first).not.toBe(deterministicUuid('message', 'different'));
+    expect(first).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u
+    );
+  });
+});

--- a/apps/mail/src/lib/mail/import/google-takeout.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout.ts
@@ -216,11 +216,13 @@ export function deterministicUuid(namespace: string, value: string) {
 }
 
 export function slugifyGoogleLabel(value: string) {
-  return value
+  const base = value
     .normalize('NFKD')
     .replaceAll(/[\u0300-\u036f]/gu, '')
     .toLowerCase()
     .replaceAll(/[^a-z0-9]+/gu, '-')
     .replaceAll(/^-|-$/gu, '')
-    .slice(0, 80);
+    .slice(0, 69);
+  const suffix = createHash('sha256').update(value).digest('hex').slice(0, 10);
+  return `${base || 'label'}-${suffix}`;
 }

--- a/apps/mail/src/lib/mail/import/google-takeout.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout.ts
@@ -44,7 +44,10 @@ function isMboxSeparator(line: Buffer) {
 }
 
 function restoreMboxrdLine(line: Buffer) {
-  return line.subarray(0, 6).toString('ascii') === '>From '
+  let markerLength = 0;
+  while (line[markerLength] === 62) markerLength += 1;
+  return markerLength > 0 &&
+    line.subarray(markerLength, markerLength + 5).toString('ascii') === 'From '
     ? line.subarray(1)
     : line;
 }

--- a/apps/mail/src/lib/mail/import/google-takeout.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout.ts
@@ -1,0 +1,223 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import PostalMime, {
+  type Address,
+  type Email,
+  type Header,
+  type Mailbox,
+} from 'postal-mime';
+
+const MBOX_SEPARATOR =
+  /^From \S+ (?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ \d]\d \d\d:\d\d(?::\d\d)?(?: [+-]\d{4})? \d{4}(?: .*)?$/u;
+
+const SYSTEM_LABEL_SLUGS = new Map([
+  ['archived', 'archive'],
+  ['draft', 'drafts'],
+  ['drafts', 'drafts'],
+  ['inbox', 'inbox'],
+  ['sent', 'sent'],
+  ['spam', 'spam'],
+  ['starred', 'starred'],
+  ['trash', 'trash'],
+]);
+
+export type TakeoutMessage = {
+  attachmentBytes: number;
+  date: string;
+  direction: 'inbound' | 'outbound';
+  email: Email;
+  gmailLabels: string[];
+  gmailThreadId: string | null;
+  isArchived: boolean;
+  isRead: boolean;
+  isStarred: boolean;
+  isTrashed: boolean;
+  providerMessageId: string;
+  raw: Uint8Array;
+  rawSha256: string;
+  status: 'draft' | 'quarantined' | 'received' | 'sent';
+  systemLabelSlugs: string[];
+};
+
+function isMboxSeparator(line: Buffer) {
+  return MBOX_SEPARATOR.test(line.toString('ascii').replace(/\r?\n$/u, ''));
+}
+
+function restoreMboxrdLine(line: Buffer) {
+  return line.subarray(0, 6).toString('ascii') === '>From '
+    ? line.subarray(1)
+    : line;
+}
+
+export async function* readMboxMessages(path: string) {
+  let pending: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  let message: Buffer[] = [];
+  let messageBytes = 0;
+
+  const emitMessage = () => {
+    if (messageBytes === 0) return null;
+    const raw = Buffer.concat(message, messageBytes);
+    message = [];
+    messageBytes = 0;
+    return raw;
+  };
+
+  for await (const chunk of createReadStream(path)) {
+    const data = pending.length
+      ? Buffer.concat([pending, chunk as Buffer])
+      : (chunk as Buffer);
+    let offset = 0;
+    let newline = data.indexOf(10, offset);
+    while (newline >= 0) {
+      const line = data.subarray(offset, newline + 1);
+      if (isMboxSeparator(line)) {
+        const raw = emitMessage();
+        if (raw) yield raw;
+      } else {
+        const restored = restoreMboxrdLine(line);
+        message.push(restored);
+        messageBytes += restored.length;
+      }
+      offset = newline + 1;
+      newline = data.indexOf(10, offset);
+    }
+    pending = data.subarray(offset);
+  }
+
+  if (pending.length && !isMboxSeparator(pending)) {
+    const restored = restoreMboxrdLine(pending);
+    message.push(restored);
+    messageBytes += restored.length;
+  }
+  const raw = emitMessage();
+  if (raw) yield raw;
+}
+
+function headerValues(headers: Header[], key: string) {
+  return headers
+    .filter((header) => header.key.toLowerCase() === key)
+    .map((header) => header.value);
+}
+
+export function normalizeGmailLabels(headers: Header[]) {
+  return [
+    ...new Set(
+      headerValues(headers, 'x-gmail-labels')
+        .flatMap((value) => value.split(','))
+        .map((label) => label.replaceAll(/\s+/gu, ' ').trim())
+        .filter(Boolean)
+    ),
+  ];
+}
+
+function hasLabel(labels: string[], value: string) {
+  return labels.some((label) => label.toLowerCase() === value);
+}
+
+export function flattenAddresses(addresses?: Address[]) {
+  return (addresses ?? []).flatMap((address) =>
+    'group' in address ? address.group : [address]
+  );
+}
+
+export function mailboxAddress(address?: Address) {
+  if (!address || 'group' in address) return null;
+  return address as Mailbox;
+}
+
+function resolveMessageDate(email: Email) {
+  const date = email.date ? new Date(email.date) : new Date(0);
+  return Number.isNaN(date.getTime())
+    ? new Date(0).toISOString()
+    : date.toISOString();
+}
+
+export async function parseTakeoutMessage({
+  account,
+  deletedMbox,
+  raw,
+}: {
+  account: string;
+  deletedMbox: boolean;
+  raw: Uint8Array;
+}): Promise<TakeoutMessage> {
+  const email = await PostalMime.parse(raw, {
+    attachmentEncoding: 'arraybuffer',
+  });
+  const gmailLabels = normalizeGmailLabels(email.headers);
+  const rawSha256 = createHash('sha256').update(raw).digest('hex');
+  const isDraft = hasLabel(gmailLabels, 'drafts');
+  const isSent = hasLabel(gmailLabels, 'sent');
+  const isSpam = hasLabel(gmailLabels, 'spam');
+  const isTrashed = deletedMbox || hasLabel(gmailLabels, 'trash');
+  const isArchived =
+    hasLabel(gmailLabels, 'archived') ||
+    (!hasLabel(gmailLabels, 'inbox') &&
+      !isDraft &&
+      !isSent &&
+      !isSpam &&
+      !isTrashed);
+  const systemLabelSlugs = [
+    ...new Set(
+      gmailLabels
+        .map((label) => SYSTEM_LABEL_SLUGS.get(label.toLowerCase()))
+        .filter((label): label is string => Boolean(label))
+        .concat(isArchived ? ['archive'] : [])
+        .concat(isTrashed ? ['trash'] : [])
+    ),
+  ];
+  const gmailThreadId =
+    headerValues(email.headers, 'x-gm-thrid')[0]?.trim() || null;
+
+  return {
+    attachmentBytes: email.attachments.reduce(
+      (sum, attachment) =>
+        sum +
+        (typeof attachment.content === 'string'
+          ? Buffer.byteLength(attachment.content)
+          : attachment.content.byteLength),
+      0
+    ),
+    date: resolveMessageDate(email),
+    direction: isDraft || isSent ? 'outbound' : 'inbound',
+    email,
+    gmailLabels,
+    gmailThreadId,
+    isArchived,
+    isRead: !hasLabel(gmailLabels, 'unread'),
+    isStarred: hasLabel(gmailLabels, 'starred'),
+    isTrashed,
+    providerMessageId: `${account}:${rawSha256}`,
+    raw,
+    rawSha256,
+    status: isDraft
+      ? 'draft'
+      : isSpam
+        ? 'quarantined'
+        : isSent
+          ? 'sent'
+          : 'received',
+    systemLabelSlugs,
+  };
+}
+
+export function deterministicUuid(namespace: string, value: string) {
+  const bytes = createHash('sha256')
+    .update(`${namespace}\0${value}`)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x50;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function slugifyGoogleLabel(value: string) {
+  return value
+    .normalize('NFKD')
+    .replaceAll(/[\u0300-\u036f]/gu, '')
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/gu, '-')
+    .replaceAll(/^-|-$/gu, '')
+    .slice(0, 80);
+}

--- a/apps/mail/src/lib/mail/repository/search-pagination.test.ts
+++ b/apps/mail/src/lib/mail/repository/search-pagination.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { loadAllRows } from './search';
+
+describe('mail repository pagination', () => {
+  it('loads every database page beyond the legacy 5,000-row boundary', async () => {
+    const source = Array.from({ length: 7344 }, (_, index) => ({ id: index }));
+    const ranges: Array<[number, number]> = [];
+
+    const rows = await loadAllRows(
+      () => ({
+        range: async (start: number, end: number) => {
+          ranges.push([start, end]);
+          return { data: source.slice(start, end + 1), error: null };
+        },
+      }),
+      'Failed to load test rows'
+    );
+
+    expect(rows).toHaveLength(7344);
+    expect(rows.at(-1)?.id).toBe(7343);
+    expect(ranges).toEqual([
+      [0, 999],
+      [1000, 1999],
+      [2000, 2999],
+      [3000, 3999],
+      [4000, 4999],
+      [5000, 5999],
+      [6000, 6999],
+      [7000, 7999],
+    ]);
+  });
+
+  it('surfaces page failures with repository context', async () => {
+    await expect(
+      loadAllRows(
+        () => ({
+          range: async () => ({
+            data: null,
+            error: { message: 'database unavailable' },
+          }),
+        }),
+        'Failed to list mail messages'
+      )
+    ).rejects.toThrow('Failed to list mail messages: database unavailable');
+  });
+});

--- a/apps/mail/src/lib/mail/repository/search.ts
+++ b/apps/mail/src/lib/mail/repository/search.ts
@@ -12,7 +12,7 @@ const MAX_INLINE_FILTER_IDS = 250;
 const MESSAGE_LIST_COLUMNS =
   'body_text,created_at,direction,from_address,from_name,has_attachments,id,mailbox_id,received_at,sent_at,snippet,status,subject,thread_id';
 const THREAD_SCAN_COLUMNS =
-  'created_at,direction,from_address,from_name,has_attachments,id,mailbox_id,received_at,sent_at,snippet,status,subject,thread_id';
+  'body_text,created_at,direction,from_address,from_name,has_attachments,id,mailbox_id,received_at,sent_at,snippet,status,subject,thread_id';
 
 export async function loadAllRows(
   createQuery: () => AnyRecord,

--- a/apps/mail/src/lib/mail/repository/search.ts
+++ b/apps/mail/src/lib/mail/repository/search.ts
@@ -7,6 +7,30 @@ type SearchResult = {
   total: number;
 };
 
+const DATABASE_PAGE_SIZE = 1000;
+const MAX_INLINE_FILTER_IDS = 250;
+const MESSAGE_LIST_COLUMNS =
+  'body_text,created_at,direction,from_address,from_name,has_attachments,id,mailbox_id,received_at,sent_at,snippet,status,subject,thread_id';
+const THREAD_SCAN_COLUMNS =
+  'created_at,direction,from_address,from_name,has_attachments,id,mailbox_id,received_at,sent_at,snippet,status,subject,thread_id';
+
+export async function loadAllRows(
+  createQuery: () => AnyRecord,
+  errorMessage: string
+) {
+  const rows: AnyRecord[] = [];
+  for (let start = 0; ; start += DATABASE_PAGE_SIZE) {
+    const { data, error } = await createQuery().range(
+      start,
+      start + DATABASE_PAGE_SIZE - 1
+    );
+    if (error) throw new Error(`${errorMessage}: ${error.message}`);
+    const page = data ?? [];
+    rows.push(...page);
+    if (page.length < DATABASE_PAGE_SIZE) return rows;
+  }
+}
+
 function intersectIds(current: Set<string> | null, next: Iterable<string>) {
   const nextSet = new Set(next);
   if (current == null) return nextSet;
@@ -22,14 +46,15 @@ async function recipientMessageIds({
   kind: 'bcc' | 'cc' | 'to';
   value: string;
 }) {
-  const { data, error } = await privateTable(admin, 'mail_recipients')
-    .select('message_id')
-    .eq('kind', kind)
-    .ilike('address', `%${escapeMailLike(value)}%`)
-    .limit(5000);
-  if (error)
-    throw new Error(`Failed to search mail recipients: ${error.message}`);
-  return (data ?? []).map((row: AnyRecord) => row.message_id as string);
+  const rows = await loadAllRows(
+    () =>
+      privateTable(admin, 'mail_recipients')
+        .select('message_id')
+        .eq('kind', kind)
+        .ilike('address', `%${escapeMailLike(value)}%`),
+    'Failed to search mail recipients'
+  );
+  return rows.map((row) => row.message_id as string);
 }
 
 async function labelMessageIds({
@@ -60,13 +85,14 @@ async function labelMessageIds({
     .map((row: AnyRecord) => row.id as string);
   if (labelIds.length === 0) return [];
 
-  const { data, error } = await privateTable(admin, 'mail_message_labels')
-    .select('message_id')
-    .in('label_id', labelIds)
-    .limit(5000);
-  if (error)
-    throw new Error(`Failed to search message labels: ${error.message}`);
-  return (data ?? []).map((row: AnyRecord) => row.message_id as string);
+  const rows = await loadAllRows(
+    () =>
+      privateTable(admin, 'mail_message_labels')
+        .select('message_id')
+        .in('label_id', labelIds),
+    'Failed to search message labels'
+  );
+  return rows.map((row) => row.message_id as string);
 }
 
 async function folderMessageIds({
@@ -76,12 +102,14 @@ async function folderMessageIds({
   admin: AnyRecord;
   folderId: string;
 }) {
-  const { data, error } = await privateTable(admin, 'mail_message_folders')
-    .select('message_id')
-    .eq('folder_id', folderId)
-    .limit(5000);
-  if (error) throw new Error(`Failed to search mail folder: ${error.message}`);
-  return (data ?? []).map((row: AnyRecord) => row.message_id as string);
+  const rows = await loadAllRows(
+    () =>
+      privateTable(admin, 'mail_message_folders')
+        .select('message_id')
+        .eq('folder_id', folderId),
+    'Failed to search mail folder'
+  );
+  return rows.map((row) => row.message_id as string);
 }
 
 function idsWithTimestamp(rows: AnyRecord[], column: string) {
@@ -106,22 +134,16 @@ export async function queryMailMessageRows({
   userId: string;
 }): Promise<SearchResult> {
   const page = Math.max(1, params.page ?? 1);
-  const pageSize = threadScan
-    ? 5000
-    : Math.min(Math.max(1, params.pageSize ?? 40), 100);
+  const pageSize = Math.min(Math.max(1, params.pageSize ?? 40), 100);
   const parsed = parseMailSearch(params.query);
-  const { data: stateRows, error: stateError } = await privateTable(
-    admin,
-    'mail_message_user_state'
-  )
-    .select('message_id, read_at, starred_at, archived_at, trashed_at')
-    .eq('mailbox_id', mailboxId)
-    .eq('user_id', userId)
-    .limit(5000);
-  if (stateError)
-    throw new Error(`Failed to search mail state: ${stateError.message}`);
-
-  const states = stateRows ?? [];
+  const states = await loadAllRows(
+    () =>
+      privateTable(admin, 'mail_message_user_state')
+        .select('message_id, read_at, starred_at, archived_at, trashed_at')
+        .eq('mailbox_id', mailboxId)
+        .eq('user_id', userId),
+    'Failed to search mail state'
+  );
   const readIds = idsWithTimestamp(states, 'read_at');
   const starredIds = idsWithTimestamp(states, 'starred_at');
   const archivedIds = idsWithTimestamp(states, 'archived_at');
@@ -174,55 +196,85 @@ export async function queryMailMessageRows({
   }
   if (includedIds?.size === 0) return { rows: [], total: 0 };
 
-  let query = privateTable(admin, 'mail_messages')
-    .select('*', { count: 'exact' })
-    .eq('mailbox_id', mailboxId);
+  const needsLocalFiltering =
+    threadScan ||
+    (includedIds?.size ?? 0) > MAX_INLINE_FILTER_IDS ||
+    excludedIds.size > MAX_INLINE_FILTER_IDS;
+  const buildQuery = ({ count = false }: { count?: boolean } = {}) => {
+    const source = privateTable(admin, 'mail_messages');
+    let query = (
+      count
+        ? source.select(MESSAGE_LIST_COLUMNS, { count: 'exact' })
+        : source.select(threadScan ? THREAD_SCAN_COLUMNS : MESSAGE_LIST_COLUMNS)
+    ).eq('mailbox_id', mailboxId);
 
-  if (privateToUser) query = query.eq('created_by', userId);
+    if (privateToUser) query = query.eq('created_by', userId);
+    if (params.folder === 'drafts' || parsed.states.includes('draft')) {
+      query = query.eq('status', 'draft');
+    } else if (params.folder === 'sent' || parsed.states.includes('sent')) {
+      query = query.eq('direction', 'outbound').neq('status', 'draft');
+    } else if (params.folder === 'spam') {
+      query = query.eq('status', 'quarantined');
+    } else if (params.folder === 'trash' && !needsLocalFiltering) {
+      query = trashedIds.length
+        ? query.or(`status.eq.quarantined,id.in.(${trashedIds.join(',')})`)
+        : query.eq('status', 'quarantined');
+    } else if (params.folder === 'inbox' || !params.folder) {
+      query = query
+        .eq('direction', 'inbound')
+        .neq('status', 'draft')
+        .neq('status', 'quarantined');
+    }
 
-  if (params.folder === 'drafts' || parsed.states.includes('draft')) {
-    query = query.eq('status', 'draft');
-  } else if (params.folder === 'sent' || parsed.states.includes('sent')) {
-    query = query.eq('direction', 'outbound').neq('status', 'draft');
-  } else if (params.folder === 'spam') {
-    query = query.eq('status', 'quarantined');
-  } else if (params.folder === 'trash') {
-    query = trashedIds.length
-      ? query.or(`status.eq.quarantined,id.in.(${trashedIds.join(',')})`)
-      : query.eq('status', 'quarantined');
-  } else if (params.folder === 'inbox' || !params.folder) {
-    query = query
-      .eq('direction', 'inbound')
-      .neq('status', 'draft')
-      .neq('status', 'quarantined');
-  }
-
-  if (includedIds) query = query.in('id', [...includedIds]);
-  if (excludedIds.size > 0) {
-    query = query.not('id', 'in', `(${[...excludedIds].join(',')})`);
-  }
-  if (parsed.hasAttachment) query = query.eq('has_attachments', true);
-  if (parsed.after)
-    query = query.gte('created_at', `${parsed.after}T00:00:00.000Z`);
-  if (parsed.before)
-    query = query.lt('created_at', `${parsed.before}T00:00:00.000Z`);
-  for (const from of parsed.from) {
-    query = query.ilike('from_address', `%${escapeMailLike(from)}%`);
-  }
-  for (const subject of parsed.subject) {
-    query = query.ilike('subject', `%${escapeMailLike(subject)}%`);
-  }
-  if (parsed.freeText.length > 0) {
-    query = query.textSearch('search_document', parsed.freeText.join(' '), {
-      config: 'simple',
-      type: 'websearch',
-    });
-  }
+    if (!needsLocalFiltering && includedIds)
+      query = query.in('id', [...includedIds]);
+    if (!needsLocalFiltering && excludedIds.size > 0) {
+      query = query.not('id', 'in', `(${[...excludedIds].join(',')})`);
+    }
+    if (parsed.hasAttachment) query = query.eq('has_attachments', true);
+    if (parsed.after)
+      query = query.gte('created_at', `${parsed.after}T00:00:00.000Z`);
+    if (parsed.before)
+      query = query.lt('created_at', `${parsed.before}T00:00:00.000Z`);
+    for (const from of parsed.from) {
+      query = query.ilike('from_address', `%${escapeMailLike(from)}%`);
+    }
+    for (const subject of parsed.subject) {
+      query = query.ilike('subject', `%${escapeMailLike(subject)}%`);
+    }
+    if (parsed.freeText.length > 0) {
+      query = query.textSearch('search_document', parsed.freeText.join(' '), {
+        config: 'simple',
+        type: 'websearch',
+      });
+    }
+    return query.order('created_at', { ascending: false });
+  };
 
   const start = threadScan ? 0 : (page - 1) * pageSize;
-  const { data, error, count } = await query
-    .order('created_at', { ascending: false })
-    .range(start, start + pageSize - 1);
+  if (needsLocalFiltering) {
+    const trashedIdSet = new Set(trashedIds);
+    const rows = (
+      await loadAllRows(buildQuery, 'Failed to list mail messages')
+    ).filter((row) => {
+      const id = row.id as string;
+      if (includedIds && !includedIds.has(id)) return false;
+      if (excludedIds.has(id)) return false;
+      if (params.folder === 'trash') {
+        return row.status === 'quarantined' || trashedIdSet.has(id);
+      }
+      return true;
+    });
+    return {
+      rows: threadScan ? rows : rows.slice(start, start + pageSize),
+      total: rows.length,
+    };
+  }
+
+  const { data, error, count } = await buildQuery({ count: true }).range(
+    start,
+    start + pageSize - 1
+  );
   if (error) throw new Error(`Failed to list mail messages: ${error.message}`);
 
   return { rows: data ?? [], total: count ?? 0 };

--- a/apps/mail/src/lib/mail/repository/search.ts
+++ b/apps/mail/src/lib/mail/repository/search.ts
@@ -51,7 +51,9 @@ async function recipientMessageIds({
       privateTable(admin, 'mail_recipients')
         .select('message_id')
         .eq('kind', kind)
-        .ilike('address', `%${escapeMailLike(value)}%`),
+        .ilike('address', `%${escapeMailLike(value)}%`)
+        .order('message_id')
+        .order('id'),
     'Failed to search mail recipients'
   );
   return rows.map((row) => row.message_id as string);
@@ -89,7 +91,9 @@ async function labelMessageIds({
     () =>
       privateTable(admin, 'mail_message_labels')
         .select('message_id')
-        .in('label_id', labelIds),
+        .in('label_id', labelIds)
+        .order('message_id')
+        .order('label_id'),
     'Failed to search message labels'
   );
   return rows.map((row) => row.message_id as string);
@@ -106,7 +110,8 @@ async function folderMessageIds({
     () =>
       privateTable(admin, 'mail_message_folders')
         .select('message_id')
-        .eq('folder_id', folderId),
+        .eq('folder_id', folderId)
+        .order('message_id'),
     'Failed to search mail folder'
   );
   return rows.map((row) => row.message_id as string);
@@ -141,7 +146,8 @@ export async function queryMailMessageRows({
       privateTable(admin, 'mail_message_user_state')
         .select('message_id, read_at, starred_at, archived_at, trashed_at')
         .eq('mailbox_id', mailboxId)
-        .eq('user_id', userId),
+        .eq('user_id', userId)
+        .order('message_id'),
     'Failed to search mail state'
   );
   const readIds = idsWithTimestamp(states, 'read_at');
@@ -248,7 +254,9 @@ export async function queryMailMessageRows({
         type: 'websearch',
       });
     }
-    return query.order('created_at', { ascending: false });
+    return query
+      .order('created_at', { ascending: false })
+      .order('id', { ascending: false });
   };
 
   const start = threadScan ? 0 : (page - 1) * pageSize;

--- a/apps/mail/src/lib/mail/repository/threads.ts
+++ b/apps/mail/src/lib/mail/repository/threads.ts
@@ -85,11 +85,13 @@ export async function listMailThreads({
     threadScan: true,
     userId: ctx.user.id,
   });
-  const rowIds = rows.map((row: AnyRecord) => row.id as string);
-  const { data: recipientRows, error: recipientError } = rowIds.length
+  const outboundRowIds = rows.flatMap((row: AnyRecord) =>
+    row.direction === 'outbound' ? [row.id as string] : []
+  );
+  const { data: recipientRows, error: recipientError } = outboundRowIds.length
     ? await privateTable(access.admin, 'mail_recipients')
         .select('address, display_name, kind, message_id')
-        .in('message_id', rowIds)
+        .in('message_id', outboundRowIds)
         .in('kind', ['to', 'cc'])
     : { data: [], error: null };
   if (recipientError) {


### PR DESCRIPTION
Google Workspace history could not be imported without flattening labels, message state, threads, and attachments, and the Mail reader stopped scanning after 5,000 rows. This adds a resumable, dry-run-by-default Google Takeout importer backed by R2 and the existing Mail schema, and paginates historical reader scans so Phuc's 7,344-message archive remains reachable.

The verified export dry run reconciles 10,417 raw MBOX messages to 10,412 unique messages after five duplicates, 6,373 threads, 3,262 attachments, and 272,918,842 attachment bytes. Suspended mailboxes remain disabled and receive no memberships; Gmail state is preserved for existing internal profiles.

Validation:
- `bunx vitest run apps/mail/src/lib/mail/import/google-takeout.test.ts apps/mail/src/lib/mail/repository/search-pagination.test.ts apps/mail/src/lib/mail/repository/threads-unread.test.ts apps/mail/src/lib/mail/search.test.ts`
- `bun --cwd apps/mail type-check`
- `NEXT_WEBPACK_BUILD=1 bun x next build --webpack` in `apps/mail`
- `bun check`
- real-data importer dry run against all 18 exported mailboxes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a resumable, dry-run-by-default Google Takeout importer backed by R2 and the existing Mail schema, and paginates historical reader scans so archives beyond 5,000 messages stay fully searchable.

**New Features**
- Runs without `--apply` first and writes a report you can reconcile against an independent MBOX inventory.
- Preserves Gmail thread IDs, original timestamps, and sent/draft/spam/trash/read/star/archive state, and reuses existing custom labels with matching display names.
- Skips existing provider or Internet Message-ID records so an interrupted run can resume safely.
- Processes Deleted MBOX files first so duplicates retain their trash state.
- Does not activate suspended mailboxes or create mailbox memberships.

**Bug Fixes**
- Replaces the 5,000-row `.limit()` on recipient, label, folder, and state lookups with paged scans.
- Applies large message-ID filters locally instead of inline SQL filters to avoid query limits.
- Only fetches recipients for outbound rows when listing threads, and narrows scanned columns to what thread listings need.

<sup>Written for commit 806e2e545e24a413f0f7d001de79228c4388c253. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

