### PR TITLE
fix(meet): recover video receivers that never decode

### DIFF
--- a/apps/docs/platform/features/meet-calls.mdx
+++ b/apps/docs/platform/features/meet-calls.mdx
@@ -625,3 +625,23 @@ relay candidate, incoming audio energy and decoded video in both directions;
 repeat with `&relay=tls` to allow only TLS/443 and rule out direct UDP success. Synthetic
 media avoids recording real microphones or cameras. This does not substitute
 for checking previously affected physical devices.
+
+
+### Audio works but a remote camera stays blank
+
+The receiving watchdog also handles video tracks with no initial RTP report when
+another incoming track proves that the browser exposes inbound statistics.
+WebRTC may create an inbound report only after the first packet, so an absent
+video report is not always an unsupported-statistics case. A live, muted video
+track with enabled remote camera and working sibling inbound stats gets a
+20-second grace period before subscriber recovery. With no usable inbound
+statistics at all, the watchdog continues to avoid guessing.
+
+Video that receives packets but reports zero decoded frames also gets a separate
+20-second first-frame deadline. Incoming byte growth does not reset this deadline.
+A successfully decoded static camera or screen does not trigger this condition.
+Disabling media, replacing a publication, or ending its track clears the deadline.
+Recovery rebuilds the subscriber connection while preserving local publishing and
+room membership, using the existing one-minute recovery throttle. This corrects
+missed recovery cases; it does not identify a codec or network fault on a device
+that has not been inspected.

--- a/apps/meet/src/features/call/lib/receiver-health.test.ts
+++ b/apps/meet/src/features/call/lib/receiver-health.test.ts
@@ -26,7 +26,11 @@ function fixture() {
     time: number,
     bytes: unknown = 0,
     report = true,
-    options: { frames?: number; otherInbound?: boolean } = {}
+    options: {
+      frames?: number;
+      otherInbound?: boolean;
+      siblingBytes?: number;
+    } = {}
   ) =>
     check(
       pc,
@@ -45,7 +49,16 @@ function fixture() {
             ]
           : []),
         ...(options.otherInbound
-          ? [['audio', { type: 'inbound-rtp', mid: '1', bytesReceived: 100 }]]
+          ? [
+              [
+                'audio',
+                {
+                  type: 'inbound-rtp',
+                  mid: '1',
+                  bytesReceived: options.siblingBytes ?? 100,
+                },
+              ],
+            ]
           : []),
       ] as Array<[string, object]>) as unknown as RTCStatsReport,
       owners,
@@ -196,4 +209,13 @@ it('clears the first-frame deadline when the camera is disabled or replaced', ()
   expect(f.sample(30_000, 300, true, { frames: 0 })).toBe(false);
   f.owners.get('0')!.subscriptionKey = 'replacement:video';
   expect(f.sample(50_000, 400, true, { frames: 0 })).toBe(false);
+});
+
+it('ignores invalid sibling counters when video has no inbound report', () => {
+  for (const siblingBytes of [Infinity, NaN, -1, 0]) {
+    const f = fixture();
+    const options = { otherInbound: true, siblingBytes };
+    f.sample(0, 0, false, options);
+    expect(f.sample(30_000, 0, false, options)).toBe(false);
+  }
 });

--- a/apps/meet/src/features/call/lib/receiver-health.test.ts
+++ b/apps/meet/src/features/call/lib/receiver-health.test.ts
@@ -22,14 +22,32 @@ function fixture() {
     },
   } as unknown as Record<string, MeetRealtimePresence>;
   const check = createReceiverHealthCheck();
