### PR TITLE
fix(meet): use personal plan model for Mira and its costs

### DIFF
--- a/apps/docs/platform/features/meet-calls.mdx
+++ b/apps/docs/platform/features/meet-calls.mdx
@@ -707,7 +707,7 @@ Files use the creator's personal Drive provider and storage capacity checks. Roo
 admission controls attachment access; a signed URL is short-lived. Mention
 `@Tuturuuu` to ask Mira using the recent 40 room messages. Uploaded file contents
 are not automatically read by Mira. The mention author's personal AI allowance is
-checked and actual reported token usage is deducted from that author's quota.
+checked and reported tokens are deducted from that author's quota. Mira uses the plan-default Google language model for checks, generation, and deduction. Cost estimates use its catalog prices and reported cached input; missing cache prices or tiered pricing remain incomplete.
 Requests are deduplicated by chat message ID. The internal server-service token
 scope is never included in browser join tokens.
 

--- a/apps/docs/platform/features/meet-calls.mdx
+++ b/apps/docs/platform/features/meet-calls.mdx
@@ -1,5 +1,6 @@
 ---
 title: Meet calls
+updated: '2026-09-09'
 description: Run Tuturuuu Meet video calls on Cloudflare Realtime SFU, including room signaling, host controls, and in-call recording.
 ---
 
@@ -8,8 +9,8 @@ Tuturuuu Meet calls are Google-Meet-style conferences carried by the
 Live, which powers one-to-many broadcast and is documented separately.
 
 Every participant holds exactly **two peer connections** to the SFU — one
-publishing, one subscribing — regardless of room size. Calls are not mesh, so
-cost and CPU stay flat as a room grows.
+publishing, one subscribing — regardless of room size. Connection count stays
+fixed; bandwidth and decoding work still grow with subscribed media tracks.
 
 ## Pieces
 

