### PR TITLE
fix(contacts): restore monthly report dialog scrolling

### DIFF
--- a/apps/contacts/src/__tests__/editable-report-preview-reset.test.tsx
+++ b/apps/contacts/src/__tests__/editable-report-preview-reset.test.tsx
@@ -144,6 +144,43 @@ describe('EditableReportPreview form reset behavior', () => {
     };
   });
 
+  it('keeps the monthly report editor within the viewport and scrollable', () => {
+    render(
+      <EditableReportPreview
+        wsId="ws-1"
+        report={{
+          id: 'report-1',
+          user_id: 'user-1',
+          user_name: 'Test User',
+          group_id: 'group-1',
+          group_name: 'Test Group',
+          title: 'Current title',
+          content: 'Current content',
+          feedback: 'Current feedback',
+          report_approval_status: 'PENDING',
+          scores: [],
+        }}
+        configs={[]}
+        isNew={false}
+        canUpdateReports
+      />
+    );
+
+    openExistingReportEditor();
+
+    expect(screen.getByRole('dialog')).toHaveClass(
+      'max-h-[calc(100dvh-1rem)]',
+      'grid-rows-[auto_minmax(0,1fr)]',
+      'overflow-hidden'
+    );
+    expect(screen.getByTestId('monthly-report-form-scroll-region')).toHaveClass(
+      'min-h-0',
+      'touch-pan-y',
+      'overflow-y-auto',
+      'overscroll-contain'
+    );
+  });
+
   it('shows the saved rejected revision and preserves local edits', () => {
     const report = {
       id: 'report-1',

--- a/apps/contacts/src/app/[locale]/[wsId]/users/reports/[reportId]/basic-info-dialog.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/users/reports/[reportId]/basic-info-dialog.tsx
@@ -121,14 +121,19 @@ export function ReportBasicInfoDialog({
               {t('ws-reports.edit_report')}
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+          <DialogContent className="grid max-h-[calc(100dvh-1rem)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden sm:max-h-[90dvh] sm:max-w-2xl">
             <DialogHeader>
               <DialogTitle>{t('ws-reports.basic_info')}</DialogTitle>
               <DialogDescription>
                 {t('ws-reports.selected_user_description')}
               </DialogDescription>
             </DialogHeader>
-            <UserReportForm {...formProps} onDelete={undefined} />
+            <div
+              className="min-h-0 touch-pan-y overflow-y-auto overscroll-contain pr-1"
+              data-testid="monthly-report-form-scroll-region"
+            >
+              <UserReportForm {...formProps} onDelete={undefined} />
+            </div>
           </DialogContent>
         </Dialog>
 


### PR DESCRIPTION
## Summary
- constrain the monthly report editor to the dynamic viewport
- give the report form a shrinkable, touch-scrollable content region
- add a regression test for the required scroll-layout class contract

## Validation
- bun vitest run src/__tests__/editable-report-preview-reset.test.tsx (apps/contacts)
- bun run type-check (apps/contacts)
- bun run type-check (packages/ui)
- bun check
- Contacts Turbopack build attempted; blocked by environment port-binding denial while processing shared CSS (source checks passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores scrolling in the monthly report editor dialog. Previously, the dialog could exceed the visible viewport on short or mobile screens; it now uses dynamic viewport sizing with a dedicated touch-scrollable form region, keeping the header visible.

- Adds a regression test for the dialog layout and scroll-region class contract.

<sup>Written for commit f2a3478d43db84813949f990e5a6191b47993aa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

