### PR TITLE
fix(meet): adapt review details to chat width

### DIFF
--- a/apps/meet/src/features/call/components/assistant-tool-preview.tsx
+++ b/apps/meet/src/features/call/components/assistant-tool-preview.tsx
@@ -34,11 +34,11 @@ export function AssistantToolPreview({
     return String(value ?? '—');
   };
   return (
-    <dl className="divide-y rounded-lg border bg-muted/20 px-3">
+    <dl className="@container divide-y rounded-lg border bg-muted/20 px-3">
       {fields.map(([name, value]) => (
         <div
           key={name}
-          className="grid gap-1 py-2 sm:grid-cols-[8rem_1fr] sm:gap-3"
+          className="grid @md:grid-cols-[8rem_1fr] @md:gap-3 gap-1 py-2"
         >
           <dt className="font-medium text-muted-foreground text-xs capitalize">
             {name.replaceAll('_', ' ')}


### PR DESCRIPTION
In a narrow desktop chat panel, the review preview used the viewport width to force two columns, squeezing titles and timestamps into a thin column. Use the preview container width so fields stack until the card itself has enough room.

Validation: `bun check` passed; compiler-enabled ChatPanel verified at 400px with Vietnamese event details and actions readable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the assistant tool review preview layout in narrow chat panels so titles and timestamps no longer get squeezed into a thin column.

- Switches the column breakpoint from viewport width to the card container width, so fields stack until the card itself has enough room.

<sup>Written for commit 558029b770a388af73966bf53ef61217c82194c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

