### PR TITLE
fix(meet): keep review decisions readable in narrow panels

### DIFF
--- a/apps/meet/src/features/call/components/assistant-private-review.tsx
+++ b/apps/meet/src/features/call/components/assistant-private-review.tsx
@@ -145,7 +145,7 @@ export function AssistantPrivateReview({
                   {t('assistant_decision_saving')}
                 </p>
               )}
-              <div className="grid @xs:grid-cols-2 grid-cols-1 gap-2">
+              <div className="grid @md:grid-cols-2 grid-cols-1 gap-2">
                 {review.status === 'interrupted' ? (
                   <Button
                     variant="outline"


### PR DESCRIPTION
At narrow chat widths, Vietnamese review actions could be clipped. Keep decision buttons stacked until the review container has enough room for both labels.

Validation: `bun check` passed; verified the compiler-enabled ChatPanel at 400px with the full Vietnamese sharing label visible.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vietnamese review decision buttons being clipped in narrow chat panels by delaying the two-column layout until the container is wider, so labels stay readable at small widths.

<sup>Written for commit 5e9e96e5420aca5860161c96dd31bad54d6a38af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

