### PR TITLE
fix(mail): consolidate synchronization controls and clarify counts

### DIFF
--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
@@ -11,7 +11,6 @@ import {
   CheckCheck,
   Info,
   Loader2,
-  RefreshCw,
   Search,
   Trash2,
   X,
@@ -35,7 +34,6 @@ import {
   ResizablePanelGroup,
 } from '@tuturuuu/ui/resizable';
 import { toast } from '@tuturuuu/ui/sonner';
-import { cn } from '@tuturuuu/utils/format';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { parseAsString, useQueryState } from 'nuqs';
@@ -378,20 +376,14 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
             {activeMailbox?.address}
           </p>
         </div>
-        <Button
-          aria-label={t('refresh')}
-          disabled={threadsQuery.isFetching || bootstrapQuery.isFetching}
-          onClick={() =>
-            activeMailboxId ? threadsQuery.refetch() : bootstrapQuery.refetch()
-          }
-          size="icon"
-          variant="ghost"
-        >
-          <RefreshCw
-            className={cn('size-4', threadsQuery.isFetching && 'animate-spin')}
-          />
-        </Button>
-        <MailSyncStatus state={syncState} />
+        <MailSyncStatus
+          state={syncState}
+          refreshing={threadsQuery.isFetching || bootstrapQuery.isFetching}
+          onRefresh={() => {
+            if (activeMailboxId) void threadsQuery.refetch();
+            else void bootstrapQuery.refetch();
+          }}
+        />
       </div>
       <div className="space-y-2 border-dynamic border-b p-3">
         <div className="relative">

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
@@ -380,7 +380,9 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
           state={syncState}
           refreshing={threadsQuery.isFetching || bootstrapQuery.isFetching}
           onRefresh={() =>
-            activeMailboxId ? threadsQuery.refetch() : bootstrapQuery.refetch()
+            activeMailboxId
+              ? threadsQuery.refetch({ throwOnError: true })
+              : bootstrapQuery.refetch({ throwOnError: true })
           }
         />
       </div>

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-client.tsx
@@ -379,10 +379,9 @@ export function MailAppClient({ folder, workspaceId }: MailAppClientProps) {
         <MailSyncStatus
           state={syncState}
           refreshing={threadsQuery.isFetching || bootstrapQuery.isFetching}
-          onRefresh={() => {
-            if (activeMailboxId) void threadsQuery.refetch();
-            else void bootstrapQuery.refetch();
-          }}
+          onRefresh={() =>
+            activeMailboxId ? threadsQuery.refetch() : bootstrapQuery.refetch()
+          }
         />
       </div>
       <div className="space-y-2 border-dynamic border-b p-3">

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.test.ts
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
 import { TooltipProvider } from '@tuturuuu/ui/tooltip';
 import { createElement } from 'react';
 import { afterEach, expect, it, vi } from 'vitest';
@@ -44,4 +50,37 @@ it.each([
   expect(error).toHaveBeenCalledTimes(
     test.state === 'failed' && !test.refreshing ? 1 : 0
   );
+});
+
+it('deduplicates immediate activations until the refresh settles', async () => {
+  let finish!: () => void;
+  const onRefresh = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        finish = resolve;
+      })
+  );
+  render(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(MailSyncStatus, {
+        state: 'synced',
+        refreshing: false,
+        onRefresh,
+      })
+    )
+  );
+  const button = screen.getByRole('button');
+  fireEvent.click(button);
+  fireEvent.click(button);
+  expect(onRefresh).toHaveBeenCalledOnce();
+  await act(async () => {
+    finish();
+  });
+  fireEvent.click(button);
+  expect(onRefresh).toHaveBeenCalledTimes(2);
+  await act(async () => {
+    finish();
+  });
 });

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.test.ts
@@ -6,7 +6,12 @@ import { afterEach, expect, it, vi } from 'vitest';
 import { MailSyncStatus } from './mail-sync-status';
 
 vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
