### PR TITLE
fix(meet): prevent chat text clipping in narrow sidebars

### DIFF
--- a/apps/meet/src/features/call/components/chat-panel.tsx
+++ b/apps/meet/src/features/call/components/chat-panel.tsx
@@ -170,7 +170,7 @@ export function ChatPanel({
   };
   return (
     <>
-      <ScrollArea className="min-h-0 flex-1 px-4 py-3">
+      <ScrollArea className="[&_[data-radix-scroll-area-viewport]>div]:!block [&_[data-radix-scroll-area-viewport]>div]:!min-w-0 min-h-0 min-w-0 flex-1 px-4 py-3 [&_[data-radix-scroll-area-viewport]>div]:w-full [&_[data-radix-scroll-area-viewport]>div]:max-w-full">
         <ol aria-live="polite" aria-relevant="additions" className="space-y-5">
           {chat.map((message) => (
             <li key={message.id} className="flex gap-2">
@@ -198,7 +198,7 @@ export function ChatPanel({
                     })}
                   </time>
                 </div>
-                <div className="text-sm">
+                <div className="wrap-break-word min-w-0 text-sm">
                   <AssistantMarkdown text={message.body} />
                 </div>
                 {message.attachmentIds?.map((id) => (


### PR DESCRIPTION
Long attachment names make Radix ScrollArea’s intrinsic table wrapper wider than the Meet sidebar, clipping every chat message. Bound that wrapper to the vertical viewport and keep message text wrapping within it.

Validation: production showed 364 px of content inside a 287 px viewport. A real Chrome fixture using the production-built CSS changed the narrow case from 351/285 px content/viewport to 285/285 px; the 390 px panel also remained within bounds. `bun check` and the Cloudflare production build passed. The final production layout check will follow deployment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat text clipping in the Meet sidebar when long attachment names widen the scroll area beyond the panel. The scroll viewport wrapper is now constrained to the sidebar width, and message text wraps within it.

<sup>Written for commit 5e66d5eee64ef645bf41e806e09368051454dd00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

