### PR TITLE
fix(meet): guard private review loading in compiled clients

### DIFF
--- a/apps/docs/platform/features/meet-calls.mdx
+++ b/apps/docs/platform/features/meet-calls.mdx
@@ -790,3 +790,9 @@ prevent duplicate approvals from repeating a mutation. If a request remains in a
 uncertain executing state, do not repeat it; inspect the platform result first. Failed or timed-out reviews can be discarded without making their actions executable again, including after the room ends.
 Web search runs in an isolated request containing only the explicit question; model-supplied query rewrites and recent room history are not forwarded. Questions containing known participant names or room-title terms are blocked at that boundary. Missing grounded sources produce an unavailable-search result. Web search is disabled while continuing private workspace results. Unsupported platform-only tools such as E2EE key setup,
 file conversion, and client UI controls are not exposed in the Meet tool set.
+
+Verify private reviews with the production React compiler enabled: let a review
+arrive while no review dialog is selected, then open it and deny the action.
+The list can load before the detail query, so callback inputs such as the revision
+must remain guarded during that interval. An uncompiled development fixture alone
+does not cover compiler-generated callback dependency reads.

--- a/apps/meet/src/features/call/components/assistant-private-review.tsx
+++ b/apps/meet/src/features/call/components/assistant-private-review.tsx
@@ -75,12 +75,15 @@ export function AssistantPrivateReviews({
   });
   if (!list.data?.length && !selected) return null;
   const review = detail.data;
-  const act = (action: 'approve' | 'deny' | 'share' | 'discard') =>
+  const revision = review?.revision;
+  const act = (action: 'approve' | 'deny' | 'share' | 'discard') => {
+    if (!selected || revision === undefined) return;
     mutation.mutate({
       action,
-      messageId: selected!,
-      revision: detail.data!.revision,
+      messageId: selected,
+      revision,
     });
+  };
   const actionable = review?.status === 'ready' && !mutation.isPending;
   return (
     <>


### PR DESCRIPTION
When a private Mira review arrives before the requester opens its dialog, the detail query has no data yet. The production React compiler hoisted the callback's non-null `revision` access into render, crashing the call view. Guard the revision before constructing the action callback and ignore actions without a selected, loaded draft.

Verified by reproducing the exact production error with the original component under React Compiler, then loading, opening, denying, and discarding a synthetic review with the compiled fix in Chrome. Private content stayed out of room chat. `bun check` and the Meet Cloudflare production build passed. Added this compiler-enabled loading-state check to Meet operating docs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Meet call view when a private Mira review arrives before its dialog is opened.

- Guards the revision before building the action callback so actions without a selected, loaded draft are ignored.
- Adds a note to Meet operating docs about verifying private reviews with the React compiler enabled.

<sup>Written for commit 28d0cab0cbdbdba8ec855e333b53d41bc0dbee06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

