### PR TITLE
feat(meet): coordinate room devices, recordings, and trusted services

### DIFF
--- a/apps/meet-realtime/src/room-do.ts
+++ b/apps/meet-realtime/src/room-do.ts
@@ -72,8 +72,10 @@ export class MeetRoomDurableObject implements DurableObject {
           this.snapshot.usage.httpRequests,
           typeof counter === 'number' ? counter : counter.requests
         );
-        if (typeof counter !== 'number')
-          this.snapshot.usage.httpCounterWrites = counter.writes;
+        this.snapshot.usage.httpCounterWrites = Math.max(
+          this.snapshot.usage.httpCounterWrites ?? 0,
+          typeof counter === 'number' ? counter : counter.writes
+        );
       }
       let migrated = false;
       for (const request of Object.values(this.snapshot.aiRequests ?? {})) {
@@ -121,15 +123,16 @@ export class MeetRoomDurableObject implements DurableObject {
   private broadcast(messages: MeetRealtimeServerMessage[]) {
     if (!messages.length) return;
     for (const socket of this.sockets()) {
+      const token = this.tokenOf(socket);
+      const admitted = token && this.snapshot.presence[token.userId];
       for (const message of messages) {
-        const token = this.tokenOf(socket);
         if (
           message.type !== 'room.ended' &&
           !(
             message.type === 'participant.removed' &&
             message.userId === token?.userId
           ) &&
-          (!token || !this.snapshot.presence[token.userId])
+          !admitted
         )
           continue;
         this.sendTo(socket, message);
@@ -222,11 +225,8 @@ export class MeetRoomDurableObject implements DurableObject {
     }
 
     if (new URL(request.url).pathname === '/room-service') {
-      const result = roomService(
-        this.snapshot,
-        token,
-        await request.json().catch(() => null)
-      );
+      const body = await request.json().catch(() => null);
+      const result = roomService(this.snapshot, token, body);
       const changed = this.snapshot !== result.state;
       this.snapshot = result.state;
       if (!result.status) {
@@ -306,7 +306,11 @@ export class MeetRoomDurableObject implements DurableObject {
     const outcome = admitOrHold(this.snapshot, token, new Date().toISOString());
     this.snapshot = outcome.state;
     if (this.snapshot.usage && this.snapshot.presence[token.userId])
-      this.snapshot.usage.devices[token.userId] = true;
+      if (Object.keys(this.snapshot.usage.devices).length < 4096)
+        this.snapshot.usage.devices[token.userId] = true;
+      else if (!this.snapshot.usage.devices[token.userId])
+        this.snapshot.usage.limitedReports =
+          (this.snapshot.usage.limitedReports ?? 0) + 1;
     this.persist();
 
     for (const message of outcome.reply) this.sendTo(server, message);

--- a/apps/meet-realtime/src/room-do.ts
+++ b/apps/meet-realtime/src/room-do.ts
@@ -18,6 +18,8 @@ import {
   remoteMeetTracks,
 } from '../../../packages/realtime/src/meet';
 import { parseMeetRoomSettingsPatch } from '../../../packages/realtime/src/meet/room-options';
+import { createRoomUsage } from '../../../packages/realtime/src/meet/room-usage';
+import { type RoomServiceState, roomService } from './room-service';
 
 import { getSessionIceServers, type TurnEnv } from './turn-credentials';
 
@@ -48,8 +50,8 @@ type SocketAttachment = {
 export class MeetRoomDurableObject implements DurableObject {
   private readonly env: MeetRoomEnv;
   private readonly state: DurableObjectState;
-  private snapshot: MeetRoomSnapshot = createMeetRoomSnapshot();
-  private loaded = false;
+  private snapshot: RoomServiceState = createMeetRoomSnapshot();
+  private loading: Promise<void> | null = null;
   private commands = new MeetCommandExecutor();
 
   constructor(state: DurableObjectState, env: MeetRoomEnv) {
@@ -57,14 +59,17 @@ export class MeetRoomDurableObject implements DurableObject {
     this.state = state;
   }
 
-  private async load() {
-    if (this.loaded) return;
-    const stored = await this.state.storage.get<MeetRoomSnapshot>(SNAPSHOT_KEY);
-    if (stored) this.snapshot = { ...createMeetRoomSnapshot(), ...stored };
-    this.loaded = true;
+  private load() {
+    this.loading ??= this.state.blockConcurrencyWhile(async () => {
+      const stored =
+        await this.state.storage.get<MeetRoomSnapshot>(SNAPSHOT_KEY);
+      if (stored) this.snapshot = { ...createMeetRoomSnapshot(), ...stored };
+    });
+    return this.loading;
   }
 
   private persist() {
+    if (this.snapshot.usage) this.snapshot.usage.storageWrites++;
     // Fire-and-forget: the in-memory snapshot is authoritative while the object
     // is alive, and storage only has to survive eviction.
     void this.state.storage.put(SNAPSHOT_KEY, this.snapshot);
@@ -93,7 +98,15 @@ export class MeetRoomDurableObject implements DurableObject {
   private broadcast(messages: MeetRealtimeServerMessage[]) {
     if (!messages.length) return;
     for (const socket of this.sockets()) {
-      for (const message of messages) this.sendTo(socket, message);
+      for (const message of messages) {
+        const token = this.tokenOf(socket);
+        if (
+          message.type !== 'room.ended' &&
+          (!token || !this.snapshot.presence[token.userId])
+        )
+          continue;
+        this.sendTo(socket, message);
+      }
     }
   }
 
@@ -158,6 +171,8 @@ export class MeetRoomDurableObject implements DurableObject {
 
   async fetch(request: Request): Promise<Response> {
     await this.load();
+    this.snapshot.usage ??= createRoomUsage();
+    this.snapshot.usage.httpRequests++;
 
     const rawToken = request.headers.get('x-meet-token');
     if (!rawToken) {
@@ -171,6 +186,58 @@ export class MeetRoomDurableObject implements DurableObject {
       return new Response('Unauthorized', { status: 401 });
     }
 
+    if (new URL(request.url).pathname === '/room-service') {
+      const result = roomService(
+        this.snapshot,
+        token,
+        await request.json().catch(() => null)
+      );
+      const changed = this.snapshot !== result.state;
+      this.snapshot = result.state;
+      if (!result.status) {
+        if (changed) this.persist();
+        this.broadcast(result.messages ?? []);
+      }
+      return Response.json(result.body, {
+        status: result.status ?? 200,
+        headers: { 'Cache-Control': 'private, no-store' },
+      });
+    }
+    if (new URL(request.url).pathname === '/room-device') {
+      const body = (await request.json().catch(() => null)) as {
+        mode?: string;
+      } | null;
+      const accountId = token.accountId ?? token.userId;
+      const others = Object.values(this.snapshot.presence).filter(
+        (person) =>
+          (person.accountId ?? person.userId) === accountId &&
+          person.userId !== token.userId
+      );
+      if (body?.mode === 'switch') {
+        for (const person of others) {
+          const result = releaseParticipant(
+            this.snapshot,
+            person.userId,
+            token.roomId
+          );
+          this.snapshot = result.state;
+          this.sendToUser(person.userId, [
+            {
+              type: 'participant.removed',
+              by: token.userId,
+              userId: person.userId,
+            },
+          ]);
+          this.broadcast(result.broadcast);
+          this.disconnect([person.userId]);
+        }
+        this.persist();
+      }
+      return Response.json(
+        { otherDeviceCount: others.length },
+        { headers: { 'Cache-Control': 'private, no-store' } }
+      );
+    }
     if (new URL(request.url).pathname === '/room-state') {
       if (request.method === 'PATCH') {
         if (token.role !== 'host')
@@ -203,6 +270,8 @@ export class MeetRoomDurableObject implements DurableObject {
 
     const outcome = admitOrHold(this.snapshot, token, new Date().toISOString());
     this.snapshot = outcome.state;
+    if (this.snapshot.usage && this.snapshot.presence[token.userId])
+      this.snapshot.usage.devices[token.userId] = true;
     this.persist();
 
     for (const message of outcome.reply) this.sendTo(server, message);
@@ -248,6 +317,8 @@ export class MeetRoomDurableObject implements DurableObject {
       return;
     }
 
+    this.snapshot.usage ??= createRoomUsage();
+    this.snapshot.usage.webSocketMessages++;
     const parsed = meetRealtimeClientMessageSchema.safeParse(json);
     if (!parsed.success) {
       this.sendTo(socket, { error: 'malformed_event', type: 'error' });

--- a/apps/meet-realtime/src/room-do.ts
+++ b/apps/meet-realtime/src/room-do.ts
@@ -8,7 +8,6 @@ import {
   type MeetRealtimeServerMessage,
   type MeetRealtimeTokenPayload,
   type MeetRoomOutcome,
-  type MeetRoomSnapshot,
   type MeetSfuIntent,
   meetAdmissionPendingMessage,
   meetPresenceMessage,
@@ -62,17 +61,31 @@ export class MeetRoomDurableObject implements DurableObject {
   private load() {
     this.loading ??= this.state.blockConcurrencyWhile(async () => {
       const stored =
-        await this.state.storage.get<MeetRoomSnapshot>(SNAPSHOT_KEY);
+        await this.state.storage.get<RoomServiceState>(SNAPSHOT_KEY);
       if (stored) this.snapshot = { ...createMeetRoomSnapshot(), ...stored };
-      const httpRequests = await this.state.storage.get<number>(
-        'usage-http-requests'
-      );
-      if (httpRequests !== undefined) {
+      const counter = await this.state.storage.get<
+        number | { requests: number; writes: number }
+      >('usage-http-requests');
+      if (counter !== undefined) {
         this.snapshot.usage ??= createRoomUsage();
         this.snapshot.usage.httpRequests = Math.max(
           this.snapshot.usage.httpRequests,
-          httpRequests
+          typeof counter === 'number' ? counter : counter.requests
         );
+        if (typeof counter !== 'number')
+          this.snapshot.usage.httpCounterWrites = counter.writes;
+      }
+      let migrated = false;
+      for (const request of Object.values(this.snapshot.aiRequests ?? {})) {
+        if (request.status === 'pending' && request.startedAt === undefined) {
+          request.startedAt = Date.now();
+          migrated = true;
+        }
+      }
+      if (migrated) {
+        this.snapshot.usage ??= createRoomUsage();
+        this.snapshot.usage.storageWrites++;
+        await this.state.storage.put(SNAPSHOT_KEY, this.snapshot);
       }
     });
     return this.loading;
@@ -112,6 +125,10 @@ export class MeetRoomDurableObject implements DurableObject {
         const token = this.tokenOf(socket);
         if (
           message.type !== 'room.ended' &&
+          !(
+            message.type === 'participant.removed' &&
+            message.userId === token?.userId
+          ) &&
           (!token || !this.snapshot.presence[token.userId])
         )
           continue;
@@ -183,11 +200,13 @@ export class MeetRoomDurableObject implements DurableObject {
     await this.load();
     this.snapshot.usage ??= createRoomUsage();
     this.snapshot.usage.httpRequests++;
+    this.snapshot.usage.httpCounterWrites =
+      (this.snapshot.usage.httpCounterWrites ?? 0) + 1;
     this.state.waitUntil(
-      this.state.storage.put(
-        'usage-http-requests',
-        this.snapshot.usage.httpRequests
-      )
+      this.state.storage.put('usage-http-requests', {
+        requests: this.snapshot.usage.httpRequests,
+        writes: this.snapshot.usage.httpCounterWrites,
+      })
     );
 
     const rawToken = request.headers.get('x-meet-token');

--- a/apps/meet-realtime/src/room-do.ts
+++ b/apps/meet-realtime/src/room-do.ts
@@ -64,6 +64,16 @@ export class MeetRoomDurableObject implements DurableObject {
       const stored =
         await this.state.storage.get<MeetRoomSnapshot>(SNAPSHOT_KEY);
       if (stored) this.snapshot = { ...createMeetRoomSnapshot(), ...stored };
+      const httpRequests = await this.state.storage.get<number>(
+        'usage-http-requests'
+      );
+      if (httpRequests !== undefined) {
+        this.snapshot.usage ??= createRoomUsage();
+        this.snapshot.usage.httpRequests = Math.max(
+          this.snapshot.usage.httpRequests,
+          httpRequests
+        );
+      }
     });
     return this.loading;
   }
@@ -173,6 +183,12 @@ export class MeetRoomDurableObject implements DurableObject {
     await this.load();
     this.snapshot.usage ??= createRoomUsage();
     this.snapshot.usage.httpRequests++;
+    this.state.waitUntil(
+      this.state.storage.put(
+        'usage-http-requests',
+        this.snapshot.usage.httpRequests
+      )
+    );
 
     const rawToken = request.headers.get('x-meet-token');
     if (!rawToken) {

--- a/apps/meet-realtime/src/room-service.ts
+++ b/apps/meet-realtime/src/room-service.ts
@@ -1,0 +1,4 @@
+export {
+  type RoomServiceState,
+  roomService,
+} from '../../../packages/realtime/src/meet/room-service';

--- a/apps/meet-realtime/src/room-state.ts
+++ b/apps/meet-realtime/src/room-state.ts
@@ -60,6 +60,10 @@ export function broadcast(
       for (const message of messages) {
         if (
           message.type !== 'room.ended' &&
+          !(
+            message.type === 'participant.removed' &&
+            message.userId === client.data.token.userId
+          ) &&
           !getRoom(roomId).snapshot.presence[client.data.token.userId]
         )
           continue;

--- a/apps/meet-realtime/src/room-state.ts
+++ b/apps/meet-realtime/src/room-state.ts
@@ -57,7 +57,14 @@ export function broadcast(
   eachClient(
     roomId,
     (client) => {
-      for (const message of messages) send(client, message);
+      for (const message of messages) {
+        if (
+          message.type !== 'room.ended' &&
+          !getRoom(roomId).snapshot.presence[client.data.token.userId]
+        )
+          continue;
+        send(client, message);
+      }
     },
     except
   );

--- a/apps/meet-realtime/src/room-state.ts
+++ b/apps/meet-realtime/src/room-state.ts
@@ -57,6 +57,8 @@ export function broadcast(
   eachClient(
     roomId,
     (client) => {
+      const admitted =
+        getRoom(roomId).snapshot.presence[client.data.token.userId];
       for (const message of messages) {
         if (
           message.type !== 'room.ended' &&
@@ -64,7 +66,7 @@ export function broadcast(
             message.type === 'participant.removed' &&
             message.userId === client.data.token.userId
           ) &&
-          !getRoom(roomId).snapshot.presence[client.data.token.userId]
+          !admitted
         )
           continue;
         send(client, message);

--- a/apps/meet-realtime/src/worker.ts
+++ b/apps/meet-realtime/src/worker.ts
@@ -19,8 +19,10 @@ export default {
     }
 
     const roomStateRequest =
-      url.pathname === '/room-state' &&
-      ['GET', 'PATCH'].includes(request.method);
+      (url.pathname === '/room-state' &&
+        ['GET', 'PATCH'].includes(request.method)) ||
+      (['/room-device', '/room-service'].includes(url.pathname) &&
+        request.method === 'POST');
     if (url.pathname !== '/realtime' && !roomStateRequest) {
       return new Response('Not found', { status: 404 });
     }

--- a/packages/realtime/src/meet/messages.ts
+++ b/packages/realtime/src/meet/messages.ts
@@ -29,6 +29,11 @@ const requestId = z.string().trim().min(1).max(120).optional();
 const participantId = z.string().uuid();
 
 export const meetRealtimeClientMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('usage.report'),
+    reportId: z.uuid(),
+    bytesReceived: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+  }),
   z.object({ type: z.literal('reaction.send'), reaction: meetReactionSchema }),
   z.object({
     type: z.literal('room.settings.update'),
@@ -59,6 +64,7 @@ export const meetRealtimeClientMessageSchema = z.discriminatedUnion('type', [
     body: z.string().trim().min(1).max(2_000),
     requestId,
     type: z.literal('chat.message'),
+    attachmentIds: z.array(z.uuid()).max(5).optional(),
   }),
   z.object({
     requestId,
@@ -183,6 +189,10 @@ export type MeetRealtimeServerMessage =
       type: 'presence';
     }
   | {
+      accountId?: string;
+      avatarUrl?: string;
+      assistant?: boolean;
+      attachmentIds?: string[];
       body: string;
       createdAt: string;
       displayName: string;
@@ -219,6 +229,7 @@ export type MeetRealtimeServerMessage =
       userId: string;
     }
   | {
+      ownerDeviceId?: string;
       recordingSessionId?: string;
       requestId?: string;
       state: MeetRealtimeRecordingState;

--- a/packages/realtime/src/meet/messages.ts
+++ b/packages/realtime/src/meet/messages.ts
@@ -22,7 +22,7 @@ import {
   type MeetReaction,
   type MeetRoomSettings,
   meetReactionSchema,
-  meetRoomSettingsSchema,
+  meetRoomSettingsPatchSchema,
 } from './room-options';
 
 const requestId = z.string().trim().min(1).max(120).optional();
@@ -32,12 +32,12 @@ export const meetRealtimeClientMessageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('usage.report'),
     reportId: z.uuid(),
-    bytesReceived: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+    bytesReceived: z.number().int().min(0).max(1_000_000_000_000),
   }),
   z.object({ type: z.literal('reaction.send'), reaction: meetReactionSchema }),
   z.object({
     type: z.literal('room.settings.update'),
-    settings: meetRoomSettingsSchema,
+    settings: meetRoomSettingsPatchSchema,
     requestId,
   }),
   z.object({

--- a/packages/realtime/src/meet/primitives.ts
+++ b/packages/realtime/src/meet/primitives.ts
@@ -98,6 +98,7 @@ export const meetRoomLimitsSchema = z
   .default(DEFAULT_ROOM_LIMITS);
 
 export const meetRealtimeTokenPayloadSchema = z.object({
+  accountId: z.string().uuid().optional(),
   admission: meetRealtimeAdmissionSchema.default('open'),
   avatarUrl: z
     .url()
@@ -121,6 +122,7 @@ export type MeetRealtimeTokenPayload = z.infer<
 >;
 
 export const meetRealtimePresenceSchema = z.object({
+  accountId: z.string().uuid().optional(),
   avatarUrl: z
     .url()
     .max(2048)
@@ -137,6 +139,7 @@ export const meetRealtimePresenceSchema = z.object({
 export type MeetRealtimePresence = z.infer<typeof meetRealtimePresenceSchema>;
 
 export const meetRealtimeWaitingParticipantSchema = z.object({
+  accountId: z.string().uuid().optional(),
   avatarUrl: z
     .url()
     .max(2048)

--- a/packages/realtime/src/meet/primitives.ts
+++ b/packages/realtime/src/meet/primitives.ts
@@ -98,7 +98,7 @@ export const meetRoomLimitsSchema = z
   .default(DEFAULT_ROOM_LIMITS);
 
 export const meetRealtimeTokenPayloadSchema = z.object({
-  accountId: z.string().uuid().optional(),
+  accountId: z.uuid().optional(),
   admission: meetRealtimeAdmissionSchema.default('open'),
   avatarUrl: z
     .url()
@@ -122,7 +122,7 @@ export type MeetRealtimeTokenPayload = z.infer<
 >;
 
 export const meetRealtimePresenceSchema = z.object({
-  accountId: z.string().uuid().optional(),
+  accountId: z.uuid().optional(),
   avatarUrl: z
     .url()
     .max(2048)
@@ -139,7 +139,7 @@ export const meetRealtimePresenceSchema = z.object({
 export type MeetRealtimePresence = z.infer<typeof meetRealtimePresenceSchema>;
 
 export const meetRealtimeWaitingParticipantSchema = z.object({
-  accountId: z.string().uuid().optional(),
+  accountId: z.uuid().optional(),
   avatarUrl: z
     .url()
     .max(2048)

--- a/packages/realtime/src/meet/room-controls.test.ts
+++ b/packages/realtime/src/meet/room-controls.test.ts
@@ -231,3 +231,16 @@ it('retains open-admission account access to shared post-meeting notes', () => {
   expect(Object.keys(ended.presence)).toHaveLength(0);
   expect(canReadRoomNotes(ended, { ...visitor, userId: hostId })).toBe(true);
 });
+it('does not restore a connected participant’s forgotten approval when the room ends', () => {
+  const visitor = { ...guest, admission: 'open' as const, accountId: guestId };
+  let state = admitOrHold(
+    admitOrHold(createMeetRoomSnapshot(), host, now).state,
+    visitor,
+    now
+  ).state;
+  state.settings = { shareNotes: false, shareNotesAfterMeeting: true };
+  state = run(state, { type: 'admission.forget', userId: guestId }).state;
+  const ended = run(state, { type: 'room.end' }).state;
+  expect(canReadRoomNotes(ended, visitor)).toBe(false);
+  expect(ended.approved?.[guestId]).toBeUndefined();
+});

--- a/packages/realtime/src/meet/room-controls.test.ts
+++ b/packages/realtime/src/meet/room-controls.test.ts
@@ -218,3 +218,16 @@ it('requires separate opt-in for notes after ending a meeting', () => {
     )
   ).toBe(false);
 });
+
+it('retains open-admission account access to shared post-meeting notes', () => {
+  const visitor = { ...guest, admission: 'open' as const, accountId: guestId };
+  const state = admitOrHold(
+    admitOrHold(createMeetRoomSnapshot(), host, now).state,
+    visitor,
+    now
+  ).state;
+  state.settings = { shareNotes: false, shareNotesAfterMeeting: true };
+  const ended = run(state, { type: 'room.end' }).state;
+  expect(Object.keys(ended.presence)).toHaveLength(0);
+  expect(canReadRoomNotes(ended, { ...visitor, userId: hostId })).toBe(true);
+});

--- a/packages/realtime/src/meet/room-controls.ts
+++ b/packages/realtime/src/meet/room-controls.ts
@@ -32,7 +32,12 @@ export function canReadRoomNotes(
       (state.ended
         ? state.settings?.shareNotesAfterMeeting
         : state.settings?.shareNotes) &&
-        (state.presence[token.userId] || state.approved?.[token.userId])
+        (Object.values(state.presence).some(
+          (person) =>
+            (person.accountId ?? person.userId) ===
+            (token.accountId ?? token.userId)
+        ) ||
+          state.approved?.[token.accountId ?? token.userId])
     )
   );
 }

--- a/packages/realtime/src/meet/room-controls.ts
+++ b/packages/realtime/src/meet/room-controls.ts
@@ -5,6 +5,7 @@ import type {
 import type { MeetRealtimeTokenPayload } from './primitives';
 import type { MeetRoomSnapshot } from './room';
 import { denied, outcome } from './room-outcome';
+import { failActiveRecording } from './room-recording';
 
 export function approvedParticipantsMessage(
   state: MeetRoomSnapshot
@@ -32,12 +33,14 @@ export function canReadRoomNotes(
       (state.ended
         ? state.settings?.shareNotesAfterMeeting
         : state.settings?.shareNotes) &&
-        (Object.values(state.presence).some(
-          (person) =>
-            (person.accountId ?? person.userId) ===
-            (token.accountId ?? token.userId)
-        ) ||
-          state.approved?.[token.accountId ?? token.userId])
+        (state.presence[token.userId] ||
+          Object.values(state.presence).some(
+            (person) =>
+              (person.accountId ?? person.userId) ===
+              (token.accountId ?? token.userId)
+          ) ||
+          state.approved?.[token.accountId ?? token.userId] ||
+          state.approved?.[token.userId])
     )
   );
 }
@@ -99,20 +102,24 @@ export function applyRoomControl(
   if (message.type === 'room.settings.update') {
     const next = {
       ...state,
-      settings: { ...state.settings, ...message.settings },
+      settings: { shareNotes: false, ...state.settings, ...message.settings },
     };
     return outcome(next, { broadcast: [roomSettingsMessage(next)] });
   }
   if (message.type === 'admission.forget') {
     const approved = { ...state.approved };
     delete approved[message.userId];
+    const accountId =
+      state.presence[message.userId]?.accountId ??
+      state.waiting[message.userId]?.accountId;
+    if (accountId) delete approved[accountId];
     const next = { ...state, approved };
     return outcome(next, { toManagers: [approvedParticipantsMessage(next)] });
   }
   if (message.type === 'room.end') {
     return outcome(
       {
-        ...state,
+        ...failActiveRecording(state, now),
         ended: true,
         presence: {},
         waiting: {},

--- a/packages/realtime/src/meet/room-controls.ts
+++ b/packages/realtime/src/meet/room-controls.ts
@@ -121,6 +121,20 @@ export function applyRoomControl(
       {
         ...failActiveRecording(state, now),
         ended: true,
+        approved: {
+          ...Object.fromEntries(
+            Object.values(state.presence).map((person) => [
+              person.accountId ?? person.userId,
+              {
+                userId: person.accountId ?? person.userId,
+                displayName: person.displayName,
+                avatarUrl: person.avatarUrl,
+                approvedAt: now,
+              },
+            ])
+          ),
+          ...state.approved,
+        },
         presence: {},
         waiting: {},
         tracks: {},

--- a/packages/realtime/src/meet/room-controls.ts
+++ b/packages/realtime/src/meet/room-controls.ts
@@ -2,7 +2,10 @@ import type {
   MeetRealtimeClientMessage,
   MeetRealtimeServerMessage,
 } from './messages';
-import type { MeetRealtimeTokenPayload } from './primitives';
+import type {
+  MeetRealtimePresence,
+  MeetRealtimeTokenPayload,
+} from './primitives';
 import type { MeetRoomSnapshot } from './room';
 import { denied, outcome } from './room-outcome';
 import { failActiveRecording } from './room-recording';
@@ -121,20 +124,6 @@ export function applyRoomControl(
       {
         ...failActiveRecording(state, now),
         ended: true,
-        approved: {
-          ...Object.fromEntries(
-            Object.values(state.presence).map((person) => [
-              person.accountId ?? person.userId,
-              {
-                userId: person.accountId ?? person.userId,
-                displayName: person.displayName,
-                avatarUrl: person.avatarUrl,
-                approvedAt: now,
-              },
-            ])
-          ),
-          ...state.approved,
-        },
         presence: {},
         waiting: {},
         tracks: {},
@@ -159,4 +148,21 @@ export function applyRoomControl(
     );
   }
   return null;
+}
+
+/** Remember admission when it occurs, so ending a room cannot undo a later revocation. */
+export function rememberAdmission(
+  state: MeetRoomSnapshot,
+  person: MeetRealtimePresence
+) {
+  if (person.role === 'host') return state.approved;
+  const accountId = person.accountId ?? person.userId;
+  return {
+    ...state.approved,
+    [accountId]: {
+      userId: accountId,
+      displayName: person.displayName,
+      avatarUrl: person.avatarUrl,
+    },
+  };
 }

--- a/packages/realtime/src/meet/room-options.ts
+++ b/packages/realtime/src/meet/room-options.ts
@@ -11,10 +11,14 @@ export const meetReactionSchema = z.enum([
 export type MeetReaction = z.infer<typeof meetReactionSchema>;
 export const meetRoomSettingsPatchSchema = z.object({
   shareNotes: z.boolean().optional(),
+  shareRecordings: z.boolean().optional(),
+  allowParticipantRecording: z.boolean().optional(),
   shareNotesAfterMeeting: z.boolean().optional(),
 });
 export const meetRoomSettingsSchema = z.object({
   shareNotes: z.boolean().default(false),
+  shareRecordings: z.boolean().optional(),
+  allowParticipantRecording: z.boolean().optional(),
   shareNotesAfterMeeting: z.boolean().optional(),
 });
 export type MeetRoomSettings = z.infer<typeof meetRoomSettingsSchema>;

--- a/packages/realtime/src/meet/room-recording.test.ts
+++ b/packages/realtime/src/meet/room-recording.test.ts
@@ -2,25 +2,30 @@ import { describe, expect, it } from 'vitest';
 import {
   admitOrHold,
   createMeetRoomSnapshot,
-  type MeetRealtimeTokenPayload,
+  meetRealtimeTokenPayloadSchema,
 } from './index';
 import { applyRecording } from './room-recording';
 
 const now = '2026-09-09T00:00:00Z';
-const host = {
-  userId: 'host-device',
-  accountId: 'host-account',
+const host = meetRealtimeTokenPayloadSchema.parse({
+  roomId: 'workspace:meeting',
+  mode: 'call',
+  admission: 'open',
+  meetingId: '5e5217de-9bb3-4e20-8d99-526ad3e7e34f',
+  wsId: '0f1a64f7-780f-4d30-9d72-5530f204e95c',
+  userId: '9b5c036d-d38d-4c12-b8e8-2e0b2b4a2691',
+  accountId: '9b5c036d-d38d-4c12-b8e8-2e0b2b4a2692',
   exp: 2000000000,
   role: 'host',
   scopes: [],
   limits: { video: { defaultCameraEnabled: false } },
-} as unknown as MeetRealtimeTokenPayload;
-const guest = {
+});
+const guest = meetRealtimeTokenPayloadSchema.parse({
   ...host,
-  userId: 'guest-device',
-  accountId: 'guest-account',
+  userId: '4b320da6-6c8a-43fe-b1bf-09fbe77303f9',
+  accountId: '4b320da6-6c8a-43fe-b1bf-09fbe77303f8',
   role: 'speaker',
-} as MeetRealtimeTokenPayload;
+});
 const initial = () =>
   admitOrHold(
     admitOrHold(createMeetRoomSnapshot(), host, now).state,
@@ -95,4 +100,15 @@ it('retains ready recordings when their owner releases the lease after upload', 
   state.recordings![0]!.status = 'ready';
   state.recordings![0]!.path = 'verified-recording.webm';
   expect(run(state, 'idle').state.recordings?.[0]?.status).toBe('ready');
+});
+
+it('lets an admin clear a stopped guest recording without clearing another session', () => {
+  const state = initial();
+  state.settings = { shareNotes: false, allowParticipantRecording: true };
+  const started = run(state, 'starting', guest).state;
+  const stopping = run(started, 'stopping', host).state;
+  expect(
+    run(stopping, 'idle', host, 'different').state.recording.sessionId
+  ).toBe('recording-a');
+  expect(run(stopping, 'idle', host).state.recording.sessionId).toBeNull();
 });

--- a/packages/realtime/src/meet/room-recording.test.ts
+++ b/packages/realtime/src/meet/room-recording.test.ts
@@ -89,3 +89,10 @@ describe('room recording lease', () => {
     expect(run(stopped, 'idle').state.recording.state).toBe('idle');
   });
 });
+
+it('retains ready recordings when their owner releases the lease after upload', () => {
+  const state = run(initial(), 'starting').state;
+  state.recordings![0]!.status = 'ready';
+  state.recordings![0]!.path = 'verified-recording.webm';
+  expect(run(state, 'idle').state.recordings?.[0]?.status).toBe('ready');
+});

--- a/packages/realtime/src/meet/room-recording.test.ts
+++ b/packages/realtime/src/meet/room-recording.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  admitOrHold,
+  createMeetRoomSnapshot,
+  type MeetRealtimeTokenPayload,
+} from './index';
+import { applyRecording } from './room-recording';
+
+const now = '2026-09-09T00:00:00Z';
+const host = {
+  userId: 'host-device',
+  accountId: 'host-account',
+  exp: 2000000000,
+  role: 'host',
+  scopes: [],
+  limits: { video: { defaultCameraEnabled: false } },
+} as unknown as MeetRealtimeTokenPayload;
+const guest = {
+  ...host,
+  userId: 'guest-device',
+  accountId: 'guest-account',
+  role: 'speaker',
+} as MeetRealtimeTokenPayload;
+const initial = () =>
+  admitOrHold(
+    admitOrHold(createMeetRoomSnapshot(), host, now).state,
+    guest,
+    now
+  ).state;
+const run = (
+  snapshot: ReturnType<typeof initial>,
+  state: 'starting' | 'recording' | 'stopping' | 'idle',
+  actor = host,
+  id = 'recording-a'
+) =>
+  applyRecording(
+    snapshot,
+    {
+      type: 'recording.state',
+      state,
+      recordingSessionId: id,
+      requestId: 'request',
+    },
+    actor,
+    now
+  );
+
+describe('room recording lease', () => {
+  it('denies participant recording unless explicitly enabled', () => {
+    expect(run(initial(), 'starting', guest).reply[0]).toMatchObject({
+      error: 'permission_denied',
+    });
+    const state = initial();
+    state.settings = {
+      shareNotes: false,
+      ...state.settings,
+      allowParticipantRecording: true,
+    };
+    expect(run(state, 'starting', guest).state.recording.ownerDeviceId).toBe(
+      guest.userId
+    );
+  });
+  it('allows only one concurrent recording, including across devices of the same admin', () => {
+    const claimed = run(initial(), 'starting').state;
+    const other = { ...host, userId: 'host-second-device' };
+    const joined = admitOrHold(claimed, other, now).state;
+    expect(
+      run(joined, 'starting', other, 'recording-b').reply[0]
+    ).toMatchObject({ error: 'recording_already_active' });
+    expect(run(claimed, 'recording').state.recording.state).toBe('recording');
+  });
+  it('cannot revive a recording after a remote stop or finalize another device recording', () => {
+    const claimed = run(initial(), 'starting').state;
+    const stopped = run(claimed, 'stopping').state;
+    expect(run(stopped, 'recording').reply[0]).toMatchObject({
+      error: 'recording_invalid_transition',
+    });
+    const shared = {
+      ...stopped,
+      settings: {
+        shareNotes: false,
+        ...stopped.settings,
+        allowParticipantRecording: true,
+      },
+    };
+    expect(run(shared, 'idle', guest).reply[0]).toMatchObject({
+      error: 'recording_not_owned',
+    });
+    expect(run(stopped, 'idle').state.recording.state).toBe('idle');
+  });
+});

--- a/packages/realtime/src/meet/room-recording.ts
+++ b/packages/realtime/src/meet/room-recording.ts
@@ -90,7 +90,12 @@ export function applyRecording(
     if (message.state === 'recording' && state.recording.state !== 'starting')
       return denied(state, 'recording_invalid_transition', message.requestId);
     if (
-      !owns ||
+      !(
+        owns ||
+        (manages &&
+          state.recording.state === 'stopping' &&
+          (message.state === 'idle' || message.state === 'error'))
+      ) ||
       (message.recordingSessionId !== undefined &&
         message.recordingSessionId !== state.recording.sessionId) ||
       (message.state === 'recording' && !message.recordingSessionId)

--- a/packages/realtime/src/meet/room-recording.ts
+++ b/packages/realtime/src/meet/room-recording.ts
@@ -42,7 +42,13 @@ export function applyRecording(
   if (!controls && !(owns && ['idle', 'error'].includes(message.state)))
     return denied(state, 'permission_denied', message.requestId);
   let next = state;
-  if (message.state === 'starting') {
+  // Older clients claimed a recording directly; keep that transition atomic too.
+  if (
+    message.state === 'starting' ||
+    (message.state === 'recording' &&
+      !token.accountId &&
+      ['idle', 'error'].includes(state.recording.state))
+  ) {
     if (!['idle', 'error'].includes(state.recording.state))
       return denied(state, 'recording_already_active', message.requestId);
     if (!message.recordingSessionId)
@@ -57,7 +63,7 @@ export function applyRecording(
       ...state,
       recording: {
         sessionId: message.recordingSessionId,
-        state: 'starting',
+        state: message.state,
         ownerDeviceId: token.userId,
       },
       recordings: [
@@ -74,14 +80,26 @@ export function applyRecording(
   } else if (message.state === 'stopping') {
     if (!state.recording.sessionId)
       return denied(state, 'recording_not_active', message.requestId);
+    if (
+      message.recordingSessionId !== undefined &&
+      message.recordingSessionId !== state.recording.sessionId
+    )
+      return denied(state, 'recording_not_owned', message.requestId);
     next = { ...state, recording: { ...state.recording, state: 'stopping' } };
   } else {
     if (message.state === 'recording' && state.recording.state !== 'starting')
       return denied(state, 'recording_invalid_transition', message.requestId);
-    if (!owns || message.recordingSessionId !== state.recording.sessionId)
+    if (
+      !owns ||
+      (message.recordingSessionId !== undefined &&
+        message.recordingSessionId !== state.recording.sessionId) ||
+      (message.state === 'recording' && !message.recordingSessionId)
+    )
       return denied(state, 'recording_not_owned', message.requestId);
     next = {
-      ...state,
+      ...(message.state === 'error' || message.state === 'idle'
+        ? failActiveRecording(state, now)
+        : state),
       recording:
         message.state === 'idle' || message.state === 'error'
           ? { sessionId: null, state: message.state }
@@ -92,4 +110,20 @@ export function applyRecording(
     reply: [recordingMessage(next, message.requestId)],
     broadcast: [recordingMessage(next)],
   });
+}
+
+export function failActiveRecording(
+  state: MeetRoomSnapshot,
+  now = new Date().toISOString()
+): MeetRoomSnapshot {
+  return {
+    ...state,
+    recording: { sessionId: null, state: 'idle' },
+    recordings: state.recordings?.map((record) =>
+      record.sessionId === state.recording.sessionId &&
+      record.status === 'recording'
+        ? { ...record, status: 'failed', endedAt: now }
+        : record
+    ),
+  };
 }

--- a/packages/realtime/src/meet/room-recording.ts
+++ b/packages/realtime/src/meet/room-recording.ts
@@ -1,0 +1,95 @@
+import type {
+  MeetRealtimeClientMessage,
+  MeetRealtimeServerMessage,
+} from './messages';
+import type { MeetRealtimeTokenPayload } from './primitives';
+import type { MeetRoomSnapshot } from './room';
+import { denied, outcome } from './room-outcome';
+
+export type RoomRecording = {
+  sessionId: string;
+  ownerAccountId: string;
+  ownerDeviceId: string;
+  startedAt: string;
+  endedAt?: string;
+  path?: string;
+  storageWsId?: string;
+  status: 'recording' | 'ready' | 'failed';
+};
+export function recordingMessage(
+  state: MeetRoomSnapshot,
+  requestId?: string
+): MeetRealtimeServerMessage {
+  return {
+    type: 'recording.state',
+    state: state.recording.state,
+    recordingSessionId: state.recording.sessionId ?? undefined,
+    ownerDeviceId: state.recording.ownerDeviceId,
+    requestId,
+  };
+}
+export function applyRecording(
+  state: MeetRoomSnapshot,
+  message: Extract<MeetRealtimeClientMessage, { type: 'recording.state' }>,
+  token: MeetRealtimeTokenPayload,
+  now: string
+) {
+  const manages = token.role === 'host';
+  const owns = state.recording.ownerDeviceId === token.userId;
+  const controls = manages || !!state.settings?.allowParticipantRecording;
+  if (!state.presence[token.userId])
+    return denied(state, 'awaiting_admission', message.requestId);
+  if (!controls && !(owns && ['idle', 'error'].includes(message.state)))
+    return denied(state, 'permission_denied', message.requestId);
+  let next = state;
+  if (message.state === 'starting') {
+    if (!['idle', 'error'].includes(state.recording.state))
+      return denied(state, 'recording_already_active', message.requestId);
+    if (!message.recordingSessionId)
+      return denied(state, 'recording_session_required', message.requestId);
+    if (
+      (state.recordings ?? []).some(
+        (r) => r.sessionId === message.recordingSessionId
+      )
+    )
+      return denied(state, 'recording_session_exists', message.requestId);
+    next = {
+      ...state,
+      recording: {
+        sessionId: message.recordingSessionId,
+        state: 'starting',
+        ownerDeviceId: token.userId,
+      },
+      recordings: [
+        ...(state.recordings ?? []),
+        {
+          sessionId: message.recordingSessionId,
+          ownerAccountId: token.accountId ?? token.userId,
+          ownerDeviceId: token.userId,
+          startedAt: now,
+          status: 'recording',
+        },
+      ],
+    };
+  } else if (message.state === 'stopping') {
+    if (!state.recording.sessionId)
+      return denied(state, 'recording_not_active', message.requestId);
+    next = { ...state, recording: { ...state.recording, state: 'stopping' } };
+  } else {
+    if (message.state === 'recording' && state.recording.state !== 'starting')
+      return denied(state, 'recording_invalid_transition', message.requestId);
+    if (!owns || message.recordingSessionId !== state.recording.sessionId)
+      return denied(state, 'recording_not_owned', message.requestId);
+    next = {
+      ...state,
+      recording:
+        message.state === 'idle' || message.state === 'error'
+          ? { sessionId: null, state: message.state }
+          : { ...state.recording, state: message.state },
+    };
+  }
+  return outcome(next, {
+    reply: [recordingMessage(next, message.requestId)],
+    broadcast: [recordingMessage(next)],
+  });
+}

--- a/packages/realtime/src/meet/room-review.test.ts
+++ b/packages/realtime/src/meet/room-review.test.ts
@@ -1,0 +1,123 @@
+import { expect, it } from 'vitest';
+import {
+  admitOrHold,
+  applyMeetRoomCommand,
+  createMeetRoomSnapshot,
+  getMeetRealtimeScopesForRole,
+  meetRealtimeClientMessageSchema,
+  meetRealtimeTokenPayloadSchema,
+  releaseParticipant,
+} from './index';
+import { canReadRoomNotes } from './room-controls';
+
+const now = '2026-09-09T00:00:00Z';
+const account = '11111111-1111-4111-8111-111111111111';
+const device = '22222222-2222-4222-8222-222222222222';
+const host = meetRealtimeTokenPayloadSchema.parse({
+  userId: '33333333-3333-4333-8333-333333333333',
+  exp: 2000000000,
+  role: 'host',
+  scopes: getMeetRealtimeScopesForRole('host'),
+  mode: 'call',
+  limits: {},
+  meetingId: account,
+  roomId: 'room',
+  wsId: account,
+});
+const guest = {
+  ...host,
+  userId: device,
+  accountId: account,
+  role: 'speaker' as const,
+  scopes: getMeetRealtimeScopesForRole('speaker'),
+};
+const initial = () =>
+  admitOrHold(
+    admitOrHold(createMeetRoomSnapshot(), host, now).state,
+    guest,
+    now
+  ).state;
+function run(
+  state: ReturnType<typeof initial>,
+  message: unknown,
+  actor = host
+) {
+  return applyMeetRoomCommand(state, {
+    message: meetRealtimeClientMessageSchema.parse(message),
+    token: actor,
+    now,
+  });
+}
+it.each(['participant.remove', 'admission.forget'])(
+  'revokes remembered account permission through a device with %s',
+  (type) => {
+    const state = initial();
+    state.approved = { [account]: { userId: account, displayName: 'Guest' } };
+    expect(
+      run(state, { type, userId: device }).state.approved?.[account]
+    ).toBeUndefined();
+  }
+);
+it('keeps opt-in notes sharing when only recording policy changes', () => {
+  const state = initial();
+  state.settings = { shareNotes: true, shareNotesAfterMeeting: true };
+  expect(
+    run(state, {
+      type: 'room.settings.update',
+      settings: { shareRecordings: true },
+    }).state.settings
+  ).toEqual({
+    shareNotes: true,
+    shareNotesAfterMeeting: true,
+    shareRecordings: true,
+  });
+});
+it('preserves access for legacy device-keyed approvals', () => {
+  const state = initial();
+  state.presence = {};
+  state.approved = { [device]: { userId: device, displayName: 'Guest' } };
+  state.settings = { shareNotes: true };
+  expect(canReadRoomNotes(state, guest)).toBe(true);
+});
+it('acknowledges chat once and sends it only to other admitted devices', () => {
+  const result = run(
+    initial(),
+    { type: 'chat.message', body: 'Hello', requestId: 'request' },
+    guest
+  );
+  expect(result.reply).toHaveLength(1);
+  expect(result.broadcast).toHaveLength(0);
+  expect(result.direct.map((entry) => entry.userId)).toEqual([host.userId]);
+});
+it('allows legacy host recordings and terminal updates without an ID', () => {
+  const result = run(initial(), {
+    type: 'recording.state',
+    state: 'recording',
+    recordingSessionId: account,
+  });
+  expect(result.state.recording.state).toBe('recording');
+  expect(
+    run(result.state, { type: 'recording.state', state: 'idle' }).state
+      .recording.sessionId
+  ).toBeNull();
+});
+it('rejects stale stop commands and marks interrupted history failed', () => {
+  const state = run(initial(), {
+    type: 'recording.state',
+    state: 'starting',
+    recordingSessionId: account,
+  }).state;
+  expect(
+    run(state, {
+      type: 'recording.state',
+      state: 'stopping',
+      recordingSessionId: device,
+    }).reply[0]
+  ).toMatchObject({ error: 'recording_not_owned' });
+  const released = releaseParticipant(state, host.userId, host.roomId).state;
+  expect(released.recording.sessionId).toBeNull();
+  expect(released.recordings?.[0]).toMatchObject({
+    status: 'failed',
+    endedAt: expect.any(String),
+  });
+});

--- a/packages/realtime/src/meet/room-service.test.ts
+++ b/packages/realtime/src/meet/room-service.test.ts
@@ -139,3 +139,26 @@ it('shares recording metadata after a call only when explicitly enabled', () => 
   expect(JSON.stringify(result.body)).not.toContain('private-storage-path');
   expect(roomService(state, token, { action: 'read' }).status).toBe(403);
 });
+
+it('permits new questions after an abandoned request while retaining late cost accounting', () => {
+  const state = initial();
+  state.aiRequests = {
+    abandoned: {
+      userId: account,
+      status: 'pending',
+      startedAt: Date.now() - 180000,
+    },
+  };
+  const next = roomService(state, token, {
+    action: 'ai.reserve',
+    messageId: 'message',
+  });
+  expect(next.status).toBeUndefined();
+  const late = roomService(next.state, token, {
+    action: 'ai.finish',
+    messageId: 'abandoned',
+    costUsd: 0.001,
+  });
+  expect(late.status).toBeUndefined();
+  expect(late.state.aiRequests?.abandoned?.costUsd).toBe(0.001);
+});

--- a/packages/realtime/src/meet/room-service.test.ts
+++ b/packages/realtime/src/meet/room-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   admitOrHold,
+  applyMeetRoomCommand,
   createMeetRoomSnapshot,
   meetRealtimeTokenPayloadSchema,
 } from './index';
@@ -170,4 +171,63 @@ it('keeps legacy pending requests active until Worker migration timestamps them'
     roomService(state, token, { action: 'ai.reserve', messageId: 'message' })
       .status
   ).toBe(409);
+});
+
+it('discards only the uploader’s unsent files and preserves sent files after an acknowledgement is lost', () => {
+  const file = {
+    id: account,
+    name: 'file.txt',
+    size: 10,
+    contentType: 'text/plain',
+    path: 'Meet/chat/file.txt',
+    storageWsId: token.wsId,
+  };
+  const state = roomService(initial(), token, {
+    action: 'attach',
+    attachment: file,
+  }).state;
+  const other = { ...token, accountId: token.meetingId };
+  expect(
+    roomService(state, other, { action: 'attachment.discard', id: account })
+      .status
+  ).toBe(404);
+  const sent = applyMeetRoomCommand(state, {
+    token: { ...token, scopes: [...token.scopes, 'chat:write'] },
+    now,
+    message: { type: 'chat.message', body: 'File', attachmentIds: [account] },
+  });
+  expect(sent.state.attachments?.[account]?.published).toBe(true);
+  expect(
+    roomService(sent.state, token, {
+      action: 'attachment.discard',
+      id: account,
+    }).status
+  ).toBe(409);
+  const discarded = roomService(state, token, {
+    action: 'attachment.discard',
+    id: account,
+  });
+  expect(discarded.status).toBeUndefined();
+  expect(
+    roomService(discarded.state, token, { action: 'attachment', id: account })
+      .status
+  ).toBe(404);
+});
+
+it('acknowledges a repeated completed assistant settlement without duplicating messages or cost', () => {
+  const reserved = roomService(initial(), token, {
+    action: 'ai.reserve',
+    messageId: 'message',
+  }).state;
+  const command = {
+    action: 'ai.finish',
+    messageId: 'message',
+    body: 'Answer',
+    costUsd: 0.001,
+  };
+  const done = roomService(reserved, token, command);
+  const retried = roomService(done.state, token, command);
+  expect(retried.status).toBeUndefined();
+  expect(retried.state).toBe(done.state);
+  expect(retried.messages).toBeUndefined();
 });

--- a/packages/realtime/src/meet/room-service.test.ts
+++ b/packages/realtime/src/meet/room-service.test.ts
@@ -244,6 +244,14 @@ it('reclaims a discarded attachment slot only after storage deletion succeeds', 
     action: 'attach',
     attachment: file,
   }).state;
+  for (let i = 0; i < 999; i++) {
+    const id = `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`;
+    state.attachments![id] = { ...file, id };
+  }
+  const nextUpload = {
+    action: 'attach',
+    attachment: { ...file, id: token.meetingId },
+  };
   expect(
     roomService(state, token, { action: 'attachment.deleted', id: account })
       .status
@@ -252,11 +260,13 @@ it('reclaims a discarded attachment slot only after storage deletion succeeds', 
     action: 'attachment.discard',
     id: account,
   }).state;
+  expect(roomService(discarded, token, nextUpload).status).toBe(409);
   const deleted = roomService(discarded, token, {
     action: 'attachment.deleted',
     id: account,
   });
   expect(deleted.state.attachments?.[account]).toBeUndefined();
+  expect(roomService(deleted.state, token, nextUpload).status).toBeUndefined();
   expect(
     roomService(deleted.state, token, {
       action: 'attachment.deleted',

--- a/packages/realtime/src/meet/room-service.test.ts
+++ b/packages/realtime/src/meet/room-service.test.ts
@@ -108,8 +108,8 @@ describe('trusted room services', () => {
         action: 'ai.finish',
         messageId: 'message',
         body: 'Duplicate',
-      }).status
-    ).toBe(409);
+      }).state
+    ).toBe(result.state);
   });
 });
 

--- a/packages/realtime/src/meet/room-service.test.ts
+++ b/packages/realtime/src/meet/room-service.test.ts
@@ -162,3 +162,12 @@ it('permits new questions after an abandoned request while retaining late cost a
   expect(late.status).toBeUndefined();
   expect(late.state.aiRequests?.abandoned?.costUsd).toBe(0.001);
 });
+
+it('keeps legacy pending requests active until Worker migration timestamps them', () => {
+  const state = initial();
+  state.aiRequests = { legacy: { userId: account, status: 'pending' } };
+  expect(
+    roomService(state, token, { action: 'ai.reserve', messageId: 'message' })
+      .status
+  ).toBe(409);
+});

--- a/packages/realtime/src/meet/room-service.test.ts
+++ b/packages/realtime/src/meet/room-service.test.ts
@@ -71,12 +71,18 @@ describe('trusted room services', () => {
       }).status
     ).toBe(409);
     const other = { ...token, accountId: 'other', userId: 'other' };
+    const otherState = initial();
+    otherState.presence[other.userId] = {
+      ...otherState.presence[token.userId]!,
+      userId: other.userId,
+      accountId: other.accountId,
+    };
     expect(
-      roomService(initial(), other, {
+      roomService(otherState, other, {
         action: 'ai.reserve',
         messageId: 'message',
       }).status
-    ).toBe(403);
+    ).toBe(404);
   });
   it('preserves incurred AI costs when the meeting ends during generation', () => {
     const reserved = roomService(initial(), token, {

--- a/packages/realtime/src/meet/room-service.test.ts
+++ b/packages/realtime/src/meet/room-service.test.ts
@@ -231,3 +231,36 @@ it('acknowledges a repeated completed assistant settlement without duplicating m
   expect(retried.state).toBe(done.state);
   expect(retried.messages).toBeUndefined();
 });
+it('reclaims a discarded attachment slot only after storage deletion succeeds', () => {
+  const file = {
+    id: account,
+    name: 'file.txt',
+    size: 10,
+    contentType: 'text/plain',
+    path: 'Meet/file.txt',
+    storageWsId: token.wsId,
+  };
+  const state = roomService(initial(), token, {
+    action: 'attach',
+    attachment: file,
+  }).state;
+  expect(
+    roomService(state, token, { action: 'attachment.deleted', id: account })
+      .status
+  ).toBe(403);
+  const discarded = roomService(state, token, {
+    action: 'attachment.discard',
+    id: account,
+  }).state;
+  const deleted = roomService(discarded, token, {
+    action: 'attachment.deleted',
+    id: account,
+  });
+  expect(deleted.state.attachments?.[account]).toBeUndefined();
+  expect(
+    roomService(deleted.state, token, {
+      action: 'attachment.deleted',
+      id: account,
+    }).status
+  ).toBeUndefined();
+});

--- a/packages/realtime/src/meet/room-service.test.ts
+++ b/packages/realtime/src/meet/room-service.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import {
+  admitOrHold,
+  createMeetRoomSnapshot,
+  meetRealtimeTokenPayloadSchema,
+} from './index';
+import { type RoomServiceState, roomService } from './room-service';
+
+const account = '9b5c036d-d38d-4c12-b8e8-2e0b2b4a2691';
+const token = meetRealtimeTokenPayloadSchema.parse({
+  exp: 2000000000,
+  limits: {},
+  meetingId: '5e5217de-9bb3-4e20-8d99-526ad3e7e34f',
+  mode: 'call',
+  role: 'speaker',
+  roomId: 'room',
+  scopes: ['meet:server'],
+  userId: account,
+  accountId: account,
+  wsId: '0f1a64f7-780f-4d30-9d72-5530f204e95c',
+});
+const now = '2026-09-09T00:00:00Z';
+const initial = (): RoomServiceState => ({
+  ...admitOrHold(createMeetRoomSnapshot(), token, now).state,
+  chat: [
+    {
+      type: 'chat.message',
+      id: 'message',
+      displayName: 'Guest',
+      userId: account,
+      accountId: account,
+      body: '@Tuturuuu summarize our discussion',
+      createdAt: now,
+    },
+  ],
+});
+
+describe('trusted room services', () => {
+  it('rejects browser tokens even when they belong to the host', () => {
+    expect(
+      roomService(
+        initial(),
+        { ...token, role: 'host', scopes: [] },
+        { action: 'costs' }
+      ).status
+    ).toBe(403);
+  });
+  it('keeps costs and recording access admin-only by default', () => {
+    expect(roomService(initial(), token, { action: 'costs' }).status).toBe(403);
+    expect(
+      roomService(initial(), token, {
+        action: 'recording.read',
+        sessionId: account,
+      }).status
+    ).toBe(403);
+    expect(
+      roomService(initial(), { ...token, role: 'host' }, { action: 'costs' })
+        .status
+    ).toBeUndefined();
+  });
+  it('deduplicates assistant requests and rejects another account’s mention', () => {
+    const reserved = roomService(initial(), token, {
+      action: 'ai.reserve',
+      messageId: 'message',
+    });
+    expect(reserved.status).toBeUndefined();
+    expect(
+      roomService(reserved.state, token, {
+        action: 'ai.reserve',
+        messageId: 'message',
+      }).status
+    ).toBe(409);
+    const other = { ...token, accountId: 'other', userId: 'other' };
+    expect(
+      roomService(initial(), other, {
+        action: 'ai.reserve',
+        messageId: 'message',
+      }).status
+    ).toBe(403);
+  });
+  it('preserves incurred AI costs when the meeting ends during generation', () => {
+    const reserved = roomService(initial(), token, {
+      action: 'ai.reserve',
+      messageId: 'message',
+    });
+    const ended = { ...reserved.state, presence: {}, ended: true };
+    const result = roomService(ended, token, {
+      action: 'ai.finish',
+      messageId: 'message',
+      body: 'Summary',
+      costUsd: 0.001,
+    });
+    expect(result.status).toBeUndefined();
+    expect(result.state.aiRequests?.message?.costUsd).toBe(0.001);
+    expect(result.messages?.[0]).toMatchObject({
+      assistant: true,
+      displayName: 'Mira',
+    });
+    expect(
+      roomService(result.state, token, {
+        action: 'ai.finish',
+        messageId: 'message',
+        body: 'Duplicate',
+      }).status
+    ).toBe(409);
+  });
+});
+
+it('shares recording metadata after a call only when explicitly enabled', () => {
+  const state: RoomServiceState = {
+    ...initial(),
+    presence: {},
+    ended: true,
+    approved: { [account]: { userId: account, displayName: 'Guest' } },
+    recordings: [
+      {
+        sessionId: account,
+        ownerAccountId: account,
+        ownerDeviceId: account,
+        startedAt: now,
+        status: 'ready',
+        path: 'private-storage-path',
+        storageWsId: account,
+      },
+    ],
+  };
+  expect(roomService(state, token, { action: 'recording.list' }).status).toBe(
+    403
+  );
+  state.settings = { shareNotes: false, shareRecordings: true };
+  const result = roomService(state, token, { action: 'recording.list' });
+  expect(result.status).toBeUndefined();
+  expect(JSON.stringify(result.body)).not.toContain('private-storage-path');
+  expect(roomService(state, token, { action: 'read' }).status).toBe(403);
+});

--- a/packages/realtime/src/meet/room-service.ts
+++ b/packages/realtime/src/meet/room-service.ts
@@ -28,6 +28,7 @@ export type RoomServiceState = MeetRoomSnapshot & {
     {
       userId: string;
       status: 'pending' | 'done' | 'failed';
+      startedAt?: number;
       costUsd?: number | null;
     }
   >;
@@ -212,7 +213,9 @@ export function roomService(
     if (
       Object.values(snapshot.aiRequests ?? {}).some(
         (request) =>
-          request.userId === accountId && request.status === 'pending'
+          request.userId === accountId &&
+          request.status === 'pending' &&
+          Date.now() - (request.startedAt ?? 0) < 120000
       )
     )
       return fail('Assistant request already in progress', 409);
@@ -231,7 +234,11 @@ export function roomService(
       ...snapshot,
       aiRequests: {
         ...snapshot.aiRequests,
-        [message.messageId]: { userId: accountId, status: 'pending' as const },
+        [message.messageId]: {
+          userId: accountId,
+          status: 'pending' as const,
+          startedAt: Date.now(),
+        },
       },
     };
     return {

--- a/packages/realtime/src/meet/room-service.ts
+++ b/packages/realtime/src/meet/room-service.ts
@@ -215,7 +215,8 @@ export function roomService(
         (request) =>
           request.userId === accountId &&
           request.status === 'pending' &&
-          Date.now() - (request.startedAt ?? 0) < 120000
+          (request.startedAt === undefined ||
+            Date.now() - request.startedAt < 120000)
       )
     )
       return fail('Assistant request already in progress', 409);

--- a/packages/realtime/src/meet/room-service.ts
+++ b/packages/realtime/src/meet/room-service.ts
@@ -1,0 +1,271 @@
+import { z } from 'zod';
+import type {
+  MeetRealtimeServerMessage,
+  MeetRealtimeTokenPayload,
+  MeetRoomSnapshot,
+} from './index';
+import type { RoomRecording } from './room-recording';
+import { summarizeRoomUsage } from './room-usage';
+
+const attachment = z.object({
+  id: z.uuid(),
+  name: z.string().min(1).max(255),
+  size: z.number().int().positive().max(100_000_000),
+  contentType: z.string().max(255),
+  path: z.string().max(1024),
+  storageWsId: z.uuid(),
+});
+export type RoomAttachment = z.infer<typeof attachment>;
+export type RoomChatMessage = Extract<
+  MeetRealtimeServerMessage,
+  { type: 'chat.message' }
+>;
+export type RoomServiceState = MeetRoomSnapshot & {
+  chat?: RoomChatMessage[];
+  attachments?: Record<string, RoomAttachment>;
+  aiRequests?: Record<
+    string,
+    {
+      userId: string;
+      status: 'pending' | 'done' | 'failed';
+      costUsd?: number | null;
+    }
+  >;
+};
+const command = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('read') }),
+  z.object({ action: z.literal('costs') }),
+  z.object({ action: z.literal('recording.list') }),
+  z.object({ action: z.literal('attach'), attachment }),
+  z.object({ action: z.literal('attachment'), id: z.uuid() }),
+  z.object({
+    action: z.literal('recording.save'),
+    sessionId: z.uuid(),
+    path: z.string().max(1024),
+    storageWsId: z.uuid(),
+  }),
+  z.object({ action: z.literal('recording.read'), sessionId: z.uuid() }),
+  z.object({ action: z.literal('recording.authorize'), sessionId: z.uuid() }),
+  z.object({ action: z.literal('ai.reserve'), messageId: z.string().max(200) }),
+  z.object({
+    action: z.literal('ai.finish'),
+    messageId: z.string().max(200),
+    body: z.string().max(16000).optional(),
+    costUsd: z.number().nonnegative().nullable().optional(),
+  }),
+]);
+export function roomService(
+  snapshot: RoomServiceState,
+  token: MeetRealtimeTokenPayload,
+  input: unknown
+): {
+  state: RoomServiceState;
+  body: unknown;
+  status?: number;
+  messages?: MeetRealtimeServerMessage[];
+} {
+  const fail = (error: string, status = 403) => ({
+    state: snapshot,
+    body: { error },
+    status,
+  });
+  if (!token.scopes.includes('meet:server')) return fail('Forbidden');
+  const parsed = command.safeParse(input);
+  if (!parsed.success) return fail('Invalid request', 400);
+  const accountId = token.accountId ?? token.userId;
+  const admitted = Object.values(snapshot.presence).some(
+    (person) => (person.accountId ?? person.userId) === accountId
+  );
+  const approved =
+    admitted ||
+    !!snapshot.approved?.[accountId] ||
+    token.scopes.includes('meet:workspace-member');
+  const admin = token.role === 'host';
+  const message = parsed.data;
+  if (message.action === 'recording.authorize') {
+    const record = snapshot.recordings?.find(
+      (r) => r.sessionId === message.sessionId && r.ownerAccountId === accountId
+    );
+    return record
+      ? { state: snapshot, body: { ok: true, saved: !!record.path } }
+      : fail('Recording unavailable', 409);
+  }
+  if (message.action === 'recording.save') {
+    const record = snapshot.recordings?.find(
+      (r) => r.sessionId === message.sessionId && r.ownerAccountId === accountId
+    );
+    if (!record) return fail('Recording unavailable', 409);
+    if (record.path)
+      return record.path === message.path &&
+        record.storageWsId === message.storageWsId
+        ? { state: snapshot, body: { ok: true } }
+        : fail('Recording unavailable', 409);
+    const recordings = snapshot.recordings!.map((r) =>
+      r === record
+        ? {
+            ...record,
+            path: message.path,
+            storageWsId: message.storageWsId,
+            status: 'ready' as const,
+            endedAt: new Date().toISOString(),
+          }
+        : r
+    );
+    return { state: { ...snapshot, recordings }, body: { ok: true } };
+  }
+  if (message.action === 'recording.list') {
+    if (!admin && !(approved && snapshot.settings?.shareRecordings))
+      return fail('Recording access is disabled');
+    return {
+      state: snapshot,
+      body: {
+        recordings: (snapshot.recordings ?? []).map(
+          ({ sessionId, startedAt, endedAt, status }) => ({
+            sessionId,
+            startedAt,
+            endedAt,
+            status,
+          })
+        ),
+      },
+    };
+  }
+  if (message.action === 'recording.read') {
+    if (!admin && !(approved && snapshot.settings?.shareRecordings))
+      return fail('Recording access is disabled');
+    const record = snapshot.recordings?.find(
+      (r) => r.sessionId === message.sessionId && r.status === 'ready'
+    );
+    return record
+      ? { state: snapshot, body: record }
+      : fail('Recording unavailable', 404);
+  }
+  if (message.action === 'costs') {
+    if (!admin) return fail('Forbidden');
+    return {
+      state: snapshot,
+      body: {
+        cloudflare: summarizeRoomUsage(snapshot.usage),
+        miraRequests: Object.values(snapshot.aiRequests ?? {}).length,
+        miraCostUsd: Object.values(snapshot.aiRequests ?? {}).reduce(
+          (sum, r) => sum + (r.costUsd ?? 0),
+          0
+        ),
+        miraUnpriced: Object.values(snapshot.aiRequests ?? {}).filter(
+          (r) => r.costUsd == null
+        ).length,
+      },
+    };
+  }
+  if (message.action === 'read') {
+    if (!admitted && !admin) return fail('Join the meeting first');
+    return {
+      state: snapshot,
+      body: {
+        chat: snapshot.chat ?? [],
+        settings: snapshot.settings ?? { shareNotes: false },
+        recording: snapshot.recording,
+        recordings:
+          admin || snapshot.settings?.shareRecordings
+            ? (snapshot.recordings ?? []).map(
+                ({ sessionId, startedAt, endedAt, status }: RoomRecording) => ({
+                  sessionId,
+                  startedAt,
+                  endedAt,
+                  status,
+                })
+              )
+            : [],
+        ...(admin
+          ? {
+              aiRequests: snapshot.aiRequests ?? {},
+              cloudflare: summarizeRoomUsage(snapshot.usage),
+            }
+          : {}),
+      },
+    };
+  }
+  // Finalize an already authorized generation even if its user left meanwhile.
+  if (message.action !== 'ai.finish' && (!admitted || snapshot.ended))
+    return fail('Join the active meeting first');
+  if (message.action === 'attach') {
+    if (Object.keys(snapshot.attachments ?? {}).length >= 1000)
+      return fail('Room attachment limit reached', 409);
+    return {
+      state: {
+        ...snapshot,
+        attachments: {
+          ...snapshot.attachments,
+          [message.attachment.id]: message.attachment,
+        },
+      },
+      body: { ok: true },
+    };
+  }
+  if (message.action === 'attachment') {
+    const file = snapshot.attachments?.[message.id];
+    return file
+      ? { state: snapshot, body: file }
+      : fail('Attachment unavailable', 404);
+  }
+  if (message.action === 'ai.reserve') {
+    if (
+      Object.values(snapshot.aiRequests ?? {}).some(
+        (request) =>
+          request.userId === accountId && request.status === 'pending'
+      )
+    )
+      return fail('Assistant request already in progress', 409);
+    if (Object.keys(snapshot.aiRequests ?? {}).length >= 1000)
+      return fail('Room assistant limit reached', 409);
+    const original = snapshot.chat?.find(
+      (m) =>
+        m.id === message.messageId &&
+        (m.accountId ?? m.userId) === accountId &&
+        /(^|\s)@Tuturuuu\b/i.test(m.body)
+    );
+    if (!original) return fail('Mention not found', 404);
+    if (snapshot.aiRequests?.[message.messageId])
+      return fail('Assistant already requested', 409);
+    const state = {
+      ...snapshot,
+      aiRequests: {
+        ...snapshot.aiRequests,
+        [message.messageId]: { userId: accountId, status: 'pending' as const },
+      },
+    };
+    return {
+      state,
+      body: { chat: snapshot.chat?.slice(-40) ?? [], prompt: original.body },
+    };
+  }
+  const pending = snapshot.aiRequests?.[message.messageId];
+  if (!pending || pending.userId !== accountId || pending.status !== 'pending')
+    return fail('Assistant request unavailable', 409);
+  const response: RoomChatMessage | undefined = message.body
+    ? {
+        type: 'chat.message',
+        id: crypto.randomUUID(),
+        userId: '00000000-0000-4000-8000-000000000001',
+        displayName: 'Mira',
+        assistant: true,
+        body: message.body,
+        createdAt: new Date().toISOString(),
+      }
+    : undefined;
+  const state = {
+    ...snapshot,
+    aiRequests: {
+      ...snapshot.aiRequests,
+      [message.messageId]: {
+        ...pending,
+        status: response ? ('done' as const) : ('failed' as const),
+        costUsd: message.costUsd,
+      },
+    },
+    chat: response
+      ? [...(snapshot.chat ?? []), response].slice(-500)
+      : snapshot.chat,
+  };
+  return { state, body: { ok: true }, messages: response ? [response] : [] };
+}

--- a/packages/realtime/src/meet/room-service.ts
+++ b/packages/realtime/src/meet/room-service.ts
@@ -44,6 +44,7 @@ const command = z.discriminatedUnion('action', [
   z.object({ action: z.literal('attach'), attachment }),
   z.object({ action: z.literal('attachment'), id: z.uuid() }),
   z.object({ action: z.literal('attachment.discard'), id: z.uuid() }),
+  z.object({ action: z.literal('attachment.deleted'), id: z.uuid() }),
   z.object({
     action: z.literal('recording.save'),
     sessionId: z.uuid(),
@@ -190,6 +191,15 @@ export function roomService(
           : {}),
       },
     };
+  }
+  if (message.action === 'attachment.deleted') {
+    const file = snapshot.attachments?.[message.id];
+    if (!file) return { state: snapshot, body: { ok: true } };
+    if (file.ownerAccountId !== accountId || !file.discarded || file.published)
+      return fail('Attachment cannot be removed');
+    const attachments = { ...snapshot.attachments };
+    delete attachments[message.id];
+    return { state: { ...snapshot, attachments }, body: { ok: true } };
   }
   if (message.action === 'attachment.discard') {
     const file = snapshot.attachments?.[message.id];

--- a/packages/realtime/src/meet/room-service.ts
+++ b/packages/realtime/src/meet/room-service.ts
@@ -15,7 +15,11 @@ const attachment = z.object({
   path: z.string().trim().min(1).max(1024),
   storageWsId: z.uuid(),
 });
-export type RoomAttachment = z.infer<typeof attachment>;
+export type RoomAttachment = z.infer<typeof attachment> & {
+  ownerAccountId?: string;
+  discarded?: boolean;
+  published?: boolean;
+};
 export type RoomChatMessage = Extract<
   MeetRealtimeServerMessage,
   { type: 'chat.message' }
@@ -39,6 +43,7 @@ const command = z.discriminatedUnion('action', [
   z.object({ action: z.literal('recording.list') }),
   z.object({ action: z.literal('attach'), attachment }),
   z.object({ action: z.literal('attachment'), id: z.uuid() }),
+  z.object({ action: z.literal('attachment.discard'), id: z.uuid() }),
   z.object({
     action: z.literal('recording.save'),
     sessionId: z.uuid(),
@@ -186,6 +191,22 @@ export function roomService(
       },
     };
   }
+  if (message.action === 'attachment.discard') {
+    const file = snapshot.attachments?.[message.id];
+    if (!file || file.ownerAccountId !== accountId)
+      return fail('Attachment unavailable', 404);
+    if (file.published) return fail('Attachment is already shared', 409);
+    return {
+      state: {
+        ...snapshot,
+        attachments: {
+          ...snapshot.attachments,
+          [message.id]: { ...file, discarded: true },
+        },
+      },
+      body: { path: file.path, storageWsId: file.storageWsId },
+    };
+  }
   // Finalize an already authorized generation even if its user left meanwhile.
   if (message.action !== 'ai.finish' && (!admitted || snapshot.ended))
     return fail('Join the active meeting first');
@@ -197,7 +218,10 @@ export function roomService(
         ...snapshot,
         attachments: {
           ...snapshot.attachments,
-          [message.attachment.id]: message.attachment,
+          [message.attachment.id]: {
+            ...message.attachment,
+            ownerAccountId: accountId,
+          },
         },
       },
       body: { ok: true },
@@ -205,7 +229,7 @@ export function roomService(
   }
   if (message.action === 'attachment') {
     const file = snapshot.attachments?.[message.id];
-    return file
+    return file && !file.discarded
       ? { state: snapshot, body: file }
       : fail('Attachment unavailable', 404);
   }
@@ -248,7 +272,10 @@ export function roomService(
     };
   }
   const pending = snapshot.aiRequests?.[message.messageId];
-  if (!pending || pending.userId !== accountId || pending.status !== 'pending')
+  if (!pending || pending.userId !== accountId)
+    return fail('Assistant request unavailable', 409);
+  if (pending.status === 'done') return { state: snapshot, body: { ok: true } };
+  if (pending.status !== 'pending')
     return fail('Assistant request unavailable', 409);
   const response: RoomChatMessage | undefined = message.body
     ? {

--- a/packages/realtime/src/meet/room-service.ts
+++ b/packages/realtime/src/meet/room-service.ts
@@ -12,7 +12,7 @@ const attachment = z.object({
   name: z.string().min(1).max(255),
   size: z.number().int().positive().max(100_000_000),
   contentType: z.string().max(255),
-  path: z.string().max(1024),
+  path: z.string().trim().min(1).max(1024),
   storageWsId: z.uuid(),
 });
 export type RoomAttachment = z.infer<typeof attachment>;
@@ -41,7 +41,7 @@ const command = z.discriminatedUnion('action', [
   z.object({
     action: z.literal('recording.save'),
     sessionId: z.uuid(),
-    path: z.string().max(1024),
+    path: z.string().trim().min(1).max(1024),
     storageWsId: z.uuid(),
   }),
   z.object({ action: z.literal('recording.read'), sessionId: z.uuid() }),

--- a/packages/realtime/src/meet/room-usage.test.ts
+++ b/packages/realtime/src/meet/room-usage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyUsageReport,
+  createRoomUsage,
+  summarizeRoomUsage,
+} from './room-usage';
+
+describe('room cost estimates', () => {
+  it('counts cumulative reports once and ignores late smaller values', () => {
+    let usage = createRoomUsage();
+    usage = applyUsageReport(usage, 'a', 'report', 1000, 'now');
+    usage = applyUsageReport(usage, 'a', 'report', 1000, 'now');
+    usage = applyUsageReport(usage, 'a', 'report', 900, 'now');
+    usage = applyUsageReport(usage, 'a', 'report', 1200, 'now');
+    usage = applyUsageReport(usage, 'b', 'report', 500, 'now');
+    expect(usage.receivedBytes).toBe(1700);
+  });
+  it('never presents missing measurements as complete billing', () => {
+    expect(summarizeRoomUsage(undefined)).toBeNull();
+    const usage = createRoomUsage();
+    usage.receivedBytes = 1_000_000_000;
+    usage.webSocketMessages = 20;
+    usage.httpRequests = 1;
+    const summary = summarizeRoomUsage(usage)!;
+    expect(summary.sfuEgressUsd).toBe(0.05);
+    expect(summary.durableRequestsUsd).toBeCloseTo(0.0000003, 12);
+    expect(summary.complete).toBe(false);
+  });
+  it('retains a zero-byte report for measurement coverage', () => {
+    const usage = applyUsageReport(createRoomUsage(), 'a', 'report', 0, 'now');
+    expect(summarizeRoomUsage(usage)?.reportingDevices).toBe(1);
+  });
+});

--- a/packages/realtime/src/meet/room-usage.test.ts
+++ b/packages/realtime/src/meet/room-usage.test.ts
@@ -85,3 +85,18 @@ it('bounds implausible reports and keeps counting after bounded history rotates'
   expect(replay.receivedBytes).toBe(usage.receivedBytes);
   expect(summarizeRoomUsage(replay)?.limitedReports).toBeGreaterThan(0);
 });
+
+it('does not let a rejected report baseline another device’s initial bytes', () => {
+  const now = new Date().toISOString();
+  const rejected = applyUsageReport(
+    createRoomUsage(),
+    'bad-device',
+    'bad-report',
+    Number.MAX_SAFE_INTEGER,
+    now
+  );
+  expect(
+    applyUsageReport(rejected, 'good-device', 'new-report', 1000, now)
+      .receivedBytes
+  ).toBe(1000);
+});

--- a/packages/realtime/src/meet/room-usage.test.ts
+++ b/packages/realtime/src/meet/room-usage.test.ts
@@ -124,3 +124,17 @@ it('bounds distinct reporting devices without resetting their allowances', () =>
   expect(next.limitedReports).toBe(1);
   expect(next.receivedBytes).toBe(0);
 });
+it('includes legacy reporting identities when enforcing the distinct-device bound', () => {
+  const usage = createRoomUsage();
+  usage.reportedDevices = Object.fromEntries(
+    Array.from({ length: 4095 }, (_, i) => [String(i), true as const])
+  );
+  usage.reports.legacy = {
+    deviceId: 'legacy',
+    bytes: 10,
+    updatedAt: usage.startedAt,
+  };
+  const next = applyUsageReport(usage, 'new', 'report', 10, usage.startedAt);
+  expect(next.limitedReports).toBe(1);
+  expect(next.deviceBytes).toBeUndefined();
+});

--- a/packages/realtime/src/meet/room-usage.test.ts
+++ b/packages/realtime/src/meet/room-usage.test.ts
@@ -8,11 +8,41 @@ import {
 describe('room cost estimates', () => {
   it('counts cumulative reports once and ignores late smaller values', () => {
     let usage = createRoomUsage();
-    usage = applyUsageReport(usage, 'a', 'report', 1000, 'now');
-    usage = applyUsageReport(usage, 'a', 'report', 1000, 'now');
-    usage = applyUsageReport(usage, 'a', 'report', 900, 'now');
-    usage = applyUsageReport(usage, 'a', 'report', 1200, 'now');
-    usage = applyUsageReport(usage, 'b', 'report', 500, 'now');
+    usage = applyUsageReport(
+      usage,
+      'a',
+      'report',
+      1000,
+      new Date().toISOString()
+    );
+    usage = applyUsageReport(
+      usage,
+      'a',
+      'report',
+      1000,
+      new Date().toISOString()
+    );
+    usage = applyUsageReport(
+      usage,
+      'a',
+      'report',
+      900,
+      new Date().toISOString()
+    );
+    usage = applyUsageReport(
+      usage,
+      'a',
+      'report',
+      1200,
+      new Date().toISOString()
+    );
+    usage = applyUsageReport(
+      usage,
+      'b',
+      'report',
+      500,
+      new Date().toISOString()
+    );
     expect(usage.receivedBytes).toBe(1700);
   });
   it('never presents missing measurements as complete billing', () => {
@@ -27,7 +57,31 @@ describe('room cost estimates', () => {
     expect(summary.complete).toBe(false);
   });
   it('retains a zero-byte report for measurement coverage', () => {
-    const usage = applyUsageReport(createRoomUsage(), 'a', 'report', 0, 'now');
+    const usage = applyUsageReport(
+      createRoomUsage(),
+      'a',
+      'report',
+      0,
+      new Date().toISOString()
+    );
     expect(summarizeRoomUsage(usage)?.reportingDevices).toBe(1);
   });
+});
+
+it('bounds implausible reports and keeps counting after bounded history rotates', () => {
+  let usage = createRoomUsage();
+  const now = new Date().toISOString();
+  expect(
+    applyUsageReport(usage, 'a', 'x', Number.MAX_SAFE_INTEGER, now)
+      .receivedBytes
+  ).toBe(0);
+  for (let i = 0; i < 513; i++)
+    usage = applyUsageReport(usage, 'a', String(i), 10, now);
+  expect(Object.keys(usage.reports)).toHaveLength(512);
+  const total = usage.receivedBytes;
+  usage = applyUsageReport(usage, 'a', '512', 30, now);
+  expect(usage.receivedBytes).toBe(total + 20);
+  const replay = applyUsageReport(usage, 'a', '0', 10, now);
+  expect(replay.receivedBytes).toBe(usage.receivedBytes);
+  expect(summarizeRoomUsage(replay)?.limitedReports).toBeGreaterThan(0);
 });

--- a/packages/realtime/src/meet/room-usage.test.ts
+++ b/packages/realtime/src/meet/room-usage.test.ts
@@ -76,8 +76,15 @@ it('bounds implausible reports and keeps counting after bounded history rotates'
       .receivedBytes
   ).toBe(0);
   for (let i = 0; i < 513; i++)
-    usage = applyUsageReport(usage, 'a', String(i), 10, now);
+    usage = applyUsageReport(
+      usage,
+      'a',
+      String(i),
+      10,
+      new Date(Date.parse(now) + i).toISOString()
+    );
   expect(Object.keys(usage.reports)).toHaveLength(512);
+  expect(usage.reports['a:0']).toBeUndefined();
   const total = usage.receivedBytes;
   usage = applyUsageReport(usage, 'a', '512', 30, now);
   expect(usage.receivedBytes).toBe(total + 20);
@@ -99,4 +106,21 @@ it('does not let a rejected report baseline another device’s initial bytes', (
     applyUsageReport(rejected, 'good-device', 'new-report', 1000, now)
       .receivedBytes
   ).toBe(1000);
+});
+
+it('bounds distinct reporting devices without resetting their allowances', () => {
+  const usage = createRoomUsage();
+  usage.deviceBytes = Object.fromEntries(
+    Array.from({ length: 4096 }, (_, i) => [String(i), 10])
+  );
+  const next = applyUsageReport(
+    usage,
+    'new-device',
+    'report',
+    10,
+    new Date().toISOString()
+  );
+  expect(Object.keys(next.deviceBytes!)).toHaveLength(4096);
+  expect(next.limitedReports).toBe(1);
+  expect(next.receivedBytes).toBe(0);
 });

--- a/packages/realtime/src/meet/room-usage.ts
+++ b/packages/realtime/src/meet/room-usage.ts
@@ -14,9 +14,9 @@ export interface RoomUsage {
   reportedDevices?: Record<string, true>;
   deviceBytes?: Record<string, number>;
 }
-export function createRoomUsage(): RoomUsage {
+export function createRoomUsage(now = new Date().toISOString()): RoomUsage {
   return {
-    startedAt: new Date().toISOString(),
+    startedAt: now,
     receivedBytes: 0,
     reports: {},
     devices: {},
@@ -43,6 +43,8 @@ export function applyUsageReport(
   const deviceTotal = usage.deviceBytes?.[deviceId] ?? 0;
   const allowance = Math.max(1, (time - started) / 1000) * 125_000_000;
   if (
+    (!(deviceId in (usage.deviceBytes ?? {})) &&
+      Object.keys(usage.deviceBytes ?? {}).length >= 4096) ||
     !Number.isSafeInteger(bytes) ||
     bytes < 0 ||
     !Number.isFinite(allowance) ||

--- a/packages/realtime/src/meet/room-usage.ts
+++ b/packages/realtime/src/meet/room-usage.ts
@@ -1,0 +1,69 @@
+export interface RoomUsage {
+  startedAt: string;
+  receivedBytes: number;
+  reports: Record<
+    string,
+    { bytes: number; deviceId: string; updatedAt: string }
+  >;
+  devices: Record<string, true>;
+  webSocketMessages: number;
+  httpRequests: number;
+  storageWrites: number;
+}
+export function createRoomUsage(): RoomUsage {
+  return {
+    startedAt: new Date().toISOString(),
+    receivedBytes: 0,
+    reports: {},
+    devices: {},
+    webSocketMessages: 0,
+    httpRequests: 0,
+    storageWrites: 0,
+  };
+}
+export function applyUsageReport(
+  usage: RoomUsage,
+  deviceId: string,
+  reportId: string,
+  bytes: number,
+  now: string
+): RoomUsage {
+  const key = `${deviceId}:${reportId}`,
+    previous = usage.reports[key]?.bytes ?? 0;
+  if (usage.reports[key] && bytes <= previous) return usage;
+  if (!usage.reports[key] && Object.keys(usage.reports).length >= 512)
+    return usage;
+  // Bound per-room telemetry storage. Keep the historical total when a stale report ages out.
+  const reports = {
+    ...usage.reports,
+    [key]: { bytes, deviceId, updatedAt: now },
+  };
+  return {
+    ...usage,
+    receivedBytes: usage.receivedBytes + bytes - previous,
+    reports,
+  };
+}
+export function summarizeRoomUsage(usage: RoomUsage | undefined) {
+  if (!usage) return null;
+  const reported = new Set(
+    Object.values(usage.reports).map((report) => report.deviceId)
+  );
+  // List prices, before account-wide allowances. TURN-to-SFU is not double charged.
+  return {
+    startedAt: usage.startedAt,
+    receivedBytes: usage.receivedBytes,
+    devices: Object.keys(usage.devices).length,
+    reportingDevices: reported.size,
+    webSocketMessages: usage.webSocketMessages,
+    httpRequests: usage.httpRequests,
+    storageWrites: usage.storageWrites,
+    sfuEgressUsd: (usage.receivedBytes / 1_000_000_000) * 0.05,
+    durableRequestsUsd:
+      ((usage.httpRequests + usage.webSocketMessages / 20) / 1_000_000) * 0.15,
+    pricingDate: '2026-09-08',
+    currency: 'USD',
+    basis: 'client-reported RTP payload and server request counters',
+    complete: false,
+  };
+}

--- a/packages/realtime/src/meet/room-usage.ts
+++ b/packages/realtime/src/meet/room-usage.ts
@@ -9,6 +9,9 @@ export interface RoomUsage {
   webSocketMessages: number;
   httpRequests: number;
   storageWrites: number;
+  limitedReports?: number;
+  reportedDevices?: Record<string, true>;
+  deviceBytes?: Record<string, number>;
 }
 export function createRoomUsage(): RoomUsage {
   return {
@@ -28,33 +31,58 @@ export function applyUsageReport(
   bytes: number,
   now: string
 ): RoomUsage {
-  const key = `${deviceId}:${reportId}`,
-    previous = usage.reports[key]?.bytes ?? 0;
-  if (usage.reports[key] && bytes <= previous) return usage;
-  if (!usage.reports[key] && Object.keys(usage.reports).length >= 512)
-    return usage;
-  // Bound per-room telemetry storage. Keep the historical total when a stale report ages out.
-  const reports = {
-    ...usage.reports,
-    [key]: { bytes, deviceId, updatedAt: now },
-  };
+  const key = `${deviceId}:${reportId}`;
+  const prior = usage.reports[key];
+  const previous = prior?.bytes ?? 0;
+  if (prior && bytes <= previous) return usage;
+  const time = Date.parse(now),
+    started = Date.parse(usage.startedAt);
+  // Client counters are estimates, never billing authority. Bound each device by
+  // elapsed server time at 1 Gbit/s, including all of its report IDs.
+  const deviceTotal = usage.deviceBytes?.[deviceId] ?? 0;
+  const allowance = Math.max(1, (time - started) / 1000) * 125_000_000;
+  if (
+    !Number.isSafeInteger(bytes) ||
+    bytes < 0 ||
+    !Number.isFinite(allowance) ||
+    deviceTotal + bytes - previous > allowance
+  )
+    return { ...usage, limitedReports: (usage.limitedReports ?? 0) + 1 };
+  const reports = { ...usage.reports };
+  const full = !prior && Object.keys(reports).length >= 512;
+  if (full) {
+    const oldest = Object.keys(reports).sort((a, b) =>
+      reports[a]!.updatedAt.localeCompare(reports[b]!.updatedAt)
+    )[0]!;
+    delete reports[oldest];
+  }
+  // Once bounded history rolls over, baseline unfamiliar streams instead of
+  // replaying their historical bytes. Subsequent increments continue counting.
+  const baseline = !prior && (full || (usage.limitedReports ?? 0) > 0);
+  const delta = baseline ? 0 : bytes - previous;
+  reports[key] = { bytes, deviceId, updatedAt: now };
   return {
     ...usage,
-    receivedBytes: usage.receivedBytes + bytes - previous,
+    receivedBytes: usage.receivedBytes + delta,
     reports,
+    deviceBytes: { ...usage.deviceBytes, [deviceId]: deviceTotal + delta },
+    reportedDevices: { ...usage.reportedDevices, [deviceId]: true },
+    limitedReports: (usage.limitedReports ?? 0) + (baseline ? 1 : 0),
   };
 }
 export function summarizeRoomUsage(usage: RoomUsage | undefined) {
   if (!usage) return null;
-  const reported = new Set(
-    Object.values(usage.reports).map((report) => report.deviceId)
-  );
+  const reported = new Set([
+    ...Object.keys(usage.reportedDevices ?? {}),
+    ...Object.values(usage.reports).map((report) => report.deviceId),
+  ]);
   // List prices, before account-wide allowances. TURN-to-SFU is not double charged.
   return {
     startedAt: usage.startedAt,
     receivedBytes: usage.receivedBytes,
     devices: Object.keys(usage.devices).length,
     reportingDevices: reported.size,
+    limitedReports: usage.limitedReports ?? 0,
     webSocketMessages: usage.webSocketMessages,
     httpRequests: usage.httpRequests,
     storageWrites: usage.storageWrites,

--- a/packages/realtime/src/meet/room-usage.ts
+++ b/packages/realtime/src/meet/room-usage.ts
@@ -9,6 +9,7 @@ export interface RoomUsage {
   webSocketMessages: number;
   httpRequests: number;
   storageWrites: number;
+  httpCounterWrites?: number;
   limitedReports?: number;
   reportedDevices?: Record<string, true>;
   deviceBytes?: Record<string, number>;
@@ -58,7 +59,7 @@ export function applyUsageReport(
   }
   // Once bounded history rolls over, baseline unfamiliar streams instead of
   // replaying their historical bytes. Subsequent increments continue counting.
-  const baseline = !prior && (full || (usage.limitedReports ?? 0) > 0);
+  const baseline = full;
   const delta = baseline ? 0 : bytes - previous;
   reports[key] = { bytes, deviceId, updatedAt: now };
   return {
@@ -85,7 +86,7 @@ export function summarizeRoomUsage(usage: RoomUsage | undefined) {
     limitedReports: usage.limitedReports ?? 0,
     webSocketMessages: usage.webSocketMessages,
     httpRequests: usage.httpRequests,
-    storageWrites: usage.storageWrites,
+    storageWrites: usage.storageWrites + (usage.httpCounterWrites ?? 0),
     sfuEgressUsd: (usage.receivedBytes / 1_000_000_000) * 0.05,
     durableRequestsUsd:
       ((usage.httpRequests + usage.webSocketMessages / 20) / 1_000_000) * 0.15,

--- a/packages/realtime/src/meet/room-usage.ts
+++ b/packages/realtime/src/meet/room-usage.ts
@@ -32,6 +32,11 @@ export function applyUsageReport(
   bytes: number,
   now: string
 ): RoomUsage {
+  const knownDevices = new Set([
+    ...Object.keys(usage.deviceBytes ?? {}),
+    ...Object.keys(usage.reportedDevices ?? {}),
+    ...Object.values(usage.reports).map((report) => report.deviceId),
+  ]);
   const key = `${deviceId}:${reportId}`;
   const prior = usage.reports[key];
   const previous = prior?.bytes ?? 0;
@@ -43,8 +48,7 @@ export function applyUsageReport(
   const deviceTotal = usage.deviceBytes?.[deviceId] ?? 0;
   const allowance = Math.max(1, (time - started) / 1000) * 125_000_000;
   if (
-    (!(deviceId in (usage.deviceBytes ?? {})) &&
-      Object.keys(usage.deviceBytes ?? {}).length >= 4096) ||
+    (!knownDevices.has(deviceId) && knownDevices.size >= 4096) ||
     !Number.isSafeInteger(bytes) ||
     bytes < 0 ||
     !Number.isFinite(allowance) ||

--- a/packages/realtime/src/meet/room.test.ts
+++ b/packages/realtime/src/meet/room.test.ts
@@ -530,8 +530,17 @@ describe('meet room lifecycle', () => {
 
   it('tracks recording state for the whole room', () => {
     const joined = admitOrHold(createMeetRoomSnapshot(), token(), NOW).state;
-    const result = run(
+    const claimed = run(
       joined,
+      {
+        type: 'recording.state',
+        state: 'starting',
+        recordingSessionId: 'session-abc',
+      },
+      token()
+    ).state;
+    const result = run(
+      claimed,
       {
         recordingSessionId: 'session-abc',
         state: 'recording',
@@ -543,6 +552,7 @@ describe('meet room lifecycle', () => {
     expect(result.state.recording).toEqual({
       sessionId: 'session-abc',
       state: 'recording',
+      ownerDeviceId: HOST_ID,
     });
     expect(result.broadcast[0]).toMatchObject({
       recordingSessionId: 'session-abc',
@@ -552,7 +562,11 @@ describe('meet room lifecycle', () => {
   });
 
   it('keeps recording control away from ordinary speakers', () => {
-    const joined = admitOrHold(createMeetRoomSnapshot(), token(), NOW).state;
+    const joined = admitOrHold(
+      createMeetRoomSnapshot(),
+      token({ role: 'speaker', userId: GUEST_ID }),
+      NOW
+    ).state;
     const result = run(
       joined,
       { state: 'recording', type: 'recording.state' },
@@ -562,4 +576,29 @@ describe('meet room lifecycle', () => {
     expect(result.reply[0]).toMatchObject({ error: 'permission_denied' });
     expect(result.state.recording.state).toBe('idle');
   });
+});
+
+it('keeps device presence separate while remembering admission by account', () => {
+  const accountId = GUEST_ID;
+  const firstDevice = token({
+    accountId,
+    userId: GUEST_ID,
+    role: 'speaker',
+    admission: 'lobby',
+  });
+  let state = admitOrHold(createMeetRoomSnapshot(), token(), NOW).state;
+  state = admitOrHold(state, firstDevice, NOW).state;
+  state = run(
+    state,
+    { type: 'admission.decide', userId: firstDevice.userId, admit: true },
+    token()
+  ).state;
+  const secondDevice = { ...firstDevice, userId: SPEAKER_ID };
+  state = admitOrHold(state, secondDevice, NOW).state;
+  expect(state.waiting[SPEAKER_ID]).toBeUndefined();
+  expect(state.presence[GUEST_ID]?.accountId).toBe(accountId);
+  expect(state.presence[SPEAKER_ID]?.accountId).toBe(accountId);
+  state = releaseParticipant(state, GUEST_ID, firstDevice.roomId).state;
+  expect(state.presence[SPEAKER_ID]).toBeDefined();
+  expect(state.approved?.[accountId]).toBeDefined();
 });

--- a/packages/realtime/src/meet/room.test.ts
+++ b/packages/realtime/src/meet/room.test.ts
@@ -579,7 +579,7 @@ describe('meet room lifecycle', () => {
 });
 
 it('keeps device presence separate while remembering admission by account', () => {
-  const accountId = GUEST_ID;
+  const accountId = '6e2d4c91-35a8-4c55-8f1e-2a7b9d6c4e10';
   const firstDevice = token({
     accountId,
     userId: GUEST_ID,

--- a/packages/realtime/src/meet/room.ts
+++ b/packages/realtime/src/meet/room.ts
@@ -1,6 +1,7 @@
 import {
   applyRoomControl,
   approvedParticipantsMessage,
+  rememberAdmission,
   roomSettingsMessage,
 } from './room-controls';
 import type { MeetApprovedParticipant, MeetRoomSettings } from './room-options';
@@ -223,16 +224,19 @@ export function admitOrHold(
     });
   }
 
+  const person = createMeetPresence(token, now);
   const next: MeetRoomSnapshot = {
     ...state,
+    approved: rememberAdmission(state, person),
     presence: {
       ...state.presence,
-      [token.userId]: createMeetPresence(token, now),
+      [token.userId]: person,
     },
   };
 
   return outcome(next, {
     broadcast: [meetPresenceMessage(next, token.roomId)],
+    toManagers: [approvedParticipantsMessage(next)],
     reply: [
       buildReady(next, token, 'admitted'),
       roomSettingsMessage(next),

--- a/packages/realtime/src/meet/room.ts
+++ b/packages/realtime/src/meet/room.ts
@@ -5,7 +5,17 @@ import {
 } from './room-controls';
 import type { MeetApprovedParticipant, MeetRoomSettings } from './room-options';
 import { denied, outcome } from './room-outcome';
+import {
+  applyRecording,
+  type RoomRecording,
+  recordingMessage,
+} from './room-recording';
 import { applySfuCommand } from './room-sfu';
+import {
+  applyUsageReport,
+  createRoomUsage,
+  type RoomUsage,
+} from './room-usage';
 
 export { meetTrackKey } from './room-tracks';
 
@@ -16,7 +26,6 @@ import type {
   MeetRealtimeSfuClientMessage,
 } from './messages';
 import {
-  canMeetRealtimeControlRecording,
   canMeetRealtimeManageParticipants,
   canMeetRealtimeUpdateStage,
   hasMeetRealtimeScope,
@@ -36,13 +45,17 @@ export const MEET_PRESENCE_TTL_MS = 30_000;
 export const MEET_CONNECTED_PRESENCE_TTL_MS = 10 * 60_000;
 
 export interface MeetRoomSnapshot {
+  usage?: RoomUsage;
   approved?: Record<string, MeetApprovedParticipant>;
   settings?: MeetRoomSettings;
   ended?: boolean;
   lastReactionAt?: Record<string, number>;
   retiredTracks?: Record<string, true>;
   presence: Record<string, MeetRealtimePresence>;
+  recordings?: RoomRecording[];
+  chat?: Extract<MeetRealtimeServerMessage, { type: 'chat.message' }>[];
   recording: {
+    ownerDeviceId?: string;
     sessionId: string | null;
     state: MeetRealtimeRecordingState;
   };
@@ -108,6 +121,7 @@ export function createMeetPresence(
   media?: Partial<MeetRealtimePresence['media']>
 ): MeetRealtimePresence {
   return {
+    accountId: token.accountId,
     avatarUrl: token.avatarUrl,
     displayName: getMeetDisplayName(token),
     joinedAt: now,
@@ -184,13 +198,14 @@ export function admitOrHold(
   if (
     token.admission === 'lobby' &&
     !state.presence[token.userId] &&
-    !state.approved?.[token.userId]
+    !state.approved?.[token.accountId ?? token.userId]
   ) {
     const next: MeetRoomSnapshot = {
       ...state,
       waiting: {
         ...state.waiting,
         [token.userId]: {
+          accountId: token.accountId,
           avatarUrl: token.avatarUrl,
           displayName: getMeetDisplayName(token),
           requestedAt: now,
@@ -218,6 +233,8 @@ export function admitOrHold(
     reply: [
       buildReady(next, token, 'admitted'),
       roomSettingsMessage(next),
+      recordingMessage(next),
+      ...(next.chat ?? []),
       ...(token.role === 'host' ? [approvedParticipantsMessage(next)] : []),
       ...(canMeetRealtimeManageParticipants(token)
         ? [meetAdmissionPendingMessage(next)]
@@ -262,6 +279,10 @@ export function releaseParticipant(
   );
   const next: MeetRoomSnapshot = {
     ...state,
+    recording:
+      state.recording.ownerDeviceId === userId
+        ? { state: 'idle', sessionId: null }
+        : state.recording,
     lastReactionAt,
     retiredTracks: Object.fromEntries(
       Object.entries(state.retiredTracks ?? {}).filter(
@@ -296,6 +317,7 @@ export function releaseParticipant(
         })
       ),
       meetPresenceMessage(next, roomId),
+      recordingMessage(next),
       { stage: next.stage, type: 'stage' },
     ],
     toManagers: [meetAdmissionPendingMessage(next)],
@@ -360,24 +382,45 @@ export function applyMeetRoomCommand(
       });
     }
 
+    case 'usage.report':
+      if (!state.presence[userId]) return denied(state, 'awaiting_admission');
+      return outcome({
+        ...state,
+        usage: applyUsageReport(
+          state.usage ?? createRoomUsage(),
+          userId,
+          message.reportId,
+          message.bytesReceived,
+          now
+        ),
+      });
+
     case 'chat.message': {
       if (!hasMeetRealtimeScope(token, MEET_REALTIME_SCOPES.chatWrite)) {
         return denied(state, 'permission_denied', message.requestId);
       }
-      return outcome(state, {
-        broadcast: [
-          {
-            body: message.body,
-            createdAt: now,
-            displayName:
-              state.presence[userId]?.displayName ?? getMeetDisplayName(token),
-            id: `${now}:${userId}`,
-            requestId: message.requestId,
-            type: 'chat.message',
-            userId,
-          },
-        ],
-      });
+      const entry: Extract<
+        MeetRealtimeServerMessage,
+        { type: 'chat.message' }
+      > = {
+        type: 'chat.message',
+        body: message.body,
+        createdAt: now,
+        displayName:
+          state.presence[userId]?.displayName ?? getMeetDisplayName(token),
+        avatarUrl: token.avatarUrl,
+        accountId: token.accountId,
+        id: crypto.randomUUID(),
+        userId,
+        attachmentIds: message.attachmentIds,
+      };
+      return outcome(
+        { ...state, chat: [...(state.chat ?? []), entry].slice(-500) },
+        {
+          broadcast: [entry],
+          reply: [{ ...entry, requestId: message.requestId }],
+        }
+      );
     }
 
     case 'stage.update': {
@@ -446,6 +489,7 @@ export function applyMeetRoomCommand(
         presence: {
           ...state.presence,
           [message.userId]: {
+            accountId: pending.accountId,
             avatarUrl: pending.avatarUrl,
             displayName: pending.displayName,
             joinedAt: now,
@@ -460,10 +504,16 @@ export function applyMeetRoomCommand(
           },
         },
         waiting,
+        usage: state.usage
+          ? {
+              ...state.usage,
+              devices: { ...state.usage.devices, [message.userId]: true },
+            }
+          : undefined,
         approved: {
           ...state.approved,
-          [message.userId]: {
-            userId: message.userId,
+          [pending.accountId ?? message.userId]: {
+            userId: pending.accountId ?? message.userId,
             displayName: pending.displayName,
             avatarUrl: pending.avatarUrl,
           },
@@ -482,6 +532,11 @@ export function applyMeetRoomCommand(
             userId: message.userId,
           },
           { userId: message.userId, message: roomSettingsMessage(next) },
+          { userId: message.userId, message: recordingMessage(next) },
+          ...(next.chat ?? []).map((entry) => ({
+            userId: message.userId,
+            message: entry,
+          })),
           ...remoteMeetTracks(next, message.userId).map((track) => ({
             userId: message.userId,
             message: {
@@ -572,28 +627,8 @@ export function applyMeetRoomCommand(
       };
     }
 
-    case 'recording.state': {
-      if (!canMeetRealtimeControlRecording(token)) {
-        return denied(state, 'permission_denied', message.requestId);
-      }
-      const next: MeetRoomSnapshot = {
-        ...state,
-        recording: {
-          sessionId: message.recordingSessionId ?? state.recording.sessionId,
-          state: message.state,
-        },
-      };
-      return outcome(next, {
-        broadcast: [
-          {
-            recordingSessionId: next.recording.sessionId ?? undefined,
-            requestId: message.requestId,
-            state: next.recording.state,
-            type: 'recording.state',
-          },
-        ],
-      });
-    }
+    case 'recording.state':
+      return applyRecording(state, message, token, now);
 
     case 'stream.state': {
       if (!hasMeetRealtimeScope(token, MEET_REALTIME_SCOPES.streamControl)) {

--- a/packages/realtime/src/meet/room.ts
+++ b/packages/realtime/src/meet/room.ts
@@ -11,6 +11,7 @@ import {
   type RoomRecording,
   recordingMessage,
 } from './room-recording';
+import type { RoomAttachment } from './room-service';
 import { applySfuCommand } from './room-sfu';
 import {
   applyUsageReport,
@@ -46,6 +47,7 @@ export const MEET_PRESENCE_TTL_MS = 30_000;
 export const MEET_CONNECTED_PRESENCE_TTL_MS = 10 * 60_000;
 
 export interface MeetRoomSnapshot {
+  attachments?: Record<string, RoomAttachment>;
   usage?: RoomUsage;
   approved?: Record<string, MeetApprovedParticipant>;
   settings?: MeetRoomSettings;
@@ -386,7 +388,7 @@ export function applyMeetRoomCommand(
       return outcome({
         ...state,
         usage: applyUsageReport(
-          state.usage ?? createRoomUsage(),
+          state.usage ?? createRoomUsage(now),
           userId,
           message.reportId,
           message.bytesReceived,
@@ -397,6 +399,17 @@ export function applyMeetRoomCommand(
     case 'chat.message': {
       if (!hasMeetRealtimeScope(token, MEET_REALTIME_SCOPES.chatWrite)) {
         return denied(state, 'permission_denied', message.requestId);
+      }
+      const attachments = { ...state.attachments };
+      for (const id of message.attachmentIds ?? []) {
+        const file = attachments[id];
+        if (
+          !file ||
+          file.discarded ||
+          file.ownerAccountId !== (token.accountId ?? userId)
+        )
+          return denied(state, 'attachment_unavailable', message.requestId);
+        attachments[id] = { ...file, published: true };
       }
       const entry: Extract<
         MeetRealtimeServerMessage,
@@ -414,7 +427,11 @@ export function applyMeetRoomCommand(
         attachmentIds: message.attachmentIds,
       };
       return outcome(
-        { ...state, chat: [...(state.chat ?? []), entry].slice(-500) },
+        {
+          ...state,
+          attachments,
+          chat: [...(state.chat ?? []), entry].slice(-500),
+        },
         {
           direct: Object.keys(state.presence)
             .filter((id) => id !== userId)
@@ -508,7 +525,16 @@ export function applyMeetRoomCommand(
         usage: state.usage
           ? {
               ...state.usage,
-              devices: { ...state.usage.devices, [message.userId]: true },
+              devices:
+                Object.keys(state.usage.devices).length < 4096
+                  ? { ...state.usage.devices, [message.userId]: true }
+                  : state.usage.devices,
+              limitedReports:
+                (state.usage.limitedReports ?? 0) +
+                (Object.keys(state.usage.devices).length >= 4096 &&
+                !state.usage.devices[message.userId]
+                  ? 1
+                  : 0),
             }
           : undefined,
         approved: {

--- a/packages/realtime/src/meet/room.ts
+++ b/packages/realtime/src/meet/room.ts
@@ -7,6 +7,7 @@ import type { MeetApprovedParticipant, MeetRoomSettings } from './room-options';
 import { denied, outcome } from './room-outcome';
 import {
   applyRecording,
+  failActiveRecording,
   type RoomRecording,
   recordingMessage,
 } from './room-recording';
@@ -278,11 +279,9 @@ export function releaseParticipant(
     Object.entries(state.tracks).filter(([, track]) => track.userId !== userId)
   );
   const next: MeetRoomSnapshot = {
-    ...state,
-    recording:
-      state.recording.ownerDeviceId === userId
-        ? { state: 'idle', sessionId: null }
-        : state.recording,
+    ...(state.recording.ownerDeviceId === userId
+      ? failActiveRecording(state)
+      : state),
     lastReactionAt,
     retiredTracks: Object.fromEntries(
       Object.entries(state.retiredTracks ?? {}).filter(
@@ -417,7 +416,9 @@ export function applyMeetRoomCommand(
       return outcome(
         { ...state, chat: [...(state.chat ?? []), entry].slice(-500) },
         {
-          broadcast: [entry],
+          direct: Object.keys(state.presence)
+            .filter((id) => id !== userId)
+            .map((userId) => ({ userId, message: entry })),
           reply: [{ ...entry, requestId: message.requestId }],
         }
       );
@@ -603,6 +604,10 @@ export function applyMeetRoomCommand(
 
       const approved = { ...state.approved };
       delete approved[message.userId];
+      const accountId =
+        state.presence[message.userId]?.accountId ??
+        state.waiting[message.userId]?.accountId;
+      if (accountId) delete approved[accountId];
       const released = releaseParticipant(
         { ...state, approved },
         message.userId,


### PR DESCRIPTION
Meet room state now distinguishes account identity from device identity, so one account can have independent media sessions while admission is remembered by account. The Durable Object also enforces one room-wide recording lease, separate opt-in recording access/control permissions, and server-only room services for chat attachments, Mira responses, and admin cost estimates.

Waiting participants cannot receive room chat broadcasts. Recording startup cannot revive a remotely stopped recording, and cost reports deduplicate cumulative received bytes while marking unallocated provider charges as incomplete.

Validation: 104 realtime tests and realtime type check pass; full repository `bun check` passed on this protocol branch; realtime Worker dry-run passes. Seven synthetic local Worker checks pass for lobby privacy, admission history, exclusive recording, private services, device switching, removal, and room end. A real Cloudflare signaling/SFU check passed admission, chat, hand raise, moderation, and session creation. CI validates this protocol commit independently.

Stack base: #5262 contains the frontend/UI and server-only token issuer. `/room-service` and `/room-device` are invoked by frontend server handlers, never cross-origin browser fetches. Legacy browser recording start/finish transitions remain supported until both layers deploy. Merge this parent with a merge commit to preserve stack ancestry; release both layers together.
