### PR TITLE
fix(tasks): refresh cached kanban lists after hydration

### DIFF
--- a/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader-hydration.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader-hydration.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render } from '@testing-library/react';
+import { listWorkspaceTasks } from '@tuturuuu/internal-api/tasks';
+import { type ReactNode, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ListPaginationState } from '../progressive-loader-context';
+import { useProgressiveBoardLoader } from '../use-progressive-board-loader';
+
+vi.mock('@tuturuuu/internal-api/tasks', () => ({
+  listWorkspaceTasks: vi.fn(),
+}));
+
+const cachedPagination: Record<string, ListPaginationState> = {
+  'list-1': {
+    page: 0,
+    hasMore: false,
+    totalCount: 1,
+    isLoading: false,
+    isInitialLoad: false,
+  },
+};
+
+function HydrationHarness({
+  initialPagination,
+}: {
+  initialPagination: Record<string, ListPaginationState>;
+}) {
+  const loader = useProgressiveBoardLoader(
+    'ws-1',
+    'board-1',
+    initialPagination
+  );
+
+  useEffect(() => {
+    if (Object.keys(initialPagination).length > 0) {
+      void loader.revalidateLoadedLists();
+    }
+  }, [initialPagination, loader.revalidateLoadedLists]);
+
+  return null;
+}
+
+describe('useProgressiveBoardLoader hydration revalidation', () => {
+  let queryClient: QueryClient;
+  let wrapper: ({ children }: { children: ReactNode }) => ReactNode;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    vi.mocked(listWorkspaceTasks).mockReset();
+    vi.mocked(listWorkspaceTasks).mockResolvedValue({ tasks: [] });
+  });
+
+  it('revalidates cached lists in the same effect pass that discovers them', async () => {
+    const { rerender } = render(<HydrationHarness initialPagination={{}} />, {
+      wrapper,
+    });
+
+    rerender(<HydrationHarness initialPagination={cachedPagination} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(listWorkspaceTasks).toHaveBeenCalledWith('ws-1', {
+      boardId: 'board-1',
+      listId: 'list-1',
+      limit: 50,
+      offset: 0,
+      includeCount: true,
+      includeRelationshipSummary: false,
+    });
+  });
+});

--- a/packages/tasks-ui/src/tu-do/shared/use-progressive-board-loader.ts
+++ b/packages/tasks-ui/src/tu-do/shared/use-progressive-board-loader.ts
@@ -66,13 +66,24 @@ export function useProgressiveBoardLoader(
   useEffect(() => {
     if (Object.keys(initialPagination).length === 0) return;
 
-    setPagination((current) => {
+    const hydrateMissingEntries = (
+      current: Record<string, ListPaginationState>
+    ) => {
       const missingEntries = Object.entries(initialPagination).filter(
         ([listId]) => !current[listId]
       );
-      if (missingEntries.length === 0) return current;
+      return missingEntries.length === 0
+        ? current
+        : { ...current, ...Object.fromEntries(missingEntries) };
+    };
 
-      const hydrated = { ...current, ...Object.fromEntries(missingEntries) };
+    // A parent effect can request cache revalidation in the same effect pass
+    // that supplies the browser-restored pagination. Keep the imperative ref in
+    // sync immediately instead of waiting for React to process the state update.
+    paginationRef.current = hydrateMissingEntries(paginationRef.current);
+
+    setPagination((current) => {
+      const hydrated = hydrateMissingEntries(current);
       paginationRef.current = hydrated;
       return hydrated;
     });


### PR DESCRIPTION
## Summary

- keep the progressive loader's imperative pagination snapshot synchronized as soon as browser-cached pagination is restored
- ensure the board's same-effect-pass background refresh sees every previously loaded list
- add a regression test for the hydration/revalidation ordering that hid tasks created through the CLI

## Root cause

On a hard reload, the board restored persisted pagination through a queued React state update and immediately requested background revalidation. The revalidation callback could still observe an empty pagination ref, skip every list, and leave the persisted task snapshot unchanged. Searching by task number used a separate server query, which is why the missing task appeared then.

## Verification

- `bun --cwd packages/tasks-ui type-check`
- `bun --cwd packages/tasks-ui test src/tu-do/shared/__tests__/use-progressive-board-loader-hydration.test.tsx src/tu-do/shared/__tests__/use-progressive-board-loader.test.tsx src/tu-do/shared/__tests__/board-client.test.tsx src/tu-do/shared/task-board-cache.test.ts`
- `bun check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the kanban board skipping cached lists during background refresh after a hard reload, which left tasks created through the CLI invisible until a manual search.

- Syncs the pagination ref immediately when browser-cached pagination is restored, before React processes the state update.
- Adds a regression test covering hydration followed by same-effect-pass revalidation.

<sup>Written for commit 6bd55b9d79cbbe98575271e93007034cab912f3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

