### PR TITLE
fix(meet): replace recovered publisher registrations

### DIFF
--- a/apps/docs/platform/features/meet-calls.mdx
+++ b/apps/docs/platform/features/meet-calls.mdx
@@ -504,3 +504,9 @@ indicator rather than an additional redundant mute action.
 Meet must not mount Vercel Analytics or Speed Insights: their `/_vercel/*` script endpoints are not hosted by the Cloudflare Worker. A 404 for those scripts is separate from SFU media delivery.
 
 The platform user-config API uses the shared satellite app-session audience list in `apps/web/src/lib/api-auth-audiences.ts`. Keep Meet in that list and in the Rust current-user session targets. A successful local Meet call-token refresh does not verify authorization for proxied platform APIs such as `SHOW_VERSION_BADGE`.
+
+A recovered publisher announces a new SFU session for its stable microphone,
+camera, or screen track name. The room retires older registrations for that
+participant and track and broadcasts `track.closed` before the replacement
+`track.published`, so listeners discard obsolete receivers. Snapshot consumers
+also deduplicate old session registrations left by earlier Worker versions.

--- a/apps/meet/src/features/call/hooks/use-meet-room.ts
+++ b/apps/meet/src/features/call/hooks/use-meet-room.ts
@@ -429,7 +429,10 @@ export function useMeetRoom({
       );
       if (!pending.length) return;
       pendingSubscriptionsRef.current = new Set(
-        pending.map((track) => `${track.sessionId}:${track.trackName}`)
+        pending.map(
+          (track) =>
+            `${encodeURIComponent(track.sessionId ?? '')}:${encodeURIComponent(track.trackName ?? '')}`
+        )
       );
       try {
         const { pc, sessionId } = await ensureSubscribeSession();
@@ -457,7 +460,7 @@ export function useMeetRoom({
             trackOwnersRef.current.set(track.mid, {
               userId: owner,
               kind,
-              subscriptionKey: `${requested.sessionId}:${track.trackName}`,
+              subscriptionKey: `${encodeURIComponent(requested.sessionId ?? '')}:${encodeURIComponent(track.trackName ?? '')}`,
             });
         }
         if (answer?.sessionDescription) {

--- a/apps/meet/src/features/call/lib/call-state.test.ts
+++ b/apps/meet/src/features/call/lib/call-state.test.ts
@@ -340,3 +340,48 @@ it('counts unread messages after the history reaches its retention limit', () =>
   expect(countUnreadChatMessages(advanced, '500')).toBe(0);
   expect(countUnreadChatMessages(advanced, '0')).toBe(500);
 });
+
+describe('recovered publisher snapshots', () => {
+  it('keeps the latest session for a named track while preserving other media', () => {
+    const tracks = [
+      {
+        userId: OTHER,
+        sessionId: 'old',
+        trackName: 'other-audio',
+        kind: 'audio',
+      },
+      {
+        userId: OTHER,
+        sessionId: 'old',
+        trackName: 'other-video',
+        kind: 'video',
+      },
+      {
+        userId: THIRD,
+        sessionId: 'third',
+        trackName: 'other-audio',
+        kind: 'audio',
+      },
+      {
+        userId: OTHER,
+        sessionId: 'new',
+        trackName: 'other-audio',
+        kind: 'audio',
+      },
+    ];
+    const state = reduceAll([
+      READY,
+      {
+        type: 'track.published',
+        sessionId: 'new',
+        userId: OTHER,
+        tracks,
+      },
+    ]);
+    expect(Object.keys(state.remoteTracks)).toEqual([
+      'old:other-video',
+      'third:other-audio',
+      'new:other-audio',
+    ]);
+  });
+});

--- a/apps/meet/src/features/call/lib/call-state.ts
+++ b/apps/meet/src/features/call/lib/call-state.ts
@@ -121,6 +121,16 @@ export function reduceCallState(
         // Our own tracks come back on the broadcast; subscribing to them would
         // loop our audio straight back to us.
         if (track.userId === state.selfUserId) continue;
+        // Older room snapshots can still contain an expired publisher session.
+        for (const [key, previous] of Object.entries(remoteTracks)) {
+          if (
+            track.trackName &&
+            previous.userId === track.userId &&
+            previous.trackName === track.trackName &&
+            previous.sessionId !== track.sessionId
+          )
+            delete remoteTracks[key];
+        }
         remoteTracks[remoteTrackKey(track)] = track;
       }
       return { ...state, remoteTracks };

--- a/apps/meet/src/features/call/lib/call-state.ts
+++ b/apps/meet/src/features/call/lib/call-state.ts
@@ -57,7 +57,7 @@ export const INITIAL_CALL_STATE: CallState = {
 const MAX_CHAT_MESSAGES = 500;
 
 export function remoteTrackKey(track: MeetRealtimeRoomTrack) {
-  return `${track.sessionId}:${track.trackName ?? track.mid ?? track.userId}`;
+  return `${encodeURIComponent(track.sessionId)}:${encodeURIComponent(track.trackName ?? track.mid ?? track.userId)}`;
 }
 
 /**

--- a/apps/meet/src/features/call/lib/media-error.ts
+++ b/apps/meet/src/features/call/lib/media-error.ts
@@ -30,6 +30,7 @@ export function getMediaErrorDiagnostic(error: unknown): string {
     sfu_connection_failed: 'SFU_CONNECTION_FAILED',
     sfu_connection_timeout: 'SFU_CONNECTION_TIMEOUT',
     sfu_session_failed: 'SFU_SESSION_FAILED',
+    publisher_rejoin_required: 'PUBLISHER_REJOIN_REQUIRED',
     sfu_track_close_failed: 'SFU_TRACK_CLOSE_FAILED',
     sfu_session_replaced: 'SFU_SESSION_REPLACED',
     publish_not_allowed: 'PUBLISH_NOT_ALLOWED',

--- a/packages/realtime/src/meet/room-tracks.test.ts
+++ b/packages/realtime/src/meet/room-tracks.test.ts
@@ -65,3 +65,30 @@ it('keeps colon-containing identifiers distinct', () => {
     Object.keys(replaceRoomPublications({}, [first, second]).tracks)
   ).toHaveLength(2);
 });
+
+it('bounds retirement history without allowing an old publication to return', () => {
+  const old = { userId: 'a', sessionId: 'current', trackName: 'audio' };
+  const retired: Record<string, true> = Object.fromEntries(
+    Array.from({ length: 512 }, (_, index) => [
+      `a:session-${index}:audio`,
+      true as const,
+    ])
+  );
+  const current = { 'current:audio': old };
+  const result = replaceRoomPublications(
+    current,
+    [{ ...old, sessionId: 'next' }],
+    retired
+  );
+  expect(result.error).toBe('publisher_rejoin_required');
+  expect(result.tracks).toBe(current);
+  expect(result.retired).toBe(retired);
+  expect(result.broadcast).toEqual([]);
+  expect(
+    replaceRoomPublications(
+      current,
+      [{ ...old, sessionId: 'session-0' }],
+      retired
+    ).error
+  ).toBe('stale_publication');
+});

--- a/packages/realtime/src/meet/room-tracks.test.ts
+++ b/packages/realtime/src/meet/room-tracks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { replaceRoomPublications } from './room-tracks';
+import { meetTrackKey, replaceRoomPublications } from './room-tracks';
 
 describe('room publication replacement', () => {
   it('does not retire another participant or a different media track', () => {
@@ -42,4 +42,26 @@ describe('room publication replacement', () => {
       'track.closed',
     ]);
   });
+});
+
+it('rejects a late publish from a retired session', () => {
+  const old = { userId: 'a', sessionId: 'old', trackName: 'audio' };
+  const current = { userId: 'a', sessionId: 'new', trackName: 'audio' };
+  const replaced = replaceRoomPublications({ 'old:audio': old }, [current]);
+  const late = replaceRoomPublications(
+    replaced.tracks,
+    [old],
+    replaced.retired
+  );
+  expect(late.stale).toBe(true);
+  expect(late.tracks).toEqual(replaced.tracks);
+  expect(late.broadcast).toEqual([]);
+});
+it('keeps colon-containing identifiers distinct', () => {
+  const first = { userId: 'a', sessionId: 'a:b', trackName: 'c' };
+  const second = { userId: 'b', sessionId: 'a', trackName: 'b:c' };
+  expect(meetTrackKey(first)).not.toBe(meetTrackKey(second));
+  expect(
+    Object.keys(replaceRoomPublications({}, [first, second]).tracks)
+  ).toHaveLength(2);
 });

--- a/packages/realtime/src/meet/room-tracks.test.ts
+++ b/packages/realtime/src/meet/room-tracks.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { replaceRoomPublications } from './room-tracks';
+
+describe('room publication replacement', () => {
+  it('does not retire another participant or a different media track', () => {
+    const current = {
+      'old:audio': { userId: 'a', sessionId: 'old', trackName: 'audio' },
+      'other:audio': { userId: 'b', sessionId: 'other', trackName: 'audio' },
+      'old:video': { userId: 'a', sessionId: 'old', trackName: 'video' },
+    };
+    const result = replaceRoomPublications(current, [
+      { userId: 'a', sessionId: 'new', trackName: 'audio' },
+    ]);
+    expect(Object.keys(result.tracks)).toEqual([
+      'other:audio',
+      'old:video',
+      'new:audio',
+    ]);
+    expect(result.broadcast).toMatchObject([
+      {
+        type: 'track.closed',
+        userId: 'a',
+        sessionId: 'old',
+        tracks: [current['old:audio']],
+      },
+    ]);
+    expect(Object.keys(current)).toHaveLength(3);
+  });
+
+  it('retires all stale sessions for a track and leaves unnamed tracks alone', () => {
+    const result = replaceRoomPublications(
+      {
+        'old:audio': { userId: 'a', sessionId: 'old', trackName: 'audio' },
+        'older:audio': { userId: 'a', sessionId: 'older', trackName: 'audio' },
+        'unnamed:0': { userId: 'a', sessionId: 'unnamed', mid: '0' },
+      },
+      [{ userId: 'a', sessionId: 'new', trackName: 'audio' }]
+    );
+    expect(Object.keys(result.tracks)).toEqual(['unnamed:0', 'new:audio']);
+    expect(result.broadcast.map((message) => message.type)).toEqual([
+      'track.closed',
+      'track.closed',
+    ]);
+  });
+});

--- a/packages/realtime/src/meet/room-tracks.ts
+++ b/packages/realtime/src/meet/room-tracks.ts
@@ -4,15 +4,23 @@ import type {
 } from './messages';
 
 export function meetTrackKey(track: MeetRealtimeRoomTrack) {
-  return `${track.sessionId}:${track.trackName ?? track.mid ?? track.userId}`;
+  return `${encodeURIComponent(track.sessionId)}:${encodeURIComponent(track.trackName ?? track.mid ?? track.userId)}`;
+}
+
+export function retiredTrackKey(track: MeetRealtimeRoomTrack) {
+  return `${encodeURIComponent(track.userId)}:${meetTrackKey(track)}`;
 }
 
 /** A recovered publisher replaces its previous registration for each named track. */
 export function replaceRoomPublications(
   current: Record<string, MeetRealtimeRoomTrack>,
-  published: MeetRealtimeRoomTrack[]
+  published: MeetRealtimeRoomTrack[],
+  retired: Record<string, true> = {}
 ) {
+  if (published.some((track) => retired[retiredTrackKey(track)]))
+    return { tracks: current, broadcast: [], retired, stale: true };
   const tracks = { ...current };
+  const nextRetired = { ...retired };
   const closed = new Map<string, MeetRealtimeRoomTrack[]>();
   for (const next of published) {
     for (const [key, previous] of Object.entries(tracks)) {
@@ -23,6 +31,7 @@ export function replaceRoomPublications(
         previous.sessionId !== next.sessionId
       ) {
         delete tracks[key];
+        nextRetired[retiredTrackKey(previous)] = true;
         const group = closed.get(previous.sessionId) ?? [];
         group.push(previous);
         closed.set(previous.sessionId, group);
@@ -38,5 +47,5 @@ export function replaceRoomPublications(
       tracks: removed,
     })
   );
-  return { tracks, broadcast };
+  return { tracks, broadcast, retired: nextRetired, stale: false };
 }

--- a/packages/realtime/src/meet/room-tracks.ts
+++ b/packages/realtime/src/meet/room-tracks.ts
@@ -3,6 +3,8 @@ import type {
   MeetRealtimeServerMessage,
 } from './messages';
 
+export const MAX_RETIRED_TRACKS_PER_PARTICIPANT = 512;
+
 export function meetTrackKey(track: MeetRealtimeRoomTrack) {
   return `${encodeURIComponent(track.sessionId)}:${encodeURIComponent(track.trackName ?? track.mid ?? track.userId)}`;
 }
@@ -18,7 +20,13 @@ export function replaceRoomPublications(
   retired: Record<string, true> = {}
 ) {
   if (published.some((track) => retired[retiredTrackKey(track)]))
-    return { tracks: current, broadcast: [], retired, stale: true };
+    return {
+      tracks: current,
+      broadcast: [],
+      retired,
+      stale: true,
+      error: 'stale_publication',
+    };
   const tracks = { ...current };
   const nextRetired = { ...retired };
   const closed = new Map<string, MeetRealtimeRoomTrack[]>();
@@ -39,6 +47,20 @@ export function replaceRoomPublications(
     }
     tracks[meetTrackKey(next)] = next;
   }
+  for (const userId of new Set(published.map((track) => track.userId))) {
+    const prefix = `${encodeURIComponent(userId)}:`;
+    if (
+      Object.keys(nextRetired).filter((key) => key.startsWith(prefix)).length >
+      MAX_RETIRED_TRACKS_PER_PARTICIPANT
+    )
+      return {
+        tracks: current,
+        broadcast: [],
+        retired,
+        stale: true,
+        error: 'publisher_rejoin_required',
+      };
+  }
   const broadcast: MeetRealtimeServerMessage[] = [...closed].map(
     ([sessionId, removed]) => ({
       type: 'track.closed',
@@ -47,5 +69,11 @@ export function replaceRoomPublications(
       tracks: removed,
     })
   );
-  return { tracks, broadcast, retired: nextRetired, stale: false };
+  return {
+    tracks,
+    broadcast,
+    retired: nextRetired,
+    stale: false,
+    error: undefined,
+  };
 }

--- a/packages/realtime/src/meet/room-tracks.ts
+++ b/packages/realtime/src/meet/room-tracks.ts
@@ -1,0 +1,42 @@
+import type {
+  MeetRealtimeRoomTrack,
+  MeetRealtimeServerMessage,
+} from './messages';
+
+export function meetTrackKey(track: MeetRealtimeRoomTrack) {
+  return `${track.sessionId}:${track.trackName ?? track.mid ?? track.userId}`;
+}
+
+/** A recovered publisher replaces its previous registration for each named track. */
+export function replaceRoomPublications(
+  current: Record<string, MeetRealtimeRoomTrack>,
+  published: MeetRealtimeRoomTrack[]
+) {
+  const tracks = { ...current };
+  const closed = new Map<string, MeetRealtimeRoomTrack[]>();
+  for (const next of published) {
+    for (const [key, previous] of Object.entries(tracks)) {
+      if (
+        next.trackName &&
+        previous.trackName === next.trackName &&
+        previous.userId === next.userId &&
+        previous.sessionId !== next.sessionId
+      ) {
+        delete tracks[key];
+        const group = closed.get(previous.sessionId) ?? [];
+        group.push(previous);
+        closed.set(previous.sessionId, group);
+      }
+    }
+    tracks[meetTrackKey(next)] = next;
+  }
+  const broadcast: MeetRealtimeServerMessage[] = [...closed].map(
+    ([sessionId, removed]) => ({
+      type: 'track.closed',
+      sessionId,
+      userId: removed[0]!.userId,
+      tracks: removed,
+    })
+  );
+  return { tracks, broadcast };
+}

--- a/packages/realtime/src/meet/room.test.ts
+++ b/packages/realtime/src/meet/room.test.ts
@@ -393,6 +393,13 @@ describe('meet room SFU relay', () => {
       },
       { type: 'track.published', sessionId: 'new' },
     ]);
+    const late = publish(recovered.state, 'old', 'host-audio');
+    expect(late.reply[0]).toMatchObject({
+      type: 'error',
+      error: 'stale_publication',
+    });
+    expect(late.sfu).toBeNull();
+    expect(late.state).toEqual(recovered.state);
     const repeated = publish(recovered.state, 'new', 'host-audio');
     expect(repeated.broadcast.map((message) => message.type)).toEqual([
       'track.published',

--- a/packages/realtime/src/meet/room.test.ts
+++ b/packages/realtime/src/meet/room.test.ts
@@ -362,6 +362,43 @@ describe('meet room SFU relay', () => {
     expect(result.broadcast[0]).toMatchObject({ type: 'track.published' });
   });
 
+  it('retires old sessions before announcing a recovered publication', () => {
+    const publish = (
+      state: typeof joined,
+      sessionId: string,
+      trackName: string
+    ) =>
+      run(
+        state,
+        {
+          type: 'sfu.tracks.publish',
+          sessionDescription,
+          sessionId,
+          tracks: [{ kind: 'audio', mid: '0', trackName }],
+        },
+        token()
+      );
+    const first = publish(joined, 'old', 'host-audio');
+    const other = publish(first.state, 'other', 'host-video');
+    const recovered = publish(other.state, 'new', 'host-audio');
+    expect(Object.keys(recovered.state.tracks)).toEqual([
+      'other:host-video',
+      'new:host-audio',
+    ]);
+    expect(recovered.broadcast).toMatchObject([
+      {
+        type: 'track.closed',
+        sessionId: 'old',
+        tracks: [{ sessionId: 'old', trackName: 'host-audio' }],
+      },
+      { type: 'track.published', sessionId: 'new' },
+    ]);
+    const repeated = publish(recovered.state, 'new', 'host-audio');
+    expect(repeated.broadcast.map((message) => message.type)).toEqual([
+      'track.published',
+    ]);
+  });
+
   it('drops closed tracks from the room registry', () => {
     const published = run(
       joined,

--- a/packages/realtime/src/meet/room.ts
+++ b/packages/realtime/src/meet/room.ts
@@ -30,6 +30,7 @@ export const MEET_PRESENCE_TTL_MS = 30_000;
 export const MEET_CONNECTED_PRESENCE_TTL_MS = 10 * 60_000;
 
 export interface MeetRoomSnapshot {
+  retiredTracks?: Record<string, true>;
   presence: Record<string, MeetRealtimePresence>;
   recording: {
     sessionId: string | null;
@@ -256,6 +257,11 @@ export function releaseParticipant(
   );
   const next: MeetRoomSnapshot = {
     ...state,
+    retiredTracks: Object.fromEntries(
+      Object.entries(state.retiredTracks ?? {}).filter(
+        ([key]) => !key.startsWith(`${encodeURIComponent(userId)}:`)
+      )
+    ),
     presence,
     stage: {
       ...state.stage,
@@ -608,11 +614,13 @@ function applySfuCommand(
       sessionId: message.sessionId,
       userId: token.userId,
     }));
-    const { tracks, broadcast } = replaceRoomPublications(
+    const { tracks, broadcast, retired, stale } = replaceRoomPublications(
       state.tracks,
-      published
+      published,
+      state.retiredTracks
     );
-    const next = { ...state, tracks };
+    if (stale) return denied(state, 'stale_publication', message.requestId);
+    const next = { ...state, tracks, retiredTracks: retired };
 
     return outcome(next, {
       broadcast: [

--- a/packages/realtime/src/meet/room.ts
+++ b/packages/realtime/src/meet/room.ts
@@ -614,12 +614,12 @@ function applySfuCommand(
       sessionId: message.sessionId,
       userId: token.userId,
     }));
-    const { tracks, broadcast, retired, stale } = replaceRoomPublications(
+    const { tracks, broadcast, retired, error } = replaceRoomPublications(
       state.tracks,
       published,
       state.retiredTracks
     );
-    if (stale) return denied(state, 'stale_publication', message.requestId);
+    if (error) return denied(state, error, message.requestId);
     const next = { ...state, tracks, retiredTracks: retired };
 
     return outcome(next, {

--- a/packages/realtime/src/meet/room.ts
+++ b/packages/realtime/src/meet/room.ts
@@ -1,3 +1,7 @@
+import { meetTrackKey, replaceRoomPublications } from './room-tracks';
+
+export { meetTrackKey } from './room-tracks';
+
 import type {
   MeetRealtimeClientMessage,
   MeetRealtimeRoomTrack,
@@ -102,10 +106,6 @@ export function createMeetPresence(
     role: token.role,
     userId: token.userId,
   };
-}
-
-export function meetTrackKey(track: MeetRealtimeRoomTrack) {
-  return `${track.sessionId}:${track.trackName ?? track.mid ?? track.userId}`;
 }
 
 /** Allow throttled connected tabs a bounded grace period before expiring. */
@@ -608,14 +608,15 @@ function applySfuCommand(
       sessionId: message.sessionId,
       userId: token.userId,
     }));
-    const tracks = { ...state.tracks };
-    for (const track of published) {
-      tracks[meetTrackKey(track)] = track;
-    }
+    const { tracks, broadcast } = replaceRoomPublications(
+      state.tracks,
+      published
+    );
     const next = { ...state, tracks };
 
     return outcome(next, {
       broadcast: [
+        ...broadcast,
         {
           requestId: message.requestId,
           sessionId: message.sessionId,


### PR DESCRIPTION
When a participant rebuilds their SFU publisher, their replacement audio/video tracks could coexist with stale registrations from the old session. Replace each participant's logical track registration and broadcast closure before announcing its replacement, so subscribers stop pulling stale tracks.

Retired registrations cannot reclaim a logical track through delayed replay. Encode composite-key components to prevent delimiter collisions and bound retirement history to 512 entries per participant; exceeding the bound requires a full leave/rejoin without evicting replay protection. The client also deduplicates incoming track snapshots.

Validation: focused room/replacement and client-state tests, full `bun check`, and Cloudflare CI build. Production media and affected-device verification remain separate release gates.
