### PR TITLE
fix(meet): save recordings when every participant is muted

### DIFF
--- a/apps/meet/src/features/call/lib/room-recorder.ts
+++ b/apps/meet/src/features/call/lib/room-recorder.ts
@@ -2,6 +2,7 @@
 export class RoomRecorder {
   private context: AudioContext | null = null;
   private destination: MediaStreamAudioDestinationNode | null = null;
+  private silence: ConstantSourceNode | null = null;
   private sources = new Map<string, MediaStreamAudioSourceNode>();
   private videos = new Map<string, HTMLVideoElement>();
   private canvas: HTMLCanvasElement | null = null;
@@ -17,10 +18,18 @@ export class RoomRecorder {
     await this.prepare();
     if (!this.context) throw new Error('Recording cancelled');
     this.destination = this.context.createMediaStreamDestination();
+    // Keep the audio clock flowing even when every participant is muted.
+    // Chromium can otherwise wait forever for the first audio sample and
+    // produce an empty recording despite receiving canvas video frames.
+    this.silence = this.context.createConstantSource();
+    this.silence.offset.value = 0;
+    this.silence.connect(this.destination);
+    this.silence.start();
     this.canvas = document.createElement('canvas');
     this.canvas.width = 1280;
     this.canvas.height = 720;
     this.update(streams);
+    this.draw();
     const video =
       typeof this.canvas.captureStream === 'function'
         ? this.canvas.captureStream(15)
@@ -102,6 +111,9 @@ export class RoomRecorder {
     this.timer = null;
     for (const source of this.sources.values()) source.disconnect();
     this.sources.clear();
+    this.silence?.stop();
+    this.silence?.disconnect();
+    this.silence = null;
     for (const video of this.videos.values()) {
       video.pause();
       video.srcObject = null;


### PR DESCRIPTION
When every participant is muted, Chromium can wait indefinitely for the recorder’s first audio sample and produce an empty file. Keep a zero-valued audio source running and draw the initial canvas frame so silent meetings can be saved.

Validation: real Chrome five-second reproduction changed from 0 bytes to a valid 21 KB WebM; all 295 Meet tests, `bun check`, and the Cloudflare production build passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent room recordings saving empty files when every participant is muted.

Chromium waits indefinitely for the first audio sample in a fully muted room, producing a 0-byte file. A zero-valued constant audio source now keeps the recording clock flowing, and the initial canvas frame is drawn so the video track starts immediately. Verified with a real Chrome reproduction that now produces a valid 21 KB WebM; all 295 Meet tests, `bun check`, and the Cloudflare production build pass.

<sup>Written for commit 1b43fb6bc21631b58b9d612ad07628a6da3b2566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