--- a/apps/meet/src/app/api/meet-call/[meetingId]/assistant/route.test.ts
+++ b/apps/meet/src/app/api/meet-call/[meetingId]/assistant/route.test.ts
@@ -108,7 +108,10 @@ it('charges the tagger personal quota and uses server-supplied recent chat', asy
     [{ body: 'Recent context', displayName: 'Guest' }],
     1024,
     '@Tuturuuu original question',
-    await mocks.model()
+    expect.objectContaining({
+      id: 'google/gemini-3.5-flash-lite',
+      providerModelId: 'gemini-3.5-flash-lite',
+    })
   );
   expect(mocks.service).toHaveBeenLastCalledWith(
     expect.anything(),

--- a/apps/meet/src/app/api/meet-call/[meetingId]/assistant/route.test.ts
+++ b/apps/meet/src/app/api/meet-call/[meetingId]/assistant/route.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  model: vi.fn(async () => ({
+    id: 'google/gemini-3.5-flash-lite',
+    providerModelId: 'gemini-3.5-flash-lite',
+    inputPricePerToken: 0.3 / 1_000_000,
+    outputPricePerToken: 2.5 / 1_000_000,
+    cacheReadPricePerToken: null,
+    tieredPricing: false,
+  })),
   personal: vi.fn(async () => 'tagger-personal-workspace'),
   service: vi.fn(async () => ({
     chat: [{ body: 'Recent context', displayName: 'Guest' }],
@@ -20,6 +28,9 @@ const mocks = vi.hoisted(() => ({
   deduct: vi.fn(async () => ({ success: true })),
 }));
 vi.mock('server-only', () => ({}));
+vi.mock('@/features/call/server/chat-model', () => ({
+  getMeetChatModel: mocks.model,
+}));
 vi.mock('@/features/call/lib/call-access', () => ({
   MeetCallAccessError: class extends Error {
     constructor(
@@ -71,9 +82,23 @@ it('charges the tagger personal quota and uses server-supplied recent chat', asy
   });
   expect(response.status).toBe(200);
   expect(mocks.personal).toHaveBeenCalledWith('tagger');
+  expect(mocks.model).toHaveBeenCalledWith('tagger-personal-workspace');
+  expect(mocks.check).toHaveBeenCalledWith(
+    'tagger-personal-workspace',
+    'google/gemini-3.5-flash-lite',
+    'chat',
+    expect.objectContaining({ userId: 'tagger' })
+  );
+  expect(mocks.cap).toHaveBeenCalledWith(
+    expect.anything(),
+    'google/gemini-3.5-flash-lite',
+    1024,
+    100
+  );
   expect(mocks.deduct).toHaveBeenCalledWith(
     expect.objectContaining({
       wsId: 'tagger-personal-workspace',
+      modelId: 'google/gemini-3.5-flash-lite',
       userId: 'tagger',
       inputTokens: 100,
       outputTokens: 20,
@@ -82,7 +107,8 @@ it('charges the tagger personal quota and uses server-supplied recent chat', asy
   expect(mocks.answer).toHaveBeenCalledWith(
     [{ body: 'Recent context', displayName: 'Guest' }],
     1024,
-    '@Tuturuuu original question'
+    '@Tuturuuu original question',
+    await mocks.model()
   );
   expect(mocks.service).toHaveBeenLastCalledWith(
     expect.anything(),

--- a/apps/meet/src/app/api/meet-call/[meetingId]/assistant/route.ts
+++ b/apps/meet/src/app/api/meet-call/[meetingId]/assistant/route.ts
@@ -4,10 +4,10 @@ import {
   deductAiCredits,
 } from '@tuturuuu/ai/credits/check-credits';
 import { answerMeetChat } from '@tuturuuu/ai/meetings/chat';
-import { MEET_AI_MODEL } from '@tuturuuu/ai/meetings/usage';
 import { createAdminClient } from '@tuturuuu/supabase/next/server';
 import { z } from 'zod';
 import { MeetCallAccessError } from '@/features/call/lib/call-access';
+import { getMeetChatModel } from '@/features/call/server/chat-model';
 import {
   callRoomService,
   personalWorkspace,
@@ -25,7 +25,8 @@ export async function POST(
     if (!input.success) throw new MeetCallAccessError(400, 'Invalid message');
     const { messageId } = input.data;
     const wsId = await personalWorkspace(access.user.id);
-    const allowance = await checkAiCredits(wsId, MEET_AI_MODEL, 'chat', {
+    const model = await getMeetChatModel(wsId);
+    const allowance = await checkAiCredits(wsId, model.id, 'chat', {
       userId: access.user.id,
       estimatedInputTokens: 16000,
     });
@@ -37,7 +38,7 @@ export async function POST(
     const db = await createAdminClient({ noCookie: true });
     const cap = await capMaxOutputTokensByCredits(
       db,
-      MEET_AI_MODEL,
+      model.id,
       Math.min(allowance.maxOutputTokens ?? 2048, 2048),
       allowance.remainingCredits
     );
@@ -49,7 +50,12 @@ export async function POST(
     let costUsd: number | null = null;
     let chargedAnswer: string | undefined;
     try {
-      const answer = await answerMeetChat(context.chat, cap, context.prompt);
+      const answer = await answerMeetChat(
+        context.chat,
+        cap,
+        context.prompt,
+        model
+      );
       costUsd = answer.costUsd;
       if (
         !answer.usage.available ||
@@ -65,7 +71,7 @@ export async function POST(
       const charge = await deductAiCredits({
         wsId,
         userId: access.user.id,
-        modelId: MEET_AI_MODEL,
+        modelId: model.id,
         inputTokens: answer.usage.inputTokens,
         outputTokens: answer.usage.outputTokens,
         feature: 'chat',

--- a/apps/meet/src/features/call/server/chat-model.test.ts
+++ b/apps/meet/src/features/call/server/chat-model.test.ts
@@ -46,6 +46,7 @@ it('selects the personal plan default and matching enabled model prices', async 
     id: 'google/gemini-3.5-flash-lite',
     providerModelId: 'gemini-3.5-flash-lite',
     inputPricePerToken: data.input_price_per_token,
+    cacheReadPricePerToken: data.cache_read_price_per_token,
     outputPricePerToken: data.output_price_per_token,
     tieredPricing: false,
   });
@@ -83,3 +84,16 @@ it('marks tiered catalog pricing for incomplete cost coverage', async () => {
     tieredPricing: true,
   });
 });
+
+it.each([-1, NaN, Infinity])(
+  'retains unknown cache pricing for invalid rate %s',
+  async (rate) => {
+    mocks.single.mockResolvedValue({
+      data: { ...data, cache_read_price_per_token: rate },
+      error: null,
+    });
+    expect(await getMeetChatModel('personal')).toMatchObject({
+      cacheReadPricePerToken: null,
+    });
+  }
+);

--- a/apps/meet/src/features/call/server/chat-model.test.ts
+++ b/apps/meet/src/features/call/server/chat-model.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  resolve: vi.fn(),
+  single: vi.fn(),
+  eq: vi.fn(),
+}));
+vi.mock('server-only', () => ({}));
+vi.mock('@tuturuuu/ai/credits/resolve-plan-model', () => ({
+  resolvePlanModel: mocks.resolve,
+}));
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: async () => {
+    const query = { eq: mocks.eq, single: mocks.single };
+    mocks.eq.mockReturnValue(query);
+    return { schema: () => ({ from: () => ({ select: () => query }) }) };
+  },
+}));
+vi.mock('../lib/call-access', () => ({
+  MeetCallAccessError: class extends Error {
+    constructor(
+      public status: number,
+      message: string
+    ) {
+      super(message);
+    }
+  },
+}));
+
+import { getMeetChatModel } from './chat-model';
+
+const data = {
+  input_price_per_token: 0.0000003,
+  output_price_per_token: 0.0000025,
+  cache_read_price_per_token: 0.00000003,
+  input_tiers: null,
+  output_tiers: null,
+};
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolve.mockResolvedValue({ modelId: 'google/gemini-3.5-flash-lite' });
+  mocks.single.mockResolvedValue({ data, error: null });
+});
+it('selects the personal plan default and matching enabled model prices', async () => {
+  expect(await getMeetChatModel('personal')).toMatchObject({
+    id: 'google/gemini-3.5-flash-lite',
+    providerModelId: 'gemini-3.5-flash-lite',
+    inputPricePerToken: data.input_price_per_token,
+    outputPricePerToken: data.output_price_per_token,
+    tieredPricing: false,
+  });
+  expect(mocks.resolve).toHaveBeenCalledWith({
+    wsId: 'personal',
+    capability: 'language',
+  });
+  expect(mocks.eq).toHaveBeenCalledWith('id', 'google/gemini-3.5-flash-lite');
+  expect(mocks.eq).toHaveBeenCalledWith('is_enabled', true);
+});
+it('does not send a non-Google plan model to the Gemini provider', async () => {
+  mocks.resolve.mockResolvedValue({ modelId: 'openai/gpt-5' });
+  await expect(getMeetChatModel('personal')).rejects.toMatchObject({
+    status: 403,
+  });
+  expect(mocks.single).not.toHaveBeenCalled();
+});
+it.each([
+  { data: null, error: null },
+  { data, error: new Error('unavailable') },
+  { data: { ...data, input_price_per_token: -1 }, error: null },
+  { data: { ...data, output_price_per_token: NaN }, error: null },
+])('rejects unavailable pricing before generation', async (result) => {
+  mocks.single.mockResolvedValue(result);
+  await expect(getMeetChatModel('personal')).rejects.toMatchObject({
+    status: 503,
+  });
+});
+it('marks tiered catalog pricing for incomplete cost coverage', async () => {
+  mocks.single.mockResolvedValue({
+    data: { ...data, input_tiers: [{ min: 0, cost: '0.1' }] },
+    error: null,
+  });
+  expect(await getMeetChatModel('personal')).toMatchObject({
+    tieredPricing: true,
+  });
+});

--- a/apps/meet/src/features/call/server/chat-model.ts
+++ b/apps/meet/src/features/call/server/chat-model.ts
@@ -1,0 +1,51 @@
+import 'server-only';
+import {
+  isGoogleModelId,
+  toBareModelName,
+} from '@tuturuuu/ai/credits/model-mapping';
+import { resolvePlanModel } from '@tuturuuu/ai/credits/resolve-plan-model';
+import type { MeetChatModel } from '@tuturuuu/ai/meetings/chat-usage';
+import { createAdminClient } from '@tuturuuu/supabase/next/server';
+import { MeetCallAccessError } from '../lib/call-access';
+
+export async function getMeetChatModel(wsId: string): Promise<MeetChatModel> {
+  const { modelId } = await resolvePlanModel({ wsId, capability: 'language' });
+  if (!isGoogleModelId(modelId))
+    throw new MeetCallAccessError(
+      403,
+      'Meeting AI requires a Google plan model'
+    );
+  const db = await createAdminClient({ noCookie: true });
+  const { data, error } = await db
+    .schema('private')
+    .from('ai_gateway_models')
+    .select(
+      'input_price_per_token, output_price_per_token, cache_read_price_per_token, input_tiers, output_tiers'
+    )
+    .eq('id', modelId)
+    .eq('is_enabled', true)
+    .single();
+  const validPrice = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0;
+  if (
+    error ||
+    !data ||
+    !validPrice(data.input_price_per_token) ||
+    !validPrice(data.output_price_per_token)
+  )
+    throw new MeetCallAccessError(503, 'Meeting AI pricing is unavailable');
+  return {
+    id: modelId,
+    providerModelId: toBareModelName(modelId),
+    inputPricePerToken: data.input_price_per_token,
+    outputPricePerToken: data.output_price_per_token,
+    cacheReadPricePerToken: validPrice(data.cache_read_price_per_token)
+      ? data.cache_read_price_per_token
+      : null,
+    // Tiered prices need context thresholds. Do not silently report a flat
+    // price as complete when the catalog specifies a different billing rule.
+    tieredPricing: [data.input_tiers, data.output_tiers].some(
+      (tiers) => tiers !== null && (!Array.isArray(tiers) || tiers.length > 0)
+    ),
+  };
+}

--- a/packages/ai/src/meetings/chat-usage.test.ts
+++ b/packages/ai/src/meetings/chat-usage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { type MeetChatModel, measureMeetChatUsage } from './chat-usage';
+
+const model: MeetChatModel = {
+  id: 'google/gemini-3.5-flash-lite',
+  providerModelId: 'gemini-3.5-flash-lite',
+  inputPricePerToken: 0.3 / 1_000_000,
+  outputPricePerToken: 2.5 / 1_000_000,
+  cacheReadPricePerToken: 0.03 / 1_000_000,
+  tieredPricing: false,
+};
+const metadata = {
+  promptTokenCount: 1000,
+  candidatesTokenCount: 100,
+  thoughtsTokenCount: 20,
+};
+describe('Mira catalog usage', () => {
+  it('uses the selected model pricing and includes thinking output', () => {
+    const result = measureMeetChatUsage(metadata, model);
+    expect(result.costUsd).toBeCloseTo(0.0006);
+    expect(result.usage).toMatchObject({
+      model: model.id,
+      inputTokens: 1000,
+      outputTokens: 120,
+      available: true,
+    });
+  });
+  it('bills cached input at its own catalog rate', () => {
+    expect(
+      measureMeetChatUsage({ ...metadata, cachedContentTokenCount: 500 }, model)
+        .costUsd
+    ).toBeCloseTo(0.000465);
+  });
+  it.each([null, {}, { promptTokenCount: 1000 }])(
+    'does not invent usage when metadata is incomplete: %s',
+    (value) => {
+      expect(measureMeetChatUsage(value, model)).toMatchObject({
+        costUsd: null,
+        usage: { available: false },
+      });
+    }
+  );
+  it('retains token accounting with incomplete cost coverage', () => {
+    for (const config of [
+      { ...model, tieredPricing: true },
+      { ...model, cacheReadPricePerToken: null },
+    ]) {
+      expect(
+        measureMeetChatUsage(
+          { ...metadata, cachedContentTokenCount: 500 },
+          config
+        )
+      ).toMatchObject({ costUsd: null, usage: { available: true } });
+    }
+    expect(
+      measureMeetChatUsage(
+        { ...metadata, cachedContentTokenCount: 2000 },
+        model
+      ).costUsd
+    ).toBeNull();
+  });
+});

--- a/packages/ai/src/meetings/chat-usage.test.ts
+++ b/packages/ai/src/meetings/chat-usage.test.ts
@@ -25,6 +25,14 @@ describe('Mira catalog usage', () => {
       available: true,
     });
   });
+  it('treats a null cache counter as no cached input', () => {
+    expect(
+      measureMeetChatUsage(
+        { ...metadata, cachedContentTokenCount: null },
+        model
+      ).costUsd
+    ).toBeCloseTo(0.0006);
+  });
   it('bills cached input at its own catalog rate', () => {
     expect(
       measureMeetChatUsage({ ...metadata, cachedContentTokenCount: 500 }, model)

--- a/packages/ai/src/meetings/chat-usage.ts
+++ b/packages/ai/src/meetings/chat-usage.ts
@@ -23,7 +23,7 @@ export function measureMeetChatUsage(metadata: unknown, model: MeetChatModel) {
   const { inputTokens, outputTokens } = tokens;
   const cached = (metadata as { cachedContentTokenCount?: unknown })
     .cachedContentTokenCount;
-  const cachedTokens = cached === undefined ? 0 : cached;
+  const cachedTokens = cached ?? 0;
   const validCache =
     typeof cachedTokens === 'number' &&
     Number.isFinite(cachedTokens) &&

--- a/packages/ai/src/meetings/chat-usage.ts
+++ b/packages/ai/src/meetings/chat-usage.ts
@@ -1,0 +1,50 @@
+import { measureMeetUsage } from './usage';
+
+export interface MeetChatModel {
+  id: string;
+  providerModelId: string;
+  inputPricePerToken: number;
+  outputPricePerToken: number;
+  cacheReadPricePerToken: number | null;
+  tieredPricing: boolean;
+}
+
+/** Catalog estimate, not an invoice; retain unknown pricing as incomplete. */
+export function measureMeetChatUsage(metadata: unknown, model: MeetChatModel) {
+  const { usage: tokens } = measureMeetUsage(metadata, 'text');
+  const base = { model: model.id, pricingSource: 'ai_gateway_models' };
+  if (
+    !tokens.available ||
+    typeof tokens.inputTokens !== 'number' ||
+    typeof tokens.outputTokens !== 'number'
+  ) {
+    return { costUsd: null, usage: { ...base, available: false } };
+  }
+  const { inputTokens, outputTokens } = tokens;
+  const cached = (metadata as { cachedContentTokenCount?: unknown })
+    .cachedContentTokenCount;
+  const cachedTokens = cached === undefined ? 0 : cached;
+  const validCache =
+    typeof cachedTokens === 'number' &&
+    Number.isFinite(cachedTokens) &&
+    cachedTokens >= 0 &&
+    cachedTokens <= inputTokens;
+  const costUsd =
+    !model.tieredPricing &&
+    validCache &&
+    (cachedTokens === 0 || model.cacheReadPricePerToken !== null)
+      ? (inputTokens - cachedTokens) * model.inputPricePerToken +
+        cachedTokens * (model.cacheReadPricePerToken ?? 0) +
+        outputTokens * model.outputPricePerToken
+      : null;
+  return {
+    costUsd,
+    usage: {
+      ...base,
+      available: true,
+      inputTokens,
+      outputTokens,
+      currency: 'USD',
+    },
+  };
+}

--- a/packages/ai/src/meetings/chat.ts
+++ b/packages/ai/src/meetings/chat.ts
@@ -1,12 +1,13 @@
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { Effect, Either } from '@tuturuuu/utils/effect';
 import { generateText } from 'ai';
-import { MEET_AI_MODEL, measureMeetUsage } from './usage';
+import { type MeetChatModel, measureMeetChatUsage } from './chat-usage';
 
 export async function answerMeetChat(
   history: Array<{ body: string; displayName: string; assistant?: boolean }>,
   maxOutputTokens: number,
-  question: string
+  question: string,
+  model: MeetChatModel
 ) {
   const response = await Effect.runPromise(
     Effect.either(
@@ -15,7 +16,7 @@ export async function answerMeetChat(
           const apiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
           if (!apiKey) throw new Error('Meeting AI is not configured');
           const result = await generateText({
-            model: createGoogleGenerativeAI({ apiKey })(MEET_AI_MODEL),
+            model: createGoogleGenerativeAI({ apiKey })(model.providerModelId),
             maxOutputTokens,
             maxRetries: 0,
             abortSignal: AbortSignal.timeout(45000),
@@ -33,9 +34,9 @@ export async function answerMeetChat(
           });
           return {
             text: result.text,
-            ...measureMeetUsage(
+            ...measureMeetChatUsage(
               result.providerMetadata?.google?.usageMetadata,
-              'text'
+              model
             ),
           };
         },


### PR DESCRIPTION
Mira requests failed on PRO because Meet hardcoded Gemini 3.1 Flash Lite while the current plan permits Gemini 3.5 Flash Lite. Resolve the mention author’s personal plan default, then use that same Google model for generation, allowance checks, output limits, and quota deduction.

Estimate cost from the selected model’s catalog prices, including reported cached input and thinking output. Missing cache pricing or tiered pricing stays incomplete instead of silently reporting another model’s flat rate. Non-Google defaults fail before contacting Gemini.

Validation: 305 Meet tests, seven focused cost-accounting tests, `bun check`, and the Cloudflare production build passed. An unrelated wallet UI test failed during the first broad run, then passed unchanged both alone and in the full rerun. Production assistant verification will follow deployment.
