### PR TITLE
fix(mail): harden Takeout imports and simplify Meet actions

### DIFF
--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -179,6 +179,11 @@ export async function ensureImportLabels({
   customLabels: Map<string, string>;
   mailboxId: string;
 }) {
+  const safeCustomLabels = [...customLabels].map(([generatedSlug, name]) => ({
+    generatedSlug,
+    name: sanitizePostgrestPayload(name),
+    slug: sanitizePostgrestPayload(generatedSlug),
+  }));
   const system = [
     ['Inbox', 'inbox'],
     ['Sent', 'sent'],
@@ -203,7 +208,7 @@ export async function ensureImportLabels({
   const existingByName = new Map(
     (existing ?? []).map((row: AnyRecord) => [String(row.name), row])
   );
-  const custom = [...customLabels].flatMap(([slug, name]) =>
+  const custom = safeCustomLabels.flatMap(({ name, slug }) =>
     existingByName.has(name)
       ? []
       : [
@@ -230,7 +235,7 @@ export async function ensureImportLabels({
   const importedByName = new Map(
     (data ?? []).map((row: AnyRecord) => [String(row.name), String(row.id)])
   );
-  for (const [generatedSlug, name] of customLabels) {
+  for (const { generatedSlug, name } of safeCustomLabels) {
     const id = importedByName.get(name);
     if (id) labelIds.set(generatedSlug, id);
   }

--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -80,12 +80,18 @@ export function sanitizePostgrestPayload<T>(value: T): T {
     return value.map(sanitizePostgrestPayload) as T;
   }
   if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [
-        sanitizePostgrestPayload(key),
-        sanitizePostgrestPayload(entry),
-      ])
-    ) as T;
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const baseKey = sanitizePostgrestPayload(key);
+      let safeKey = baseKey;
+      let duplicate = 2;
+      while (Object.hasOwn(sanitized, safeKey)) {
+        safeKey = `${baseKey} [import duplicate ${duplicate}]`;
+        duplicate += 1;
+      }
+      sanitized[safeKey] = sanitizePostgrestPayload(entry);
+    }
+    return sanitized as T;
   }
   return value;
 }
@@ -208,18 +214,18 @@ export async function ensureImportLabels({
   const existingByName = new Map(
     (existing ?? []).map((row: AnyRecord) => [String(row.name), row])
   );
-  const custom = safeCustomLabels.flatMap(({ name, slug }) =>
-    existingByName.has(name)
-      ? []
-      : [
-          {
-            kind: 'custom',
-            mailbox_id: mailboxId,
-            name,
-            slug,
-          },
-        ]
-  );
+  const newCustomByName = new Map<string, AnyRecord>();
+  for (const { name, slug } of safeCustomLabels) {
+    if (!existingByName.has(name) && !newCustomByName.has(name)) {
+      newCustomByName.set(name, {
+        kind: 'custom',
+        mailbox_id: mailboxId,
+        name,
+        slug,
+      });
+    }
+  }
+  const custom = [...newCustomByName.values()];
   const { error } = await table(admin, 'mail_labels').upsert(
     [...system, ...custom],
     { onConflict: 'mailbox_id,slug' }

--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -69,6 +69,31 @@ function table(admin: AnyRecord, name: string) {
   return admin.schema('private').from(name);
 }
 
+export function sanitizePostgrestPayload<T>(value: T): T {
+  if (typeof value === 'string') {
+    return value.replaceAll(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/gu,
+      '\uFFFD'
+    ) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizePostgrestPayload) as T;
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        sanitizePostgrestPayload(key),
+        sanitizePostgrestPayload(entry),
+      ])
+    ) as T;
+  }
+  return value;
+}
+
+function importRows<T>(rows: T) {
+  return sanitizePostgrestPayload(rows);
+}
+
 export function escapeLikePattern(value: string) {
   return value.replaceAll(/([\\%_])/gu, '\\$1');
 }
@@ -274,7 +299,7 @@ export async function persistImportBatch({
     message.storedObjects.map((object) => ({ ...object, message_id: null }))
   );
   let result = await table(admin, 'mail_stored_objects').upsert(
-    initialObjects,
+    importRows(initialObjects),
     {
       onConflict: 'id',
     }
@@ -282,93 +307,104 @@ export async function persistImportBatch({
   if (result.error) throw result.error;
 
   result = await table(admin, 'mail_raw_messages').upsert(
-    messages.map((message) => ({
-      id: message.rawMessageId,
-      provider: 'google_takeout',
-      provider_message_id: message.providerMessageId,
-      provider_payload: {
-        account: message.account,
-        gmailLabels: message.gmailLabels,
-        gmailThreadId: message.gmailThreadId,
-        source: 'google_workspace_export',
-      },
-      raw_headers: headerRecord(message.email),
-      sha256: message.rawSha256,
-      size_bytes: message.raw.byteLength,
-      status: 'imported',
-      stored_object_id: message.storedObjects[0]?.id ?? null,
-      created_at: message.date,
-    })),
+    importRows(
+      messages.map((message) => ({
+        id: message.rawMessageId,
+        provider: 'google_takeout',
+        provider_message_id: message.providerMessageId,
+        provider_payload: {
+          account: message.account,
+          gmailLabels: message.gmailLabels,
+          gmailThreadId: message.gmailThreadId,
+          source: 'google_workspace_export',
+        },
+        raw_headers: headerRecord(message.email),
+        sha256: message.rawSha256,
+        size_bytes: message.raw.byteLength,
+        status: 'imported',
+        stored_object_id: message.storedObjects[0]?.id ?? null,
+        created_at: message.date,
+      }))
+    ),
     { onConflict: 'id' }
   );
   if (result.error) throw result.error;
 
-  result = await table(admin, 'mail_threads').upsert(threadRows, {
+  result = await table(admin, 'mail_threads').upsert(importRows(threadRows), {
     ignoreDuplicates: true,
     onConflict: 'id',
   });
   if (result.error) throw result.error;
 
   result = await table(admin, 'mail_messages').upsert(
-    messages.map((message) => {
-      const from = mailboxAddress(message.email.from);
-      const sanitizedHtml = message.email.html
-        ? sanitizeMailHtml(message.email.html)
-        : null;
-      const bodyText =
-        message.email.text ?? (sanitizedHtml ? stripHtml(sanitizedHtml) : null);
-      return {
-        body_html: message.email.html ?? null,
-        body_text: bodyText,
-        created_at: message.date,
-        direction: message.direction,
-        from_address:
-          from?.address?.trim().toLowerCase() ?? 'unknown@example.invalid',
-        from_name: from?.name?.trim() || null,
-        has_attachments: message.attachmentRows.length > 0,
-        id: message.messageId,
-        in_reply_to: message.email.inReplyTo ?? null,
-        internet_message_id: message.email.messageId ?? null,
-        mailbox_id: message.mailboxId,
-        metadata: {
-          googleTakeout: {
-            gmailLabels: message.gmailLabels,
-            gmailThreadId: message.gmailThreadId,
-            rawSha256: message.rawSha256,
+    importRows(
+      messages.map((message) => {
+        const from = mailboxAddress(message.email.from);
+        const sanitizedHtml = message.email.html
+          ? sanitizeMailHtml(message.email.html)
+          : null;
+        const bodyText =
+          message.email.text ??
+          (sanitizedHtml ? stripHtml(sanitizedHtml) : null);
+        return {
+          body_html: message.email.html ?? null,
+          body_text: bodyText,
+          created_at: message.date,
+          direction: message.direction,
+          from_address:
+            from?.address?.trim().toLowerCase() ?? 'unknown@example.invalid',
+          from_name: from?.name?.trim() || null,
+          has_attachments: message.attachmentRows.length > 0,
+          id: message.messageId,
+          in_reply_to: message.email.inReplyTo ?? null,
+          internet_message_id: message.email.messageId ?? null,
+          mailbox_id: message.mailboxId,
+          metadata: {
+            googleTakeout: {
+              gmailLabels: message.gmailLabels,
+              gmailThreadId: message.gmailThreadId,
+              rawSha256: message.rawSha256,
+            },
           },
-        },
-        provider: 'google_takeout',
-        provider_message_id: message.providerMessageId,
-        raw_message_id: message.rawMessageId,
-        received_at: message.direction === 'inbound' ? message.date : null,
-        references_headers:
-          message.email.references?.split(/\s+/u).filter(Boolean) ?? [],
-        sanitized_html: sanitizedHtml,
-        sent_at: message.direction === 'outbound' ? message.date : null,
-        size_bytes: message.raw.byteLength,
-        snippet: createSnippet({ html: sanitizedHtml, text: bodyText }),
-        status: message.status,
-        subject: message.email.subject?.trim() || '(no subject)',
-        thread_id: message.threadId,
-        updated_at: message.date,
-      };
-    }),
+          provider: 'google_takeout',
+          provider_message_id: message.providerMessageId,
+          raw_message_id: message.rawMessageId,
+          received_at: message.direction === 'inbound' ? message.date : null,
+          references_headers:
+            message.email.references?.split(/\s+/u).filter(Boolean) ?? [],
+          sanitized_html: sanitizedHtml,
+          sent_at: message.direction === 'outbound' ? message.date : null,
+          size_bytes: message.raw.byteLength,
+          snippet: createSnippet({ html: sanitizedHtml, text: bodyText }),
+          status: message.status,
+          subject: message.email.subject?.trim() || '(no subject)',
+          thread_id: message.threadId,
+          updated_at: message.date,
+        };
+      })
+    ),
     { onConflict: 'id' }
   );
   if (result.error) throw result.error;
 
   const recipients = messages.flatMap(recipientRows);
   if (recipients.length) {
-    result = await table(admin, 'mail_recipients').upsert(recipients, {
-      onConflict: 'id',
-    });
+    result = await table(admin, 'mail_recipients').upsert(
+      importRows(recipients),
+      {
+        onConflict: 'id',
+      }
+    );
     if (result.error) throw result.error;
   }
   const attachments = messages.flatMap((message) => message.attachmentRows);
   if (attachments.length) {
-    result = await table(admin, 'mail_attachments').upsert(attachments, {
-      onConflict: 'id',
-    });
+    result = await table(admin, 'mail_attachments').upsert(
+      importRows(attachments),
+      {
+        onConflict: 'id',
+      }
+    );
     if (result.error) throw result.error;
   }
   const messageLabels = messages.flatMap((message) =>
@@ -380,28 +416,31 @@ export async function persistImportBatch({
     })
   );
   if (messageLabels.length) {
-    result = await table(admin, 'mail_message_labels').upsert(messageLabels, {
-      onConflict: 'message_id,label_id',
-    });
+    result = await table(admin, 'mail_message_labels').upsert(
+      importRows(messageLabels),
+      { onConflict: 'message_id,label_id' }
+    );
     if (result.error) throw result.error;
   }
   if (mailboxOwnerId) {
     result = await table(admin, 'mail_message_user_state').upsert(
-      messages.map((message) => ({
-        archived_at: message.isArchived ? message.date : null,
-        mailbox_id: message.mailboxId,
-        message_id: message.messageId,
-        read_at: message.isRead ? message.date : null,
-        starred_at: message.isStarred ? message.date : null,
-        trashed_at: message.isTrashed ? message.date : null,
-        user_id: mailboxOwnerId,
-      })),
+      importRows(
+        messages.map((message) => ({
+          archived_at: message.isArchived ? message.date : null,
+          mailbox_id: message.mailboxId,
+          message_id: message.messageId,
+          read_at: message.isRead ? message.date : null,
+          starred_at: message.isStarred ? message.date : null,
+          trashed_at: message.isTrashed ? message.date : null,
+          user_id: mailboxOwnerId,
+        }))
+      ),
       { onConflict: 'message_id,user_id' }
     );
     if (result.error) throw result.error;
   }
   result = await table(admin, 'mail_stored_objects').upsert(
-    messages.flatMap((message) => message.storedObjects),
+    importRows(messages.flatMap((message) => message.storedObjects)),
     { onConflict: 'id' }
   );
   if (result.error) throw result.error;
@@ -417,18 +456,20 @@ export async function finalizeThreads({
   threads: ThreadSummary[];
 }) {
   const { error } = await table(admin, 'mail_threads').upsert(
-    threads.map((thread) => ({
-      created_at: thread.firstMessageAt,
-      id: thread.id,
-      last_message_at: thread.lastMessageAt,
-      mailbox_id: mailboxId,
-      message_count: thread.messageCount,
-      normalized_subject: thread.normalizedSubject,
-      status: thread.status,
-      subject: thread.subject,
-      unread_count: thread.unreadCount,
-      updated_at: thread.lastMessageAt,
-    })),
+    importRows(
+      threads.map((thread) => ({
+        created_at: thread.firstMessageAt,
+        id: thread.id,
+        last_message_at: thread.lastMessageAt,
+        mailbox_id: mailboxId,
+        message_count: thread.messageCount,
+        normalized_subject: thread.normalizedSubject,
+        status: thread.status,
+        subject: thread.subject,
+        unread_count: thread.unreadCount,
+        updated_at: thread.lastMessageAt,
+      }))
+    ),
     { onConflict: 'id' }
   );
   if (error) throw error;

--- a/apps/mail/scripts/google-takeout-db.ts
+++ b/apps/mail/scripts/google-takeout-db.ts
@@ -80,7 +80,7 @@ export function sanitizePostgrestPayload<T>(value: T): T {
     return value.map(sanitizePostgrestPayload) as T;
   }
   if (value && typeof value === 'object') {
-    const sanitized: Record<string, unknown> = {};
+    const sanitized = Object.create(null) as Record<string, unknown>;
     for (const [key, entry] of Object.entries(value)) {
       const baseKey = sanitizePostgrestPayload(key);
       let safeKey = baseKey;

--- a/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   ensureImportLabels,
   escapeLikePattern,
+  sanitizePostgrestPayload,
 } from '../../../../scripts/google-takeout-db';
 import type { AnyRecord } from '../repository/shared';
 
@@ -10,6 +11,18 @@ describe('Google Takeout database helpers', () => {
     expect(escapeLikePattern(String.raw`Name_%\\Box@Example.com`)).toBe(
       String.raw`Name\_\%\\\\Box@Example.com`
     );
+  });
+
+  it('replaces unpaired UTF-16 surrogates throughout PostgREST rows', () => {
+    expect(
+      sanitizePostgrestPayload({
+        header: `before\uD800after`,
+        nested: [`low\uDC00`, 'valid \uD83D\uDE80'],
+      })
+    ).toEqual({
+      header: 'before�after',
+      nested: ['low�', 'valid 🚀'],
+    });
   });
 
   it('reuses an existing label with the same display name', async () => {

--- a/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
@@ -25,6 +25,18 @@ describe('Google Takeout database helpers', () => {
     });
   });
 
+  it('preserves values whose object keys collide after sanitizing', () => {
+    expect(
+      sanitizePostgrestPayload({
+        'legacy\uD800header': 'first',
+        'legacy\uDC00header': 'second',
+      })
+    ).toEqual({
+      'legacy�header': 'first',
+      'legacy�header [import duplicate 2]': 'second',
+    });
+  });
+
   it('reuses an existing label with the same display name', async () => {
     const existing = [{ id: 'existing-id', name: 'Résumé', slug: 'resume' }];
     let upserted: AnyRecord[] = [];
@@ -83,5 +95,47 @@ describe('Google Takeout database helpers', () => {
       expect.objectContaining({ name: `Legacy \uD800 label` })
     );
     expect(ids.get('legacy-generated')).toBe('safe-id');
+  });
+
+  it('groups custom labels whose names collide after sanitizing', async () => {
+    let upserted: AnyRecord[] = [];
+    const persisted = [
+      { id: 'grouped-id', name: 'Legacy � label', slug: 'legacy-high' },
+    ];
+    let selectCount = 0;
+    const admin = {
+      schema: () => ({
+        from: () => ({
+          select: () => ({
+            eq: async () => {
+              selectCount += 1;
+              return {
+                data: selectCount === 1 ? [] : persisted,
+                error: null,
+              };
+            },
+          }),
+          upsert: async (rows: AnyRecord[]) => {
+            upserted = rows;
+            return { error: null };
+          },
+        }),
+      }),
+    } as AnyRecord;
+
+    const ids = await ensureImportLabels({
+      admin,
+      customLabels: new Map([
+        ['legacy-high', `Legacy \uD800 label`],
+        ['legacy-low', `Legacy \uDC00 label`],
+      ]),
+      mailboxId: 'mailbox-id',
+    });
+
+    expect(
+      upserted.filter((row) => row.name === 'Legacy � label')
+    ).toHaveLength(1);
+    expect(ids.get('legacy-high')).toBe('grouped-id');
+    expect(ids.get('legacy-low')).toBe('grouped-id');
   });
 });

--- a/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
@@ -53,4 +53,35 @@ describe('Google Takeout database helpers', () => {
     );
     expect(ids.get('resume-generated-hash')).toBe('existing-id');
   });
+
+  it('sanitizes malformed custom label names before persistence', async () => {
+    let upserted: AnyRecord[] = [];
+    const admin = {
+      schema: () => ({
+        from: () => ({
+          select: () => ({
+            eq: async () => ({
+              data: [{ id: 'safe-id', name: 'Legacy � label', slug: 'legacy' }],
+              error: null,
+            }),
+          }),
+          upsert: async (rows: AnyRecord[]) => {
+            upserted = rows;
+            return { error: null };
+          },
+        }),
+      }),
+    } as AnyRecord;
+
+    const ids = await ensureImportLabels({
+      admin,
+      customLabels: new Map([['legacy-generated', `Legacy \uD800 label`]]),
+      mailboxId: 'mailbox-id',
+    });
+
+    expect(upserted).not.toContainEqual(
+      expect.objectContaining({ name: `Legacy \uD800 label` })
+    );
+    expect(ids.get('legacy-generated')).toBe('safe-id');
+  });
 });

--- a/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
+++ b/apps/mail/src/lib/mail/import/google-takeout-db.test.ts
@@ -37,6 +37,22 @@ describe('Google Takeout database helpers', () => {
     });
   });
 
+  it('preserves an own __proto__ key without mutating the accumulator', () => {
+    const payload = Object.create(null) as Record<string, string>;
+    Object.defineProperty(payload, '__proto__', {
+      configurable: true,
+      enumerable: true,
+      value: 'legacy header value',
+    });
+
+    const sanitized = sanitizePostgrestPayload(payload);
+
+    expect(Object.getPrototypeOf(sanitized)).toBeNull();
+    expect(Object.getOwnPropertyDescriptor(sanitized, '__proto__')?.value).toBe(
+      'legacy header value'
+    );
+  });
+
   it('reuses an existing label with the same display name', async () => {
     const existing = [{ id: 'existing-id', name: 'Résumé', slug: 'resume' }];
     let upserted: AnyRecord[] = [];

--- a/apps/meet/messages/en.json
+++ b/apps/meet/messages/en.json
@@ -3896,6 +3896,25 @@
       "you": "You",
       "your_name": "Your name"
     },
+    "meetings": {
+      "cancel": "Cancel",
+      "code_placeholder": "Paste a meeting link or code",
+      "create": "Create meeting",
+      "create_description": "Name the meeting and optionally schedule it for later.",
+      "create_failed": "Could not create the meeting. Please try again.",
+      "create_title": "Create a meeting",
+      "creating": "Creating…",
+      "invalid_code": "Enter a valid Tuturuuu Meet code or link.",
+      "join": "Join meeting",
+      "join_description": "Use a Tuturuuu Meet link or meeting code.",
+      "join_title": "Join a meeting",
+      "meeting_code": "Meeting link or code",
+      "name": "Name",
+      "name_placeholder": "Weekly sync",
+      "name_required": "Enter a meeting name.",
+      "time": "Date and time",
+      "time_hint": "Leave blank to create it for now."
+    },
     "transcription": {
       "empty": "This recording contains no audio to transcribe. The saved recording remains available.",
       "too_large": "This recording is too large for inline transcription. The saved recording remains available.",

--- a/apps/meet/messages/vi.json
+++ b/apps/meet/messages/vi.json
@@ -3896,6 +3896,25 @@
       "you": "Bạn",
       "your_name": "Tên của bạn"
     },
+    "meetings": {
+      "cancel": "Hủy",
+      "code_placeholder": "Dán liên kết hoặc mã cuộc họp",
+      "create": "Tạo cuộc họp",
+      "create_description": "Đặt tên và tùy chọn lên lịch cuộc họp.",
+      "create_failed": "Không thể tạo cuộc họp. Vui lòng thử lại.",
+      "create_title": "Tạo cuộc họp",
+      "creating": "Đang tạo…",
+      "invalid_code": "Vui lòng nhập mã hoặc liên kết Tuturuuu Meet hợp lệ.",
+      "join": "Tham gia",
+      "join_description": "Dùng liên kết Tuturuuu Meet hoặc mã cuộc họp.",
+      "join_title": "Tham gia cuộc họp",
+      "meeting_code": "Liên kết hoặc mã cuộc họp",
+      "name": "Tên",
+      "name_placeholder": "Họp hàng tuần",
+      "name_required": "Vui lòng nhập tên cuộc họp.",
+      "time": "Ngày và giờ",
+      "time_hint": "Để trống để tạo cuộc họp ngay bây giờ."
+    },
     "transcription": {
       "empty": "Bản ghi này không có dữ liệu âm thanh để phiên âm. Bản ghi đã lưu vẫn còn khả dụng.",
       "too_large": "Bản ghi này quá lớn để phiên âm trực tiếp. Bản ghi đã lưu vẫn còn khả dụng.",

--- a/apps/meet/src/app/[locale]/[wsId]/meetings/meetings-content.tsx
+++ b/apps/meet/src/app/[locale]/[wsId]/meetings/meetings-content.tsx
@@ -1,17 +1,8 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { Calendar, Clock, Play, Search, Trash2, Users } from '@tuturuuu/icons';
 import {
-  Calendar,
-  Clock,
-  Play,
-  Plus,
-  Search,
-  Trash2,
-  Users,
-} from '@tuturuuu/icons';
-import {
-  createWorkspaceMeeting,
   deleteWorkspaceMeeting,
   getWorkspaceMeetings,
   updateWorkspaceMeeting,
@@ -34,7 +25,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@tuturuuu/ui/dialog';
 import { Input } from '@tuturuuu/ui/input';
 import { Label } from '@tuturuuu/ui/label';
@@ -83,19 +73,14 @@ export function MeetingsContent({
   const t = useTranslations('meet.call');
   const [searchTerm, setSearchTerm] = useState(search);
   const [currentPage, setCurrentPage] = useState(page);
-  const [dialogOpen, setDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [editingMeeting, setEditingMeeting] = useState<Meeting | null>(null);
   const [deletingMeetingId, setDeletingMeetingId] = useState<string | null>(
     null
   );
-  const [creating, setCreating] = useState(false);
   const [editing, setEditing] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [formError, setFormError] = useState<string | null>(null);
   const [editFormError, setEditFormError] = useState<string | null>(null);
-  const nameRef = useRef<HTMLInputElement>(null);
-  const timeRef = useRef<HTMLInputElement>(null);
   const editNameRef = useRef<HTMLInputElement>(null);
   const editTimeRef = useRef<HTMLInputElement>(null);
 
@@ -115,42 +100,6 @@ export function MeetingsContent({
   const meetings: Meeting[] = data?.meetings || [];
   const totalCount = data?.totalCount || 0;
   const totalPages = Math.ceil(totalCount / pageSize);
-
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    setCurrentPage(1);
-  };
-
-  const handleCreate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!canCreate) return;
-    setFormError(null);
-    setCreating(true);
-    const name = nameRef.current?.value.trim();
-    let time = timeRef.current?.value;
-    if (!name) {
-      setFormError('Name is required.');
-      setCreating(false);
-      return;
-    }
-    if (!time) {
-      time = new Date().toISOString();
-    }
-    try {
-      await createWorkspaceMeeting(wsId, {
-        name,
-        time: normalizeMeetingTime(time),
-      });
-      setDialogOpen(false);
-      setCreating(false);
-      setFormError(null);
-      refetch();
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (_err) {
-      setFormError('Failed to create meeting.');
-      setCreating(false);
-    }
-  };
 
   const handleEdit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -238,26 +187,25 @@ export function MeetingsContent({
   return (
     <>
       <div className="space-y-6">
-        <MeetingEntry canCreate={canCreate} wsId={wsId} />
-        {/* Search and Filters */}
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <form
-            onSubmit={handleSearch}
-            className="flex w-full max-w-sm items-center space-x-2"
-          >
-            <div className="relative flex-1">
-              <Search className="absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="Search meetings..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-8"
-              />
-            </div>
-            <Button type="submit" size="sm">
-              Search
-            </Button>
-          </form>
+        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="relative w-full sm:max-w-sm">
+            <Search className="absolute top-2.5 left-3 size-4 text-muted-foreground" />
+            <Input
+              aria-label="Search meetings"
+              className="pl-9"
+              placeholder="Search meetings..."
+              value={searchTerm}
+              onChange={(event) => {
+                setSearchTerm(event.target.value);
+                setCurrentPage(1);
+              }}
+            />
+          </div>
+          <MeetingEntry
+            canCreate={canCreate}
+            onCreated={() => void refetch()}
+            wsId={wsId}
+          />
         </div>
 
         {/* Meetings Grid */}
@@ -281,14 +229,9 @@ export function MeetingsContent({
             <div className="text-center">
               <Calendar className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
               <h3 className="mb-2 font-semibold text-lg">No meetings found</h3>
-              <p className="mb-4 text-muted-foreground">
-                Create your first meeting to get started with video conferencing
-                and AI-powered features.
+              <p className="max-w-md text-muted-foreground">
+                Your scheduled and recent meetings will appear here.
               </p>
-              <Button disabled={!canCreate} onClick={() => setDialogOpen(true)}>
-                <Plus className="mr-2 h-4 w-4" />
-                Create First Meeting
-              </Button>
             </div>
           </div>
         ) : (
@@ -392,63 +335,6 @@ export function MeetingsContent({
           </div>
         )}
       </div>
-
-      {/* Create Meeting Dialog */}
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogTrigger asChild>
-          <Button
-            className="flex items-center gap-2"
-            disabled={!canCreate}
-            onClick={() => setDialogOpen(true)}
-          >
-            <Plus className="h-4 w-4" />
-            Create
-          </Button>
-        </DialogTrigger>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>New Meeting</DialogTitle>
-            <DialogDescription>Enter meeting details below.</DialogDescription>
-          </DialogHeader>
-          <form onSubmit={handleCreate} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="meeting-name">Name</Label>
-              <Input
-                id="meeting-name"
-                ref={nameRef}
-                required
-                placeholder="Meeting name"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="meeting-time">Time</Label>
-              <Input
-                id="meeting-time"
-                ref={timeRef}
-                type="datetime-local"
-                placeholder="Leave blank for now"
-              />
-            </div>
-            {formError && (
-              <div className="text-dynamic-red text-sm">{formError}</div>
-            )}
-            <DialogFooter>
-              <Button
-                type="submit"
-                disabled={creating || !canCreate}
-                className="w-full"
-              >
-                {creating ? 'Creating...' : 'Create'}
-              </Button>
-              <DialogClose asChild>
-                <Button type="button" variant="outline" className="w-full">
-                  Cancel
-                </Button>
-              </DialogClose>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
 
       {/* Edit Meeting Dialog */}
       <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>

--- a/apps/meet/src/features/call/components/meeting-entry.tsx
+++ b/apps/meet/src/features/call/components/meeting-entry.tsx
@@ -1,86 +1,191 @@
 'use client';
 
+import { LogIn, Plus, Video } from '@tuturuuu/icons';
 import { createWorkspaceMeeting } from '@tuturuuu/internal-api';
 import { Button } from '@tuturuuu/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@tuturuuu/ui/dialog';
 import { Input } from '@tuturuuu/ui/input';
 import { Label } from '@tuturuuu/ui/label';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { parseMeetingCode } from '../lib/meeting-code-input';
+import { normalizeMeetingTime } from '../lib/meeting-time';
 import { encodeRoomCode } from '../lib/room-code';
 
 export function MeetingEntry({
   canCreate,
+  onCreated,
   wsId,
 }: {
   canCreate: boolean;
+  onCreated: () => void;
   wsId: string;
 }) {
-  const t = useTranslations('meet.call');
+  const t = useTranslations('meet.meetings');
   const router = useRouter();
+  const nameRef = useRef<HTMLInputElement>(null);
+  const timeRef = useRef<HTMLInputElement>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [joinOpen, setJoinOpen] = useState(false);
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const start = async () => {
+  const createMeeting = async (event: React.FormEvent) => {
+    event.preventDefault();
     if (busy || !canCreate) return;
+    const name = nameRef.current?.value.trim();
+    if (!name) {
+      setError(t('name_required'));
+      return;
+    }
+
     setBusy(true);
     setError(null);
     try {
-      const result = await createWorkspaceMeeting<{ meeting: { id: string } }>(
-        wsId,
-        { name: t('untitled_meeting'), time: new Date().toISOString() }
-      );
-      router.push(`/r/${encodeRoomCode(result.meeting.id)}`);
+      const time = timeRef.current?.value || new Date().toISOString();
+      await createWorkspaceMeeting(wsId, {
+        name,
+        time: normalizeMeetingTime(time),
+      });
+      setCreateOpen(false);
+      onCreated();
     } catch {
-      setError(t('start_failed'));
+      setError(t('create_failed'));
+    } finally {
       setBusy(false);
     }
   };
 
+  const joinMeeting = (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    const meetingId = parseMeetingCode(code, window.location.origin);
+    if (!meetingId) {
+      setError(t('invalid_code'));
+      return;
+    }
+    router.push(`/r/${encodeRoomCode(meetingId)}`);
+  };
+
   return (
-    <section className="mb-6 space-y-3 rounded-xl border p-4">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
-        <Button disabled={!canCreate || busy} onClick={() => void start()}>
-          {busy ? t('starting_meeting') : t('start_meeting')}
-        </Button>
-        <form
-          className="flex flex-1 items-end gap-2"
-          onSubmit={(event) => {
-            event.preventDefault();
-            setError(null);
-            const meetingId = parseMeetingCode(code, window.location.origin);
-            if (!meetingId) {
-              setError(t('invalid_code'));
-              return;
-            }
-            router.push(`/r/${encodeRoomCode(meetingId)}`);
-          }}
-        >
-          <div className="flex-1 space-y-1">
-            <Label htmlFor="join-code">{t('enter_code')}</Label>
-            <Input
-              id="join-code"
-              value={code}
-              onChange={(event) => setCode(event.target.value)}
-            />
-          </div>
-          <Button type="submit" variant="outline" disabled={!code.trim()}>
-            {t('join_now')}
+    <div className="flex shrink-0 items-center gap-2">
+      <Dialog
+        open={createOpen}
+        onOpenChange={(open) => {
+          setCreateOpen(open);
+          setError(null);
+        }}
+      >
+        <DialogTrigger asChild>
+          <Button disabled={!canCreate} size="sm">
+            <Plus className="size-4" />
+            {t('create')}
           </Button>
-        </form>
-      </div>
-      {!canCreate && (
-        <p className="text-muted-foreground text-sm">
-          {t('creation_restricted')}
-        </p>
-      )}
-      {error && (
-        <p role="alert" className="text-dynamic-red text-sm">
-          {error}
-        </p>
-      )}
-    </section>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <div className="mb-2 flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <Video className="size-5" />
+            </div>
+            <DialogTitle>{t('create_title')}</DialogTitle>
+            <DialogDescription>{t('create_description')}</DialogDescription>
+          </DialogHeader>
+          <form className="space-y-4" onSubmit={createMeeting}>
+            <div className="space-y-2">
+              <Label htmlFor="meeting-name">{t('name')}</Label>
+              <Input
+                autoFocus
+                id="meeting-name"
+                placeholder={t('name_placeholder')}
+                ref={nameRef}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="meeting-time">{t('time')}</Label>
+              <Input id="meeting-time" ref={timeRef} type="datetime-local" />
+              <p className="text-muted-foreground text-xs">{t('time_hint')}</p>
+            </div>
+            {error && (
+              <p className="text-dynamic-red text-sm" role="alert">
+                {error}
+              </p>
+            )}
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  {t('cancel')}
+                </Button>
+              </DialogClose>
+              <Button disabled={busy} type="submit">
+                {busy ? t('creating') : t('create')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={joinOpen}
+        onOpenChange={(open) => {
+          setJoinOpen(open);
+          setError(null);
+        }}
+      >
+        <DialogTrigger asChild>
+          <Button size="sm" variant="outline">
+            <LogIn className="size-4" />
+            {t('join')}
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <div className="mb-2 flex size-10 items-center justify-center rounded-xl bg-muted text-foreground">
+              <LogIn className="size-5" />
+            </div>
+            <DialogTitle>{t('join_title')}</DialogTitle>
+            <DialogDescription>{t('join_description')}</DialogDescription>
+          </DialogHeader>
+          <form className="space-y-4" onSubmit={joinMeeting}>
+            <div className="space-y-2">
+              <Label htmlFor="join-code">{t('meeting_code')}</Label>
+              <Input
+                autoFocus
+                id="join-code"
+                onChange={(event) => setCode(event.target.value)}
+                placeholder={t('code_placeholder')}
+                value={code}
+              />
+            </div>
+            {error && (
+              <p className="text-dynamic-red text-sm" role="alert">
+                {error}
+              </p>
+            )}
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  {t('cancel')}
+                </Button>
+              </DialogClose>
+              <Button disabled={!code.trim()} type="submit">
+                {t('join')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }


### PR DESCRIPTION
The completed Google Takeout production import exposed malformed legacy Unicode that PostgREST rejects. This change sanitizes lone UTF-16 surrogates at the persistence boundary, preserves colliding dynamic object keys, groups custom labels whose sanitized names converge, and adds regression coverage.\n\nIt also simplifies the Meet meetings page to one compact action row with two icon buttons. Create and Join now open focused dialogs; duplicate create controls and the redundant search submit button are removed.\n\nValidation: `bun check`; Mail importer helper tests (6 passing); Meet type-check; Meet production build.