### PR TITLE
fix(meet): clear stale avatar overlays over playing video

### DIFF
--- a/apps/meet/src/features/call/components/participant-tile.tsx
+++ b/apps/meet/src/features/call/components/participant-tile.tsx
@@ -15,6 +15,7 @@ import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { attachMediaPlayback } from '../lib/media-playback';
+import { observeVideoPresentation } from '../lib/video-presentation';
 import {
   MediaReceivingStatus,
   useStreamReadiness,
@@ -68,6 +69,19 @@ function ParticipantTileImpl({
   );
   const videoRef = useRef<HTMLVideoElement>(null);
   const tileRef = useRef<HTMLDivElement>(null);
+  const [presentedStream, setPresentedStream] = useState<MediaStream | null>(
+    null
+  );
+  const presentingVideo = Boolean(
+    videoStream && presentedStream === videoStream
+  );
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !videoStream) return;
+    return observeVideoPresentation(video, videoStream, (presenting) =>
+      setPresentedStream(presenting ? videoStream : null)
+    );
+  }, [videoStream]);
   useEffect(() => {
     const changed = () =>
       setFullscreen(document.fullscreenElement === tileRef.current);
@@ -83,7 +97,7 @@ function ParticipantTileImpl({
   }, []);
   const readiness = useStreamReadiness(stream);
   const showVideo = Boolean(
-    readiness.video &&
+    (readiness.video || presentingVideo) &&
       (kind === 'screen'
         ? participant.media.screenEnabled
         : participant.media.videoEnabled)
@@ -129,6 +143,7 @@ function ParticipantTileImpl({
         ref={videoRef}
         className={cn(
           'absolute inset-0 size-full object-contain',
+          !showVideo && 'opacity-0',
           isSelf && kind === 'camera' && '-scale-x-100'
         )}
       />
@@ -199,7 +214,7 @@ function ParticipantTileImpl({
         {!isSelf && (
           <MediaReceivingStatus
             audio={readiness.receivingAudio}
-            video={readiness.receivingVideo}
+            video={presentingVideo || readiness.receivingVideo}
             expectAudio={kind === 'camera' && participant.media.audioEnabled}
             expectVideo={
               kind === 'camera'

--- a/apps/meet/src/features/call/components/participant-tile.tsx
+++ b/apps/meet/src/features/call/components/participant-tile.tsx
@@ -69,6 +69,10 @@ function ParticipantTileImpl({
   );
   const videoRef = useRef<HTMLVideoElement>(null);
   const tileRef = useRef<HTMLDivElement>(null);
+  const videoEnabled =
+    kind === 'screen'
+      ? participant.media.screenEnabled
+      : participant.media.videoEnabled;
   const [presentedStream, setPresentedStream] = useState<MediaStream | null>(
     null
   );
@@ -77,11 +81,15 @@ function ParticipantTileImpl({
   );
   useEffect(() => {
     const video = videoRef.current;
-    if (!video || !videoStream) return;
-    return observeVideoPresentation(video, videoStream, (presenting) =>
-      setPresentedStream(presenting ? videoStream : null)
+    setPresentedStream(null);
+    if (!video || !videoStream || !videoEnabled) return;
+    return observeVideoPresentation(
+      video,
+      videoStream,
+      (presenting) => setPresentedStream(presenting ? videoStream : null),
+      kind === 'camera'
     );
-  }, [videoStream]);
+  }, [videoStream, videoEnabled, kind]);
   useEffect(() => {
     const changed = () =>
       setFullscreen(document.fullscreenElement === tileRef.current);
@@ -97,7 +105,7 @@ function ParticipantTileImpl({
   }, []);
   const readiness = useStreamReadiness(stream);
   const showVideo = Boolean(
-    (readiness.video || presentingVideo) &&
+    presentingVideo &&
       (kind === 'screen'
         ? participant.media.screenEnabled
         : participant.media.videoEnabled)

--- a/apps/meet/src/features/call/components/participant-video-presentation.test.tsx
+++ b/apps/meet/src/features/call/components/participant-video-presentation.test.tsx
@@ -142,3 +142,61 @@ it('cancels frame observation on unmount', () => {
   expect(frames.size).toBe(0);
   expect(vi.getTimerCount()).toBe(0);
 });
+
+it('supports browsers without frame callbacks', () => {
+  Reflect.deleteProperty(
+    HTMLVideoElement.prototype,
+    'requestVideoFrameCallback'
+  );
+  const { container } = render(tile(makeStream()));
+  const video = container.querySelector('video')!;
+  Object.defineProperties(video, {
+    paused: { value: false },
+    readyState: { value: 2 },
+    videoWidth: { value: 640 },
+  });
+  act(() => video.dispatchEvent(new Event('timeupdate')));
+  expect(screen.queryByText('P')).toBeNull();
+});
+it('clears stale evidence across camera off and on', () => {
+  const stream = makeStream();
+  const { rerender } = render(tile(stream));
+  presentFrame();
+  rerender(tile(stream, false));
+  rerender(tile(stream, true));
+  expect(screen.getByText('P')).toBeTruthy();
+  presentFrame();
+  expect(screen.queryByText('P')).toBeNull();
+});
+it('expires camera presentation even if the receiver stays unmuted', () => {
+  const stream = makeStream();
+  Object.defineProperty(stream.getVideoTracks()[0], 'muted', { value: false });
+  render(tile(stream));
+  presentFrame();
+  act(() => vi.advanceTimersByTime(4000));
+  expect(
+    screen.getByRole('button', { name: 'Reconnect incoming video' })
+  ).toBeTruthy();
+});
+it('retains a presented static screen without inventing a camera stall', () => {
+  render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ParticipantTile
+        participant={{
+          ...participant,
+          media: { ...participant.media, screenEnabled: true },
+        }}
+        kind="screen"
+        stream={makeStream()}
+        resumePlaybackLabel="Play audio"
+        onRetry={() => undefined}
+      />
+    </NextIntlClientProvider>
+  );
+  presentFrame();
+  act(() => vi.advanceTimersByTime(10000));
+  expect(screen.queryByText('P')).toBeNull();
+  expect(
+    screen.queryByRole('button', { name: 'Reconnect incoming video' })
+  ).toBeNull();
+});

--- a/apps/meet/src/features/call/components/participant-video-presentation.test.tsx
+++ b/apps/meet/src/features/call/components/participant-video-presentation.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from '@testing-library/react';
+import type { MeetRealtimePresence } from '@tuturuuu/realtime/meet';
+import { NextIntlClientProvider } from 'next-intl';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import messages from '../../../../messages/en.json';
+import { ParticipantTile } from './participant-tile';
+
+let frames: Map<number, VideoFrameRequestCallback>;
+let nextFrame: number;
+const participant = {
+  userId: 'peer',
+  displayName: 'Peer',
+  media: { audioEnabled: true, videoEnabled: true, screenEnabled: false },
+} as MeetRealtimePresence;
+function makeStream() {
+  const track = Object.assign(new EventTarget(), {
+    id: crypto.randomUUID(),
+    kind: 'video',
+    readyState: 'live',
+    muted: true,
+    enabled: true,
+  });
+  return new MediaStream([track as unknown as MediaStreamTrack]);
+}
+function tile(stream: MediaStream, cameraEnabled = true) {
+  return (
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ParticipantTile
+        participant={{
+          ...participant,
+          media: { ...participant.media, videoEnabled: cameraEnabled },
+        }}
+        stream={stream}
+        resumePlaybackLabel="Play audio"
+        onRetry={() => undefined}
+      />
+    </NextIntlClientProvider>
+  );
+}
+function presentFrame() {
+  act(() => {
+    const pending = [...frames.values()];
+    frames.clear();
+    for (const callback of pending)
+      callback(performance.now(), {} as VideoFrameCallbackMetadata);
+  });
+}
+beforeEach(() => {
+  vi.useFakeTimers();
+  frames = new Map();
+  nextFrame = 0;
+  vi.stubGlobal(
+    'MediaStream',
+    class {
+      constructor(private tracks: MediaStreamTrack[]) {}
+      getTracks() {
+        return this.tracks;
+      }
+      getVideoTracks() {
+        return this.tracks.filter((t) => t.kind === 'video');
+      }
+      getAudioTracks() {
+        return this.tracks.filter((t) => t.kind === 'audio');
+      }
+    }
+  );
+  vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+  Object.defineProperty(
+    HTMLVideoElement.prototype,
+    'requestVideoFrameCallback',
+    {
+      configurable: true,
+      value: (callback: VideoFrameRequestCallback) => {
+        frames.set(++nextFrame, callback);
+        return nextFrame;
+      },
+    }
+  );
+  Object.defineProperty(
+    HTMLVideoElement.prototype,
+    'cancelVideoFrameCallback',
+    { configurable: true, value: (id: number) => frames.delete(id) }
+  );
+});
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(
+    HTMLVideoElement.prototype,
+    'requestVideoFrameCallback'
+  );
+  Reflect.deleteProperty(
+    HTMLVideoElement.prototype,
+    'cancelVideoFrameCallback'
+  );
+});
+it('removes the avatar and reconnect action when a muted receiver presents video frames', () => {
+  const { container } = render(tile(makeStream()));
+  expect(screen.getByText('P')).toBeTruthy();
+  expect(
+    screen.getByRole('button', { name: 'Reconnect incoming video' })
+  ).toBeTruthy();
+  presentFrame();
+  expect(screen.queryByText('P')).toBeNull();
+  expect(
+    screen.queryByRole('button', { name: 'Reconnect incoming video' })
+  ).toBeNull();
+  expect(container.querySelector('video')?.className).not.toContain(
+    'opacity-0'
+  );
+  expect(screen.getByRole('img', { name: 'Receiving video' })).toBeTruthy();
+});
+it('does not reuse presentation evidence for a replacement stream or a disabled camera', () => {
+  const { rerender, container } = render(tile(makeStream()));
+  presentFrame();
+  const replacement = makeStream();
+  rerender(tile(replacement));
+  expect(screen.getByText('P')).toBeTruthy();
+  presentFrame();
+  expect(screen.queryByText('P')).toBeNull();
+  rerender(tile(replacement, false));
+  expect(screen.getByText('P')).toBeTruthy();
+  expect(container.querySelector('video')?.className).toContain('opacity-0');
+});
+it('restores recovery for stalled muted video and clears it when frames resume', () => {
+  render(tile(makeStream()));
+  presentFrame();
+  act(() => vi.advanceTimersByTime(4000));
+  expect(
+    screen.getByRole('button', { name: 'Reconnect incoming video' })
+  ).toBeTruthy();
+  presentFrame();
+  expect(screen.queryByText('P')).toBeNull();
+});
+it('cancels frame observation on unmount', () => {
+  const { unmount } = render(tile(makeStream()));
+  expect(frames.size).toBe(1);
+  unmount();
+  expect(frames.size).toBe(0);
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/apps/meet/src/features/call/lib/video-presentation.ts
+++ b/apps/meet/src/features/call/lib/video-presentation.ts
@@ -1,0 +1,67 @@
+/** Observe rendered video independently of delayed receiver mute/packet flags. */
+export function observeVideoPresentation(
+  video: HTMLVideoElement,
+  stream: MediaStream,
+  onChange: (presenting: boolean) => void
+) {
+  let active = true;
+  let presenting = false;
+  let lastFrame = Number.NEGATIVE_INFINITY;
+  let frameId: number | undefined;
+  const tracks = stream.getVideoTracks();
+  const current = () =>
+    active &&
+    video.srcObject === stream &&
+    tracks.some((track) => track.readyState === 'live' && track.enabled);
+  const update = (value: boolean) => {
+    if (!active || presenting === value) return;
+    presenting = value;
+    onChange(value);
+  };
+  const frame = () => {
+    if (!active) return;
+    if (current()) {
+      lastFrame = performance.now();
+      update(true);
+    }
+    frameId = video.requestVideoFrameCallback(frame);
+  };
+  const fallback = () => {
+    if (
+      current() &&
+      !video.paused &&
+      video.readyState >= 2 &&
+      video.videoWidth > 0
+    ) {
+      lastFrame = performance.now();
+      update(true);
+    }
+  };
+  const reset = () => {
+    lastFrame = Number.NEGATIVE_INFINITY;
+    update(false);
+  };
+  const supportsFrames = typeof video.requestVideoFrameCallback === 'function';
+  video.addEventListener('playing', fallback);
+  if (supportsFrames) frameId = video.requestVideoFrameCallback(frame);
+  else {
+    video.addEventListener('timeupdate', fallback);
+    fallback();
+  }
+  for (const event of ['emptied', 'ended', 'error'])
+    video.addEventListener(event, reset);
+  for (const track of tracks) track.addEventListener('ended', reset);
+  const timer = setInterval(() => {
+    if (!current() || performance.now() - lastFrame > 3000) update(false);
+  }, 1000);
+  return () => {
+    active = false;
+    clearInterval(timer);
+    if (frameId !== undefined) video.cancelVideoFrameCallback(frameId);
+    video.removeEventListener('playing', fallback);
+    video.removeEventListener('timeupdate', fallback);
+    for (const event of ['emptied', 'ended', 'error'])
+      video.removeEventListener(event, reset);
+    for (const track of tracks) track.removeEventListener('ended', reset);
+  };
+}

--- a/apps/meet/src/features/call/lib/video-presentation.ts
+++ b/apps/meet/src/features/call/lib/video-presentation.ts
@@ -2,7 +2,8 @@
 export function observeVideoPresentation(
   video: HTMLVideoElement,
   stream: MediaStream,
-  onChange: (presenting: boolean) => void
+  onChange: (presenting: boolean) => void,
+  expireIdleFrames = true
 ) {
   let active = true;
   let presenting = false;
@@ -52,7 +53,11 @@ export function observeVideoPresentation(
     video.addEventListener(event, reset);
   for (const track of tracks) track.addEventListener('ended', reset);
   const timer = setInterval(() => {
-    if (!current() || performance.now() - lastFrame > 3000) update(false);
+    if (
+      !current() ||
+      (expireIdleFrames && performance.now() - lastFrame > 3000)
+    )
+      update(false);
   }, 1000);
   return () => {
     active = false;


### PR DESCRIPTION
Remote video could be visibly playing while a delayed receiver mute flag kept the avatar, reconnect button, and waiting badge over the feed. Observe video presentation independently, clear those overlays when frames are displayed, and expire that evidence if playback stalls. Keep camera-off video hidden and scope presentation state to the current stream.

Validation: all 331 Meet tests and `bun check` passed. Four new component regressions cover muted receivers with presented frames, stream replacement/camera-off, stall recovery, and cleanup. The affected physical device has not yet been retested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Meet tile so playing remote video clears the avatar and reconnect overlay that could linger when receiver mute flags are delayed. The tile now observes actual video frame presentation, uses it as the source of truth for overlays, and resets that evidence on camera toggles, stream changes, and playback stalls.

**Bug Fixes**
- Overlays are removed only when frames appear on the current stream, so camera-off video stays hidden.
- Camera toggles and stream replacement reset presentation state, so stale evidence isn't reused.
- Stalls longer than 3 seconds bring the overlay back for camera video; static screen shares keep theirs hidden.
- Adds regression tests for muted receivers, stream replacement, camera toggles, stall recovery, browser fallback, and cleanup.

<sup>Written for commit 328fb410ba2eb05eb72d6d3bc0e845bf73191cfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

