### PR TITLE
fix(meet): resolve active personal Drive workspaces

### DIFF
--- a/apps/meet/src/features/call/server/room-service.test.ts
+++ b/apps/meet/src/features/call/server/room-service.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const single = vi.fn();
+  const query = { select: vi.fn(), eq: vi.fn(), single };
+  query.select.mockReturnValue(query);
+  query.eq.mockReturnValue(query);
+  return { query, single, from: vi.fn(() => query) };
+});
+vi.mock('server-only', () => ({}));
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: async () => ({ from: mocks.from }),
+}));
+vi.mock('@tuturuuu/storage-core/workspace-storage-provider', () => ({
+  WorkspaceStorageError: class extends Error {},
+}));
+vi.mock('../lib/call-access', () => ({
+  getMeetCallAccess: vi.fn(),
+  MeetCallAccessError: class extends Error {
+    constructor(
+      public status: number,
+      message: string
+    ) {
+      super(message);
+    }
+  },
+}));
+vi.mock('../lib/call-session', () => ({ getMeetCallSession: vi.fn() }));
+
+import { personalWorkspace } from './room-service';
+
+beforeEach(() => vi.clearAllMocks());
+
+it.each([false, null])(
+  'resolves an active personal Drive with deleted=%s',
+  async (deleted) => {
+    mocks.single.mockResolvedValue({
+      data: { id: 'personal-drive', deleted },
+      error: null,
+    });
+    await expect(personalWorkspace('creator')).resolves.toBe('personal-drive');
+    expect(mocks.from).toHaveBeenCalledWith('workspaces');
+    expect(mocks.query.eq).toHaveBeenCalledWith('creator_id', 'creator');
+    expect(mocks.query.eq).toHaveBeenCalledWith('personal', true);
+  }
+);
+
+it.each([
+  { data: { id: 'deleted-drive', deleted: true }, error: null },
+  { data: null, error: null },
+  { data: null, error: { message: 'database unavailable' } },
+])('rejects unavailable or deleted personal Drives', async (result) => {
+  mocks.single.mockResolvedValue(result);
+  await expect(personalWorkspace('creator')).rejects.toMatchObject({
+    status: 503,
+  });
+});

--- a/apps/meet/src/features/call/server/room-service.test.ts
+++ b/apps/meet/src/features/call/server/room-service.test.ts
@@ -40,6 +40,7 @@ it.each([false, null])(
     });
     await expect(personalWorkspace('creator')).resolves.toBe('personal-drive');
     expect(mocks.from).toHaveBeenCalledWith('workspaces');
+    expect(mocks.query.select).toHaveBeenCalledWith('id, deleted');
     expect(mocks.query.eq).toHaveBeenCalledWith('creator_id', 'creator');
     expect(mocks.query.eq).toHaveBeenCalledWith('personal', true);
   }

--- a/apps/meet/src/features/call/server/room-service.ts
+++ b/apps/meet/src/features/call/server/room-service.ts
@@ -42,12 +42,11 @@ export async function personalWorkspace(userId: string) {
   const db = await createAdminClient({ noCookie: true });
   const { data, error } = await db
     .from('workspaces')
-    .select('id')
+    .select('id, deleted')
     .eq('creator_id', userId)
     .eq('personal', true)
-    .is('deleted_at', null)
     .single();
-  if (error || !data)
+  if (error || !data || data.deleted === true)
     throw new MeetCallAccessError(503, 'Personal workspace is unavailable');
   return data.id;
 }


### PR DESCRIPTION
Production chat uploads returned 503 because Meet queried a nonexistent `workspaces.deleted_at` column when resolving the creator’s personal Drive. Read the schema’s `deleted` flag instead, accept active or legacy-null workspaces, and reject deleted workspaces. This also restores the shared lookup used by recording saves and Mira quota attribution.

Validation: the new regression fails before the fix and passes afterward; all 295 Meet tests, full `bun check`, and the Cloudflare production build pass. Authenticated production upload testing exposed the failure; the same workflow will be retested after deployment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Production chat uploads returned 503 because Meet queried a nonexistent `workspaces.deleted_at` column when resolving the creator's personal Drive.

**Bug Fixes**
- Reads the `deleted` flag, accepts active or legacy-null workspaces, and rejects deleted workspaces.
- Restores the shared lookup used by recording saves and Mira quota attribution.
- Adds a regression test that fails before the fix and passes after; all 295 Meet tests, `bun check`, and the Cloudflare production build pass.

<sup>Written for commit ecd76d313ace70b8e292c27872bc863f28f9e3e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

