### PR TITLE
fix(tasks): preserve recovered drafts during dialog initialization

### DIFF
--- a/packages/tasks-ui/src/tu-do/drafts/drafts-page.test.tsx
+++ b/packages/tasks-ui/src/tu-do/drafts/drafts-page.test.tsx
@@ -75,10 +75,11 @@ beforeEach(() => {
   saveDraft(savedKey, { name: 'Recover saved draft' });
   saveDraft(ordinaryKey, { name: 'Keep ordinary draft' });
 });
-function mount() {
-  const client = new QueryClient({
+function mount(
+  client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
+  })
+) {
   return render(
     <QueryClientProvider client={client}>
       <DraftsPage wsId="ws-1" />
@@ -93,11 +94,14 @@ it('clears only the matching recovery copy after deletion is confirmed', async (
       resolveDelete = resolve;
     })
   );
-  mount();
+  const client = new QueryClient();
+  mount(client);
   fireEvent.click(
     await screen.findByRole('button', { name: 'Delete saved draft' })
   );
   await waitFor(() => expect(deleteDraft).toHaveBeenCalledOnce());
+  act(() => client.setQueryData(['task-drafts', 'ws-1', 'all', false], []));
+  await screen.findByText('empty');
   expect(localStorage.getItem(savedKey)).not.toBeNull();
   await act(async () => resolveDelete());
   await waitFor(() => expect(localStorage.getItem(savedKey)).toBeNull());

--- a/packages/tasks-ui/src/tu-do/drafts/drafts-page.test.tsx
+++ b/packages/tasks-ui/src/tu-do/drafts/drafts-page.test.tsx
@@ -1,0 +1,130 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { toast } from '@tuturuuu/ui/sonner';
+import { beforeEach, expect, it, vi } from 'vitest';
+import {
+  getDraftStorageKey,
+  saveDraft,
+} from '../shared/task-edit-dialog/utils';
+import type { TaskDraft } from './draft-card';
+import { DraftsPage } from './drafts-page';
+
+const { listDrafts, deleteDraft } = vi.hoisted(() => ({
+  listDrafts: vi.fn(),
+  deleteDraft: vi.fn(),
+}));
+vi.mock('@tuturuuu/internal-api/tasks', () => ({
+  listWorkspaceTaskDrafts: listDrafts,
+  deleteWorkspaceTaskDraft: deleteDraft,
+}));
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+vi.mock('@tuturuuu/ui/sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../providers/task-dialog-provider', () => ({
+  useTaskDialogContext: () => ({ editDraft: vi.fn() }),
+}));
+vi.mock('./draft-card', () => ({
+  DraftCard: ({
+    draft,
+    onDelete,
+    onConvert,
+  }: {
+    draft: TaskDraft;
+    onDelete: (id: string) => void;
+    onConvert: (draft: TaskDraft) => void;
+  }) => (
+    <>
+      <button type="button" onClick={() => onDelete(draft.id)}>
+        Delete saved draft
+      </button>
+      <button type="button" onClick={() => onConvert(draft)}>
+        Convert saved draft
+      </button>
+    </>
+  ),
+}));
+vi.mock('./draft-convert-dialog', () => ({
+  DraftConvertDialog: ({
+    isOpen,
+    onConverted,
+  }: {
+    isOpen: boolean;
+    onConverted: () => void;
+  }) =>
+    isOpen ? (
+      <button type="button" onClick={onConverted}>
+        Confirm converted
+      </button>
+    ) : null,
+}));
+
+const draft = { id: 'saved-1', board_id: 'board-1', name: 'Saved draft' };
+const savedKey = getDraftStorageKey('board-1', 'saved-1');
+const ordinaryKey = getDraftStorageKey('board-1');
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  listDrafts.mockResolvedValue([draft]);
+  saveDraft(savedKey, { name: 'Recover saved draft' });
+  saveDraft(ordinaryKey, { name: 'Keep ordinary draft' });
+});
+function mount() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <DraftsPage wsId="ws-1" />
+    </QueryClientProvider>
+  );
+}
+
+it('clears only the matching recovery copy after deletion is confirmed', async () => {
+  let resolveDelete!: () => void;
+  deleteDraft.mockReturnValueOnce(
+    new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    })
+  );
+  mount();
+  fireEvent.click(
+    await screen.findByRole('button', { name: 'Delete saved draft' })
+  );
+  await waitFor(() => expect(deleteDraft).toHaveBeenCalledOnce());
+  expect(localStorage.getItem(savedKey)).not.toBeNull();
+  await act(async () => resolveDelete());
+  await waitFor(() => expect(localStorage.getItem(savedKey)).toBeNull());
+  expect(JSON.parse(localStorage.getItem(ordinaryKey)!)).toEqual({
+    name: 'Keep ordinary draft',
+  });
+});
+
+it('keeps recovery data when deletion fails', async () => {
+  deleteDraft.mockRejectedValueOnce(new Error('Unavailable'));
+  mount();
+  fireEvent.click(
+    await screen.findByRole('button', { name: 'Delete saved draft' })
+  );
+  await waitFor(() =>
+    expect(toast.error).toHaveBeenCalledWith('delete_failed')
+  );
+  expect(localStorage.getItem(savedKey)).not.toBeNull();
+  expect(localStorage.getItem(ordinaryKey)).not.toBeNull();
+});
+
+it('clears the converted draft recovery without removing another board draft', async () => {
+  mount();
+  fireEvent.click(
+    await screen.findByRole('button', { name: 'Convert saved draft' })
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Confirm converted' }));
+  expect(localStorage.getItem(savedKey)).toBeNull();
+  expect(localStorage.getItem(ordinaryKey)).not.toBeNull();
+});

--- a/packages/tasks-ui/src/tu-do/drafts/drafts-page.tsx
+++ b/packages/tasks-ui/src/tu-do/drafts/drafts-page.tsx
@@ -56,12 +56,10 @@ export function DraftsPage({
   });
 
   const deleteMutation = useMutation({
-    mutationFn: async (draftId: string) =>
-      deleteWorkspaceTaskDraft(wsId, draftId, getBrowserInternalApiOptions()),
-    onSuccess: (_result, draftId) => {
-      const deletedDraft = drafts.find((draft) => draft.id === draftId);
-      if (deletedDraft)
-        clearDraft(getDraftStorageKey(deletedDraft.board_id ?? '', draftId));
+    mutationFn: async (draft: TaskDraft) =>
+      deleteWorkspaceTaskDraft(wsId, draft.id, getBrowserInternalApiOptions()),
+    onSuccess: (_result, draft) => {
+      clearDraft(getDraftStorageKey(draft.board_id ?? '', draft.id));
       queryClient.invalidateQueries({ queryKey: ['task-drafts', wsId] });
       toast.success(t('deleted_success'));
     },
@@ -115,7 +113,7 @@ export function DraftsPage({
             onConvert={setConvertDraft}
             onEdit={handleEdit}
             onClick={handleEdit}
-            onDelete={(id) => deleteMutation.mutate(id)}
+            onDelete={() => deleteMutation.mutate(draft)}
             isDeleting={deleteMutation.isPending}
           />
         ))}

--- a/packages/tasks-ui/src/tu-do/drafts/drafts-page.tsx
+++ b/packages/tasks-ui/src/tu-do/drafts/drafts-page.tsx
@@ -10,6 +10,10 @@ import { toast } from '@tuturuuu/ui/sonner';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { useTaskDialogContext } from '../providers/task-dialog-provider';
+import {
+  clearDraft,
+  getDraftStorageKey,
+} from '../shared/task-edit-dialog/utils';
 import { DraftCard, type TaskDraft } from './draft-card';
 import { DraftConvertDialog } from './draft-convert-dialog';
 
@@ -54,7 +58,10 @@ export function DraftsPage({
   const deleteMutation = useMutation({
     mutationFn: async (draftId: string) =>
       deleteWorkspaceTaskDraft(wsId, draftId, getBrowserInternalApiOptions()),
-    onSuccess: () => {
+    onSuccess: (_result, draftId) => {
+      const deletedDraft = drafts.find((draft) => draft.id === draftId);
+      if (deletedDraft)
+        clearDraft(getDraftStorageKey(deletedDraft.board_id ?? '', draftId));
       queryClient.invalidateQueries({ queryKey: ['task-drafts', wsId] });
       toast.success(t('deleted_success'));
     },
@@ -64,6 +71,10 @@ export function DraftsPage({
   });
 
   const handleConverted = () => {
+    if (convertDraft)
+      clearDraft(
+        getDraftStorageKey(convertDraft.board_id ?? '', convertDraft.id)
+      );
     queryClient.invalidateQueries({ queryKey: ['task-drafts', wsId] });
     setConvertDraft(null);
   };

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog.tsx
@@ -1172,8 +1172,8 @@ export function TaskEditDialog({
     onUpdate,
   });
 
-  // Form reset
   useTaskFormReset({
+    boardId,
     isOpen,
     isCreateMode,
     task,

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog.tsx
@@ -298,8 +298,8 @@ export function TaskEditDialog({
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  // Form state
   const formState = useTaskFormState({
+    draftId,
     task,
     boardId,
     isOpen,
@@ -939,9 +939,8 @@ export function TaskEditDialog({
     formState.autoSchedule,
   ]);
 
-  const draftStorageKey = getDraftStorageKey(boardId);
+  const draftStorageKey = getDraftStorageKey(boardId, draftId);
 
-  // Suggestion menus
   const suggestionMenus = useSuggestionMenus({
     editorInstance,
     isOpen,
@@ -959,7 +958,6 @@ export function TaskEditDialog({
     setShowAdvancedOptions,
   });
 
-  // Change detection
   const { hasUnsavedChanges, canSave } = useTaskChangeDetection({
     task,
     name: formState.name,
@@ -1162,6 +1160,7 @@ export function TaskEditDialog({
     savingRelationship,
     pendingRelationships,
   } = useTaskDependencies({
+    draftId,
     isOpen,
     taskId: task?.id,
     boardId,
@@ -1173,6 +1172,7 @@ export function TaskEditDialog({
   });
 
   useTaskFormReset({
+    draftId,
     boardId,
     isOpen,
     isCreateMode,

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-pending-task-relationships.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-pending-task-relationships.test.tsx
@@ -43,3 +43,21 @@ it('reloads relationships across editing sessions while preserving changes durin
   expect(result.current.pendingParent).toBeNull();
   expect(result.current.pendingChildren).toEqual([]);
 });
+
+it('does not inherit a board recovery relationship when opening a saved draft', () => {
+  saveDraft(getDraftStorageKey('board-1'), {
+    pendingTaskRelationships: getSeededPendingTaskRelationships({
+      parentTaskId: 'other-local-parent',
+    }),
+  });
+  const { result } = renderHook(() =>
+    usePendingTaskRelationships({
+      boardId: 'board-1',
+      wsId: 'ws-1',
+      draftId: 'saved-draft',
+      isCreateMode: true,
+      isOpen: true,
+    })
+  );
+  expect(result.current.pendingParent).toBeNull();
+});

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-pending-task-relationships.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-pending-task-relationships.ts
@@ -6,6 +6,7 @@ import { dedupeById } from './task-create-relationships';
 
 export function usePendingTaskRelationships({
   taskId,
+  draftId,
   boardId,
   wsId,
   isCreateMode,
@@ -13,6 +14,7 @@ export function usePendingTaskRelationships({
   seededRelationships,
 }: {
   taskId?: string;
+  draftId?: string;
   boardId: string;
   wsId: string;
   isCreateMode: boolean;
@@ -24,6 +26,7 @@ export function usePendingTaskRelationships({
     boardId,
     isCreateMode,
     taskId,
+    draftId,
     isOpen,
     seededRelationships?.parentTask?.id,
     seededRelationships?.childTasks.map((task) => task.id),
@@ -33,8 +36,8 @@ export function usePendingTaskRelationships({
   ]);
   const readInitial = () =>
     isCreateMode
-      ? (loadDraft(getDraftStorageKey(boardId))?.pendingTaskRelationships ??
-        seededRelationships)
+      ? (loadDraft(getDraftStorageKey(boardId, draftId))
+          ?.pendingTaskRelationships ?? seededRelationships)
       : undefined;
   const [session, setSession] = useState(sessionKey);
   const [initialPendingRelationships, setInitial] = useState(readInitial);

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-dependencies.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-dependencies.ts
@@ -39,6 +39,7 @@ import { usePendingTaskRelationships } from './use-pending-task-relationships';
  */
 export function useTaskDependencies({
   taskId,
+  draftId,
   boardId,
   wsId,
   listId,
@@ -69,6 +70,7 @@ export function useTaskDependencies({
     pendingRelated,
     setPendingRelated,
   } = usePendingTaskRelationships({
+    draftId,
     taskId,
     boardId,
     wsId,
@@ -145,9 +147,7 @@ export function useTaskDependencies({
     [taskId, wsId, queryClient, onUpdate, broadcast]
   );
 
-  // =========================================================================
   // Parent Task Operations
-  // =========================================================================
 
   const setParentTask = useCallback(
     async (task: RelatedTaskInfo | null) => {

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-draft-reopen.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-draft-reopen.test.tsx
@@ -91,6 +91,7 @@ it('keeps a server-backed draft separate from the board creation recovery draft'
     id: 'draft-server-1',
     name: 'Server draft',
     list_id: 'list-1',
+    assignees: [{ id: 'server-assignee' }],
   } as Task;
   const { result } = renderHook(() => {
     const props = {
@@ -102,10 +103,11 @@ it('keeps a server-backed draft separate from the board creation recovery draft'
       isSaving: false,
     };
     const form = useTaskFormState(props);
-    useTaskFormReset({ ...form, ...props });
+    useTaskFormReset({ ...form, ...props, filters: filtersWithAssignee });
     return form;
   });
   expect(result.current.name).toBe('Server draft');
+  expect(result.current.selectedAssignees).toEqual([{ id: 'server-assignee' }]);
   act(() => {
     result.current.setName('Edited server draft');
     vi.runAllTimers();

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-draft-reopen.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-draft-reopen.test.tsx
@@ -6,7 +6,20 @@ import { getDraftStorageKey, saveDraft } from '../utils';
 import { useTaskFormReset } from './use-task-form-reset';
 import { useTaskFormState } from './use-task-form-state';
 
+const { getUser, getProfile } = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  getProfile: vi.fn(),
+}));
+vi.mock('@tuturuuu/supabase/next/client', () => ({
+  createClient: () => ({ auth: { getUser } }),
+}));
+vi.mock('@tuturuuu/internal-api', async (original) => ({
+  ...(await original<typeof import('@tuturuuu/internal-api')>()),
+  getCurrentUserProfile: getProfile,
+}));
+
 beforeEach(() => {
+  vi.clearAllMocks();
   localStorage.clear();
   vi.useFakeTimers();
 });
@@ -64,5 +77,95 @@ it.each([undefined, filtersWithAssignee])(
     expect(result.current.selectedAssignees).toEqual(draft.selectedAssignees);
     expect(result.current.selectedProjects).toEqual(draft.selectedProjects);
     expect(JSON.parse(localStorage.getItem(key)!)).toMatchObject(draft);
+  }
+);
+
+it('keeps a server-backed draft separate from the board creation recovery draft', () => {
+  const boardKey = getDraftStorageKey('board-1');
+  const localDraft = {
+    name: 'Unsubmitted local task',
+    persistedTask: { id: 'local-row' },
+  };
+  saveDraft(boardKey, localDraft);
+  const task = {
+    id: 'draft-server-1',
+    name: 'Server draft',
+    list_id: 'list-1',
+  } as Task;
+  const { result } = renderHook(() => {
+    const props = {
+      boardId: 'board-1',
+      draftId: 'server-1',
+      task,
+      isOpen: true,
+      isCreateMode: true,
+      isSaving: false,
+    };
+    const form = useTaskFormState(props);
+    useTaskFormReset({ ...form, ...props });
+    return form;
+  });
+  expect(result.current.name).toBe('Server draft');
+  act(() => {
+    result.current.setName('Edited server draft');
+    vi.runAllTimers();
+  });
+  act(() => vi.runAllTimers());
+  expect(JSON.parse(localStorage.getItem(boardKey)!)).toEqual(localDraft);
+  expect(
+    JSON.parse(localStorage.getItem(getDraftStorageKey('board-1', 'server-1'))!)
+      .name
+  ).toBe('Edited server draft');
+});
+
+it.each(['recover', 'unmount'])(
+  'ignores an old auto-assignment lookup after %s',
+  async (mode) => {
+    let resolveUser!: (value: { data: { user: { id: string } } }) => void;
+    getUser.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveUser = resolve;
+      })
+    );
+    getProfile.mockResolvedValue({ id: 'me', display_name: 'Me' });
+    const task = { id: 'new', name: '', list_id: 'list-1' } as Task;
+    const filters = {
+      ...filtersWithAssignee,
+      assignees: [],
+      includeMyTasks: true,
+    };
+    const { result, rerender, unmount } = renderHook(
+      ({ isOpen }) => {
+        const props = {
+          boardId: 'board-1',
+          task,
+          isOpen,
+          isCreateMode: true,
+          isSaving: false,
+        };
+        const form = useTaskFormState(props);
+        useTaskFormReset({ ...form, ...props, filters });
+        return form;
+      },
+      { initialProps: { isOpen: true } }
+    );
+    expect(getUser).toHaveBeenCalledOnce();
+    if (mode === 'unmount') unmount();
+    else {
+      rerender({ isOpen: false });
+      saveDraft(getDraftStorageKey('board-1'), {
+        name: 'Recovered',
+        selectedAssignees: [{ id: 'recovered-assignee' }],
+      });
+      rerender({ isOpen: true });
+    }
+    await act(async () => {
+      resolveUser({ data: { user: { id: 'me' } } });
+    });
+    expect(getProfile).not.toHaveBeenCalled();
+    if (mode === 'recover')
+      expect(result.current.selectedAssignees).toEqual([
+        { id: 'recovered-assignee' },
+      ]);
   }
 );

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-draft-reopen.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-draft-reopen.test.tsx
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react';
+import type { Task } from '@tuturuuu/types/primitives/Task';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { TaskFilters } from '../../types';
+import { getDraftStorageKey, saveDraft } from '../utils';
+import { useTaskFormReset } from './use-task-form-reset';
+import { useTaskFormState } from './use-task-form-state';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+afterEach(() => vi.useRealTimers());
+
+const filtersWithAssignee: TaskFilters = {
+  labels: [],
+  assignees: [{ id: 'filter-assignee', display_name: null }],
+  projects: [],
+  priorities: [],
+  dueDateRange: null,
+  estimationRange: null,
+  includeMyTasks: false,
+  includeUnassigned: false,
+  sourceScope: 'all_visible',
+  sourceWorkspaceIds: [],
+  sourceBoardIds: [],
+};
+
+it.each([undefined, filtersWithAssignee])(
+  'retains a recovered draft when the real dialog reset hook also mounts with filters %j',
+  (filters) => {
+    const task = { id: 'new', name: '', list_id: 'default-list' } as Task;
+    const draft = {
+      name: 'Recover this task',
+      selectedListId: 'saved-list',
+      selectedAssignees: [{ id: 'saved-assignee' }],
+      selectedProjects: [{ id: 'saved-project', name: 'Saved project' }],
+      persistedTask: { id: 'confirmed-row' },
+      persistedWorkspaceId: 'ws-1',
+    };
+    const key = getDraftStorageKey('board-1');
+    saveDraft(key, draft);
+    const { result } = renderHook(() => {
+      const form = useTaskFormState({
+        task,
+        boardId: 'board-1',
+        isOpen: true,
+        isCreateMode: true,
+        isSaving: false,
+      });
+      useTaskFormReset({
+        ...form,
+        boardId: 'board-1',
+        filters,
+        task,
+        isOpen: true,
+        isCreateMode: true,
+      });
+      return form;
+    });
+    act(() => vi.runAllTimers());
+    expect(result.current.name).toBe(draft.name);
+    expect(result.current.selectedListId).toBe(draft.selectedListId);
+    expect(result.current.selectedAssignees).toEqual(draft.selectedAssignees);
+    expect(result.current.selectedProjects).toEqual(draft.selectedProjects);
+    expect(JSON.parse(localStorage.getItem(key)!)).toMatchObject(draft);
+  }
+);

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-form-reset.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-form-reset.ts
@@ -8,7 +8,12 @@ import type React from 'react';
 import { useEffect, useRef } from 'react';
 import type { TaskFilters } from '../../types';
 import type { WorkspaceTaskLabel } from '../types';
-import { getDescriptionContent } from '../utils';
+import {
+  getDescriptionContent,
+  getDraftStorageKey,
+  hasDraftContent,
+  loadDraft,
+} from '../utils';
 
 // Module-level singleton to avoid repeated instantiation
 const supabase = createClient();
@@ -26,6 +31,7 @@ export interface WorkspaceProject {
 }
 
 export interface UseTaskFormResetProps {
+  boardId?: string;
   isOpen: boolean;
   isCreateMode: boolean;
   task?: Task;
@@ -53,6 +59,7 @@ export interface UseTaskFormResetProps {
 }
 
 export function useTaskFormReset({
+  boardId,
   isOpen,
   isCreateMode,
   task,
@@ -82,6 +89,17 @@ export function useTaskFormReset({
       previousTaskHydrationVersionRef.current !== taskHydrationVersion;
     const justOpened = isOpen && !previousIsOpenRef.current;
     previousIsOpenRef.current = isOpen;
+    // useTaskFormState restores this draft in the same effect flush. Preserve
+    // its values instead of replacing them with the empty creation placeholder.
+    if (
+      isOpen &&
+      isCreateMode &&
+      boardId &&
+      hasDraftContent(loadDraft(getDraftStorageKey(boardId)) ?? {})
+    ) {
+      previousTaskIdRef.current = task?.id ?? null;
+      return;
+    }
 
     // Helper to check if filters have any active values
     const hasActiveFilters =
@@ -133,6 +151,7 @@ export function useTaskFormReset({
       if (task?.id) previousTaskIdRef.current = task.id;
     }
   }, [
+    boardId,
     isCreateMode,
     isOpen,
     task,
@@ -161,6 +180,13 @@ export function useTaskFormReset({
   useEffect(() => {
     isMountedRef.current = true;
 
+    if (
+      isOpen &&
+      isCreateMode &&
+      boardId &&
+      hasDraftContent(loadDraft(getDraftStorageKey(boardId)) ?? {})
+    )
+      return;
     if (isOpen && isCreateMode && filters) {
       // Apply labels from filters
       if (filters.labels && filters.labels.length > 0) {
@@ -220,6 +246,7 @@ export function useTaskFormReset({
       isMountedRef.current = false;
     };
   }, [
+    boardId,
     isOpen,
     isCreateMode,
     filters,

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-form-reset.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-form-reset.ts
@@ -185,7 +185,7 @@ export function useTaskFormReset({
     const hasRecoveryDraft =
       boardId &&
       hasDraftContent(loadDraft(getDraftStorageKey(boardId, draftId)) ?? {});
-    if (isOpen && isCreateMode && filters && !hasRecoveryDraft) {
+    if (isOpen && isCreateMode && filters && !draftId && !hasRecoveryDraft) {
       // Apply labels from filters
       if (filters.labels && filters.labels.length > 0) {
         setSelectedLabels(filters.labels);

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-form-reset.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-form-reset.ts
@@ -32,6 +32,7 @@ export interface WorkspaceProject {
 
 export interface UseTaskFormResetProps {
   boardId?: string;
+  draftId?: string;
   isOpen: boolean;
   isCreateMode: boolean;
   task?: Task;
@@ -60,6 +61,7 @@ export interface UseTaskFormResetProps {
 
 export function useTaskFormReset({
   boardId,
+  draftId,
   isOpen,
   isCreateMode,
   task,
@@ -80,7 +82,6 @@ export function useTaskFormReset({
   const previousTaskIdRef = useRef<string | null>(null);
   const previousTaskHydrationVersionRef = useRef<number>(taskHydrationVersion);
   const previousIsOpenRef = useRef<boolean>(false);
-  const isMountedRef = useRef(true);
 
   // Reset form when task changes or dialog opens
   useEffect(() => {
@@ -95,7 +96,7 @@ export function useTaskFormReset({
       isOpen &&
       isCreateMode &&
       boardId &&
-      hasDraftContent(loadDraft(getDraftStorageKey(boardId)) ?? {})
+      hasDraftContent(loadDraft(getDraftStorageKey(boardId, draftId)) ?? {})
     ) {
       previousTaskIdRef.current = task?.id ?? null;
       return;
@@ -152,6 +153,7 @@ export function useTaskFormReset({
     }
   }, [
     boardId,
+    draftId,
     isCreateMode,
     isOpen,
     task,
@@ -178,16 +180,12 @@ export function useTaskFormReset({
 
   // Apply filters when dialog opens in create mode
   useEffect(() => {
-    isMountedRef.current = true;
+    let cancelled = false;
 
-    if (
-      isOpen &&
-      isCreateMode &&
+    const hasRecoveryDraft =
       boardId &&
-      hasDraftContent(loadDraft(getDraftStorageKey(boardId)) ?? {})
-    )
-      return;
-    if (isOpen && isCreateMode && filters) {
+      hasDraftContent(loadDraft(getDraftStorageKey(boardId, draftId)) ?? {});
+    if (isOpen && isCreateMode && filters && !hasRecoveryDraft) {
       // Apply labels from filters
       if (filters.labels && filters.labels.length > 0) {
         setSelectedLabels(filters.labels);
@@ -209,13 +207,13 @@ export function useTaskFormReset({
               data: { user },
             } = await supabase.auth.getUser();
 
-            if (!user || !isMountedRef.current) {
+            if (!user || cancelled) {
               return;
             }
 
             const userData = await getCurrentUserProfile().catch(() => null);
 
-            if (userData && isMountedRef.current) {
+            if (userData && !cancelled) {
               setSelectedAssignees([
                 {
                   user_id: user.id,
@@ -243,10 +241,11 @@ export function useTaskFormReset({
     }
 
     return () => {
-      isMountedRef.current = false;
+      cancelled = true;
     };
   }, [
     boardId,
+    draftId,
     isOpen,
     isCreateMode,
     filters,

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-form-state.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-form-state.ts
@@ -16,6 +16,7 @@ import {
 interface UseTaskFormStateProps {
   task?: Task;
   boardId: string;
+  draftId?: string;
   isOpen: boolean;
   isCreateMode: boolean;
   isSaving: boolean;
@@ -24,6 +25,7 @@ interface UseTaskFormStateProps {
 export function useTaskFormState({
   task,
   boardId,
+  draftId,
   isOpen,
   isCreateMode,
   isSaving,
@@ -81,7 +83,7 @@ export function useTaskFormState({
   // Draft state
   const [hasDraft, setHasDraft] = useState(false);
   const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const draftStorageKey = getDraftStorageKey(boardId);
+  const draftStorageKey = getDraftStorageKey(boardId, draftId);
   const skipDraftSaveRef = useRef(false);
 
   // Get current form state

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-save.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/hooks/use-task-save.ts
@@ -660,7 +660,7 @@ async function handleSaveAsDraft({
       throw new Error(err.error || 'Failed to save draft');
     }
 
-    clearDraft(getDraftStorageKey(boardId));
+    clearDraft(getDraftStorageKey(boardId, draftId));
 
     // Invalidate drafts query so the drafts page updates
     await queryClient.invalidateQueries({ queryKey: ['task-drafts'] });

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/types/task-dependencies.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/types/task-dependencies.ts
@@ -6,6 +6,7 @@ import type { PendingTaskRelationships } from './pending-relationship';
 
 export interface UseTaskDependenciesProps {
   taskId?: string;
+  draftId?: string;
   boardId: string;
   wsId: string;
   listId?: string;

--- a/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/utils.ts
+++ b/packages/tasks-ui/src/tu-do/shared/task-edit-dialog/utils.ts
@@ -516,8 +516,8 @@ export function getTaskDescriptionPreviewText(
 /**
  * Generate draft storage key for a board
  */
-export function getDraftStorageKey(boardId: string): string {
-  return `tu-do:task-draft:${boardId}`;
+export function getDraftStorageKey(boardId: string, draftId?: string): string {
+  return `tu-do:task-draft:${boardId}${draftId ? `:saved:${draftId}` : ''}`;
 }
 
 /**


### PR DESCRIPTION
Opening a saved creation draft hydrates its content, but the dialog reset hook then replaces it with the empty new-task placeholder. Active board filters can overwrite the recovered assignments. A combined-hook regression reproduced the empty task name before this fix.

Preserve the matching recovery draft during initialization. Saved server drafts have separate recovery keys, and creation filters never replace their saved fields. The scoped key is shared by the form, relationships, and successful-save cleanup. Effect-scoped cancellation prevents stale auto-assignment requests from overwriting recovered fields or updating an unmounted form.

Saved server drafts always use the draft-update save path in TaskEditDialog. Conversion happens separately through DraftConvertDialog and DraftsPage; the confirmed conversion and deletion callbacks now clear only the matching recovery copy. Failed deletion retains it. Cleanup uses the submitted draft identity even if a background refresh removes its list row before the response arrives. Ordinary board drafts remain untouched.

This completes the reopen recovery path introduced by #5237.

Validation:
- 27 focused task/draft tests cover recovery with filters, saved-draft storage isolation, stale async requests, delayed or failed deletion, conversion cleanup, relationship recovery, close guards, and partial-save retries.
- Tasks UI type checking and the final Tasks production Webpack build pass.
- `bun check --run-all`: tests and every non-type gate pass. The remaining local type errors are generated Tasks `.next/types` checks against unchanged API signatures after building; no authored source type errors remain.

