### PR TITLE
fix(mail): speed inbox loading and independent archive actions

### DIFF
--- a/apps/docs/platform/applications/mail.mdx
+++ b/apps/docs/platform/applications/mail.mdx
@@ -56,7 +56,8 @@ skips all selected conversations when choosing the next message. Loaded unread
 conversations are marked read even when opened through restored URLs or archive
 navigation. Read updates wait for pending archive/trash operations to settle.
 Archive controls track the affected conversation, so the next conversation remains
-actionable while earlier requests finish. Failed operations restore only their
+actionable while earlier requests finish. Its header remains available from the
+inbox summary while the message body loads. Failed operations restore only their
 own conversations and counters; mailbox reconciliation waits for overlapping
 operations to finish. Catch-all headers fall back to the observed delivery
 recipient, then the envelope recipient when parsed To recipients are absent.

--- a/apps/docs/platform/applications/mail.mdx
+++ b/apps/docs/platform/applications/mail.mdx
@@ -37,6 +37,15 @@ token refresh same-origin through `/api/auth/refresh-app-session`; a valid
 refresh cookie should rotate the Mail-local and Web-issued app-session cookies
 without sending the browser back through `apps/web` login.
 
+Authenticated root and personal workspace entry requests redirect directly to
+`/personal/inbox` in the proxy, preserving query state and locale. Mailbox discovery
+uses bootstrap `?view=mailboxes`; unread badges load separately through
+`?view=counts` and stay unknown until available. Both paths retain session and
+membership checks. The default bootstrap response still includes counts for other
+clients. Thread scans fetch previews rather than full bodies; missing legacy
+snippets are loaded only for the visible page. State scans exclude read-only rows
+unless the requested search needs read state.
+
 ## Reading and attachment previews
 
 Settings → Reading stores the archive navigation and email appearance preferences
@@ -46,6 +55,12 @@ the loaded list. Users can choose to return to the list instead. Bulk archive
 skips all selected conversations when choosing the next message. Loaded unread
 conversations are marked read even when opened through restored URLs or archive
 navigation. Read updates wait for pending archive/trash operations to settle.
