### PR TITLE
fix(meet): verify idle delivery without periodic presence broadcasts

### DIFF
--- a/apps/meet-realtime/src/integration-check.ts
+++ b/apps/meet-realtime/src/integration-check.ts
@@ -182,15 +182,22 @@ try {
 
   if (REMOTE_URL) {
     // Background browser tabs can delay timers beyond the heartbeat TTL.
-    const start = host.received.length;
     await Bun.sleep(40_000);
+    // Idle rooms do not broadcast periodically. Probe the still-open room with
+    // real delivery instead of requiring a heartbeat-triggered presence event.
+    const probeBody = `Idle survival probe ${MEETING_ID}`;
+    host.send({ type: 'chat.message', body: probeBody });
+    const probe = await guest.waitFor(
+      'chat.message',
+      (message) => message.type === 'chat.message' && message.body === probeBody
+    );
     const latest = host.received
-      .slice(start)
       .filter((message) => message.type === 'presence')
       .at(-1);
     check(
       'connected participants survive delayed browser heartbeats',
-      latest?.presence.some((entry) => entry.userId === HOST_ID) === true &&
+      Boolean(probe) &&
+        latest?.presence.some((entry) => entry.userId === HOST_ID) === true &&
         latest.presence.some((entry) => entry.userId === GUEST_ID)
     );
   }

--- a/apps/meet-realtime/src/integration-check.ts
+++ b/apps/meet-realtime/src/integration-check.ts
@@ -191,15 +191,24 @@ try {
       'chat.message',
       (message) => message.type === 'chat.message' && message.body === probeBody
     );
-    const latest = host.received
-      .filter((message) => message.type === 'presence')
-      .at(-1);
-    check(
-      'connected participants survive delayed browser heartbeats',
-      Boolean(probe) &&
-        latest?.presence.some((entry) => entry.userId === HOST_ID) === true &&
-        latest.presence.some((entry) => entry.userId === GUEST_ID)
-    );
+    const observer = new TestClient();
+    try {
+      // A new observer requests fresh room state without refreshing either
+      // original participant, so silently pruned presence cannot be hidden.
+      const observerId = crypto.randomUUID();
+      await observer.connect(
+        mintToken('speaker', observerId, 'open', 'Observer')
+      );
+      const latest = await observer.waitFor('presence');
+      check(
+        'connected participants survive delayed browser heartbeats',
+        Boolean(probe) &&
+          latest?.presence.some((entry) => entry.userId === HOST_ID) === true &&
+          latest.presence.some((entry) => entry.userId === GUEST_ID)
+      );
+    } finally {
+      observer.close();
+    }
   }
 
   // --- Cloudflare SFU ----------------------------------------------------


### PR DESCRIPTION
The production check still required a periodic presence broadcast after 40 idle seconds. Meet #5286 intentionally removes those broadcasts so idle rooms can hibernate, causing a false failure after the Workers had deployed successfully.

Probe actual host-to-guest chat delivery after the idle interval and inspect the latest presence snapshot. This verifies that connected participants remain usable without requiring periodic broadcasts. Runtime behavior is unchanged.

Validation: `bun check` passed. The corrected integration check passed against production, including the 40-second idle probe, admission, chat, SFU/TURN, moderation, and notes-sharing checks. Production assets match the #5286 CI artifact; signed-in solo/private-Mira/sharing and chat-replay checks also passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the meet production integration check so idle rooms no longer fail verification after Meet #5286 removed periodic presence broadcasts.

The check now probes host-to-guest chat delivery after the 40-second idle interval and connects a fresh observer to fetch the latest presence snapshot, preventing silently pruned participants from hiding behind stale state. Runtime behavior is unchanged.

<sup>Written for commit 4b9d7cf067b61d9b3be5b1b32c8f9eb186a638a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

