### PR TITLE
fix(meet): make Calendar scheduling atomic

### DIFF
--- a/apps/calendar/src/app/[locale]/(dashboard)/[wsId]/page.tsx
+++ b/apps/calendar/src/app/[locale]/(dashboard)/[wsId]/page.tsx
@@ -19,9 +19,13 @@ interface PageProps {
     locale: string;
   }>;
   searchParams: Promise<{
-    date?: string;
-    eventId?: string;
+    date?: string | string[];
+    eventId?: string | string[];
   }>;
+}
+
+function firstQueryValue(value?: string | string[]) {
+  return Array.isArray(value) ? value[0] : value;
 }
 
 export default async function CalendarPage({
@@ -32,11 +36,8 @@ export default async function CalendarPage({
 
   const { wsId, locale } = await params;
   const deepLink = await searchParams;
-  const deepLinkDate = deepLink.date ? new Date(deepLink.date) : null;
-  const initialDate =
-    deepLinkDate && !Number.isNaN(deepLinkDate.getTime())
-      ? deepLinkDate.toISOString()
-      : undefined;
+  const eventId = firstQueryValue(deepLink.eventId);
+  const requestedDate = firstQueryValue(deepLink.date);
   const user = await getSatelliteAppSessionUser('calendar');
 
   if (!user?.id) redirect('/login');
@@ -52,6 +53,22 @@ export default async function CalendarPage({
   if (withoutPermission('manage_calendar')) redirect(`/${wsId}/tasks`);
 
   const sbAdmin = await createAdminClient({ noCookie: true });
+
+  let initialDate = requestedDate;
+  if (!initialDate && eventId) {
+    const { data: linkedEvent } = await sbAdmin
+      .from('workspace_calendar_events')
+      .select('start_at')
+      .eq('id', eventId)
+      .eq('ws_id', workspace.id)
+      .maybeSingle();
+    initialDate = linkedEvent?.start_at;
+  }
+  const parsedDate = initialDate ? new Date(initialDate) : null;
+  const normalizedInitialDate =
+    parsedDate && !Number.isNaN(parsedDate.getTime())
+      ? parsedDate.toISOString()
+      : undefined;
 
   const [googleToken, smartSchedulingTasks] = await Promise.all([
     fetchUserWorkspaceCalendarGoogleTokenForClient(sbAdmin, {
@@ -71,8 +88,8 @@ export default async function CalendarPage({
     <CalendarWorkspacePage
       enableSmartScheduling={enableSmartScheduling}
       experimentalGoogleToken={googleToken}
-      initialDate={initialDate}
-      initialEventId={deepLink.eventId}
+      initialDate={normalizedInitialDate}
+      initialEventId={eventId}
       isPersonalWorkspace={isPersonalWorkspace}
       locale={locale}
       smartSchedulingTasks={smartSchedulingTasks}

--- a/apps/calendar/src/app/[locale]/(dashboard)/[wsId]/page.tsx
+++ b/apps/calendar/src/app/[locale]/(dashboard)/[wsId]/page.tsx
@@ -54,7 +54,11 @@ export default async function CalendarPage({
 
   const sbAdmin = await createAdminClient({ noCookie: true });
 
-  let initialDate = requestedDate;
+  const requestedDateValue = requestedDate ? new Date(requestedDate) : null;
+  let initialDate =
+    requestedDateValue && !Number.isNaN(requestedDateValue.getTime())
+      ? requestedDateValue.toISOString()
+      : undefined;
   if (!initialDate && eventId) {
     const { data: linkedEvent, error: linkedEventError } = await sbAdmin
       .from('workspace_calendar_events')

--- a/apps/calendar/src/app/[locale]/(dashboard)/[wsId]/page.tsx
+++ b/apps/calendar/src/app/[locale]/(dashboard)/[wsId]/page.tsx
@@ -56,12 +56,13 @@ export default async function CalendarPage({
 
   let initialDate = requestedDate;
   if (!initialDate && eventId) {
-    const { data: linkedEvent } = await sbAdmin
+    const { data: linkedEvent, error: linkedEventError } = await sbAdmin
       .from('workspace_calendar_events')
       .select('start_at')
       .eq('id', eventId)
       .eq('ws_id', workspace.id)
       .maybeSingle();
+    if (linkedEventError) throw linkedEventError;
     initialDate = linkedEvent?.start_at;
   }
   const parsedDate = initialDate ? new Date(initialDate) : null;

--- a/apps/database/supabase/migrations/20260907160000_create_scheduled_workspace_meeting.sql
+++ b/apps/database/supabase/migrations/20260907160000_create_scheduled_workspace_meeting.sql
@@ -19,6 +19,8 @@ as $$
 declare
   meeting_row public.workspace_meetings;
   calendar_row public.workspace_calendar_events;
+  primary_calendar_id uuid;
+  creator jsonb;
 begin
   if p_end_at <= p_start_at then
     raise exception 'meeting end time must be after its start time';
@@ -28,9 +30,19 @@ begin
   values (p_meeting_id, p_ws_id, p_name, p_start_at, p_creator_id)
   returning * into meeting_row;
 
+  select id into primary_calendar_id
+  from public.workspace_calendars
+  where ws_id = p_ws_id and calendar_type = 'primary'
+  limit 1;
+
+  if primary_calendar_id is null then
+    raise exception 'workspace primary calendar not found';
+  end if;
+
   insert into public.workspace_calendar_events (
     ws_id, title, description, location, start_at, end_at, color,
-    is_encrypted, provider, scheduling_source, scheduling_metadata, sync_status
+    is_encrypted, provider, scheduling_source, scheduling_metadata, sync_status,
+    source_calendar_id
   )
   values (
     p_ws_id, p_encrypted_title, p_encrypted_description,
@@ -41,12 +53,16 @@ begin
       'meeting_id', p_meeting_id,
       'meeting_url', p_meeting_url
     ),
-    'local_only'
+    'local_only', primary_calendar_id
   )
   returning * into calendar_row;
 
+  select jsonb_build_object('display_name', display_name) into creator
+  from public.users
+  where id = p_creator_id;
+
   return jsonb_build_object(
-    'meeting', to_jsonb(meeting_row),
+    'meeting', to_jsonb(meeting_row) || jsonb_build_object('creator', creator),
     'calendar_event', to_jsonb(calendar_row)
   );
 end;

--- a/apps/database/supabase/migrations/20260907160000_create_scheduled_workspace_meeting.sql
+++ b/apps/database/supabase/migrations/20260907160000_create_scheduled_workspace_meeting.sql
@@ -1,0 +1,68 @@
+create or replace function public.create_scheduled_workspace_meeting(
+  p_meeting_id uuid,
+  p_ws_id uuid,
+  p_creator_id uuid,
+  p_name text,
+  p_start_at timestamptz,
+  p_end_at timestamptz,
+  p_encrypted_title text,
+  p_encrypted_description text,
+  p_encrypted_location text,
+  p_is_encrypted boolean,
+  p_meeting_url text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  meeting_row public.workspace_meetings;
+  calendar_row public.workspace_calendar_events;
+begin
+  if p_end_at <= p_start_at then
+    raise exception 'meeting end time must be after its start time';
+  end if;
+
+  insert into public.workspace_meetings (id, ws_id, name, time, creator_id)
+  values (p_meeting_id, p_ws_id, p_name, p_start_at, p_creator_id)
+  returning * into meeting_row;
+
+  insert into public.workspace_calendar_events (
+    ws_id, title, description, location, start_at, end_at, color,
+    is_encrypted, provider, scheduling_source, scheduling_metadata, sync_status
+  )
+  values (
+    p_ws_id, p_encrypted_title, p_encrypted_description,
+    p_encrypted_location, p_start_at, p_end_at, 'BLUE', p_is_encrypted,
+    'tuturuuu', 'manual',
+    jsonb_build_object(
+      'type', 'tuturuuu_meeting',
+      'meeting_id', p_meeting_id,
+      'meeting_url', p_meeting_url
+    ),
+    'local_only'
+  )
+  returning * into calendar_row;
+
+  return jsonb_build_object(
+    'meeting', to_jsonb(meeting_row),
+    'calendar_event', to_jsonb(calendar_row)
+  );
+end;
+$$;
+
+revoke all on function public.create_scheduled_workspace_meeting(
+  uuid, uuid, uuid, text, timestamptz, timestamptz,
+  text, text, text, boolean, text
+) from public, anon, authenticated;
+
+grant execute on function public.create_scheduled_workspace_meeting(
+  uuid, uuid, uuid, text, timestamptz, timestamptz,
+  text, text, text, boolean, text
+) to service_role;
+
+comment on function public.create_scheduled_workspace_meeting(
+  uuid, uuid, uuid, text, timestamptz, timestamptz,
+  text, text, text, boolean, text
+) is 'Atomically creates a Meet room and encrypted native Calendar event. Service role only; callers authorize access first.';

--- a/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/meeting-calendar-event.test.ts
+++ b/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/meeting-calendar-event.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadMeetingCalendarEvent } from './meeting-calendar-event';
+
+describe('loadMeetingCalendarEvent', () => {
+  it('skips admin calendar access when permissions are unavailable', async () => {
+    const from = vi.fn();
+
+    const result = await loadMeetingCalendarEvent({
+      supabase: { from } as never,
+      permissions: null,
+      wsId: 'workspace-id',
+      meetingId: 'meeting-id',
+    });
+
+    expect(result).toBeNull();
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('skips admin calendar access when calendar management is denied', async () => {
+    const from = vi.fn();
+
+    const result = await loadMeetingCalendarEvent({
+      supabase: { from } as never,
+      permissions: {
+        withoutPermission: vi.fn().mockReturnValue(true),
+      } as never,
+      wsId: 'workspace-id',
+      meetingId: 'meeting-id',
+    });
+
+    expect(result).toBeNull();
+    expect(from).not.toHaveBeenCalled();
+  });
+});

--- a/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/meeting-calendar-event.test.ts
+++ b/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/meeting-calendar-event.test.ts
@@ -31,4 +31,30 @@ describe('loadMeetingCalendarEvent', () => {
     expect(result).toBeNull();
     expect(from).not.toHaveBeenCalled();
   });
+
+  it('selects the oldest linked event when legacy duplicates exist', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: 'event-id', start_at: '2026-09-07T10:00:00Z' },
+      error: null,
+    });
+    const limit = vi.fn().mockReturnValue({ maybeSingle });
+    const order = vi.fn().mockReturnValue({ limit });
+    const eq = vi.fn();
+    eq.mockReturnValue({ eq, order });
+    const select = vi.fn().mockReturnValue({ eq });
+    const from = vi.fn().mockReturnValue({ select });
+
+    const result = await loadMeetingCalendarEvent({
+      supabase: { from } as never,
+      permissions: {
+        withoutPermission: vi.fn().mockReturnValue(false),
+      } as never,
+      wsId: 'workspace-id',
+      meetingId: 'meeting-id',
+    });
+
+    expect(order).toHaveBeenCalledWith('created_at', { ascending: true });
+    expect(limit).toHaveBeenCalledWith(1);
+    expect(result?.id).toBe('event-id');
+  });
 });

--- a/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/meeting-calendar-event.ts
+++ b/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/meeting-calendar-event.ts
@@ -1,0 +1,30 @@
+import type { TypedSupabaseClient } from '@tuturuuu/supabase/types';
+import type { getPermissions } from '@tuturuuu/utils/workspace-helper';
+
+interface LoadMeetingCalendarEventOptions {
+  supabase: TypedSupabaseClient;
+  permissions: Awaited<ReturnType<typeof getPermissions>>;
+  wsId: string;
+  meetingId: string;
+}
+
+export async function loadMeetingCalendarEvent({
+  supabase,
+  permissions,
+  wsId,
+  meetingId,
+}: LoadMeetingCalendarEventOptions) {
+  if (!permissions || permissions.withoutPermission('manage_calendar')) {
+    return null;
+  }
+
+  const { data } = await supabase
+    .from('workspace_calendar_events')
+    .select('id, start_at')
+    .eq('ws_id', wsId)
+    .eq('scheduling_metadata->>type', 'tuturuuu_meeting')
+    .eq('scheduling_metadata->>meeting_id', meetingId)
+    .maybeSingle();
+
+  return data;
+}

--- a/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/meeting-calendar-event.ts
+++ b/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/meeting-calendar-event.ts
@@ -18,13 +18,16 @@ export async function loadMeetingCalendarEvent({
     return null;
   }
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('workspace_calendar_events')
     .select('id, start_at')
     .eq('ws_id', wsId)
     .eq('scheduling_metadata->>type', 'tuturuuu_meeting')
     .eq('scheduling_metadata->>meeting_id', meetingId)
+    .order('created_at', { ascending: true })
+    .limit(1)
     .maybeSingle();
+  if (error) throw error;
 
   return data;
 }

--- a/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/page.tsx
+++ b/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/page.tsx
@@ -15,6 +15,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@tuturuuu/ui/card';
+import { getPermissions } from '@tuturuuu/utils/workspace-helper';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -48,7 +49,7 @@ export default async function MeetingDetailPage({
   await connection();
 
   const { wsId: id, meetingId } = await params;
-  const { workspaceSlug, wsId } = await getMeetWorkspaceContext(id);
+  const { user, workspaceSlug, wsId } = await getMeetWorkspaceContext(id);
   const t = await getTranslations('meet.call');
   const supabase = await createAdminClient({ noCookie: true });
 
@@ -71,13 +72,18 @@ export default async function MeetingDetailPage({
     notFound();
   }
 
-  const { data: calendarEvent } = await supabase
-    .from('workspace_calendar_events')
-    .select('id, start_at')
-    .eq('ws_id', wsId)
-    .eq('scheduling_metadata->>type', 'tuturuuu_meeting')
-    .eq('scheduling_metadata->>meeting_id', meetingId)
-    .maybeSingle();
+  const permissions = await getPermissions({ user, wsId });
+  const calendarEvent = permissions?.withoutPermission('manage_calendar')
+    ? null
+    : (
+        await supabase
+          .from('workspace_calendar_events')
+          .select('id, start_at')
+          .eq('ws_id', wsId)
+          .eq('scheduling_metadata->>type', 'tuturuuu_meeting')
+          .eq('scheduling_metadata->>meeting_id', meetingId)
+          .maybeSingle()
+      ).data;
 
   return (
     <div className="container mx-auto max-w-4xl p-6">

--- a/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/page.tsx
+++ b/apps/meet/src/app/[locale]/[wsId]/meetings/[meetingId]/page.tsx
@@ -28,6 +28,7 @@ import { encodeRoomCode } from '@/features/call/lib/room-code';
 import { MeetingAiOverview } from '@/features/meeting-ai/meeting-ai-overview';
 import { getMeetWorkspaceContext } from '../../workspace-context';
 import { MeetingActions } from './meeting-actions';
+import { loadMeetingCalendarEvent } from './meeting-calendar-event';
 import { RecordingSessionsOverview } from './recording-sessions-overview';
 
 export const metadata: Metadata = {
@@ -73,17 +74,12 @@ export default async function MeetingDetailPage({
   }
 
   const permissions = await getPermissions({ user, wsId });
-  const calendarEvent = permissions?.withoutPermission('manage_calendar')
-    ? null
-    : (
-        await supabase
-          .from('workspace_calendar_events')
-          .select('id, start_at')
-          .eq('ws_id', wsId)
-          .eq('scheduling_metadata->>type', 'tuturuuu_meeting')
-          .eq('scheduling_metadata->>meeting_id', meetingId)
-          .maybeSingle()
-      ).data;
+  const calendarEvent = await loadMeetingCalendarEvent({
+    supabase,
+    permissions,
+    wsId,
+    meetingId,
+  });
 
   return (
     <div className="container mx-auto max-w-4xl p-6">

--- a/apps/meet/src/features/call/components/meeting-entry.tsx
+++ b/apps/meet/src/features/call/components/meeting-entry.tsx
@@ -78,6 +78,7 @@ export function MeetingEntry({
       router.push(`/r/${encodeRoomCode(response.meeting.id)}`);
     } catch {
       toast.error(t('create_failed'));
+    } finally {
       setBusy(false);
     }
   };
@@ -98,9 +99,12 @@ export function MeetingEntry({
     }
 
     const startAt = normalizeMeetingTime(localTime);
-    const endAt = new Date(
-      new Date(startAt).getTime() + duration * 60_000
-    ).toISOString();
+    const endDate = new Date(new Date(startAt).getTime() + duration * 60_000);
+    if (Number.isNaN(endDate.getTime())) {
+      setError(t('schedule_invalid'));
+      return;
+    }
+    const endAt = endDate.toISOString();
     setBusy(true);
     setError(null);
     try {

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/meetings/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/meetings/route.test.ts
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   adminFrom: vi.fn(),
+  adminRpc: vi.fn(),
   auth: vi.fn(),
-  calendarInsert: vi.fn(),
   encryptEvent: vi.fn(),
   from: vi.fn(),
   getWorkspaceKey: vi.fn(),
@@ -19,6 +19,7 @@ vi.mock('@tuturuuu/supabase/next/server', () => ({
   createAdminClient: async () => ({
     auth: { admin: { getUserById: mocks.identity } },
     from: mocks.adminFrom,
+    rpc: mocks.adminRpc,
   }),
 }));
 vi.mock('@/lib/api-auth', () => ({ resolveSessionAuthContext: mocks.auth }));
@@ -62,7 +63,11 @@ function authenticatedContext(...args: [email?: string]) {
   const email = args.length === 0 ? 'host@tuturuuu.com' : args[0];
   return {
     ok: true,
-    user: { id: 'actor', email },
+    user: {
+      id: 'actor',
+      email,
+      user_metadata: { email: 'spoof@tuturuuu.com' },
+    },
     supabase: { from: mocks.from, rpc: mocks.rpc },
   };
 }
@@ -89,18 +94,16 @@ beforeEach(() => {
       single: async () => ({ data: { id: 'meeting-id' }, error: null }),
     }),
   });
-  mocks.adminFrom.mockReturnValue({ insert: mocks.calendarInsert });
-  mocks.calendarInsert.mockReturnValue({
-    select: () => ({
-      single: async () => ({
-        data: {
-          id: 'calendar-event-id',
-          start_at: '2026-09-06T10:00:00Z',
-          end_at: '2026-09-06T11:00:00Z',
-        },
-        error: null,
-      }),
-    }),
+  mocks.adminRpc.mockResolvedValue({
+    data: {
+      meeting: { id: 'meeting-id' },
+      calendar_event: {
+        id: 'calendar-event-id',
+        start_at: '2026-09-06T10:00:00Z',
+        end_at: '2026-09-06T11:00:00Z',
+      },
+    },
+    error: null,
   });
 });
 
@@ -200,15 +203,14 @@ describe('Calendar scheduling', () => {
       p_user_id: 'actor',
       p_permission: 'manage_calendar',
     });
-    expect(mocks.calendarInsert).toHaveBeenCalledWith(
+    expect(mocks.adminRpc).toHaveBeenCalledWith(
+      'create_scheduled_workspace_meeting',
       expect.objectContaining({
-        start_at: '2026-09-06T10:00:00Z',
-        end_at: '2026-09-06T11:00:00Z',
-        scheduling_metadata: expect.objectContaining({
-          type: 'tuturuuu_meeting',
-          meeting_id: 'meeting-id',
-          meeting_url: 'https://meet.tuturuuu.com/personal/meetings/meeting-id',
-        }),
+        p_start_at: '2026-09-06T10:00:00Z',
+        p_end_at: '2026-09-06T11:00:00Z',
+        p_meeting_url: expect.stringContaining(
+          'https://meet.tuturuuu.com/personal/meetings/'
+        ),
       })
     );
     expect(await response.json()).toEqual(
@@ -237,7 +239,7 @@ describe('Calendar scheduling', () => {
     expect(response.status).toBe(403);
     expect((await response.json()).code).toBe('CALENDAR_PERMISSION_REQUIRED');
     expect(mocks.insert).not.toHaveBeenCalled();
-    expect(mocks.calendarInsert).not.toHaveBeenCalled();
+    expect(mocks.adminRpc).not.toHaveBeenCalled();
   });
 
   it('rejects a schedule whose end is not after its start', async () => {
@@ -253,6 +255,27 @@ describe('Calendar scheduling', () => {
     );
 
     expect(response.status).toBe(400);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 without a partial meeting when the atomic RPC fails', async () => {
+    mocks.auth.mockResolvedValue(authenticatedContext());
+    mocks.adminRpc.mockResolvedValue({
+      data: null,
+      error: new Error('calendar insert failed'),
+    });
+
+    const response = await POST(
+      request({
+        name: 'Design review',
+        time: '2026-09-06T10:00:00Z',
+        schedule: { endTime: '2026-09-06T11:00:00Z' },
+      }),
+      params
+    );
+
+    expect(response.status).toBe(500);
+    expect(mocks.adminRpc).toHaveBeenCalledOnce();
     expect(mocks.insert).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/meetings/route.test.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/meetings/route.test.ts
@@ -96,7 +96,10 @@ beforeEach(() => {
   });
   mocks.adminRpc.mockResolvedValue({
     data: {
-      meeting: { id: 'meeting-id' },
+      meeting: {
+        id: 'meeting-id',
+        creator: { display_name: 'Host' },
+      },
       calendar_event: {
         id: 'calendar-event-id',
         start_at: '2026-09-06T10:00:00Z',
@@ -215,6 +218,9 @@ describe('Calendar scheduling', () => {
     );
     expect(await response.json()).toEqual(
       expect.objectContaining({
+        meeting: expect.objectContaining({
+          creator: { display_name: 'Host' },
+        }),
         calendarEvent: expect.objectContaining({
           id: 'calendar-event-id',
           url: expect.stringContaining('eventId=calendar-event-id'),

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/meetings/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/meetings/route.ts
@@ -352,7 +352,61 @@ export async function POST(
       }
     }
 
-    // Create new meeting
+    if (schedule) {
+      const meetingId = crypto.randomUUID();
+      const meetingUrl = buildMeetingDetailUrl(rawWsId, meetingId);
+      const workspaceKey = await getWorkspaceKey(wsId);
+      const encryptedFields = await encryptEventForStorage(
+        wsId,
+        {
+          title: name,
+          description: meetingUrl,
+          location: meetingUrl,
+        },
+        workspaceKey
+      );
+      const { data: scheduledResult, error: schedulingError } = await admin.rpc(
+        'create_scheduled_workspace_meeting',
+        {
+          p_meeting_id: meetingId,
+          p_ws_id: wsId,
+          p_creator_id: user.id,
+          p_name: name,
+          p_start_at: time,
+          p_end_at: schedule.endTime,
+          p_encrypted_title: encryptedFields.title,
+          p_encrypted_description: encryptedFields.description,
+          p_encrypted_location: encryptedFields.location,
+          p_is_encrypted: encryptedFields.is_encrypted,
+          p_meeting_url: meetingUrl,
+        }
+      );
+
+      if (schedulingError || !scheduledResult) {
+        console.error('Failed to schedule meeting on Calendar', {
+          wsId,
+          error: schedulingError,
+        });
+        return NextResponse.json(
+          { error: 'Failed to schedule meeting on Calendar' },
+          { status: 500 }
+        );
+      }
+
+      const result = scheduledResult as unknown as {
+        meeting: { id: string };
+        calendar_event: { id: string; start_at: string; end_at: string };
+      };
+      return NextResponse.json({
+        meeting: result.meeting,
+        calendarEvent: {
+          ...result.calendar_event,
+          url: buildCalendarEventUrl(rawWsId, result.calendar_event.id, time),
+        },
+      });
+    }
+
+    // Instant meetings do not create Calendar events.
     const { data: meeting, error } = await supabase
       .from('workspace_meetings')
       .insert({
@@ -379,69 +433,7 @@ export async function POST(
       );
     }
 
-    if (!schedule) {
-      return NextResponse.json({ meeting });
-    }
-
-    const meetingUrl = buildMeetingDetailUrl(rawWsId, meeting.id);
-    const workspaceKey = await getWorkspaceKey(wsId);
-    const encryptedFields = await encryptEventForStorage(
-      wsId,
-      {
-        title: name,
-        description: meetingUrl,
-        location: meetingUrl,
-      },
-      workspaceKey
-    );
-    const { data: calendarEvent, error: calendarError } = await admin
-      .from('workspace_calendar_events')
-      .insert({
-        ws_id: wsId,
-        title: encryptedFields.title,
-        description: encryptedFields.description,
-        location: encryptedFields.location,
-        start_at: time,
-        end_at: schedule.endTime,
-        color: 'BLUE',
-        is_encrypted: encryptedFields.is_encrypted,
-        provider: 'tuturuuu',
-        scheduling_source: 'manual',
-        scheduling_metadata: {
-          type: 'tuturuuu_meeting',
-          meeting_id: meeting.id,
-          meeting_url: meetingUrl,
-        },
-        sync_status: 'local_only',
-      })
-      .select('id, start_at, end_at')
-      .single();
-
-    if (calendarError || !calendarEvent) {
-      const { error: rollbackError } = await supabase
-        .from('workspace_meetings')
-        .delete()
-        .eq('id', meeting.id)
-        .eq('ws_id', wsId);
-      console.error('Failed to schedule meeting on Calendar', {
-        wsId,
-        meetingId: meeting.id,
-        error: calendarError,
-        rollbackError,
-      });
-      return NextResponse.json(
-        { error: 'Failed to schedule meeting on Calendar' },
-        { status: 500 }
-      );
-    }
-
-    return NextResponse.json({
-      meeting,
-      calendarEvent: {
-        ...calendarEvent,
-        url: buildCalendarEventUrl(rawWsId, calendarEvent.id, time),
-      },
-    });
+    return NextResponse.json({ meeting });
   } catch (error) {
     if (error instanceof WorkspaceNotFoundError) {
       return NextResponse.json(

--- a/apps/web/src/app/api/v1/workspaces/[wsId]/meetings/route.ts
+++ b/apps/web/src/app/api/v1/workspaces/[wsId]/meetings/route.ts
@@ -394,7 +394,7 @@ export async function POST(
       }
 
       const result = scheduledResult as unknown as {
-        meeting: { id: string };
+        meeting: { id: string; creator: { display_name: string | null } };
         calendar_event: { id: string; start_at: string; end_at: string };
       };
       return NextResponse.json({

--- a/packages/types/src/supabase.ts
+++ b/packages/types/src/supabase.ts
@@ -41630,6 +41630,22 @@ export type Database = {
         };
         Returns: string;
       };
+      create_scheduled_workspace_meeting: {
+        Args: {
+          p_creator_id: string;
+          p_encrypted_description: string;
+          p_encrypted_location: string;
+          p_encrypted_title: string;
+          p_end_at: string;
+          p_is_encrypted: boolean;
+          p_meeting_id: string;
+          p_meeting_url: string;
+          p_name: string;
+          p_start_at: string;
+          p_ws_id: string;
+        };
+        Returns: Json;
+      };
       create_system_announcement: {
         Args: {
           p_action_url?: string;

--- a/packages/ui/src/components/ui/legacy/calendar/calendar-meeting-link.ts
+++ b/packages/ui/src/components/ui/legacy/calendar/calendar-meeting-link.ts
@@ -1,7 +1,15 @@
 import type { CalendarEvent } from '@tuturuuu/types/primitives/calendar-event';
 
-export function getCalendarMeetingUrl(event: Partial<CalendarEvent>) {
-  const metadata = event.scheduling_metadata;
+type CalendarEventWithScheduling = Partial<CalendarEvent> & {
+  scheduling_metadata?: Record<string, unknown> | null;
+};
+
+export function getCalendarMeetingMetadata(event: Partial<CalendarEvent>) {
+  return (event as CalendarEventWithScheduling).scheduling_metadata;
+}
+
+export function getCalendarMeetingUrl(event: CalendarEventWithScheduling) {
+  const metadata = getCalendarMeetingMetadata(event);
   if (
     metadata?.type !== 'tuturuuu_meeting' ||
     typeof metadata.meeting_url !== 'string'

--- a/packages/ui/src/components/ui/legacy/calendar/event-modal-header.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/event-modal-header.tsx
@@ -27,10 +27,10 @@ export function EventModalHeader({
       <DialogTitle className="flex flex-wrap items-center gap-2 font-semibold text-xl">
         <span>{isEditing ? 'Edit Event' : 'Create Event'}</span>
         {providerDisplay && (
-          <div className="ml-3 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-1 text-sm">
+          <span className="ml-3 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-1 text-sm">
             <CalendarEventProviderIcon className="h-4.5 w-4.5" event={event} />
             <span className="font-medium text-xs">{providerDisplay.label}</span>
-          </div>
+          </span>
         )}
         {meetingUrl && (
           <Button asChild className="ml-auto" size="sm" variant="outline">

--- a/packages/ui/src/components/ui/legacy/calendar/event-modal.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/event-modal.tsx
@@ -78,6 +78,7 @@ import {
 import { z } from 'zod';
 import { Alert, AlertDescription, AlertTitle } from '../../alert';
 import { AutosizeTextarea } from '../../custom/autosize-textarea';
+import { getCalendarMeetingMetadata } from './calendar-meeting-link';
 import {
   COLOR_OPTIONS,
   DateError,
@@ -322,6 +323,7 @@ export function EventModal() {
           external_event_id: activeEvent.external_event_id,
           google_event_id: activeEvent.google_event_id,
           google_calendar_id: activeEvent.google_calendar_id,
+          scheduling_metadata: getCalendarMeetingMetadata(activeEvent),
         };
 
         setEvent(cleanEventData);

--- a/packages/ui/src/components/ui/legacy/calendar/event-modal.tsx
+++ b/packages/ui/src/components/ui/legacy/calendar/event-modal.tsx
@@ -208,7 +208,6 @@ export function EventModal() {
     Intl.DateTimeFormat().resolvedOptions().timeZone
   );
 
-  // Get the current event being previewed
   const generatedEvent = generatedEvents?.[currentEventIndex];
 
   // Determine if we're editing an existing event
@@ -335,7 +334,6 @@ export function EventModal() {
           sourceOption?.id ?? sourceData?.defaultSource?.id ?? null
         );
 
-        // Only check for all-day if this is an existing event (not a new one)
         if (activeEvent.id !== 'new') {
           setIsAllDay(isAllDayEvent(cleanEventData as CalendarEvent));
         } else {

--- a/packages/ui/src/hooks/__tests__/use-calendar-readonly.test.tsx
+++ b/packages/ui/src/hooks/__tests__/use-calendar-readonly.test.tsx
@@ -106,6 +106,26 @@ describe('CalendarProvider Read-Only Mode', () => {
     expect(result.current.isModalOpen).toBe(true);
   });
 
+  it('routes a deep-linked event through a custom event adapter', async () => {
+    calendarMockState.events = [baseEvent];
+    const onOpen = vi.fn();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CalendarProvider
+        eventAdapter={{ disableBuiltInEventUi: true, onOpen }}
+        initialEventId="event-1"
+        useQuery={mockUseQuery}
+        useQueryClient={mockUseQueryClient}
+        ws={workspace}
+      >
+        {children}
+      </CalendarProvider>
+    );
+
+    renderHook(() => useCalendar(), { wrapper });
+    await act(async () => undefined);
+    expect(onOpen).toHaveBeenCalledWith('event-1', baseEvent);
+  });
+
   it('should have readOnly set to true when passed as prop', () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
       <CalendarProvider

--- a/packages/ui/src/hooks/use-calendar.tsx
+++ b/packages/ui/src/hooks/use-calendar.tsx
@@ -429,19 +429,16 @@ export const CalendarProvider = ({
 }) => {
   const queryClient = useQueryClient();
 
-  // Add debounce timer reference for update events
   const updateDebounceTimerRef = useRef<NodeJS.Timeout | null>(null);
   const pendingUpdatesRef = useRef<Map<string, PendingEventUpdate>>(
     new Map<string, PendingEventUpdate>()
   );
 
-  // Queue for processing updates in order
   const updateQueueRef = useRef<PendingEventUpdate[]>([]);
   const isProcessingQueueRef = useRef<boolean>(false);
 
   const { events, refresh, patchVisibleEvents } = useCalendarSync();
 
-  // Modal state
   const [activeEventId, setActiveEventId] = useState<string | null>(null);
   const [previewEventId, setPreviewEventId] = useState<string | null>(null);
   const [isModalHidden, setModalHidden] = useState(false);
@@ -451,7 +448,6 @@ export const CalendarProvider = ({
     'manual'
   );
 
-  // Callback for when a task is scheduled (allows components to refresh)
   const [onTaskScheduled, setOnTaskScheduled] = useState<
     (() => void) | undefined
   >(undefined);

--- a/packages/ui/src/hooks/use-calendar.tsx
+++ b/packages/ui/src/hooks/use-calendar.tsx
@@ -451,8 +451,6 @@ export const CalendarProvider = ({
     'manual'
   );
 
-  useOpenInitialCalendarEvent({ events, initialEventId, setActiveEventId });
-
   // Callback for when a task is scheduled (allows components to refresh)
   const [onTaskScheduled, setOnTaskScheduled] = useState<
     (() => void) | undefined
@@ -1265,6 +1263,12 @@ export const CalendarProvider = ({
     },
     [ws?.id, eventAdapter, events]
   );
+
+  useOpenInitialCalendarEvent({
+    events,
+    initialEventId,
+    onOpen: openEventEditor,
+  });
 
   const openModal = useCallback(
     (

--- a/packages/ui/src/hooks/use-open-initial-calendar-event.ts
+++ b/packages/ui/src/hooks/use-open-initial-calendar-event.ts
@@ -1,15 +1,14 @@
 import type { CalendarEvent } from '@tuturuuu/types/primitives/calendar-event';
-import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useRef } from 'react';
 
 export function useOpenInitialCalendarEvent({
   events,
   initialEventId,
-  setActiveEventId,
+  onOpen,
 }: {
   events: CalendarEvent[];
   initialEventId?: string;
-  setActiveEventId: Dispatch<SetStateAction<string | null>>;
+  onOpen: (eventId: string) => void;
 }) {
   const openedEventIdRef = useRef<string | null>(null);
 
@@ -22,7 +21,7 @@ export function useOpenInitialCalendarEvent({
       return;
     }
 
-    setActiveEventId(initialEventId);
+    onOpen(initialEventId);
     openedEventIdRef.current = initialEventId;
-  }, [events, initialEventId, setActiveEventId]);
+  }, [events, initialEventId, onOpen]);
 }


### PR DESCRIPTION
PR #5248 introduced instant meeting creation and scheduled Calendar events, but post-merge review found several edge cases around atomicity, deep links, permissions, and shared Calendar UI state. This follow-up makes scheduled creation transactional through a service-role-only database function, so the meeting and encrypted Calendar event commit together or neither is written.

It also preserves meeting metadata through Calendar edits, opens deep links through custom Calendar adapters, loads event-only links outside the current date window, enforces `manage_calendar` before showing Calendar links, normalizes repeated query parameters, validates large durations, clears instant-creation busy state after navigation, restores forged-session coverage, and fixes invalid dialog title markup.

Validation:
- `bun check`
- Web tests: 2,915 passed, 1 skipped, 3 todo
- focused meeting route tests: 18 passed
- focused Calendar UI tests: 17 passed
- `bun --filter @tuturuuu/meet build`
- `bun --filter @tuturuuu/calendar build`
- `bun --filter @tuturuuu/web build`
- local Supabase migration application and `bun sb:typegen`

The migration adds one service-role-only function and does not expose it to public, anonymous, or authenticated roles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes scheduled meeting creation atomic so the meeting and its encrypted Calendar event are written together or not at all, and fixes Calendar deep-link, permission, metadata, and duplicate-link edge cases found in post-merge review.

**Migration**
- Adds service-role-only `create_scheduled_workspace_meeting`, which inserts the meeting and encrypted Calendar event in one transaction.
- Requires applying the new migration and regenerating Supabase types.

**Bug Fixes**
- Routes deep links through custom event adapters, loads event-only links from their event's start date, and selects the oldest linked event when legacy duplicates exist.
- Preserves scheduling metadata through Calendar edits and enforces `manage_calendar` before showing Calendar links on meeting pages.
- Normalizes repeated query parameters, rejects invalid durations, clears the busy state after navigation, and fixes invalid dialog title markup.

Validation:
- `bun check`
- Web tests: 2,915 passed, 1 skipped, 3 todo
- focused meeting route tests: 18 passed
- focused Calendar UI tests: 17 passed
- `bun --filter @tuturuuu/meet build`
- `bun --filter @tuturuuu/calendar build`
- `bun --filter @tuturuuu/web build`
- local Supabase migration application and `bun sb:typegen`

<sup>Written for commit f40c56975ec38172e5a6417408b0598901e75dd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