+Archive controls track the affected conversation, so the next conversation remains
+actionable while earlier requests finish. Failed operations restore only their
+own conversations and counters; mailbox reconciliation waits for overlapping
+operations to finish. Catch-all headers fall back to the observed delivery
+recipient, then the envelope recipient when parsed To recipients are absent.
+Sender and recipient summaries clamp long addresses and expose full text in tooltips.
 
 Email frames remain hidden until the saved appearance is restored and contrast
 adjustments finish. Dark mode matches neutral paper surfaces to the reader's

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-concurrency.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-concurrency.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import {
+  type InfiniteData,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import type {
+  MailThreadSummary,
+  MailThreadsResponse,
+} from '@tuturuuu/internal-api';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  update: vi.fn(),
+  bulk: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock('@tuturuuu/internal-api', () => ({
+  updateMailThreadState: mocks.update,
+  bulkUpdateMailThreads: mocks.bulk,
+}));
+vi.mock('@tuturuuu/ui/sonner', () => ({ toast: { error: mocks.error } }));
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+
+import { useMailThreadActions } from './use-mail-thread-actions';
+
+const key = ['mail', 'ws', 'box', 'threads', 'inbox', null, null, ''];
+const rows = ['a', 'b', 'c'].map((id) => ({
+  id,
+  unreadCount: 1,
+  starred: false,
+})) as MailThreadSummary[];
+function deferred() {
+  let resolve!: (value: object) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<object>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  client.setQueryData<InfiniteData<MailThreadsResponse>>(key, {
+    pageParams: [1],
+    pages: [
+      {
+        threads: rows,
+        pagination: {
+          page: 1,
+          pageSize: 40,
+          total: 3,
+          hasMore: false,
+          truncated: false,
+        },
+      },
+    ],
+  });
+  client.setQueryData(['mail', 'ws', 'bootstrap-counts'], { box: 3 });
+  const invalidateMailbox = vi.fn(async () => {});
+  const reopenThread = vi.fn();
+  const props = {
+    activeMailboxId: 'box',
+    workspaceId: 'ws',
+    threadId: 'a',
+    threads: rows,
+    folder: 'inbox' as const,
+    closeThread: vi.fn(),
+    reopenThread,
+    invalidateMailbox,
+    selectedThreads: new Set<string>(),
+    setSelectedThreads: vi.fn(),
+  };
+  const hook = renderHook(useMailThreadActions, {
+    initialProps: props,
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children),
+  });
+  const ids = () =>
+    client
+      .getQueryData<InfiniteData<MailThreadsResponse>>(key)
+      ?.pages[0]?.threads.map((row) => row.id);
+  return { ...hook, client, props, ids, invalidateMailbox, reopenThread };
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+afterEach(cleanup);
+describe('concurrent archive navigation', () => {
+  it('allows the next email while the first waits and reconciles only after both finish', async () => {
+    const a = deferred();
+    const b = deferred();
+    mocks.update.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+    const hook = setup();
+    act(() => {
+      hook.result.current.mutateThread('archive');
+      hook.result.current.mutateThread('archive');
+    });
+    await waitFor(() => expect(hook.reopenThread).toHaveBeenCalledWith('b'));
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+    hook.rerender({ ...hook.props, threadId: 'b', threads: rows.slice(1) });
+    expect(hook.result.current.actionPending).toBe(false);
+    act(() => hook.result.current.mutateThread('archive'));
+    await waitFor(() => expect(hook.ids()).toEqual(['c']));
+    await act(async () => a.resolve({}));
+    expect(hook.invalidateMailbox).not.toHaveBeenCalled();
+    expect(hook.ids()).toEqual(['c']);
+    await act(async () => b.resolve({}));
+    await waitFor(() =>
+      expect(hook.invalidateMailbox).toHaveBeenCalledTimes(1)
+    );
+  });
+  it('restores only a failed email while another archive succeeds out of order', async () => {
+    const a = deferred();
+    const b = deferred();
+    mocks.update.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+    const hook = setup();
+    act(() => hook.result.current.mutateThread('archive'));
+    await waitFor(() => expect(hook.ids()).toEqual(['b', 'c']));
+    hook.rerender({ ...hook.props, threadId: 'b', threads: rows.slice(1) });
+    act(() => hook.result.current.mutateThread('archive'));
+    await waitFor(() => expect(hook.ids()).toEqual(['c']));
+    hook.rerender({ ...hook.props, threadId: 'c', threads: rows.slice(2) });
+    await act(async () => b.resolve({}));
+    expect(hook.invalidateMailbox).not.toHaveBeenCalled();
+    await act(async () => a.reject(new Error('offline')));
+    await waitFor(() => expect(hook.ids()).toEqual(['a', 'c']));
+    expect(
+      hook.client.getQueryData(['mail', 'ws', 'bootstrap-counts'])
+    ).toEqual({ box: 2 });
+    expect(
+      hook.client.getQueryData<InfiniteData<MailThreadsResponse>>(key)?.pages[0]
+        ?.pagination.total
+    ).toBe(2);
+    expect(hook.reopenThread).not.toHaveBeenCalledWith('a');
+    expect(hook.invalidateMailbox).toHaveBeenCalledTimes(1);
+  });
+});
+
+it('reconciles when concurrent requests finish in the same microtask', async () => {
+  const a = deferred();
+  const b = deferred();
+  mocks.update.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+  const hook = setup();
+  act(() => hook.result.current.mutateThread('archive', 'a'));
+  await waitFor(() => expect(hook.ids()).toEqual(['b', 'c']));
+  act(() => hook.result.current.mutateThread('archive', 'b'));
+  await waitFor(() => expect(hook.ids()).toEqual(['c']));
+  await act(async () => {
+    a.resolve({});
+    b.resolve({});
+  });
+  await waitFor(() => expect(hook.invalidateMailbox).toHaveBeenCalledTimes(1));
+});
+
+it('pins rollback and reconciliation to the original mailbox after navigation', async () => {
+  const request = deferred();
+  mocks.update.mockReturnValueOnce(request.promise);
+  const hook = setup();
+  act(() => hook.result.current.mutateThread('archive'));
+  await waitFor(() => expect(hook.ids()).toEqual(['b', 'c']));
+  const otherInvalidate = vi.fn(async () => {});
+  hook.rerender({
+    ...hook.props,
+    activeMailboxId: 'other',
+    threadId: 'other-thread',
+    invalidateMailbox: otherInvalidate,
+  });
+  expect(hook.result.current.actionPending).toBe(false);
+  await act(async () => request.reject(new Error('offline')));
+  await waitFor(() => expect(hook.ids()).toEqual(['a', 'b', 'c']));
+  expect(mocks.update).toHaveBeenCalledWith('ws', 'box', 'a', {
+    action: 'archive',
+  });
+  expect(hook.invalidateMailbox).toHaveBeenCalledTimes(1);
+  expect(otherInvalidate).not.toHaveBeenCalled();
+  expect(hook.reopenThread).not.toHaveBeenCalledWith('a');
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-concurrency.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-concurrency.test.ts
@@ -179,5 +179,6 @@ it('pins rollback and reconciliation to the original mailbox after navigation', 
   });
   expect(hook.invalidateMailbox).toHaveBeenCalledTimes(1);
   expect(otherInvalidate).not.toHaveBeenCalled();
+  expect(hook.result.current.syncState).toBe('idle');
   expect(hook.reopenThread).not.toHaveBeenCalledWith('a');
 });

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-concurrency.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-concurrency.test.ts
@@ -64,7 +64,7 @@ function setup() {
   const invalidateMailbox = vi.fn(async () => {});
   const reopenThread = vi.fn();
   const props = {
-    activeMailboxId: 'box',
+    activeMailboxId: 'box' as string | null,
     workspaceId: 'ws',
     threadId: 'a',
     threads: rows,
@@ -181,4 +181,21 @@ it('pins rollback and reconciliation to the original mailbox after navigation', 
   expect(otherInvalidate).not.toHaveBeenCalled();
   expect(hook.result.current.syncState).toBe('idle');
   expect(hook.reopenThread).not.toHaveBeenCalledWith('a');
+});
+
+it('does not send single or bulk actions during an unresolved mailbox transition', async () => {
+  const hook = setup();
+  hook.rerender({
+    ...hook.props,
+    activeMailboxId: null,
+    selectedThreads: new Set(['a']),
+  });
+  await act(async () => {
+    hook.result.current.mutateThread('archive');
+    hook.result.current.bulkMutation.mutate('archive');
+  });
+  expect(mocks.update).not.toHaveBeenCalled();
+  expect(mocks.bulk).not.toHaveBeenCalled();
+  expect(hook.ids()).toEqual(['a', 'b', 'c']);
+  expect(hook.result.current.syncState).toBe('idle');
 });

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-order.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-archive-order.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   }>,
   reopen: vi.fn(),
   client: {
+    isMutating: vi.fn().mockReturnValue(1),
     cancelQueries: vi.fn().mockResolvedValue(undefined),
     getQueriesData: vi.fn().mockReturnValue([]),
     getQueryData: vi.fn(),
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 vi.mock('@tanstack/react-query', () => ({
+  useMutationState: () => [],
   useQueryClient: () => mocks.client,
   useMutation: (options: { mutationKey: string[]; [key: string]: any }) => {
     const mutation = { options, mutate: vi.fn() };
@@ -24,7 +26,10 @@ vi.mock('@tanstack/react-query', () => ({
   },
 }));
 vi.mock('react', () => ({
-  useRef: () => mocks.selected,
+  useRef: (value: unknown) =>
+    value instanceof Set || value instanceof Map
+      ? { current: value }
+      : mocks.selected,
   useState: () => ['idle', vi.fn()],
 }));
 vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
@@ -60,7 +65,10 @@ describe('archive and auto-read ordering', () => {
       const mutation = mocks.mutations.find(
         (entry) => entry.options.mutationKey.at(-1) === key
       )!;
-      const settled = mutation.options.onSettled();
+      const settled = mutation.options.onSettled(undefined, undefined, {
+        targetThreadId: 'a',
+        threadIds: ['a'],
+      });
       expect(settled).toBeInstanceOf(Promise);
       await settled;
     }
@@ -73,7 +81,7 @@ describe('archive and auto-read ordering', () => {
           entry.options.mutationKey.at(-1) === (bulk ? 'bulk' : 'state')
       )!;
       const variables = bulk
-        ? 'archive'
+        ? { action: 'archive', threadIds: ['a'] }
         : { action: 'archive', targetThreadId: 'a' };
       const context = await archive.options.onMutate!(variables);
       expect(mocks.reopen).toHaveBeenCalledWith('b');

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-automation-settings.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-automation-settings.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
-  getMailBootstrap,
   type MailMailbox,
   type MailMailboxSettings,
   updateMailMailboxSettings,
@@ -20,6 +19,7 @@ import { toast } from '@tuturuuu/ui/sonner';
 import { Switch } from '@tuturuuu/ui/switch';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
+import { useMailBootstrap } from './use-mail-bootstrap';
 
 export function MailAutomationSettings({
   mailbox,
@@ -38,10 +38,7 @@ export function MailAutomationSettings({
   };
   const [automation, setAutomation] = useState(initial);
   const canManage = ['owner', 'admin'].includes(mailbox.role);
-  const bootstrap = useQuery({
-    queryKey: ['mail', workspaceId, 'bootstrap'],
-    queryFn: () => getMailBootstrap(workspaceId),
-  });
+  const bootstrap = useMailBootstrap(workspaceId);
   const candidates = (bootstrap.data?.mailboxes ?? []).filter(
     (candidate) =>
       candidate.id !== mailbox.id &&

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
@@ -18,7 +18,6 @@ import {
 } from '@tuturuuu/icons';
 import {
   deleteMailDraft,
-  getMailBootstrap,
   getMailThread,
   listMailThreads,
   type MailMessageDetail,
@@ -62,6 +61,7 @@ import {
   MAIL_THREAD_PAGE_SIZE,
 } from './mail-thread-query';
 import { ThreadDetail } from './thread-detail';
+import { useMailBootstrap } from './use-mail-bootstrap';
 import { useMailThreadActions } from './use-mail-thread-actions';
 import { useMailViewedThreadRead } from './use-mail-viewed-thread-read';
 
@@ -119,10 +119,7 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
     layoutReadyRef.current = true;
   }, []);
 
-  const bootstrapQuery = useQuery({
-    queryFn: () => getMailBootstrap(workspaceId),
-    queryKey: ['mail', workspaceId, 'bootstrap'],
-  });
+  const bootstrapQuery = useMailBootstrap(workspaceId);
   const mailboxes = bootstrapQuery.data?.mailboxes ?? [];
   const activeMailbox =
     mailboxes.find((mailbox) => mailbox.id === mailboxId) ?? mailboxes[0];
@@ -186,6 +183,9 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
       queryClient.invalidateQueries({
         queryKey: ['mail', workspaceId, 'bootstrap'],
       }),
+      queryClient.invalidateQueries({
+        queryKey: ['mail', workspaceId, 'bootstrap-counts'],
+      }),
     ]);
   };
 
@@ -209,29 +209,30 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
     },
   });
 
-  const { bulkMutation, mutateThread, stateMutation, syncState } =
-    useMailThreadActions({
-      activeMailboxId,
-      closeThread: () => void setThreadId(null),
-      folder,
-      invalidateMailbox,
-      reopenThread: (nextThreadId) => void setThreadId(nextThreadId),
-      selectedThreads,
-      setSelectedThreads,
-      threadId,
-      threads,
-      workspaceId,
-    });
+  const {
+    bulkMutation,
+    mutateThread,
+    actionPending,
+    actionsPending,
+    syncState,
+  } = useMailThreadActions({
+    activeMailboxId,
+    closeThread: () => void setThreadId(null),
+    folder,
+    invalidateMailbox,
+    reopenThread: (nextThreadId) => void setThreadId(nextThreadId),
+    selectedThreads,
+    setSelectedThreads,
+    threadId,
+    threads,
+    workspaceId,
+  });
   useMailViewedThreadRead({
     workspaceId,
     mailboxId: activeMailboxId,
     threadId,
     detail: detailQuery.data,
-    blocked:
-      stateMutation.isPending ||
-      bulkMutation.isPending ||
-      detailQuery.isError ||
-      folder === 'drafts',
+    blocked: actionsPending || detailQuery.isError || folder === 'drafts',
   });
   const deleteDraftMutation = useMutation({
     mutationFn: (draftId: string) =>
@@ -437,7 +438,7 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
             </span>
             <Button
               aria-label={t('mark_read')}
-              disabled={bulkMutation.isPending}
+              disabled={actionsPending}
               onClick={() => bulkMutation.mutate('mark_read')}
               size="icon"
               variant="ghost"
@@ -446,7 +447,7 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
             </Button>
             <Button
               aria-label={t('archive')}
-              disabled={bulkMutation.isPending}
+              disabled={actionsPending}
               onClick={() => bulkMutation.mutate('archive')}
               size="icon"
               variant="ghost"
@@ -463,7 +464,7 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
             ) : null}
             <Button
               aria-label={t('trash')}
-              disabled={bulkMutation.isPending}
+              disabled={actionsPending}
               onClick={() => bulkMutation.mutate('trash')}
               size="icon"
               variant="ghost"
@@ -552,7 +553,7 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
     <section className="flex h-full min-h-0 min-w-0 max-w-full bg-muted/20">
       <ThreadDetail
         folder={folder}
-        actionPending={stateMutation.isPending || deleteDraftMutation.isPending}
+        actionPending={actionPending || deleteDraftMutation.isPending}
         isDraft={folder === 'drafts'}
         labelActions={
           activeMailboxId && threadId ? (

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
@@ -549,6 +549,8 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
     </section>
   );
 
+  const selectedSummary =
+    threads.find((thread) => thread.id === threadId) ?? null;
   const detailPanel = (
     <section className="flex h-full min-h-0 min-w-0 max-w-full bg-muted/20">
       <ThreadDetail
@@ -575,7 +577,10 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
         onReplyAll={handleReplyAll}
         onStar={() =>
           mutateThread(
-            detailQuery.data?.messages.at(-1)?.starred ? 'unstar' : 'star'
+            (detailQuery.data?.messages.at(-1)?.starred ??
+              selectedSummary?.starred)
+              ? 'unstar'
+              : 'star'
           )
         }
         onTrash={() => {
@@ -587,6 +592,7 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
           else mutateThread('trash');
         }}
         thread={detailQuery.data ?? null}
+        summary={selectedSummary}
       />
     </section>
   );

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-message-addresses.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-message-addresses.test.ts
@@ -20,6 +20,9 @@ describe('mail participants', () => {
   });
   it('preserves parsed recipients and full names', () => {
     expect(formatMailSender(message)).toBe('Sender <sender@example.com>');
+    expect(formatMailSender({ ...message, fromName: '   ' })).toBe(
+      'sender@example.com'
+    );
     expect(
       formatMailRecipients(
         {

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-message-addresses.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-message-addresses.test.ts
@@ -1,0 +1,46 @@
+import type { MailMessageDetail } from '@tuturuuu/internal-api';
+import { describe, expect, it } from 'vitest';
+import {
+  formatMailRecipients,
+  formatMailSender,
+} from './mail-message-addresses';
+
+const message = {
+  fromName: ' Sender ',
+  fromAddress: 'sender@example.com',
+  recipients: [],
+  observedRecipient: ' contact@example.com ',
+  envelopeTo: 'catchall@example.com',
+} as unknown as MailMessageDetail;
+describe('mail participants', () => {
+  it('uses recorded catch-all delivery when To is missing without inventing Cc or Bcc', () => {
+    expect(formatMailRecipients(message, 'to')).toBe('contact@example.com');
+    expect(formatMailRecipients(message, 'cc')).toBe('');
+    expect(formatMailRecipients(message, 'bcc')).toBe('');
+  });
+  it('preserves parsed recipients and full names', () => {
+    expect(formatMailSender(message)).toBe('Sender <sender@example.com>');
+    expect(
+      formatMailRecipients(
+        {
+          ...message,
+          recipients: [
+            { kind: 'to', address: 'to@example.com', displayName: 'Recipient' },
+          ],
+        },
+        'to'
+      )
+    ).toBe('Recipient <to@example.com>');
+  });
+  it('falls back to envelope delivery and leaves unknown recipients empty', () => {
+    expect(
+      formatMailRecipients({ ...message, observedRecipient: ' ' }, 'to')
+    ).toBe('catchall@example.com');
+    expect(
+      formatMailRecipients(
+        { ...message, observedRecipient: null, envelopeTo: null },
+        'to'
+      )
+    ).toBe('');
+  });
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-message-addresses.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-message-addresses.ts
@@ -1,0 +1,26 @@
+import type { MailMessageDetail } from '@tuturuuu/internal-api';
+
+export function formatMailSender(message: MailMessageDetail) {
+  return message.fromName?.trim()
+    ? `${message.fromName.trim()} <${message.fromAddress}>`
+    : message.fromAddress;
+}
+
+export function formatMailRecipients(
+  message: MailMessageDetail,
+  kind: 'bcc' | 'cc' | 'to'
+) {
+  const recipients = message.recipients
+    .filter((recipient) => recipient.kind === kind && recipient.address.trim())
+    .map((recipient) =>
+      recipient.displayName?.trim()
+        ? `${recipient.displayName.trim()} <${recipient.address.trim()}>`
+        : recipient.address.trim()
+    );
+  if (recipients.length) return [...new Set(recipients)].join(', ');
+  // Catch-all delivery can have no parsed To header (including Bcc mail).
+  // Use the recorded delivery address, never the catch-all mailbox owner.
+  return kind === 'to'
+    ? message.observedRecipient?.trim() || message.envelopeTo?.trim() || ''
+    : '';
+}

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sidebar-panel.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sidebar-panel.tsx
@@ -3,7 +3,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, Mail, PenLine, Settings, Users } from '@tuturuuu/icons';
 import {
-  getMailBootstrap,
   getMailboxOrganization,
   listMailThreads,
   type MailMailbox,
@@ -32,6 +31,7 @@ import {
   MAIL_THREAD_PAGE_SIZE,
 } from './mail-thread-query';
 import { MailboxGroups } from './mailbox-groups';
+import { useMailBootstrap } from './use-mail-bootstrap';
 
 export function MailSidebarPanel({
   closeOnMobile,
@@ -51,10 +51,7 @@ export function MailSidebarPanel({
   const queryClient = useQueryClient();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const bootstrapQuery = useQuery({
-    queryFn: () => getMailBootstrap(workspaceId),
-    queryKey: ['mail', workspaceId, 'bootstrap'],
-  });
+  const bootstrapQuery = useMailBootstrap(workspaceId);
   const mailboxes = bootstrapQuery.data?.mailboxes ?? [];
   const visibleMailboxes = mailboxes.filter((mailbox) =>
     `${mailbox.displayName} ${mailbox.address}`
@@ -378,7 +375,7 @@ function MailboxButton({
           {mailbox.address}
         </span>
       </span>
-      {mailbox.unreadCount > 0 ? (
+      {(mailbox.unreadCount ?? 0) > 0 ? (
         <span className="rounded-full bg-foreground px-2 py-0.5 text-background text-xs tabular-nums">
           {mailbox.unreadCount}
         </span>

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-thread-header.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-thread-header.tsx
@@ -1,0 +1,85 @@
+'use client';
+import { Archive, ArrowLeft, Star, Trash2 } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { useTranslations } from 'next-intl';
+import type { ReactNode } from 'react';
+
+export function MailThreadHeader({
+  subject,
+  messageCount,
+  starred,
+  actionPending,
+  isDraft,
+  labelActions,
+  onBack,
+  onStar,
+  onArchive,
+  onTrash,
+}: {
+  subject: string;
+  messageCount: number;
+  starred: boolean;
+  actionPending: boolean;
+  isDraft: boolean;
+  labelActions?: ReactNode;
+  onBack: () => void;
+  onStar: () => void;
+  onArchive: () => void;
+  onTrash: () => void;
+}) {
+  const t = useTranslations('mail');
+  return (
+    <header className="bg-background/90 px-4 py-3 backdrop-blur md:px-5">
+      <div className="flex flex-wrap items-start gap-2">
+        <Button
+          aria-label={t('back_to_messages')}
+          className="shrink-0"
+          onClick={onBack}
+          size="icon"
+          variant="ghost"
+        >
+          <ArrowLeft className="size-4" />
+        </Button>
+        <div className="min-w-0 flex-1 basis-40">
+          <h1 className="text-pretty break-words font-semibold text-lg leading-tight md:text-xl">
+            {subject || t('no_subject')}
+          </h1>
+          <p className="mt-1 text-muted-foreground text-xs">
+            {t('message_count', { count: messageCount })}
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          {labelActions}
+          <Button
+            aria-label={starred ? t('unstar') : t('star')}
+            aria-pressed={Boolean(starred)}
+            disabled={actionPending}
+            onClick={onStar}
+            size="icon"
+            variant="ghost"
+          >
+            <Star className={starred ? 'size-4 fill-current' : 'size-4'} />
+          </Button>
+          <Button
+            aria-label={t('archive')}
+            disabled={actionPending}
+            onClick={onArchive}
+            size="icon"
+            variant="ghost"
+          >
+            <Archive className="size-4" />
+          </Button>
+          <Button
+            aria-label={isDraft ? t('delete_draft') : t('trash')}
+            disabled={actionPending}
+            onClick={onTrash}
+            size="icon"
+            variant="ghost"
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-thread-rollback.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-thread-rollback.ts
@@ -1,0 +1,65 @@
+import type { InfiniteData } from '@tanstack/react-query';
+import type { MailThreadsResponse } from '@tuturuuu/internal-api';
+
+// Restore only this operation's conversations. Other successful/pending actions
+// must survive a failed archive, even when their snapshots overlap.
+export function restoreThreadPages(
+  current: InfiniteData<MailThreadsResponse> | undefined,
+  before: InfiniteData<MailThreadsResponse> | undefined,
+  ids: Set<string>
+) {
+  if (!current || !before) return current;
+  const existingIds = new Set(
+    current.pages.flatMap((page) => page.threads.map((thread) => thread.id))
+  );
+  const restoredIds = new Set<string>();
+  const originals = new Map(
+    before.pages.flatMap((page) =>
+      page.threads
+        .filter((thread) => ids.has(thread.id))
+        .map((thread) => [thread.id, thread] as const)
+    )
+  );
+  const pages = current.pages.map((page, pageIndex) => {
+    const threads = page.threads.map(
+      (thread) => originals.get(thread.id) ?? thread
+    );
+    const originalPage = before.pages[pageIndex];
+    for (const [index, thread] of (originalPage?.threads ?? []).entries()) {
+      if (
+        !ids.has(thread.id) ||
+        existingIds.has(thread.id) ||
+        restoredIds.has(thread.id)
+      )
+        continue;
+      const next = originalPage?.threads
+        .slice(index + 1)
+        .find((candidate) => threads.some((row) => row.id === candidate.id));
+      const previous = originalPage?.threads
+        .slice(0, index)
+        .reverse()
+        .find((candidate) => threads.some((row) => row.id === candidate.id));
+      const position = next
+        ? threads.findIndex((row) => row.id === next.id)
+        : previous
+          ? threads.findIndex((row) => row.id === previous.id) + 1
+          : Math.min(index, threads.length);
+      threads.splice(position, 0, thread);
+      restoredIds.add(thread.id);
+    }
+    return { ...page, threads };
+  });
+  return {
+    ...current,
+    pages: pages.map((page) => ({
+      ...page,
+      pagination: {
+        ...page.pagination,
+        total:
+          page.pagination.total === null
+            ? null
+            : page.pagination.total + restoredIds.size,
+      },
+    })),
+  };
+}

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail-loading.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail-loading.test.ts
@@ -44,3 +44,25 @@ describe('reader actions while loading the next body', () => {
     expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
   });
 });
+
+it('does not show a misleading retry-backed compose action when no message is selected', () => {
+  const onRetry = vi.fn();
+  render(
+    createElement(ThreadDetail, {
+      thread: null,
+      loading: false,
+      isDraft: false,
+      actionPending: false,
+      onRetry,
+      onArchive: vi.fn(),
+      onBack: vi.fn(),
+      onForward: vi.fn(),
+      onReply: vi.fn(),
+      onReplyAll: vi.fn(),
+      onStar: vi.fn(),
+      onTrash: vi.fn(),
+    })
+  );
+  expect(screen.queryByRole('button', { name: 'compose' })).toBeNull();
+  expect(screen.queryByRole('button', { name: 'retry' })).toBeNull();
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail-loading.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail-loading.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { MailThreadSummary } from '@tuturuuu/internal-api';
+import { createElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+
+import { ThreadDetail } from './thread-detail';
+
+afterEach(cleanup);
+describe('reader actions while loading the next body', () => {
+  it('keeps the selected summary archive action enabled while the body is loading', () => {
+    const onArchive = vi.fn();
+    render(
+      createElement(ThreadDetail, {
+        summary: {
+          id: 'next',
+          subject: 'Next email',
+          messageCount: 1,
+          starred: true,
+        } as MailThreadSummary,
+        thread: null,
+        loading: true,
+        isDraft: false,
+        actionPending: false,
+        onArchive,
+        onBack: vi.fn(),
+        onForward: vi.fn(),
+        onReply: vi.fn(),
+        onReplyAll: vi.fn(),
+        onStar: vi.fn(),
+        onTrash: vi.fn(),
+      })
+    );
+    expect(screen.getByRole('heading', { name: 'Next email' })).toBeTruthy();
+    const archive = screen.getByRole('button', {
+      name: 'archive',
+    }) as HTMLButtonElement;
+    expect(archive.disabled).toBe(false);
+    expect(screen.getByRole('button', { name: 'unstar' })).toBeTruthy();
+    fireEvent.click(archive);
+    expect(onArchive).toHaveBeenCalledOnce();
+    expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
+  });
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail.tsx
@@ -92,7 +92,7 @@ export function ThreadDetail({
         <div className="min-h-0 flex-1 overflow-y-auto">
           <MailContentState
             kind={loading ? 'loading' : error ? 'error' : 'reader'}
-            onAction={onRetry}
+            onAction={error ? onRetry : undefined}
           />
         </div>
       </div>

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-detail.tsx
@@ -1,18 +1,10 @@
 'use client';
 
-import {
-  Archive,
-  ArrowLeft,
-  Forward,
-  Paperclip,
-  Reply,
-  ReplyAll,
-  Star,
-  Trash2,
-} from '@tuturuuu/icons';
+import { Forward, Paperclip, Reply, ReplyAll } from '@tuturuuu/icons';
 import type {
   MailMessageDetail,
   MailThreadDetail,
+  MailThreadSummary,
 } from '@tuturuuu/internal-api';
 import { Accordion } from '@tuturuuu/ui/accordion';
 import {
@@ -34,6 +26,7 @@ import { MailAppearanceControls } from './mail-appearance-controls';
 import { MailAttachmentCard } from './mail-attachment-card';
 import { MailContentState } from './mail-content-state';
 import type { MailFolder } from './mail-folders';
+import { MailThreadHeader } from './mail-thread-header';
 import { ThreadMessageCard } from './thread-message-card';
 
 export function ThreadDetail({
@@ -52,6 +45,7 @@ export function ThreadDetail({
   onStar,
   onTrash,
   thread,
+  summary,
 }: {
   folder?: MailFolder;
   actionPending: boolean;
@@ -68,17 +62,43 @@ export function ThreadDetail({
   onStar: () => void;
   onTrash: () => void;
   thread: MailThreadDetail | null;
+  summary?: MailThreadSummary | null;
 }) {
   const t = useTranslations('mail');
   const [replyMessageId, setReplyMessageId] = useState<string | null>(null);
   const [deleteDraftOpen, setDeleteDraftOpen] = useState(false);
 
-  if (loading) return <MailContentState kind="loading" />;
-  if (error) return <MailContentState kind="error" onAction={onRetry} />;
-  if (!thread) return <MailContentState kind="reader" />;
+  const newest = thread?.messages.at(-1);
+  const threadInfo = thread?.thread ?? summary;
+  const header = threadInfo ? (
+    <MailThreadHeader
+      subject={threadInfo.subject}
+      messageCount={thread?.messages.length ?? threadInfo.messageCount}
+      starred={newest?.starred ?? summary?.starred ?? false}
+      actionPending={actionPending || (isDraft && !thread)}
+      isDraft={isDraft}
+      labelActions={labelActions}
+      onBack={onBack}
+      onStar={onStar}
+      onArchive={onArchive}
+      onTrash={() => (isDraft ? setDeleteDraftOpen(true) : onTrash())}
+    />
+  ) : null;
+
+  if (loading || error || !thread)
+    return (
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+        {header}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <MailContentState
+            kind={loading ? 'loading' : error ? 'error' : 'reader'}
+            onAction={onRetry}
+          />
+        </div>
+      </div>
+    );
 
   const hasHtml = thread.messages.some((message) => message.sanitizedHtml);
-  const newest = thread.messages.at(-1);
   const replyMessage =
     thread.messages.find((message) => message.id === replyMessageId) ?? newest;
   const attachments = thread.messages.flatMap((message) =>
@@ -87,60 +107,7 @@ export function ThreadDetail({
 
   return (
     <div className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-muted/20">
-      <header className="bg-background/90 px-4 py-3 backdrop-blur md:px-5">
-        <div className="flex flex-wrap items-start gap-2">
-          <Button
-            aria-label={t('back_to_messages')}
-            className="shrink-0"
-            onClick={onBack}
-            size="icon"
-            variant="ghost"
-          >
-            <ArrowLeft className="size-4" />
-          </Button>
-          <div className="min-w-0 flex-1 basis-40">
-            <h1 className="text-pretty break-words font-semibold text-lg leading-tight md:text-xl">
-              {thread.thread.subject || t('no_subject')}
-            </h1>
-            <p className="mt-1 text-muted-foreground text-xs">
-              {t('message_count', { count: thread.messages.length })}
-            </p>
-          </div>
-          <div className="flex items-center gap-1">
-            {labelActions}
-            <Button
-              aria-label={newest?.starred ? t('unstar') : t('star')}
-              aria-pressed={Boolean(newest?.starred)}
-              disabled={actionPending}
-              onClick={onStar}
-              size="icon"
-              variant="ghost"
-            >
-              <Star
-                className={newest?.starred ? 'size-4 fill-current' : 'size-4'}
-              />
-            </Button>
-            <Button
-              aria-label={t('archive')}
-              disabled={actionPending}
-              onClick={onArchive}
-              size="icon"
-              variant="ghost"
-            >
-              <Archive className="size-4" />
-            </Button>
-            <Button
-              aria-label={isDraft ? t('delete_draft') : t('trash')}
-              disabled={actionPending}
-              onClick={() => (isDraft ? setDeleteDraftOpen(true) : onTrash())}
-              size="icon"
-              variant="ghost"
-            >
-              <Trash2 className="size-4" />
-            </Button>
-          </div>
-        </div>
-      </header>
+      {header}
 
       <Tabs
         className="min-h-0 min-w-0 flex-1 gap-0"

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-message-card.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-message-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronDown } from '@tuturuuu/icons';
+import { ArrowRight, ChevronDown } from '@tuturuuu/icons';
 import type { MailMessageDetail } from '@tuturuuu/internal-api';
 import {
   AccordionContent,
@@ -8,9 +8,14 @@ import {
   AccordionTrigger,
 } from '@tuturuuu/ui/accordion';
 import { Badge } from '@tuturuuu/ui/badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import { useLocale, useTranslations } from 'next-intl';
 import { MailAttachmentCard } from './mail-attachment-card';
 import type { MailFolder } from './mail-folders';
+import {
+  formatMailRecipients,
+  formatMailSender,
+} from './mail-message-addresses';
 import { MailMessagePreview } from './mail-message-preview';
 import { visibleMailLabels } from './mail-visible-labels';
 
@@ -31,7 +36,8 @@ export function ThreadMessageCard({
 }) {
   const t = useTranslations('mail');
   const locale = useLocale();
-  const displayName = message.fromName || message.fromAddress;
+  const sender = formatMailSender(message);
+  const recipient = formatMailRecipients(message, 'to');
 
   return (
     <AccordionItem
@@ -44,12 +50,16 @@ export function ThreadMessageCard({
       >
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <span className="min-w-0 flex-1 basis-40 truncate font-semibold">
-              {displayName}
-              {message.fromName ? (
-                <span className="mt-0.5 block truncate font-normal text-muted-foreground text-xs">
-                  &lt;{message.fromAddress}&gt;
-                </span>
+            <span className="flex min-w-0 flex-1 basis-60 items-center gap-2 text-left">
+              <Address value={sender} />
+              {recipient ? (
+                <>
+                  <ArrowRight
+                    aria-hidden="true"
+                    className="size-3.5 shrink-0 text-muted-foreground"
+                  />
+                  <Address value={recipient} muted />
+                </>
               ) : null}
             </span>
             {message.deliveryRoute === 'catch_all' ? (
@@ -83,7 +93,7 @@ export function ThreadMessageCard({
               className="flex max-w-full cursor-pointer list-none items-center gap-1 text-muted-foreground text-xs hover:text-foreground"
             >
               <span className="truncate">
-                {t('to')}: {formatRecipients(message, 'to')}
+                {t('to')}: {formatMailRecipients(message, 'to')}
               </span>
               <ChevronDown className="size-3 shrink-0 transition-transform group-open:rotate-180" />
             </summary>
@@ -96,11 +106,17 @@ export function ThreadMessageCard({
                     : message.fromAddress
                 }
               />
-              <Detail label={t('to')} value={formatRecipients(message, 'to')} />
-              <Detail label={t('cc')} value={formatRecipients(message, 'cc')} />
+              <Detail
+                label={t('to')}
+                value={formatMailRecipients(message, 'to')}
+              />
+              <Detail
+                label={t('cc')}
+                value={formatMailRecipients(message, 'cc')}
+              />
               <Detail
                 label={t('bcc')}
-                value={formatRecipients(message, 'bcc')}
+                value={formatMailRecipients(message, 'bcc')}
               />
               {message.observedRecipient ? (
                 <Detail
@@ -149,18 +165,19 @@ export function ThreadMessageCard({
   );
 }
 
-function formatRecipients(
-  message: MailMessageDetail,
-  kind: 'bcc' | 'cc' | 'to'
-) {
-  return message.recipients
-    .filter((recipient) => recipient.kind === kind)
-    .map((recipient) =>
-      recipient.displayName
-        ? `${recipient.displayName} <${recipient.address}>`
-        : recipient.address
-    )
-    .join(', ');
+function Address({ value, muted = false }: { value: string; muted?: boolean }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={`line-clamp-2 min-w-0 flex-1 break-all ${muted ? 'font-normal text-muted-foreground text-xs' : 'font-semibold'}`}
+        >
+          {value}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-sm break-all">{value}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 function Detail({ label, value }: { label: string; value: string }) {

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-message-card.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/thread-message-card.tsx
@@ -98,14 +98,7 @@ export function ThreadMessageCard({
               <ChevronDown className="size-3 shrink-0 transition-transform group-open:rotate-180" />
             </summary>
             <dl className="mt-3 grid gap-2 rounded-xl bg-foreground/[0.035] p-3 text-xs">
-              <Detail
-                label={t('from')}
-                value={
-                  message.fromName
-                    ? `${message.fromName} <${message.fromAddress}>`
-                    : message.fromAddress
-                }
-              />
+              <Detail label={t('from')} value={sender} />
               <Detail
                 label={t('to')}
                 value={formatMailRecipients(message, 'to')}

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-bootstrap.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-bootstrap.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -20,7 +20,12 @@ describe('progressive Mail bootstrap', () => {
       labels: [],
       mailboxes: [{ id: 'box', unreadCount: null }],
     });
-    mocks.counts.mockReturnValue(new Promise(() => {}));
+    let resolveCounts!: (counts: Record<string, number | null>) => void;
+    mocks.counts.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCounts = resolve;
+      })
+    );
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -34,5 +39,9 @@ describe('progressive Mail bootstrap', () => {
     ]);
     expect(mocks.bootstrap).toHaveBeenCalledWith('ws', undefined, false);
     await waitFor(() => expect(mocks.counts).toHaveBeenCalledWith('ws'));
+    await act(async () => resolveCounts({ box: 0 }));
+    await waitFor(() =>
+      expect(result.current.data?.mailboxes[0]?.unreadCount).toBe(0)
+    );
   });
 });

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-bootstrap.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-bootstrap.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ bootstrap: vi.fn(), counts: vi.fn() }));
+vi.mock('@tuturuuu/internal-api', () => ({
+  getMailBootstrap: mocks.bootstrap,
+  getMailUnreadCounts: mocks.counts,
+}));
+
+import { useMailBootstrap } from './use-mail-bootstrap';
+
+afterEach(cleanup);
+describe('progressive Mail bootstrap', () => {
+  it('exposes mailboxes before slow unread counts finish, keeping unknown counts distinct from zero', async () => {
+    mocks.bootstrap.mockResolvedValue({
+      user: { id: 'user' },
+      labels: [],
+      mailboxes: [{ id: 'box', unreadCount: null }],
+    });
+    mocks.counts.mockReturnValue(new Promise(() => {}));
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => useMailBootstrap('ws'), {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client }, children),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.mailboxes).toEqual([
+      { id: 'box', unreadCount: null },
+    ]);
+    expect(mocks.bootstrap).toHaveBeenCalledWith('ws', undefined, false);
+    await waitFor(() => expect(mocks.counts).toHaveBeenCalledWith('ws'));
+  });
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-bootstrap.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-bootstrap.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getMailBootstrap, getMailUnreadCounts } from '@tuturuuu/internal-api';
+
+export function useMailBootstrap(workspaceId: string) {
+  const bootstrap = useQuery({
+    queryKey: ['mail', workspaceId, 'bootstrap'],
+    queryFn: () => getMailBootstrap(workspaceId, undefined, false),
+    staleTime: 30_000,
+  });
+  const counts = useQuery({
+    queryKey: ['mail', workspaceId, 'bootstrap-counts'],
+    queryFn: () => getMailUnreadCounts(workspaceId),
+    enabled: Boolean(bootstrap.data),
+    staleTime: 30_000,
+  });
+  return {
+    ...bootstrap,
+    data: bootstrap.data
+      ? {
+          ...bootstrap.data,
+          mailboxes: bootstrap.data.mailboxes.map((mailbox) => ({
+            ...mailbox,
+            unreadCount: counts.data?.[mailbox.id] ?? mailbox.unreadCount,
+          })),
+        }
+      : undefined,
+  };
+}

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
@@ -5,6 +5,7 @@ import {
   type QueryClient,
   type QueryKey,
   useMutation,
+  useMutationState,
   useQueryClient,
 } from '@tanstack/react-query';
 import {
@@ -23,6 +24,7 @@ import {
   getMailArchiveBehavior,
   nextMailThreadId,
 } from './mail-reading-preferences';
+import { restoreThreadPages } from './mail-thread-rollback';
 
 type ThreadAction = Parameters<typeof updateMailThreadState>[3]['action'];
 type BulkAction = 'archive' | 'mark_read' | 'trash';
@@ -32,7 +34,10 @@ type ThreadCacheSnapshot = Array<
   [QueryKey, InfiniteData<MailThreadsResponse> | undefined]
 >;
 type OptimisticContext = {
-  bootstrap: MailBootstrapResponse | undefined;
+  mailboxId: string;
+  workspaceId: string;
+  ids: Set<string>;
+  unreadDelta: number;
   details: Array<readonly [string, MailThreadDetail | undefined]>;
   threadCaches: ThreadCacheSnapshot;
 };
@@ -174,6 +179,16 @@ function applyOptimisticUpdate({
     unreadCount > 0 &&
     ['archive', 'mark_read', 'trash'].includes(action)
   ) {
+    queryClient.setQueryData<Record<string, number | null>>(
+      ['mail', workspaceId, 'bootstrap-counts'],
+      (current) =>
+        current && current[mailboxId] != null
+          ? {
+              ...current,
+              [mailboxId]: Math.max(0, current[mailboxId] - unreadCount),
+            }
+          : current
+    );
     queryClient.setQueryData<MailBootstrapResponse>(
       ['mail', workspaceId, 'bootstrap'],
       (current) =>
@@ -184,10 +199,10 @@ function applyOptimisticUpdate({
                 mailbox.id === mailboxId
                   ? {
                       ...mailbox,
-                      unreadCount: Math.max(
-                        0,
-                        mailbox.unreadCount - unreadCount
-                      ),
+                      unreadCount:
+                        mailbox.unreadCount === null
+                          ? null
+                          : Math.max(0, mailbox.unreadCount - unreadCount),
                     }
                   : mailbox
               ),
@@ -223,6 +238,40 @@ export function useMailThreadActions({
   const t = useTranslations('mail');
   const queryClient = useQueryClient();
   const [syncState, setSyncState] = useState<MailSyncState>('idle');
+  const actionKey = ['mail', workspaceId, activeMailboxId, 'actions'];
+  const pendingActions = useMutationState({
+    filters: { mutationKey: actionKey, status: 'pending' },
+    select: (mutation) =>
+      mutation.state.variables as {
+        targetThreadId?: string;
+        threadIds?: string[];
+      },
+  });
+  const inFlight = useRef(new Set<string>());
+  const operations = useRef(new Map<string, number>());
+  const operationScope = `${workspaceId}/${activeMailboxId}`;
+  const beginOperation = () =>
+    operations.current.set(
+      operationScope,
+      (operations.current.get(operationScope) ?? 0) + 1
+    );
+  const settleOperation = async () => {
+    const remaining = Math.max(
+      0,
+      (operations.current.get(operationScope) ?? 1) - 1
+    );
+    operations.current.set(operationScope, remaining);
+    if (!remaining) {
+      operations.current.delete(operationScope);
+      await invalidateMailbox();
+    }
+  };
+  const actionsPending = pendingActions.length > 0;
+  const actionPending = pendingActions.some(
+    (variables) =>
+      variables.targetThreadId === threadId ||
+      Boolean(threadId && variables.threadIds?.includes(threadId))
+  );
   const selectedThreadIdRef = useRef(threadId);
   selectedThreadIdRef.current = threadId;
 
@@ -231,9 +280,14 @@ export function useMailThreadActions({
     action: ThreadAction
   ): Promise<OptimisticContext | null> => {
     if (!activeMailboxId) return null;
-    await queryClient.cancelQueries({
-      queryKey: ['mail', workspaceId, activeMailboxId],
-    });
+    await Promise.all([
+      queryClient.cancelQueries({
+        queryKey: ['mail', workspaceId, activeMailboxId],
+      }),
+      queryClient.cancelQueries({
+        queryKey: ['mail', workspaceId, 'bootstrap-counts'],
+      }),
+    ]);
     const threadCaches = queryClient.getQueriesData<
       InfiniteData<MailThreadsResponse>
     >({ queryKey: ['mail', workspaceId, activeMailboxId, 'threads'] });
@@ -242,6 +296,9 @@ export function useMailThreadActions({
       workspaceId,
       'bootstrap',
     ]);
+    const beforeCounts = queryClient.getQueryData<
+      Record<string, number | null>
+    >(['mail', workspaceId, 'bootstrap-counts']);
     const details = [...ids].map(
       (id) =>
         [
@@ -267,17 +324,73 @@ export function useMailThreadActions({
       unreadCount,
       workspaceId,
     });
-    return { bootstrap, details, threadCaches };
+    const nextBootstrap = queryClient.getQueryData<MailBootstrapResponse>([
+      'mail',
+      workspaceId,
+      'bootstrap',
+    ]);
+    const beforeUnread =
+      beforeCounts?.[activeMailboxId] ??
+      bootstrap?.mailboxes.find((mailbox) => mailbox.id === activeMailboxId)
+        ?.unreadCount ??
+      0;
+    const afterUnread =
+      queryClient.getQueryData<Record<string, number | null>>([
+        'mail',
+        workspaceId,
+        'bootstrap-counts',
+      ])?.[activeMailboxId] ??
+      nextBootstrap?.mailboxes.find((mailbox) => mailbox.id === activeMailboxId)
+        ?.unreadCount ??
+      0;
+    return {
+      ids,
+      mailboxId: activeMailboxId,
+      workspaceId,
+      unreadDelta: beforeUnread - afterUnread,
+      details,
+      threadCaches,
+    };
   };
 
   const restore = (context: OptimisticContext | null | undefined) => {
-    if (!context || !activeMailboxId) return;
+    if (!context) return;
+    const { mailboxId: activeMailboxId, workspaceId } = context;
     for (const [key, data] of context.threadCaches as ThreadCacheSnapshot) {
-      queryClient.setQueryData(key, data);
+      queryClient.setQueryData<InfiniteData<MailThreadsResponse>>(
+        key,
+        (current) => restoreThreadPages(current, data, context.ids)
+      );
     }
-    queryClient.setQueryData(
+    queryClient.setQueryData<MailBootstrapResponse>(
       ['mail', workspaceId, 'bootstrap'],
-      context.bootstrap
+      (current) =>
+        current
+          ? {
+              ...current,
+              mailboxes: current.mailboxes.map((mailbox) =>
+                mailbox.id === activeMailboxId
+                  ? {
+                      ...mailbox,
+                      unreadCount:
+                        mailbox.unreadCount === null
+                          ? null
+                          : mailbox.unreadCount + context.unreadDelta,
+                    }
+                  : mailbox
+              ),
+            }
+          : current
+    );
+    queryClient.setQueryData<Record<string, number | null>>(
+      ['mail', workspaceId, 'bootstrap-counts'],
+      (current) =>
+        current && current[activeMailboxId] != null
+          ? {
+              ...current,
+              [activeMailboxId]: current[activeMailboxId] + context.unreadDelta,
+            }
+          : current
     );
     for (const [id, detail] of context.details) {
       queryClient.setQueryData(
@@ -288,21 +401,23 @@ export function useMailThreadActions({
   };
 
   const stateMutation = useMutation({
-    mutationKey: ['mail', workspaceId, activeMailboxId, 'state'],
+    mutationKey: [...actionKey, 'state'],
     mutationFn: ({
       action,
       targetThreadId,
+      mailboxId,
+      targetWorkspaceId,
     }: {
       action: ThreadAction;
       targetThreadId: string;
+      mailboxId: string;
+      targetWorkspaceId: string;
     }) =>
-      updateMailThreadState(
-        workspaceId,
-        activeMailboxId ?? '',
-        targetThreadId,
-        { action }
-      ),
+      updateMailThreadState(targetWorkspaceId, mailboxId, targetThreadId, {
+        action,
+      }),
     onMutate: async ({ action, targetThreadId }) => {
+      beginOperation();
       setSyncState('syncing');
       const context = await snapshot(new Set([targetThreadId]), action);
       let navigatedTo: string | null | undefined;
@@ -323,12 +438,14 @@ export function useMailThreadActions({
         if (navigatedTo) reopenThread(navigatedTo);
         else closeThread();
       }
-      return { navigatedTo, snapshot: context };
+      return { navigatedTo, snapshot: context, settle: settleOperation };
     },
     onError: (_error, variables, context) => {
       restore(context?.snapshot);
       if (
-        context?.navigatedTo !== undefined &&
+        context?.snapshot?.mailboxId === activeMailboxId &&
+        context.snapshot.workspaceId === workspaceId &&
+        context.navigatedTo !== undefined &&
         selectedThreadIdRef.current === context.navigatedTo &&
         (variables.action === 'archive' || variables.action === 'trash')
       ) {
@@ -340,19 +457,35 @@ export function useMailThreadActions({
     onSuccess: () => {
       setSyncState('synced');
     },
-    onSettled: () => invalidateMailbox(),
+    onSettled: async (_data, _error, variables, context) => {
+      inFlight.current.delete(variables.targetThreadId);
+      // Earlier requests must not refetch and resurrect later optimistic archives.
+      await (context?.settle ?? settleOperation)();
+    },
   });
 
   const bulkMutation = useMutation({
-    mutationKey: ['mail', workspaceId, activeMailboxId, 'bulk'],
-    mutationFn: (action: BulkAction) =>
-      bulkUpdateMailThreads(workspaceId, activeMailboxId ?? '', {
+    mutationKey: [...actionKey, 'bulk'],
+    mutationFn: ({
+      action,
+      threadIds,
+      mailboxId,
+      targetWorkspaceId,
+    }: {
+      action: BulkAction;
+      threadIds: string[];
+      mailboxId: string;
+      targetWorkspaceId: string;
+    }) =>
+      bulkUpdateMailThreads(targetWorkspaceId, mailboxId, {
         action,
-        threadIds: [...selectedThreads],
+        threadIds,
       }),
-    onMutate: async (action) => {
+    onMutate: async ({ action, threadIds }) => {
+      beginOperation();
       setSyncState('syncing');
-      const ids = new Set(selectedThreads);
+      const ids = new Set(threadIds);
+      for (const id of ids) inFlight.current.add(id);
       const optimistic = await snapshot(ids, action);
       const previousThreadId = selectedThreadIdRef.current;
       let navigatedTo: string | null | undefined;
@@ -371,13 +504,26 @@ export function useMailThreadActions({
         else closeThread();
       }
       setSelectedThreads(new Set());
-      return { ids, optimistic, previousThreadId, navigatedTo };
+      return {
+        ids,
+        optimistic,
+        previousThreadId,
+        navigatedTo,
+        settle: settleOperation,
+      };
     },
     onError: (_error, _action, context) => {
       restore(context?.optimistic);
-      if (context?.ids) setSelectedThreads(context.ids);
       if (
-        context?.previousThreadId &&
+        context?.ids &&
+        context.optimistic?.mailboxId === activeMailboxId &&
+        context.optimistic.workspaceId === workspaceId
+      )
+        setSelectedThreads(context.ids);
+      if (
+        context?.optimistic?.mailboxId === activeMailboxId &&
+        context.optimistic.workspaceId === workspaceId &&
+        context.previousThreadId &&
         context.navigatedTo !== undefined &&
         selectedThreadIdRef.current === context.navigatedTo
       ) {
@@ -389,15 +535,42 @@ export function useMailThreadActions({
     onSuccess: () => {
       setSyncState('synced');
     },
-    onSettled: () => invalidateMailbox(),
+    onSettled: async (_data, _error, variables, context) => {
+      for (const id of variables.threadIds) inFlight.current.delete(id);
+      await (context?.settle ?? settleOperation)();
+    },
   });
 
   return {
-    bulkMutation,
+    actionPending,
+    actionsPending,
+    bulkMutation: {
+      ...bulkMutation,
+      mutate: (action: BulkAction) => {
+        const threadIds = [...selectedThreads].filter(
+          (id) => !inFlight.current.has(id)
+        );
+        if (!threadIds.length) return;
+        for (const id of threadIds) inFlight.current.add(id);
+        bulkMutation.mutate({
+          action,
+          threadIds,
+          mailboxId: activeMailboxId ?? '',
+          targetWorkspaceId: workspaceId,
+        });
+      },
+    },
     mutateThread: (action: ThreadAction, targetThreadId = threadId) => {
-      if (targetThreadId) stateMutation.mutate({ action, targetThreadId });
+      if (!targetThreadId || inFlight.current.has(targetThreadId)) return;
+      inFlight.current.add(targetThreadId);
+      stateMutation.mutate({
+        action,
+        targetThreadId,
+        mailboxId: activeMailboxId ?? '',
+        targetWorkspaceId: workspaceId,
+      });
     },
     stateMutation,
-    syncState,
+    syncState: actionsPending ? ('syncing' as const) : syncState,
   };
 }

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
@@ -237,7 +237,18 @@ export function useMailThreadActions({
 }) {
   const t = useTranslations('mail');
   const queryClient = useQueryClient();
-  const [syncState, setSyncState] = useState<MailSyncState>('idle');
+  const [syncStates, setSyncStates] = useState<Record<string, MailSyncState>>(
+    {}
+  );
+  const setSyncState = (
+    scope: { mailboxId: string; targetWorkspaceId: string },
+    state: MailSyncState
+  ) => {
+    setSyncStates((current) => ({
+      ...current,
+      [`${scope.targetWorkspaceId}/${scope.mailboxId}`]: state,
+    }));
+  };
   const actionKey = ['mail', workspaceId, activeMailboxId, 'actions'];
   const pendingActions = useMutationState({
     filters: { mutationKey: actionKey, status: 'pending' },
@@ -416,9 +427,10 @@ export function useMailThreadActions({
       updateMailThreadState(targetWorkspaceId, mailboxId, targetThreadId, {
         action,
       }),
-    onMutate: async ({ action, targetThreadId }) => {
+    onMutate: async (variables) => {
+      const { action, targetThreadId } = variables;
       beginOperation();
-      setSyncState('syncing');
+      setSyncState(variables, 'syncing');
       const context = await snapshot(new Set([targetThreadId]), action);
       let navigatedTo: string | null | undefined;
       if (
@@ -451,11 +463,11 @@ export function useMailThreadActions({
       ) {
         reopenThread(variables.targetThreadId);
       }
-      setSyncState('failed');
+      setSyncState(variables, 'failed');
       toast.error(t('update_failed'));
     },
-    onSuccess: () => {
-      setSyncState('synced');
+    onSuccess: (_data, variables) => {
+      setSyncState(variables, 'synced');
     },
     onSettled: async (_data, _error, variables, context) => {
       inFlight.current.delete(variables.targetThreadId);
@@ -481,9 +493,10 @@ export function useMailThreadActions({
         action,
         threadIds,
       }),
-    onMutate: async ({ action, threadIds }) => {
+    onMutate: async (variables) => {
+      const { action, threadIds } = variables;
       beginOperation();
-      setSyncState('syncing');
+      setSyncState(variables, 'syncing');
       const ids = new Set(threadIds);
       for (const id of ids) inFlight.current.add(id);
       const optimistic = await snapshot(ids, action);
@@ -512,7 +525,7 @@ export function useMailThreadActions({
         settle: settleOperation,
       };
     },
-    onError: (_error, _action, context) => {
+    onError: (_error, variables, context) => {
       restore(context?.optimistic);
       if (
         context?.ids &&
@@ -529,11 +542,11 @@ export function useMailThreadActions({
       ) {
         reopenThread(context.previousThreadId);
       }
-      setSyncState('failed');
+      setSyncState(variables, 'failed');
       toast.error(t('update_failed'));
     },
-    onSuccess: () => {
-      setSyncState('synced');
+    onSuccess: (_data, variables) => {
+      setSyncState(variables, 'synced');
     },
     onSettled: async (_data, _error, variables, context) => {
       for (const id of variables.threadIds) inFlight.current.delete(id);
@@ -571,6 +584,8 @@ export function useMailThreadActions({
       });
     },
     stateMutation,
-    syncState: actionsPending ? ('syncing' as const) : syncState,
+    syncState: actionsPending
+      ? ('syncing' as const)
+      : (syncStates[operationScope] ?? 'idle'),
   };
 }

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-thread-actions.ts
@@ -560,6 +560,7 @@ export function useMailThreadActions({
     bulkMutation: {
       ...bulkMutation,
       mutate: (action: BulkAction) => {
+        if (!activeMailboxId) return;
         const threadIds = [...selectedThreads].filter(
           (id) => !inFlight.current.has(id)
         );
@@ -568,18 +569,19 @@ export function useMailThreadActions({
         bulkMutation.mutate({
           action,
           threadIds,
-          mailboxId: activeMailboxId ?? '',
+          mailboxId: activeMailboxId,
           targetWorkspaceId: workspaceId,
         });
       },
     },
     mutateThread: (action: ThreadAction, targetThreadId = threadId) => {
+      if (!activeMailboxId) return;
       if (!targetThreadId || inFlight.current.has(targetThreadId)) return;
       inFlight.current.add(targetThreadId);
       stateMutation.mutate({
         action,
         targetThreadId,
-        mailboxId: activeMailboxId ?? '',
+        mailboxId: activeMailboxId,
         targetWorkspaceId: workspaceId,
       });
     },

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-viewed-thread-read.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/use-mail-viewed-thread-read.ts
@@ -44,12 +44,21 @@ export function useMailViewedThreadRead({
       }),
     onError: () => toast.error(t('update_failed')),
     onSettled: async (_data, _error, target) => {
+      if (
+        client.isMutating({
+          mutationKey: ['mail', workspaceId, target.mailboxId, 'actions'],
+        }) > 0
+      )
+        return;
       await Promise.all([
         client.invalidateQueries({
           queryKey: ['mail', workspaceId, target.mailboxId],
         }),
         client.invalidateQueries({
           queryKey: ['mail', workspaceId, 'bootstrap'],
+        }),
+        client.invalidateQueries({
+          queryKey: ['mail', workspaceId, 'bootstrap-counts'],
         }),
       ]);
     },

--- a/apps/mail/src/app/[locale]/page.tsx
+++ b/apps/mail/src/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function HomePage() {
-  redirect('/personal');
+  redirect('/personal/inbox');
 }

--- a/apps/mail/src/app/api/v1/workspaces/[wsId]/mail/bootstrap/route.ts
+++ b/apps/mail/src/app/api/v1/workspaces/[wsId]/mail/bootstrap/route.ts
@@ -1,5 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { getMailBootstrap } from '@/lib/mail/repository';
+import {
+  getMailBootstrap,
+  getMailUnreadCounts,
+} from '@/lib/mail/repository/bootstrap';
 import { withMailContext } from '@/lib/mail/route-utils';
 
 type RouteParams = {
@@ -13,7 +16,11 @@ export async function GET(
   const { wsId } = await params;
 
   return withMailContext(request, wsId, async (ctx) => {
-    const payload = await getMailBootstrap(ctx);
+    const view = request.nextUrl.searchParams.get('view');
+    const payload =
+      view === 'counts'
+        ? await getMailUnreadCounts(ctx)
+        : await getMailBootstrap(ctx, view !== 'mailboxes');
     return NextResponse.json(payload);
   });
 }

--- a/apps/mail/src/lib/mail/repository/bootstrap-access.test.ts
+++ b/apps/mail/src/lib/mail/repository/bootstrap-access.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_GROUP_POLICY } from '../groups/policy';
 import type { MailRouteContext } from '../types';
-import { requireMailboxAccess } from './bootstrap';
+import { getMailUnreadCounts, requireMailboxAccess } from './bootstrap';
+import { queryMailMessageRows } from './search';
 import { getAdminClient } from './shared';
 
+vi.mock('./search', () => ({ queryMailMessageRows: vi.fn() }));
 vi.mock('./shared', async (original) => ({
   ...(await original<object>()),
   getAdminClient: vi.fn(),
@@ -66,4 +68,30 @@ describe('group access', () => {
     setAccess('owner', 'disabled');
     expect(await requireMailboxAccess(ctx, 'group')).toBeNull();
   });
+});
+
+it('counts only active mailboxes from the authenticated user membership query', async () => {
+  const eq = vi.fn();
+  const query = {
+    select: vi.fn(() => query),
+    eq: (...args: unknown[]) => {
+      eq(...args);
+      return query;
+    },
+    // biome-ignore lint/suspicious/noThenProperty: Supabase query builders are intentionally thenable.
+    then: (resolve: (value: object) => unknown) =>
+      Promise.resolve({ data: [{ mailbox_id: 'allowed' }], error: null }).then(
+        resolve
+      ),
+  };
+  vi.mocked(getAdminClient).mockResolvedValue({
+    schema: () => ({ from: () => query }),
+  } as never);
+  vi.mocked(queryMailMessageRows).mockResolvedValue({ rows: [], total: 4 });
+  expect(await getMailUnreadCounts(ctx)).toEqual({ allowed: 4 });
+  expect(eq).toHaveBeenCalledWith('user_id', 'user');
+  expect(eq).toHaveBeenCalledWith('mailbox.status', 'active');
+  expect(queryMailMessageRows).toHaveBeenCalledWith(
+    expect.objectContaining({ mailboxId: 'allowed', userId: 'user' })
+  );
 });

--- a/apps/mail/src/lib/mail/repository/bootstrap-access.test.ts
+++ b/apps/mail/src/lib/mail/repository/bootstrap-access.test.ts
@@ -70,10 +70,15 @@ describe('group access', () => {
   });
 });
 
-it('counts only active mailboxes from the authenticated user membership query', async () => {
+it('counts the same non-archived mailboxes from the authenticated user membership query', async () => {
   const eq = vi.fn();
+  const neq = vi.fn();
   const query = {
     select: vi.fn(() => query),
+    neq: (...args: unknown[]) => {
+      neq(...args);
+      return query;
+    },
     eq: (...args: unknown[]) => {
       eq(...args);
       return query;
@@ -90,7 +95,7 @@ it('counts only active mailboxes from the authenticated user membership query', 
   vi.mocked(queryMailMessageRows).mockResolvedValue({ rows: [], total: 4 });
   expect(await getMailUnreadCounts(ctx)).toEqual({ allowed: 4 });
   expect(eq).toHaveBeenCalledWith('user_id', 'user');
-  expect(eq).toHaveBeenCalledWith('mailbox.status', 'active');
+  expect(neq).toHaveBeenCalledWith('mailbox.status', 'archived');
   expect(queryMailMessageRows).toHaveBeenCalledWith(
     expect.objectContaining({ mailboxId: 'allowed', userId: 'user' })
   );

--- a/apps/mail/src/lib/mail/repository/bootstrap.ts
+++ b/apps/mail/src/lib/mail/repository/bootstrap.ts
@@ -160,7 +160,8 @@ async function ensurePersonalMailbox(ctx: MailRouteContext) {
 }
 
 export async function getMailBootstrap(
-  ctx: MailRouteContext
+  ctx: MailRouteContext,
+  includeUnreadCounts = true
 ): Promise<MailBootstrapResponse> {
   const admin = await getAdminClient();
   await ensurePersonalMailbox(ctx);
@@ -206,7 +207,13 @@ export async function getMailBootstrap(
     (memberRows ?? []).map((row: AnyRecord) => [row.mailbox_id, row.role])
   );
   const [unreadByMailbox, personalDisplayNames, labels] = await Promise.all([
-    getUnreadInboxCounts(admin, mailboxIds, ctx.user.id),
+    includeUnreadCounts
+      ? getUnreadInboxCounts(
+          admin,
+          (mailboxRows ?? []).map((row: AnyRecord) => row.id),
+          ctx.user.id
+        )
+      : Promise.resolve(new Map<string, number | null>()),
     getCanonicalUserDisplayNames(
       admin,
       (mailboxRows ?? [])
@@ -225,7 +232,7 @@ export async function getMailBootstrap(
         roleByMailboxId.get(row.id) ?? 'viewer',
         personalDisplayNames.get(row.created_by)
       ),
-      unreadCount: unreadByMailbox.get(row.id) ?? 0,
+      unreadCount: unreadByMailbox.get(row.id) ?? null,
     })
   );
   return {
@@ -317,11 +324,12 @@ export async function requireMailboxAccess(
     return null;
   }
 
-  await ensureSystemLabels(admin, mailboxId);
-  const personalDisplayName =
+  const [, personalDisplayName] = await Promise.all([
+    ensureSystemLabels(admin, mailboxId),
     mailbox.type === 'personal'
-      ? await getCanonicalUserDisplayName(admin, mailbox.created_by)
-      : null;
+      ? getCanonicalUserDisplayName(admin, mailbox.created_by)
+      : Promise.resolve(null),
+  ]);
 
   return {
     admin,
@@ -329,4 +337,25 @@ export async function requireMailboxAccess(
     mailbox: toMailbox(mailbox, member.role, personalDisplayName),
     role: member.role as MailMailboxRole,
   };
+}
+
+// Counts are optional navigation metadata, fetched after mailbox discovery.
+// Resolve membership again on the server; never trust client-supplied mailbox IDs.
+export async function getMailUnreadCounts(ctx: MailRouteContext) {
+  const admin = await getAdminClient();
+  const { data, error } = await privateTable(admin, 'mail_mailbox_members')
+    .select(
+      'mailbox_id, mailbox:mail_mailboxes!mail_mailbox_members_mailbox_id_fkey!inner(status)'
+    )
+    .eq('user_id', ctx.user.id)
+    .eq('mailbox.status', 'active');
+  if (error)
+    throw new Error(`Failed to load mail memberships: ${error.message}`);
+  return Object.fromEntries(
+    await getUnreadInboxCounts(
+      admin,
+      (data ?? []).map((row: AnyRecord) => row.mailbox_id),
+      ctx.user.id
+    )
+  );
 }

--- a/apps/mail/src/lib/mail/repository/bootstrap.ts
+++ b/apps/mail/src/lib/mail/repository/bootstrap.ts
@@ -348,7 +348,7 @@ export async function getMailUnreadCounts(ctx: MailRouteContext) {
       'mailbox_id, mailbox:mail_mailboxes!mail_mailbox_members_mailbox_id_fkey!inner(status)'
     )
     .eq('user_id', ctx.user.id)
-    .eq('mailbox.status', 'active');
+    .neq('mailbox.status', 'archived');
   if (error)
     throw new Error(`Failed to load mail memberships: ${error.message}`);
   return Object.fromEntries(

--- a/apps/mail/src/lib/mail/repository/search-state-filter.test.ts
+++ b/apps/mail/src/lib/mail/repository/search-state-filter.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { mailStateFilter } from './search';
+
+describe('mail state scan projection', () => {
+  it('does not scan read-only rows for a normal inbox', () => {
+    expect(mailStateFilter({ folder: 'inbox' })).toBe(
+      'archived_at.not.is.null,trashed_at.not.is.null'
+    );
+  });
+  it.each(['is:unread', 'is:"read"'])('includes read state for %s', (query) => {
+    expect(mailStateFilter({ query })).toContain('read_at.not.is.null');
+  });
+  it('preserves starred search and folder state', () => {
+    expect(mailStateFilter({ folder: 'starred' })).toContain(
+      'starred_at.not.is.null'
+    );
+    expect(mailStateFilter({ query: 'is:"starred"' })).toContain(
+      'starred_at.not.is.null'
+    );
+  });
+});

--- a/apps/mail/src/lib/mail/repository/search.ts
+++ b/apps/mail/src/lib/mail/repository/search.ts
@@ -14,7 +14,7 @@ const MAX_INLINE_FILTER_IDS = 250;
 const MESSAGE_LIST_COLUMNS =
   'body_text,created_at,direction,from_address,from_name,has_attachments,id,mailbox_id,received_at,sent_at,snippet,status,subject,thread_id';
 const THREAD_SCAN_COLUMNS =
-  'body_text,created_at,direction,from_address,from_name,has_attachments,id,mailbox_id,received_at,sent_at,snippet,status,subject,thread_id';
+  'created_at,direction,from_address,from_name,has_attachments,id,mailbox_id,received_at,sent_at,snippet,status,subject,thread_id';
 
 export async function loadAllRows(
   createQuery: () => AnyRecord,
@@ -182,6 +182,7 @@ export async function queryMailMessageRows({
         .select('message_id, read_at, starred_at, archived_at, trashed_at')
         .eq('mailbox_id', mailboxId)
         .eq('user_id', userId)
+        .or(mailStateFilter(params))
         .order('message_id'),
     'Failed to search mail state'
   );
@@ -342,4 +343,14 @@ export async function queryMailMessageRows({
   if (error) throw new Error(`Failed to list mail messages: ${error.message}`);
 
   return { rows: data ?? [], total: count ?? 0 };
+}
+
+export function mailStateFilter(params: ListMailMessagesParams) {
+  const { states } = parseMailSearch(params.query);
+  const fields = ['archived_at', 'trashed_at'];
+  if (states.includes('read') || states.includes('unread'))
+    fields.push('read_at');
+  if (params.folder === 'starred' || states.includes('starred'))
+    fields.push('starred_at');
+  return fields.map((field) => `${field}.not.is.null`).join(',');
 }

--- a/apps/mail/src/lib/mail/repository/threads.ts
+++ b/apps/mail/src/lib/mail/repository/threads.ts
@@ -375,17 +375,17 @@ async function loadMissingSnippets(
   const ids = messages
     .filter((message) => message.snippet == null)
     .map((message) => message.id);
-  if (!ids.length) return new Map<string, string>();
+  if (!ids.length) return new Map<string, string | null>();
   const { data, error } = await privateTable(admin, 'mail_messages')
     .select('id,body_text')
     .eq('mailbox_id', mailboxId)
     .in('id', ids);
   if (error)
     throw new Error(`Failed to load thread previews: ${error.message}`);
-  return new Map<string, string>(
+  return new Map<string, string | null>(
     (data ?? []).map((row: AnyRecord) => [
       row.id,
-      row.body_text?.slice(0, 500) ?? '',
+      row.body_text?.slice(0, 500) ?? null,
     ])
   );
 }

--- a/apps/mail/src/lib/mail/repository/threads.ts
+++ b/apps/mail/src/lib/mail/repository/threads.ts
@@ -126,23 +126,32 @@ export async function listMailThreads({
   const messageIds = threadIds
     .map((threadId) => latestByThread.get(threadId)?.id as string | undefined)
     .filter((id): id is string => Boolean(id));
-  const [{ data: threads, error }, visibleMessageRows, labels] =
-    await Promise.all([
-      privateTable(access.admin, 'mail_threads')
-        .select('*')
-        .eq('mailbox_id', mailboxId)
-        .in('id', threadIds),
-      loadAllRows(
-        () =>
-          mailMessageTable(access, ctx)
-            .select(THREAD_PARTICIPANT_COLUMNS)
-            .eq('mailbox_id', mailboxId)
-            .in('thread_id', threadIds)
-            .order('id'),
-        'Failed to load visible thread messages'
-      ),
-      getLabelsByMessageId(access.admin, messageIds),
-    ]);
+  const [
+    { data: threads, error },
+    visibleMessageRows,
+    labels,
+    fallbackSnippets,
+  ] = await Promise.all([
+    privateTable(access.admin, 'mail_threads')
+      .select('*')
+      .eq('mailbox_id', mailboxId)
+      .in('id', threadIds),
+    loadAllRows(
+      () =>
+        mailMessageTable(access, ctx)
+          .select(THREAD_PARTICIPANT_COLUMNS)
+          .eq('mailbox_id', mailboxId)
+          .in('thread_id', threadIds)
+          .order('id'),
+      'Failed to load visible thread messages'
+    ),
+    getLabelsByMessageId(access.admin, messageIds),
+    loadMissingSnippets(
+      access.admin,
+      mailboxId,
+      threadIds.map((id) => latestByThread.get(id)!)
+    ),
+  ]);
   if (error) throw new Error(`Failed to list mail threads: ${error.message}`);
   const outboundRowIds = visibleMessageRows.flatMap((row: AnyRecord) =>
     row.direction === 'outbound' ? [row.id as string] : []
@@ -217,7 +226,8 @@ export async function listMailThreads({
         hasAttachments: attachmentThreads.has(threadId),
         labels: labels.get(message.id) ?? [],
         latestMessageId: message.id,
-        latestSnippet: message.snippet ?? message.body_text ?? null,
+        latestSnippet:
+          message.snippet ?? fallbackSnippets.get(message.id) ?? null,
         participants: [...(participantsByThread.get(threadId)?.values() ?? [])],
         starred: Boolean(state?.starred_at),
         subject: resolveMailThreadSubject(thread.subject, message.subject),
@@ -355,4 +365,27 @@ export async function updateMailThreadState({
   }
 
   return getMailThread({ ctx, mailboxId, threadId });
+}
+
+async function loadMissingSnippets(
+  admin: AnyRecord,
+  mailboxId: string,
+  messages: AnyRecord[]
+) {
+  const ids = messages
+    .filter((message) => message.snippet == null)
+    .map((message) => message.id);
+  if (!ids.length) return new Map<string, string>();
+  const { data, error } = await privateTable(admin, 'mail_messages')
+    .select('id,body_text')
+    .eq('mailbox_id', mailboxId)
+    .in('id', ids);
+  if (error)
+    throw new Error(`Failed to load thread previews: ${error.message}`);
+  return new Map<string, string>(
+    (data ?? []).map((row: AnyRecord) => [
+      row.id,
+      row.body_text?.slice(0, 500) ?? '',
+    ])
+  );
 }

--- a/apps/mail/src/proxy-auth.test.ts
+++ b/apps/mail/src/proxy-auth.test.ts
@@ -221,3 +221,18 @@ describe('Mail entry redirect', () => {
     }
   );
 });
+
+it('persists an explicit English entry locale over a Vietnamese cookie or language header', async () => {
+  mocks.authProxy.mockResolvedValue(NextResponse.next());
+  mocks.consumeVerifyTokenRequest.mockResolvedValue(null);
+  mocks.hasSupportedSupabaseAuthCookie.mockReturnValue(true);
+  const response = await proxy(
+    new NextRequest('https://mail.tuturuuu.localhost/en/personal', {
+      headers: { cookie: 'NEXT_LOCALE=vi', 'accept-language': 'vi' },
+    })
+  );
+  expect(response.headers.get('location')).toBe(
+    'https://mail.tuturuuu.localhost/personal/inbox'
+  );
+  expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('en');
+});

--- a/apps/mail/src/proxy-auth.test.ts
+++ b/apps/mail/src/proxy-auth.test.ts
@@ -143,7 +143,7 @@ describe('Mail proxy auth handoff', () => {
     expect(mocks.normalizeAuthRedirectPath).toHaveBeenCalledWith(
       '/personal',
       'https://mail.tuturuuu.localhost',
-      '/personal'
+      '/personal/inbox'
     );
   });
 
@@ -187,4 +187,37 @@ describe('Mail proxy auth handoff', () => {
     expect(mocks.refreshAppSessionForRequest).toHaveBeenCalledOnce();
     expect(mocks.guardApiProxyRequest).toHaveBeenCalledOnce();
   });
+});
+
+describe('Mail entry redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authProxy.mockResolvedValue(NextResponse.next());
+    mocks.consumeVerifyTokenRequest.mockResolvedValue(null);
+    mocks.getAppSessionClaimsFromRequest.mockReturnValue({ sub: 'user' });
+    mocks.hasWebAppSessionTokenFromRequest.mockReturnValue(true);
+  });
+  it.each(['/', '/en', '/vi', '/personal', '/vi/personal'])(
+    'opens personal inbox directly from %s and preserves query state',
+    async (path) => {
+      const response = await proxy(
+        new NextRequest(
+          `https://mail.tuturuuu.localhost${path}?mailbox=selected`
+        )
+      );
+      expect(response.headers.get('location')).toBe(
+        `https://mail.tuturuuu.localhost${path.startsWith('/vi') ? '/vi' : ''}/personal/inbox?mailbox=selected`
+      );
+      expect(mocks.propagateAuthCookies).toHaveBeenCalled();
+    }
+  );
+  it.each(['no-redirect', 'hash-nav', 'multiAccount'])(
+    'preserves the %s auth/navigation escape hatch',
+    async (flag) => {
+      const response = await proxy(
+        new NextRequest(`https://mail.tuturuuu.localhost/?${flag}=1`)
+      );
+      expect(response.headers.get('location')).toBeNull();
+    }
+  );
 });

--- a/apps/mail/src/proxy.ts
+++ b/apps/mail/src/proxy.ts
@@ -13,10 +13,6 @@ import {
   propagateAuthCookies,
   refreshAppSessionForRequest,
 } from '@tuturuuu/auth/proxy';
-import {
-  getCurrentUserDefaultWorkspace,
-  withForwardedInternalApiAuth,
-} from '@tuturuuu/internal-api';
 import { guardApiProxyRequest } from '@tuturuuu/utils/api-proxy-guard';
 import { ROOT_WORKSPACE_ID } from '@tuturuuu/utils/constants';
 import { isPersonalWorkspace } from '@tuturuuu/utils/workspace-helper';
@@ -185,7 +181,7 @@ export async function proxy(req: NextRequest): Promise<NextResponse> {
       req.nextUrl.searchParams.get('next') ??
         req.nextUrl.searchParams.get('nextUrl'),
       req.nextUrl.origin,
-      '/personal'
+      '/personal/inbox'
     );
     const loginRedirect = clearSupabaseAuthCookies(
       req,
@@ -260,39 +256,29 @@ export async function proxy(req: NextRequest): Promise<NextResponse> {
     pathSegments.length === 1 &&
     supportedLocales.includes(pathSegments[0] as Locale);
 
+  const isPersonalIndex =
+    pathSegments[loginSegmentIndex] === 'personal' &&
+    pathSegments.length === loginSegmentIndex + 1;
+
   const skipWorkspaceRedirect = req.nextUrl.searchParams.has('no-redirect');
   const isHashNavigation = req.nextUrl.searchParams.has('hash-nav');
   const isMultiAccountFlow = req.nextUrl.searchParams.has('multiAccount');
 
   if (
-    (isRootPath || isLocaleRootPath) &&
+    (isRootPath || isLocaleRootPath || isPersonalIndex) &&
     !skipWorkspaceRedirect &&
     !isHashNavigation &&
     !isMultiAccountFlow &&
     hasSatelliteSession
   ) {
-    try {
-      const defaultWorkspace = await getCurrentUserDefaultWorkspace(
-        withForwardedInternalApiAuth(authRequestHeaders)
-      );
-      const target = defaultWorkspace
-        ? defaultWorkspace.personal
-          ? 'personal'
-          : defaultWorkspace.id === ROOT_WORKSPACE_ID
-            ? 'internal'
-            : defaultWorkspace.id
-        : 'personal';
-      const redirectUrl = new URL(`/${target}`, req.nextUrl);
-      const wsRedirect = NextResponse.redirect(redirectUrl);
-      propagateAuthCookies(authRes, wsRedirect);
-      return wsRedirect;
-    } catch {
-      const fallbackRedirect = NextResponse.redirect(
-        new URL('/personal', req.nextUrl)
-      );
-      propagateAuthCookies(authRes, fallbackRedirect);
-      return fallbackRedirect;
-    }
+    const redirectUrl = req.nextUrl.clone();
+    redirectUrl.pathname =
+      loginSegmentIndex === 1 && pathSegments[0] !== defaultLocale
+        ? `/${pathSegments[0]}/personal/inbox`
+        : '/personal/inbox';
+    const inboxRedirect = NextResponse.redirect(redirectUrl);
+    propagateAuthCookies(authRes, inboxRedirect);
+    return inboxRedirect;
   }
 
   const localeRes = handleLocale({ req });

--- a/apps/mail/src/proxy.ts
+++ b/apps/mail/src/proxy.ts
@@ -278,6 +278,12 @@ export async function proxy(req: NextRequest): Promise<NextResponse> {
         : '/personal/inbox';
     const inboxRedirect = NextResponse.redirect(redirectUrl);
     propagateAuthCookies(authRes, inboxRedirect);
+    if (loginSegmentIndex === 1)
+      inboxRedirect.cookies.set(
+        LOCALE_COOKIE_NAME,
+        pathSegments[0] ?? defaultLocale,
+        { path: '/', sameSite: 'lax' }
+      );
     return inboxRedirect;
   }
 

--- a/apps/mail/vitest.config.ts
+++ b/apps/mail/vitest.config.ts
@@ -4,6 +4,8 @@ import { defineConfig } from 'vitest/config';
 const silent = process.env.CHECK_DETAILS === '1' ? false : 'passed-only';
 
 export default defineConfig({
+  esbuild: { jsx: 'automatic' },
+  oxc: false,
   resolve: {
     alias: [{ find: '@', replacement: resolve(__dirname, './src') }],
   },

--- a/packages/internal-api/src/mail-bootstrap.ts
+++ b/packages/internal-api/src/mail-bootstrap.ts
@@ -1,0 +1,37 @@
+import {
+  encodePathSegment,
+  getInternalApiClient,
+  type InternalApiClientOptions,
+  withMailApiBaseUrl,
+} from './client';
+import type { MailBootstrapResponse } from './mail-types';
+
+export async function getMailBootstrap(
+  workspaceId: string,
+  options?: InternalApiClientOptions,
+  includeUnreadCounts = true
+) {
+  return getInternalApiClient(
+    withMailApiBaseUrl(options)
+  ).json<MailBootstrapResponse>(
+    `/api/v1/workspaces/${encodePathSegment(workspaceId)}/mail/bootstrap`,
+    {
+      cache: 'no-store',
+      credentials: 'include',
+      query: includeUnreadCounts ? undefined : { view: 'mailboxes' },
+    }
+  );
+}
+
+export async function getMailUnreadCounts(
+  workspaceId: string,
+  options?: InternalApiClientOptions
+) {
+  return getInternalApiClient(withMailApiBaseUrl(options)).json<
+    Record<string, number | null>
+  >(`/api/v1/workspaces/${encodePathSegment(workspaceId)}/mail/bootstrap`, {
+    cache: 'no-store',
+    credentials: 'include',
+    query: { view: 'counts' },
+  });
+}

--- a/packages/internal-api/src/mail-types.ts
+++ b/packages/internal-api/src/mail-types.ts
@@ -72,7 +72,7 @@ export interface MailMailbox {
   signatureText: string | null;
   status: MailMailboxStatus;
   type: MailMailboxType;
-  unreadCount: number;
+  unreadCount: number | null;
 }
 
 export interface MailGroupPolicy {

--- a/packages/internal-api/src/mail.test.ts
+++ b/packages/internal-api/src/mail.test.ts
@@ -9,6 +9,7 @@ import {
   getMailCatchAllConfiguration,
   getMailMailboxSettings,
   getMailThread,
+  getMailUnreadCounts,
   listMailDomains,
   listMailMessages,
   listMailThreads,
@@ -298,4 +299,24 @@ describe('mail internal API helpers', () => {
       expect.objectContaining({ method: 'POST' })
     );
   });
+});
+
+it('separates mailbox discovery from unread counts without caching authenticated responses', async () => {
+  const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}));
+  const options = {
+    baseUrl: 'https://internal.example.com',
+    fetch: fetchMock as unknown as typeof fetch,
+  };
+  await getMailBootstrap('personal', options, false);
+  await getMailUnreadCounts('personal', options);
+  expect(fetchMock).toHaveBeenNthCalledWith(
+    1,
+    'https://internal.example.com/api/v1/workspaces/personal/mail/bootstrap?view=mailboxes',
+    expect.objectContaining({ cache: 'no-store', credentials: 'include' })
+  );
+  expect(fetchMock).toHaveBeenNthCalledWith(
+    2,
+    'https://internal.example.com/api/v1/workspaces/personal/mail/bootstrap?view=counts',
+    expect.objectContaining({ cache: 'no-store', credentials: 'include' })
+  );
 });

--- a/packages/internal-api/src/mail.ts
+++ b/packages/internal-api/src/mail.ts
@@ -16,7 +16,6 @@ import type {
   ListMailMessagesParams,
   ListMailThreadsParams,
   MailAttachment,
-  MailBootstrapResponse,
   MailCatchAllConfiguration,
   MailDomain,
   MailFolderDefinition,
@@ -41,6 +40,7 @@ import type {
 } from './mail-types';
 
 export { getMailAttachmentText } from './mail-attachment-preview';
+export { getMailBootstrap, getMailUnreadCounts } from './mail-bootstrap';
 export * from './mail-types';
 
 function workspaceMailPath(workspaceId: string, suffix = '') {
@@ -87,20 +87,6 @@ export async function listWorkspaceEmails(
   );
 
   return payload.emails ?? [];
-}
-
-export async function getMailBootstrap(
-  workspaceId: string,
-  options?: InternalApiClientOptions
-) {
-  const client = getInternalApiClient(withMailApiBaseUrl(options));
-  return client.json<MailBootstrapResponse>(
-    workspaceMailPath(workspaceId, '/bootstrap'),
-    {
-      cache: 'no-store',
-      credentials: 'include',
-    }
-  );
 }
 
 export async function listMailMessages(


### PR DESCRIPTION
# Description

Mail now shows the catch-all delivery recipient when a message has no parsed To header, and presents sender → recipient with clamped text and full-address tooltips. Archiving the open conversation immediately advances to an independently actionable next conversation.

## What?

- Track pending actions per conversation, deduplicate repeated clicks, and preserve other archives when one request fails. Capture mailbox scope for late responses and reconcile once overlapping operations finish. Keep the next summary header actionable while its body loads.
- Redirect authenticated root/personal entry requests directly to Inbox, preserving locale, query state, auth handoffs, and navigation escape hatches.
- Load mailbox discovery before unread badge counts. Reduce thread scan payloads and skip read-only state rows unless the search needs them; keep legacy snippet fallback on the visible page.

## Why?

Empty To fields obscure catch-all delivery, a global pending flag interrupts rapid triage, and serial metadata work delays the first inbox. The authenticated baseline recorded approximately 2.9 seconds for bootstrap followed by 4.5 seconds for the inbox request; this is diagnostic evidence, not a claimed post-change benchmark.

## How?

Scoped optimistic rollback restores only affected conversations/counter deltas. The existing protected bootstrap endpoint accepts lightweight mailbox and counts views; the default response remains compatible. Unknown badge counts remain null. Authorization and membership checks remain in place.

Validation: 214 Mail tests, 10 focused internal API tests, Mail type-check, `bun check`, and the real Mail production build. Browser fixture verified full-address hover tooltip and a collapsed message at 390×844 without horizontal overflow. No production email state was changed for verification.

## Screenshots for proof (must have)

A rapid-archive fixture also advanced three loading message headers through three successive clicks. Desktop and mobile screenshots of the actual message-card component with synthetic catch-all data were captured in the task transcript. The 390px fixture reports document width = scroll width = 390px; expanded To shows the observed recipient and collapsed content truncates within the card. Authenticated production appearance and timing will be verified after delivery.
