### PR TITLE
fix(mail): polish viewed state and dark reader controls

### DIFF
--- a/apps/docs/platform/applications/mail.mdx
+++ b/apps/docs/platform/applications/mail.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tuturuuu Mail
+updated: '2026-09-09'
 description: Multi-mailbox client with permanent SES and Cloudflare transports.
 ---
 

--- a/apps/docs/platform/applications/mail.mdx
+++ b/apps/docs/platform/applications/mail.mdx
@@ -42,12 +42,16 @@ Settings → Reading stores the archive navigation and email appearance preferen
 in the current browser. Archiving an open inbox conversation selects the next
 visible conversation by default, falling back to the previous one at the end of
 the loaded list. Users can choose to return to the list instead. Bulk archive
-skips all selected conversations when choosing the next message.
+skips all selected conversations when choosing the next message. Loaded unread
+conversations are marked read even when opened through restored URLs or archive
+navigation. Read updates wait for pending archive/trash operations to settle.
 
 Email frames remain hidden until the saved appearance is restored and contrast
 adjustments finish. Dark mode matches neutral paper surfaces to the reader's
-background while preserving colored panels and images. Original mode retains the
-sender's colors. Neither mode enables scripts inside email HTML.
+background, including black and gray panels and neutral gradients, and softens
+bright neutral borders while preserving colored panels and images. Compact
+Dark/Original icon controls live on the floating action toolbar with tooltips.
+Original mode retains the sender's colors. Neither mode enables scripts inside email HTML.
 
 The protected attachment endpoint accepts `?preview=1` for a passive-format
 allowlist: raster images, supported video/audio types, and plain text (including
@@ -540,8 +544,8 @@ assignment itself is idempotent. Forwarding errors remain retryable through the
 inbound delivery job. Configuration is stored in mailbox metadata; this feature
 requires no schema migration.
 
-The reader preserves original newsletter colors by default, with an optional
-dark appearance. Stylesheets are retained only inside a sandboxed iframe with
+The reader defaults to dark appearance, with original newsletter colors available
+from the floating toolbar or Reading settings. Stylesheets are retained only inside a sandboxed iframe with
 scripts, forms, remote stylesheets/fonts and network APIs blocked by CSP. The
 iframe grants same-origin access to the parent solely for height measurement and
 protected inline images; it never grants script execution. External links open
@@ -555,9 +559,8 @@ Thread lists always display both the message date and delivery time. The mobile
 reader uses constrained native scrolling to prevent wide tables, subjects or
 attachment names from widening the application viewport.
 
-The reader opens messages in their original appearance, preserves hidden newsletter
-preheaders and isolated inline CSS, and offers an optional dark canvas without
-forcing colors onto every message element. Message content uses the full pane
+The reader preserves hidden newsletter preheaders and isolated inline CSS. Dark
+appearance adapts neutral surfaces and borders while preserving branded colors. Message content uses the full pane
 width; reply actions float over the bottom edge with reserved scroll space so the
 last line remains reachable. The collapsed sidebar contains folder actions only.
 Expanded navigation groups shared mailboxes by repeated address prefixes (for

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-appearance-controls.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-appearance-controls.tsx
@@ -6,12 +6,20 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import { useTranslations } from 'next-intl';
 import { useMailPreviewAppearance } from './mail-preview-appearance';
 
-export function MailAppearanceControls() {
+export function MailAppearanceControls({
+  standalone = false,
+}: {
+  standalone?: boolean;
+}) {
   const t = useTranslations('mail');
   const [mode, setMode] = useMailPreviewAppearance();
   return (
     <fieldset
-      className="ml-1 flex shrink-0 items-center gap-0.5 border-border border-l pl-1"
+      className={
+        standalone
+          ? 'flex shrink-0 items-center gap-0.5'
+          : 'ml-1 flex shrink-0 items-center gap-0.5 border-border border-l pl-1'
+      }
       aria-label={t('message_appearance')}
     >
       {(['dark', 'original'] as const).map((value) => {
@@ -23,7 +31,7 @@ export function MailAppearanceControls() {
               <Button
                 type="button"
                 size="icon"
-                className="size-8"
+                className="size-8!"
                 variant={mode === value ? 'secondary' : 'ghost'}
                 aria-label={label}
                 aria-pressed={mode === value}

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-appearance-controls.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-appearance-controls.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Moon, Sun } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
+import { useTranslations } from 'next-intl';
+import { useMailPreviewAppearance } from './mail-preview-appearance';
+
+export function MailAppearanceControls() {
+  const t = useTranslations('mail');
+  const [mode, setMode] = useMailPreviewAppearance();
+  return (
+    <fieldset
+      className="ml-1 flex shrink-0 items-center gap-0.5 border-border border-l pl-1"
+      aria-label={t('message_appearance')}
+    >
+      {(['dark', 'original'] as const).map((value) => {
+        const Icon = value === 'dark' ? Moon : Sun;
+        const label = t(value === 'dark' ? 'dark_view' : 'original_view');
+        return (
+          <Tooltip key={value}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                size="icon"
+                className="size-8"
+                variant={mode === value ? 'secondary' : 'ghost'}
+                aria-label={label}
+                aria-pressed={mode === value}
+                onClick={() => setMode(value)}
+              >
+                <Icon className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-order.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-order.test.ts
@@ -55,11 +55,8 @@ beforeEach(() => {
 
 describe('archive and auto-read ordering', () => {
   it.each([false, true])(
-    'waits for archive success before reading the next message (bulk=%s)',
+    'leaves read tracking to the loaded reader instead of nesting mutations (bulk=%s)',
     async (bulk) => {
-      const autoRead = mocks.mutations.find(
-        (entry) => entry.options.mutationKey.at(-1) === 'auto-read'
-      )!;
       const archive = mocks.mutations.find(
         (entry) =>
           entry.options.mutationKey.at(-1) === (bulk ? 'bulk' : 'state')
@@ -69,11 +66,15 @@ describe('archive and auto-read ordering', () => {
         : { action: 'archive', targetThreadId: 'a' };
       const context = await archive.options.onMutate!(variables);
       expect(mocks.reopen).toHaveBeenCalledWith('b');
-      expect(autoRead.mutate).not.toHaveBeenCalled();
+      expect(
+        mocks.mutations.every((entry) => !entry.mutate.mock.calls.length)
+      ).toBe(true);
       // A fast response can arrive before navigation renders.
       expect(mocks.selected.current).toBe('a');
       archive.options.onSuccess!({}, variables, context);
-      expect(autoRead.mutate).toHaveBeenCalledWith('b');
+      expect(
+        mocks.mutations.every((entry) => !entry.mutate.mock.calls.length)
+      ).toBe(true);
     }
   );
   it('restores a failed archive without starting another optimistic read mutation', async () => {
@@ -86,9 +87,7 @@ describe('archive and auto-read ordering', () => {
     archive.options.onError!(new Error('failed'), variables, context);
     expect(mocks.reopen).toHaveBeenLastCalledWith('a');
     expect(
-      mocks.mutations.find(
-        (entry) => entry.options.mutationKey.at(-1) === 'auto-read'
-      )!.mutate
-    ).not.toHaveBeenCalled();
+      mocks.mutations.every((entry) => !entry.mutate.mock.calls.length)
+    ).toBe(true);
   });
 });

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-order.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-order.test.ts
@@ -54,6 +54,17 @@ beforeEach(() => {
 });
 
 describe('archive and auto-read ordering', () => {
+  it.each(['state', 'bulk'])(
+    'keeps %s pending until mailbox invalidation completes',
+    async (key) => {
+      const mutation = mocks.mutations.find(
+        (entry) => entry.options.mutationKey.at(-1) === key
+      )!;
+      const settled = mutation.options.onSettled();
+      expect(settled).toBeInstanceOf(Promise);
+      await settled;
+    }
+  );
   it.each([false, true])(
     'leaves read tracking to the loaded reader instead of nesting mutations (bulk=%s)',
     async (bulk) => {

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
@@ -63,6 +63,7 @@ import {
 } from './mail-thread-query';
 import { ThreadDetail } from './thread-detail';
 import { useMailThreadActions } from './use-mail-thread-actions';
+import { useMailViewedThreadRead } from './use-mail-viewed-thread-read';
 
 interface MailAppClientProps {
   folder: MailFolder;
@@ -221,6 +222,17 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
       threads,
       workspaceId,
     });
+  useMailViewedThreadRead({
+    workspaceId,
+    mailboxId: activeMailboxId,
+    threadId,
+    detail: detailQuery.data,
+    blocked:
+      stateMutation.isPending ||
+      bulkMutation.isPending ||
+      detailQuery.isError ||
+      folder === 'drafts',
+  });
   const deleteDraftMutation = useMutation({
     mutationFn: (draftId: string) =>
       deleteMailDraft(workspaceId, activeMailboxId ?? '', draftId),
@@ -248,8 +260,6 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
   };
   const openThread = (thread: MailThreadSummary): void => {
     void setThreadId(thread.id);
-    if (!activeMailboxId || thread.unreadCount <= 0) return;
-    mutateThread('mark_read', thread.id);
   };
   const prefetchThread = (nextThreadId: string) => {
     if (!activeMailboxId) return;

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-message-preview.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-message-preview.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { MailAttachment } from '@tuturuuu/internal-api';
-import { Button } from '@tuturuuu/ui/button';
 import {
   useCallback,
   useEffect,
@@ -18,19 +17,13 @@ const subscribeHydration = () => () => {};
 export function MailMessagePreview({
   content,
   attachments,
-  darkLabel,
-  originalLabel,
   title,
-  viewLabel,
 }: {
   content: string;
   attachments: MailAttachment[];
-  darkLabel: string;
-  originalLabel: string;
   title: string;
-  viewLabel: string;
 }) {
-  const [mode, setSelectedMode] = useMailPreviewAppearance();
+  const [mode] = useMailPreviewAppearance();
   const hydrated = useSyncExternalStore(
     subscribeHydration,
     () => true,
@@ -108,29 +101,6 @@ export function MailMessagePreview({
 
   return (
     <div className="min-w-0 max-w-full overflow-hidden bg-background">
-      <fieldset
-        className="flex items-center justify-end gap-1 px-4 pb-2 md:px-6"
-        aria-label={viewLabel}
-      >
-        <Button
-          aria-pressed={mode === 'dark'}
-          onClick={() => setSelectedMode('dark')}
-          size="sm"
-          type="button"
-          variant={mode === 'dark' ? 'secondary' : 'ghost'}
-        >
-          {darkLabel}
-        </Button>
-        <Button
-          aria-pressed={mode === 'original'}
-          onClick={() => setSelectedMode('original')}
-          size="sm"
-          type="button"
-          variant={mode === 'original' ? 'secondary' : 'ghost'}
-        >
-          {originalLabel}
-        </Button>
-      </fieldset>
       <iframe
         key={previewDocument}
         className="block w-full max-w-full border-0 bg-background"

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-preview-contrast-dom.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-preview-contrast-dom.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { applyMailPreviewContrast } from './mail-preview-contrast';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+describe('email border rendering', () => {
+  it('softens currentColor borders after dark text becomes readable and preserves colored borders', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+    document.body.innerHTML =
+      '<div id="neutral" style="background:white;color:black;border:1px solid currentColor">Text</div><div id="brand" style="border:1px solid rgb(0,80,180)">Brand</div><hr style="border:1px solid white">';
+    applyMailPreviewContrast(document);
+    const neutral = document.getElementById('neutral')!;
+    expect(getComputedStyle(neutral).color).toBe('rgb(231, 231, 231)');
+    expect(getComputedStyle(neutral).borderTopColor).toBe('rgb(61, 61, 61)');
+    expect(
+      getComputedStyle(document.getElementById('brand')!).borderTopColor
+    ).toBe('rgb(0, 80, 180)');
+    expect(getComputedStyle(document.querySelector('hr')!).borderTopColor).toBe(
+      'rgb(61, 61, 61)'
+    );
+  });
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-preview-contrast.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-preview-contrast.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   contrastRatio,
+  mailBorderColor,
   mailDarkSurface,
+  neutralMailSurface,
   readableMailColor,
 } from './mail-preview-contrast';
 
@@ -26,5 +28,25 @@ describe('mail contrast', () => {
     expect(mailDarkSurface([10, 10, 10])).toEqual([10, 10, 10]);
     expect(mailDarkSurface([255, 255, 255])).toEqual([18, 18, 18]);
     expect(mailDarkSurface([230, 230, 230])).toEqual([18, 18, 18]);
+  });
+});
+
+describe('neutral email surfaces and borders', () => {
+  it('recognizes black, gray and white panels without flattening brand colors', () => {
+    for (const color of [
+      [0, 0, 0],
+      [128, 128, 128],
+      [255, 255, 255],
+    ] as [number, number, number][])
+      expect(neutralMailSurface(color)).toBe(true);
+    expect(neutralMailSurface([0, 80, 180])).toBe(false);
+  });
+  it('softens bright neutral borders while retaining subtle and colored dividers', () => {
+    const surface: [number, number, number] = [10, 10, 10];
+    const border = mailBorderColor([255, 255, 255], surface);
+    expect(contrastRatio(border, surface)).toBeGreaterThan(1.5);
+    expect(contrastRatio(border, surface)).toBeLessThan(3);
+    expect(mailBorderColor([40, 40, 40], surface)).toEqual([40, 40, 40]);
+    expect(mailBorderColor([0, 80, 180], surface)).toEqual([0, 80, 180]);
   });
 });

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-preview-contrast.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-preview-contrast.ts
@@ -44,6 +44,21 @@ export function mailDarkSurface(sampled: RGB): RGB {
   return luminance(sampled) < 0.05 ? sampled : darkBackground;
 }
 
+export function neutralMailSurface(color: RGB) {
+  return Math.max(...color) - Math.min(...color) < 24;
+}
+
+export function mailBorderColor(color: RGB, background: RGB): RGB {
+  // Keep useful dividers, but prevent white/currentColor borders from glowing.
+  if (
+    !neutralMailSurface(color) ||
+    luminance(background) >= 0.1 ||
+    contrastRatio(color, background) < 3
+  )
+    return color;
+  return composite(lightText, background, 0.2);
+}
+
 function css(color: RGB) {
   return `rgb(${color.join(',')})`;
 }
@@ -55,22 +70,30 @@ export function applyMailPreviewContrast(
 ) {
   const view = document.defaultView;
   if (!view) return;
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 1;
+  const context = canvas.getContext('2d');
+  const readColor = (value: string) => {
+    const parsed = parseColor(value);
+    if (parsed) return parsed;
+    if (!context || !view.CSS.supports('color', value)) return null;
+    context.clearRect(0, 0, 1, 1);
+    context.fillStyle = value;
+    context.fillRect(0, 0, 1, 1);
+    const [r, g, b, alpha] = context.getImageData(0, 0, 1, 1).data;
+    return { rgb: [r!, g!, b!] as RGB, alpha: alpha! / 255 };
+  };
   let surfaceBackground = darkBackground;
   if (surface) {
     const color =
       surface.ownerDocument.defaultView?.getComputedStyle(
         surface
       ).backgroundColor;
-    const canvas = surface.ownerDocument.createElement('canvas');
-    canvas.width = canvas.height = 1;
-    const context = canvas.getContext('2d');
-    if (context && color) {
-      context.fillStyle = color;
-      context.fillRect(0, 0, 1, 1);
-      const [r, g, b, alpha] = context.getImageData(0, 0, 1, 1).data;
-      if (alpha) surfaceBackground = mailDarkSurface([r!, g!, b!]);
-    }
+    const sampled = color ? readColor(color) : null;
+    if (sampled && sampled.alpha > 0)
+      surfaceBackground = mailDarkSurface(sampled.rgb);
   }
+
   document.documentElement.style.setProperty(
     'background-color',
     css(surfaceBackground),
@@ -89,16 +112,12 @@ export function applyMailPreviewContrast(
     const style = view.getComputedStyle(element);
     const parentBackground =
       backgrounds.get(element.parentElement!) ?? surfaceBackground;
-    const original = parseColor(style.backgroundColor);
+    const original = readColor(style.backgroundColor);
     let background = parentBackground;
     if (original && original.alpha > 0) {
       background = composite(original.rgb, parentBackground, original.alpha);
-      // Convert light neutral paper surfaces, preserving colored brand panels.
-      if (
-        Math.max(...background) - Math.min(...background) < 24 &&
-        (luminance(background) > 0.5 || luminance(background) < 0.05) &&
-        element.tagName !== 'IMG'
-      ) {
+      // Normalize neutral paper, black and gray panels to the host surface.
+      if (neutralMailSurface(background) && element.tagName !== 'IMG') {
         background = surfaceBackground;
         element.style.setProperty(
           'background-color',
@@ -107,9 +126,34 @@ export function applyMailPreviewContrast(
         );
       }
     }
+    // Sender gradients can paint opaque black/white over background-color.
+    // Only remove entirely neutral gradients; keep brand gradients and images.
+    const gradientColors = style.backgroundImage.match(
+      /(?:rgba?|color|oklch|oklab|lab|lch)\([^)]*\)/g
+    );
+    if (
+      element.tagName !== 'IMG' &&
+      !style.backgroundImage.includes('url(') &&
+      gradientColors?.length &&
+      gradientColors.every((value) => {
+        const color = readColor(value);
+        return color && neutralMailSurface(color.rgb);
+      })
+    ) {
+      element.style.setProperty('background-image', 'none', 'important');
+    }
     backgrounds.set(element, background);
+    for (const side of ['top', 'right', 'bottom', 'left']) {
+      const property = `border-${side}-color`;
+      const color = readColor(style.getPropertyValue(property));
+      if (!color || color.alpha === 0) continue;
+      const visible = composite(color.rgb, background, color.alpha);
+      const softened = mailBorderColor(visible, background);
+      if (softened !== visible)
+        element.style.setProperty(property, css(softened), 'important');
+    }
     if (['IMG', 'STYLE', 'BR', 'HR'].includes(element.tagName)) continue;
-    const foreground = parseColor(style.color);
+    const foreground = readColor(style.color);
     if (!foreground || foreground.alpha === 0) continue;
     const visibleColor = composite(
       foreground.rgb,

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-preview-contrast.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-preview-contrast.ts
@@ -143,31 +143,42 @@ export function applyMailPreviewContrast(
       element.style.setProperty('background-image', 'none', 'important');
     }
     backgrounds.set(element, background);
+    const foreground = readColor(style.color);
+    if (
+      !['IMG', 'STYLE', 'BR', 'HR'].includes(element.tagName) &&
+      foreground &&
+      foreground.alpha > 0
+    ) {
+      const visibleColor = composite(
+        foreground.rgb,
+        background,
+        foreground.alpha
+      );
+      const readable = readableMailColor(visibleColor, background);
+      if (readable !== visibleColor) {
+        element.style.setProperty('color', css(readable), 'important');
+        element.style.setProperty(
+          '-webkit-text-fill-color',
+          css(readable),
+          'important'
+        );
+      }
+    }
+    // Resolve currentColor after foreground correction so borders cannot turn white.
+    const borderStyle = view.getComputedStyle(element);
     for (const side of ['top', 'right', 'bottom', 'left']) {
+      if (
+        borderStyle.getPropertyValue(`border-${side}-style`) === 'none' ||
+        parseFloat(borderStyle.getPropertyValue(`border-${side}-width`)) === 0
+      )
+        continue;
       const property = `border-${side}-color`;
-      const color = readColor(style.getPropertyValue(property));
+      const color = readColor(borderStyle.getPropertyValue(property));
       if (!color || color.alpha === 0) continue;
       const visible = composite(color.rgb, background, color.alpha);
       const softened = mailBorderColor(visible, background);
       if (softened !== visible)
         element.style.setProperty(property, css(softened), 'important');
-    }
-    if (['IMG', 'STYLE', 'BR', 'HR'].includes(element.tagName)) continue;
-    const foreground = readColor(style.color);
-    if (!foreground || foreground.alpha === 0) continue;
-    const visibleColor = composite(
-      foreground.rgb,
-      background,
-      foreground.alpha
-    );
-    const readable = readableMailColor(visibleColor, background);
-    if (readable !== visibleColor) {
-      element.style.setProperty('color', css(readable), 'important');
-      element.style.setProperty(
-        '-webkit-text-fill-color',
-        css(readable),
-        'important'
-      );
     }
   }
 }

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail.tsx
@@ -77,6 +77,7 @@ export function ThreadDetail({
   if (error) return <MailContentState kind="error" onAction={onRetry} />;
   if (!thread) return <MailContentState kind="reader" />;
 
+  const hasHtml = thread.messages.some((message) => message.sanitizedHtml);
   const newest = thread.messages.at(-1);
   const replyMessage =
     thread.messages.find((message) => message.id === replyMessageId) ?? newest;
@@ -179,60 +180,70 @@ export function ThreadDetail({
               ))}
             </Accordion>
           </div>
-          {!isDraft && replyMessage && (
+          {(hasHtml || (!isDraft && replyMessage)) && (
             <div className="pointer-events-none absolute inset-x-0 bottom-[max(1rem,env(safe-area-inset-bottom))] z-20 flex justify-center px-3">
               <div
                 className="pointer-events-auto flex max-w-full items-center gap-1 rounded-2xl bg-background/95 p-1.5 shadow-foreground/10 shadow-lg backdrop-blur"
                 role="toolbar"
                 aria-label={t('message_actions')}
               >
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
-                      aria-label={t('reply')}
-                      onClick={() => onReply(replyMessage)}
-                      size="sm"
-                      variant="secondary"
-                    >
-                      <Reply className="size-4" />
-                      <span className="hidden sm:inline">{t('reply')}</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t('reply')}</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
-                      aria-label={t('reply_all')}
-                      onClick={() => onReplyAll(replyMessage)}
-                      size="sm"
-                      variant="ghost"
-                    >
-                      <ReplyAll className="size-4" />
-                      <span className="hidden sm:inline">{t('reply_all')}</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t('reply_all')}</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
-                      aria-label={t('forward')}
-                      onClick={() => onForward(replyMessage)}
-                      size="sm"
-                      variant="ghost"
-                    >
-                      <Forward className="size-4" />
-                      <span className="hidden sm:inline">{t('forward')}</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t('forward')}</TooltipContent>
-                </Tooltip>
-                {thread.messages.some((message) => message.sanitizedHtml) && (
-                  <MailAppearanceControls />
+                {!isDraft && replyMessage && (
+                  <>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
+                          aria-label={t('reply')}
+                          onClick={() => onReply(replyMessage)}
+                          size="sm"
+                          variant="secondary"
+                        >
+                          <Reply className="size-4" />
+                          <span className="hidden sm:inline">{t('reply')}</span>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('reply')}</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
+                          aria-label={t('reply_all')}
+                          onClick={() => onReplyAll(replyMessage)}
+                          size="sm"
+                          variant="ghost"
+                        >
+                          <ReplyAll className="size-4" />
+                          <span className="hidden sm:inline">
+                            {t('reply_all')}
+                          </span>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('reply_all')}</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
+                          aria-label={t('forward')}
+                          onClick={() => onForward(replyMessage)}
+                          size="sm"
+                          variant="ghost"
+                        >
+                          <Forward className="size-4" />
+                          <span className="hidden sm:inline">
+                            {t('forward')}
+                          </span>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('forward')}</TooltipContent>
+                    </Tooltip>
+                  </>
+                )}
+                {hasHtml && (
+                  <MailAppearanceControls
+                    standalone={isDraft || !replyMessage}
+                  />
                 )}
               </div>
             </div>

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail.tsx
@@ -27,8 +27,10 @@ import {
 } from '@tuturuuu/ui/alert-dialog';
 import { Button } from '@tuturuuu/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@tuturuuu/ui/tabs';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import { useTranslations } from 'next-intl';
 import { type ReactNode, useState } from 'react';
+import { MailAppearanceControls } from './mail-appearance-controls';
 import { MailAttachmentCard } from './mail-attachment-card';
 import { MailContentState } from './mail-content-state';
 import type { MailFolder } from './mail-folders';
@@ -184,33 +186,54 @@ export function ThreadDetail({
                 role="toolbar"
                 aria-label={t('message_actions')}
               >
-                <Button
-                  className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
-                  onClick={() => onReply(replyMessage)}
-                  size="sm"
-                  variant="secondary"
-                >
-                  <Reply className="size-4" />
-                  {t('reply')}
-                </Button>
-                <Button
-                  className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
-                  onClick={() => onReplyAll(replyMessage)}
-                  size="sm"
-                  variant="ghost"
-                >
-                  <ReplyAll className="size-4" />
-                  {t('reply_all')}
-                </Button>
-                <Button
-                  className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
-                  onClick={() => onForward(replyMessage)}
-                  size="sm"
-                  variant="ghost"
-                >
-                  <Forward className="size-4" />
-                  {t('forward')}
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
+                      aria-label={t('reply')}
+                      onClick={() => onReply(replyMessage)}
+                      size="sm"
+                      variant="secondary"
+                    >
+                      <Reply className="size-4" />
+                      <span className="hidden sm:inline">{t('reply')}</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('reply')}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
+                      aria-label={t('reply_all')}
+                      onClick={() => onReplyAll(replyMessage)}
+                      size="sm"
+                      variant="ghost"
+                    >
+                      <ReplyAll className="size-4" />
+                      <span className="hidden sm:inline">{t('reply_all')}</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('reply_all')}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      className="gap-1 px-2 text-xs sm:px-3 sm:text-sm"
+                      aria-label={t('forward')}
+                      onClick={() => onForward(replyMessage)}
+                      size="sm"
+                      variant="ghost"
+                    >
+                      <Forward className="size-4" />
+                      <span className="hidden sm:inline">{t('forward')}</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('forward')}</TooltipContent>
+                </Tooltip>
+                {thread.messages.some((message) => message.sanitizedHtml) && (
+                  <MailAppearanceControls />
+                )}
               </div>
             </div>
           )}

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-message-card.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-message-card.tsx
@@ -126,10 +126,7 @@ export function ThreadMessageCard({
             <MailMessagePreview
               content={message.bodyHtml ?? message.sanitizedHtml}
               attachments={message.attachments}
-              darkLabel={t('dark_view')}
-              originalLabel={t('original_view')}
               title={message.subject || t('no_subject')}
-              viewLabel={t('message_appearance')}
             />
           ) : (
             <pre className="whitespace-pre-wrap break-words px-4 pb-6 font-sans text-sm leading-7 md:px-6">

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
@@ -340,7 +340,7 @@ export function useMailThreadActions({
     onSuccess: () => {
       setSyncState('synced');
     },
-    onSettled: () => void invalidateMailbox(),
+    onSettled: () => invalidateMailbox(),
   });
 
   const bulkMutation = useMutation({
@@ -389,7 +389,7 @@ export function useMailThreadActions({
     onSuccess: () => {
       setSyncState('synced');
     },
-    onSettled: () => void invalidateMailbox(),
+    onSettled: () => invalidateMailbox(),
   });
 
   return {

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
@@ -287,32 +287,6 @@ export function useMailThreadActions({
     }
   };
 
-  // Read the auto-selected conversation only after archive succeeds. This
-  // request has no optimistic snapshot that could overwrite archive rollback.
-  const autoReadMutation = useMutation({
-    mutationKey: ['mail', workspaceId, activeMailboxId, 'auto-read'],
-    mutationFn: (targetThreadId: string) =>
-      updateMailThreadState(
-        workspaceId,
-        activeMailboxId ?? '',
-        targetThreadId,
-        { action: 'mark_read' }
-      ),
-    onError: () => toast.error(t('update_failed')),
-    onSettled: () => void invalidateMailbox(),
-  });
-  // The successful navigation intent is authoritative even before React renders it.
-  const markAutoSelectedRead = (nextThreadId: string | null | undefined) => {
-    if (
-      nextThreadId &&
-      threads.some(
-        (thread) => thread.id === nextThreadId && thread.unreadCount > 0
-      )
-    ) {
-      autoReadMutation.mutate(nextThreadId);
-    }
-  };
-
   const stateMutation = useMutation({
     mutationKey: ['mail', workspaceId, activeMailboxId, 'state'],
     mutationFn: ({
@@ -363,9 +337,8 @@ export function useMailThreadActions({
       setSyncState('failed');
       toast.error(t('update_failed'));
     },
-    onSuccess: (_data, _variables, context) => {
+    onSuccess: () => {
       setSyncState('synced');
-      markAutoSelectedRead(context?.navigatedTo);
     },
     onSettled: () => void invalidateMailbox(),
   });
@@ -413,9 +386,8 @@ export function useMailThreadActions({
       setSyncState('failed');
       toast.error(t('update_failed'));
     },
-    onSuccess: (_data, _variables, context) => {
+    onSuccess: () => {
       setSyncState('synced');
-      markAutoSelectedRead(context?.navigatedTo);
     },
     onSettled: () => void invalidateMailbox(),
   });

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-viewed-thread-read.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-viewed-thread-read.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { MailThreadDetail } from '@tuturuuu/internal-api';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ update: vi.fn(), error: vi.fn() }));
+vi.mock('@tuturuuu/internal-api', () => ({
+  updateMailThreadState: mocks.update,
+}));
+vi.mock('@tuturuuu/ui/sonner', () => ({ toast: { error: mocks.error } }));
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+
+import { useMailViewedThreadRead } from './use-mail-viewed-thread-read';
+
+function detail(
+  id = 'a',
+  unread = true,
+  messageId = 'message'
+): MailThreadDetail {
+  return {
+    thread: { id },
+    messages: [{ id: messageId, unread }],
+  } as MailThreadDetail;
+}
+const base = {
+  workspaceId: 'ws',
+  mailboxId: 'mailbox',
+  threadId: 'a',
+  blocked: false,
+  detail: detail(),
+};
+function setup(props = base) {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  const invalidate = vi.spyOn(client, 'invalidateQueries');
+  const hook = renderHook(useMailViewedThreadRead, {
+    initialProps: props,
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children),
+  });
+  return { ...hook, invalidate };
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.update.mockResolvedValue({});
+});
+afterEach(cleanup);
+
+describe('viewed thread read tracking', () => {
+  it('marks a loaded restored URL read without a list click and refreshes mailbox counts', async () => {
+    const { invalidate } = setup();
+    await waitFor(() =>
+      expect(mocks.update).toHaveBeenCalledWith('ws', 'mailbox', 'a', {
+        action: 'mark_read',
+      })
+    );
+    await waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: ['mail', 'ws', 'bootstrap'],
+      })
+    );
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+  });
+  it('waits for loaded matching unread content and for archive rollback to settle', async () => {
+    const { rerender } = setup({ ...base, blocked: true });
+    expect(mocks.update).not.toHaveBeenCalled();
+    rerender({ ...base, detail: detail('other') });
+    expect(mocks.update).not.toHaveBeenCalled();
+    rerender({ ...base, detail: detail('a', false) });
+    expect(mocks.update).not.toHaveBeenCalled();
+    rerender(base);
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledTimes(1));
+  });
+  it('deduplicates in-flight reads and handles a new unread arrival in the open thread', async () => {
+    let resolve!: (value: object) => void;
+    mocks.update.mockImplementationOnce(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        })
+    );
+    const { rerender } = setup();
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledTimes(1));
+    rerender({ ...base, detail: detail() });
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+    await act(async () => resolve({}));
+    rerender({ ...base, detail: detail('a', true, 'new-message') });
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledTimes(2));
+  });
+  it('does not retry a failing read in a render loop and can retry after reopening', async () => {
+    mocks.update.mockRejectedValue(new Error('offline'));
+    const { rerender } = setup();
+    await waitFor(() => expect(mocks.error).toHaveBeenCalledTimes(1));
+    rerender({ ...base, detail: detail() });
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+    rerender({ ...base, threadId: 'other', detail: detail('other', false) });
+    rerender(base);
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-viewed-thread-read.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-viewed-thread-read.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  type MailThreadDetail,
+  updateMailThreadState,
+} from '@tuturuuu/internal-api';
+import { toast } from '@tuturuuu/ui/sonner';
+import { useTranslations } from 'next-intl';
+import { useEffect, useRef } from 'react';
+
+/** Reading follows the loaded reader, including restored URLs and archive navigation. */
+export function useMailViewedThreadRead({
+  workspaceId,
+  mailboxId,
+  threadId,
+  detail,
+  blocked,
+}: {
+  workspaceId: string;
+  mailboxId: string | null;
+  threadId: string | null;
+  detail: MailThreadDetail | undefined;
+  blocked: boolean;
+}) {
+  const client = useQueryClient();
+  const t = useTranslations('mail');
+  const attempted = useRef<string | null>(null);
+  const selection = `${workspaceId}/${mailboxId}/${threadId}`;
+  const previousSelection = useRef(selection);
+  const unreadIds =
+    detail?.thread.id === threadId
+      ? detail.messages
+          .filter((message) => message.unread)
+          .map((message) => message.id)
+          .sort()
+          .join(',')
+      : '';
+  const { mutate, isPending } = useMutation({
+    mutationKey: ['mail', workspaceId, mailboxId, 'viewed-read'],
+    mutationFn: (target: { mailboxId: string; threadId: string }) =>
+      updateMailThreadState(workspaceId, target.mailboxId, target.threadId, {
+        action: 'mark_read',
+      }),
+    onError: () => toast.error(t('update_failed')),
+    onSettled: async (_data, _error, target) => {
+      await Promise.all([
+        client.invalidateQueries({
+          queryKey: ['mail', workspaceId, target.mailboxId],
+        }),
+        client.invalidateQueries({
+          queryKey: ['mail', workspaceId, 'bootstrap'],
+        }),
+      ]);
+    },
+  });
+
+  useEffect(() => {
+    if (previousSelection.current !== selection) {
+      previousSelection.current = selection;
+      attempted.current = null;
+    }
+    if (!unreadIds) attempted.current = null;
+    // Wait for optimistic archive/trash to settle, avoiding nested rollback snapshots.
+    if (blocked || isPending || !mailboxId || !threadId || !unreadIds) return;
+    const signature = `${selection}/${unreadIds}`;
+    if (attempted.current === signature) return;
+    attempted.current = signature;
+    mutate({ mailboxId, threadId });
+  }, [blocked, isPending, mailboxId, mutate, selection, threadId, unreadIds]);
+}


### PR DESCRIPTION
Opened conversations could stay unread when reached through a restored URL or navigation instead of a list click. Track the loaded unread conversation, deduplicate read requests, and wait for archive/trash operations to settle before updating read state.

Move Dark/Original into compact tooltip icon controls on the floating action toolbar. Adapt neutral black/gray panels, modern CSS colors, and neutral gradients to the reader background, and soften bright neutral borders while retaining branded panels, gradients, and images. Keep reply controls compact on narrow screens with accessible labels and tooltips.

Validation: 186 Mail tests, Mail type check, full `bun check`, and Mail production build passed. Chrome fixture verified matching dark surfaces, subtle white-border conversion, retained branded colors/gradients, and control selection/keyboard tooltips. Production mailbox data was not changed during validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes conversations opened through restored URLs or navigation staying unread, and moves Dark/Original controls into the floating toolbar with improved dark-mode contrast handling.

- Read tracking follows the loaded reader, deduplicates requests, and waits for archive/trash operations to settle before marking read.
- Dark mode now adapts neutral black, gray, and gradient surfaces, softens bright neutral borders, and preserves branded panels and images.
- Reply actions become icon-only on narrow screens with accessible labels and tooltips.

<sup>Written for commit 986a10737f8b6ec00ccaef15421a9488f614852b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