-afterEach(cleanup);
+const error = vi.hoisted(() => vi.fn());
+vi.mock('@tuturuuu/ui/sonner', () => ({ toast: { error } }));
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 it.each([
   { state: 'synced' as const, refreshing: false, label: 'synced', calls: 1 },
@@ -18,6 +23,7 @@ it.each([
   },
   { state: 'syncing' as const, refreshing: false, label: 'syncing', calls: 0 },
   { state: 'synced' as const, refreshing: true, label: 'syncing', calls: 0 },
+  { state: 'failed' as const, refreshing: true, label: 'syncing', calls: 0 },
 ])('exposes $label and refreshes only when idle ($refreshing)', (test) => {
   const onRefresh = vi.fn();
   render(
@@ -35,4 +41,7 @@ it.each([
   expect(screen.getAllByRole('button')).toHaveLength(1);
   fireEvent.click(button);
   expect(onRefresh).toHaveBeenCalledTimes(test.calls);
+  expect(error).toHaveBeenCalledTimes(
+    test.state === 'failed' && !test.refreshing ? 1 : 0
+  );
 });

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { TooltipProvider } from '@tuturuuu/ui/tooltip';
+import { createElement } from 'react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { MailSyncStatus } from './mail-sync-status';
+
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+afterEach(cleanup);
+
+it.each([
+  { state: 'synced' as const, refreshing: false, label: 'synced', calls: 1 },
+  {
+    state: 'failed' as const,
+    refreshing: false,
+    label: 'sync_failed',
+    calls: 1,
+  },
+  { state: 'syncing' as const, refreshing: false, label: 'syncing', calls: 0 },
+  { state: 'synced' as const, refreshing: true, label: 'syncing', calls: 0 },
+])('exposes $label and refreshes only when idle ($refreshing)', (test) => {
+  const onRefresh = vi.fn();
+  render(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(MailSyncStatus, {
+        state: test.state,
+        refreshing: test.refreshing,
+        onRefresh,
+      })
+    )
+  );
+  const button = screen.getByRole('button', { name: `refresh: ${test.label}` });
+  expect(screen.getAllByRole('button')).toHaveLength(1);
+  fireEvent.click(button);
+  expect(onRefresh).toHaveBeenCalledTimes(test.calls);
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.test.ts
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.test.ts
@@ -84,3 +84,30 @@ it('deduplicates immediate activations until the refresh settles', async () => {
     finish();
   });
 });
+
+it('reports a refresh failure and allows another attempt', async () => {
+  const onRefresh = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValue(undefined);
+  render(
+    createElement(
+      TooltipProvider,
+      null,
+      createElement(MailSyncStatus, {
+        state: 'synced',
+        refreshing: false,
+        onRefresh,
+      })
+    )
+  );
+  const button = screen.getByRole('button');
+  await act(async () => {
+    fireEvent.click(button);
+  });
+  expect(error).toHaveBeenCalledWith('load_failed');
+  await act(async () => {
+    fireEvent.click(button);
+  });
+  expect(onRefresh).toHaveBeenCalledTimes(2);
+});

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.tsx
@@ -1,53 +1,51 @@
 'use client';
 
-import { CloudAlert, CloudCheck, CloudUpload } from '@tuturuuu/icons';
+import { CloudAlert, RefreshCw } from '@tuturuuu/icons';
 import { Button } from '@tuturuuu/ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@tuturuuu/ui/popover';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
 import type { MailSyncState } from './use-mail-thread-actions';
 
-export function MailSyncStatus({ state }: { state: MailSyncState }) {
+export function MailSyncStatus({
+  state,
+  refreshing,
+  onRefresh,
+}: {
+  state: MailSyncState;
+  refreshing: boolean;
+  onRefresh: () => void;
+}) {
   const t = useTranslations('mail');
-  const syncing = state === 'syncing';
+  const busy = refreshing || state === 'syncing';
   const failed = state === 'failed';
-  const Icon = failed ? CloudAlert : syncing ? CloudUpload : CloudCheck;
-  const label = failed
-    ? t('sync_failed')
-    : syncing
-      ? t('syncing')
-      : t('synced');
+  const Icon = failed && !busy ? CloudAlert : RefreshCw;
+  const label = busy ? t('syncing') : failed ? t('sync_failed') : t('synced');
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
+    <Tooltip>
+      <TooltipTrigger asChild>
         <Button
-          aria-label={t('sync_status')}
+          aria-label={`${t('refresh')}: ${label}`}
+          aria-busy={busy}
+          aria-disabled={busy}
           className={cn(failed && 'text-destructive')}
+          onClick={() => {
+            if (!busy) onRefresh();
+          }}
           size="icon"
           variant="ghost"
         >
-          <Icon className={cn('size-4', syncing && 'animate-pulse')} />
+          <Icon className={cn('size-4', busy && 'animate-spin')} />
         </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-64 rounded-xl p-3">
-        <div className="flex items-start gap-2.5">
-          <span
-            className={cn(
-              'mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg bg-foreground/[0.05]',
-              failed && 'text-destructive'
-            )}
-          >
-            <Icon className={cn('size-3.5', syncing && 'animate-pulse')} />
-          </span>
-          <div className="min-w-0">
-            <p className="font-medium text-sm">{label}</p>
-            <p className="mt-0.5 text-muted-foreground text-xs leading-5">
-              {failed ? t('sync_failed_description') : t('sync_description')}
-            </p>
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-64">
+        <p className="font-medium">{t('refresh')}</p>
+        <p role="status">{label}</p>
+        <p className="mt-1 text-xs leading-5">
+          {failed ? t('sync_failed_description') : t('sync_description')}
+        </p>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.tsx
@@ -6,6 +6,7 @@ import { toast } from '@tuturuuu/ui/sonner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
+import { useRef } from 'react';
 import type { MailSyncState } from './use-mail-thread-actions';
 
 export function MailSyncStatus({
@@ -15,9 +16,10 @@ export function MailSyncStatus({
 }: {
   state: MailSyncState;
   refreshing: boolean;
-  onRefresh: () => void;
+  onRefresh: () => unknown;
 }) {
   const t = useTranslations('mail');
+  const refreshingRef = useRef(false);
   const busy = refreshing || state === 'syncing';
   const failed = state === 'failed' && !busy;
   const Icon = failed ? CloudAlert : RefreshCw;
@@ -31,10 +33,17 @@ export function MailSyncStatus({
           aria-busy={busy}
           aria-disabled={busy}
           className={cn(failed && 'text-destructive')}
-          onClick={() => {
-            if (busy) return;
-            if (failed) toast.error(t('sync_failed_description'));
-            onRefresh();
+          onClick={async () => {
+            if (busy || refreshingRef.current) return;
+            refreshingRef.current = true;
+            try {
+              if (failed) toast.error(t('sync_failed_description'));
+              await onRefresh();
+            } catch {
+              toast.error(t('load_failed'));
+            } finally {
+              refreshingRef.current = false;
+            }
           }}
           size="icon"
           variant="ghost"

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-sync-status.tsx
@@ -2,6 +2,7 @@
 
 import { CloudAlert, RefreshCw } from '@tuturuuu/icons';
 import { Button } from '@tuturuuu/ui/button';
+import { toast } from '@tuturuuu/ui/sonner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@tuturuuu/ui/tooltip';
 import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
@@ -18,8 +19,8 @@ export function MailSyncStatus({
 }) {
   const t = useTranslations('mail');
   const busy = refreshing || state === 'syncing';
-  const failed = state === 'failed';
-  const Icon = failed && !busy ? CloudAlert : RefreshCw;
+  const failed = state === 'failed' && !busy;
+  const Icon = failed ? CloudAlert : RefreshCw;
   const label = busy ? t('syncing') : failed ? t('sync_failed') : t('synced');
 
   return (
@@ -31,7 +32,9 @@ export function MailSyncStatus({
           aria-disabled={busy}
           className={cn(failed && 'text-destructive')}
           onClick={() => {
-            if (!busy) onRefresh();
+            if (busy) return;
+            if (failed) toast.error(t('sync_failed_description'));
+            onRefresh();
           }}
           size="icon"
           variant="ghost"

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-thread-header.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-thread-header.tsx
@@ -33,7 +33,7 @@ export function MailThreadHeader({
           <h1 className="text-pretty break-words font-semibold text-lg leading-tight md:text-xl">
             {subject || t('no_subject')}
           </h1>
-          <p className="mt-1 text-muted-foreground text-xs">
+          <p className="mt-2 inline-flex items-center rounded-md bg-muted px-2 py-0.5 font-medium text-foreground text-sm tabular-nums">
             {t('message_count', { count: messageCount })}
           </p>
         </div>

--- a/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-thread-list.tsx
+++ b/apps/mail/src/app/[locale]/(dashboard)/[wsId]/mail-thread-list.tsx
@@ -102,8 +102,14 @@ export function MailThreadRow({
               : ''}
           </span>
           {thread.messageCount > 1 ? (
-            <span className="text-muted-foreground text-xs tabular-nums">
-              {thread.messageCount}
+            <span
+              title={t('message_count', { count: thread.messageCount })}
+              className="inline-flex min-w-6 shrink-0 items-center justify-center rounded-md bg-muted px-1.5 py-0.5 font-semibold text-foreground text-xs tabular-nums"
+            >
+              <span aria-hidden="true">{thread.messageCount}</span>
+              <span className="sr-only">
+                {t('message_count', { count: thread.messageCount })}
+              </span>
             </span>
           ) : null}
           <span className="max-w-[45%] shrink-0 text-right text-muted-foreground text-xs tabular-nums">


### PR DESCRIPTION
The mailbox header now uses one refresh button with synchronization progress and failure details in its tooltip. Clicking refresh remains a single action; repeated refreshes are ignored while loading or synchronizing, and the control stays keyboard-focusable for status inspection.

Thread counts use higher-contrast badges in the message list and reader header, with an accessible full message-count label in the list.

Validation: all 270 Mail tests and `bun check` pass, including idle, failed, syncing and refreshing control states.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the mailbox refresh button and sync status into one control and clarifies message count badges. Refresh clicks are ignored while loading or syncing, repeated clicks while a refresh is in flight are deduplicated until it settles, and failed refreshes show an error toast and allow retry. The tooltip shows status and failure details. Thread count badges use higher-contrast styling with a full accessible label. Adds tests for the control's states, refresh deduplication, and failure reporting.

<sup>Written for commit 18d1e0970a89d6afc9630217d740d735b74dcc86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