-  const sample = (time: number, bytes: unknown = 0, report = true) =>
+  const sample = (
+    time: number,
+    bytes: unknown = 0,
+    report = true,
+    options: { frames?: number; otherInbound?: boolean } = {}
+  ) =>
     check(
       pc,
-      new Map(
-        report
-          ? [['in', { type: 'inbound-rtp', mid: '0', bytesReceived: bytes }]]
-          : []
-      ) as unknown as RTCStatsReport,
+      new Map([
+        ...(report
+          ? [
+              [
+                'in',
+                {
+                  type: 'inbound-rtp',
+                  mid: '0',
+                  bytesReceived: bytes,
+                  framesDecoded: options.frames,
+                },
+              ],
+            ]
+          : []),
+        ...(options.otherInbound
+          ? [['audio', { type: 'inbound-rtp', mid: '1', bytesReceived: 100 }]]
+          : []),
+      ] as Array<[string, object]>) as unknown as RTCStatsReport,
       owners,
       participants,
       time
@@ -139,3 +157,43 @@ for (const kind of ['audio', 'video', 'screen', 'screen_audio'] as const) {
     expect(f.sample(23_000, 200)).toBe(true);
   });
 }
+
+it('recovers missing video RTP reports while another track proves inbound stats work', () => {
+  const f = fixture();
+  expect(f.sample(0, 0, false, { otherInbound: true })).toBe(false);
+  expect(f.sample(20_000, 0, false, { otherInbound: true })).toBe(true);
+});
+it('does not recover missing stats on an unmuted track', () => {
+  const f = fixture();
+  f.track.muted = false;
+  f.sample(0, 0, false, { otherInbound: true });
+  expect(f.sample(30_000, 0, false, { otherInbound: true })).toBe(false);
+});
+it('recovers video that receives bytes but never decodes its first frame', () => {
+  const f = fixture();
+  f.track.muted = false;
+  expect(f.sample(0, 100, true, { frames: 0 })).toBe(false);
+  expect(f.sample(20_000, 2000, true, { frames: 0 })).toBe(true);
+  expect(receiverPacketState(f.track as unknown as MediaStreamTrack)).toBe(
+    false
+  );
+});
+it('does not rebuild a decoded static video or unsupported frame counters', () => {
+  for (const frames of [1, undefined]) {
+    const f = fixture();
+    f.track.muted = false;
+    f.sample(0, 100, true, { frames });
+    expect(f.sample(30_000, 1000, true, { frames })).toBe(false);
+  }
+});
+it('clears the first-frame deadline when the camera is disabled or replaced', () => {
+  const f = fixture();
+  f.track.muted = false;
+  f.sample(0, 100, true, { frames: 0 });
+  f.participants.peer!.media.videoEnabled = false;
+  f.sample(10_000, 200, true, { frames: 0 });
+  f.participants.peer!.media.videoEnabled = true;
+  expect(f.sample(30_000, 300, true, { frames: 0 })).toBe(false);
+  f.owners.get('0')!.subscriptionKey = 'replacement:video';
+  expect(f.sample(50_000, 400, true, { frames: 0 })).toBe(false);
+});

--- a/apps/meet/src/features/call/lib/receiver-health.ts
+++ b/apps/meet/src/features/call/lib/receiver-health.ts
@@ -62,6 +62,7 @@ export function createReceiverHealthCheck() {
           (stat) =>
             stat.type === 'inbound-rtp' &&
             typeof stat.bytesReceived === 'number' &&
+            Number.isFinite(stat.bytesReceived) &&
             stat.bytesReceived > 0
         );
       if (missingVideo) {

--- a/apps/meet/src/features/call/lib/receiver-health.ts
+++ b/apps/meet/src/features/call/lib/receiver-health.ts
@@ -9,6 +9,8 @@ export function createReceiverHealthCheck() {
     { bytes: number; since: number; baseline: number }
   >();
   const resumedTracks = new WeakSet<MediaStreamTrack>();
+  const missingVideoSince = new Map<string, number>();
+  const undecodedSince = new Map<string, number>();
   return (
     pc: RTCPeerConnection,
     stats: RTCStatsReport,
@@ -48,7 +50,27 @@ export function createReceiverHealthCheck() {
           stat.type === 'inbound-rtp' &&
           (stat.mid === mid || stat.trackIdentifier === track.id)
       );
-      // Unsupported stats cannot establish a failed stream.
+      const video = owner.kind === 'video' || owner.kind === 'screen';
+      // Inbound stats may not exist until the first packet. A working sibling
+      // stream plus a persistently muted video track distinguishes this from
+      // a browser that supplies no inbound statistics at all.
+      const missingVideo =
+        video &&
+        track.muted &&
+        !inbound.length &&
+        [...stats.values()].some(
+          (stat) =>
+            stat.type === 'inbound-rtp' &&
+            typeof stat.bytesReceived === 'number' &&
+            stat.bytesReceived > 0
+        );
+      if (missingVideo) {
+        const since = missingVideoSince.get(key) ?? now;
+        missingVideoSince.set(key, since);
+        setReceiverPacketState(track, false);
+        if (now - since >= 20_000) stalled = true;
+      } else missingVideoSince.delete(key);
+      // Unsupported stats alone cannot establish a failed stream.
       if (
         !inbound.length ||
         inbound.some(
@@ -59,7 +81,8 @@ export function createReceiverHealthCheck() {
         )
       ) {
         observations.delete(key);
-        setReceiverPacketState(track, undefined);
+        undecodedSince.delete(key);
+        if (!missingVideo) setReceiverPacketState(track, undefined);
         continue;
       }
       const bytes = inbound.reduce((sum, stat) => sum + stat.bytesReceived, 0);
@@ -67,7 +90,17 @@ export function createReceiverHealthCheck() {
       const baseline =
         previous?.baseline ?? (resumedTracks.has(track) ? bytes : 0);
       resumedTracks.delete(track);
-      setReceiverPacketState(track, bytes > baseline && !track.muted);
+      const noDecodedFrames =
+        video && bytes > 0 && inbound.every((stat) => stat.framesDecoded === 0);
+      if (noDecodedFrames) {
+        const since = undecodedSince.get(key) ?? now;
+        undecodedSince.set(key, since);
+        if (now - since >= 20_000) stalled = true;
+      } else undecodedSince.delete(key);
+      setReceiverPacketState(
+        track,
+        bytes > baseline && !track.muted && !noDecodedFrames
+      );
       if (!previous || previous.bytes !== bytes)
         observations.set(key, { bytes, since: now, baseline });
       else if (now - previous.since >= 20_000 && (bytes === 0 || track.muted))
@@ -75,8 +108,8 @@ export function createReceiverHealthCheck() {
       // The resume baseline controls the badge only. Prior packets on an unmuted
       // receiver may be followed by legitimate silence/DTX or static screen content.
     }
-    for (const key of observations.keys())
-      if (!active.has(key)) observations.delete(key);
+    for (const map of [observations, missingVideoSince, undecodedSince])
+      for (const key of map.keys()) if (!active.has(key)) map.delete(key);
     return stalled;
   };
 }


### PR DESCRIPTION
Remote cameras could remain blank indefinitely while audio worked when video never produced an inbound RTP report, or received packets without decoding a frame. Recover the subscriber after a 20-second grace period in these cases, retaining the existing recovery throttle and outgoing microphone/camera connections. Unsupported statistics and already-decoded static video remain exempt.

Validation: 243 Meet tests pass, including regressions that failed before the fix; `bun check` and the Cloudflare production build pass. Two isolated Chrome participants using production SFU and TLS TURN recovered both injected video failures, with decoded frames and audio energy restored and publishers still connected. The original physical-device failure has not been reproduced directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote video that could stay blank indefinitely by recovering the subscriber when video never produces an inbound RTP report or receives packets without decoding a frame. Adds a 20-second grace period before recovery, keeping the existing recovery throttle and outgoing microphone/camera connections; unsupported statistics, already-decoded static video, and invalid sibling packet counters remain exempt.

<sup>Written for commit 3194e886d41af7eba9faf944c8257eecd3b20293. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

