### PR TITLE
fix(meet): use supported redirects in Live Worker requests

### DIFF
--- a/apps/docs/platform/features/meet-live-assistants.mdx
+++ b/apps/docs/platform/features/meet-live-assistants.mdx
@@ -133,3 +133,10 @@ permission gate are not exposed.
 Deployment checks require `GOOGLE_GENERATIVE_AI_API_KEY` on the Meet Worker.
 Missing provider token allocation or search grounding usage remains marked as
 incomplete cost coverage instead of being counted as free.
+
+Server requests carrying room tokens or database credentials use `redirect: 'manual'`
+and reject non-success statuses. Cloudflare's workerd runtime does not implement
+`redirect: 'error'`; using it throws before the request reaches the upstream and
+can fail the Live WebSocket upgrade. Do not replace this with `follow`, which
+could forward credentials to a redirect target. Verify the deployed upgrade in
+addition to the Next.js start-session route and provider-only tests.

--- a/apps/meet/cloudflare/live/room.ts
+++ b/apps/meet/cloudflare/live/room.ts
@@ -39,7 +39,9 @@ export async function liveRoomCommand<T>(
   url.search = '';
   const response = await fetch(url, {
     method: 'POST',
-    redirect: 'error',
+    // workerd does not support redirect: 'error'. Never forward this token
+    // to a redirect target; the non-2xx check below rejects redirects.
+    redirect: 'manual',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',

--- a/apps/meet/cloudflare/live/storage.ts
+++ b/apps/meet/cloudflare/live/storage.ts
@@ -40,7 +40,9 @@ export async function liveDatabase<T>(
   if (url.protocol !== 'https:' && !(local && url.protocol === 'http:'))
     throw new Error('live_database_tls_required');
   const response = await fetch(url, {
-    redirect: 'error',
+    // Reject redirects through the status check without forwarding credentials.
+    // workerd supports manual/follow, but throws for redirect: 'error'.
+    redirect: 'manual',
     method: init?.method ?? 'GET',
     headers: {
       apikey: env.SUPABASE_SECRET_KEY,

--- a/apps/meet/src/features/live-assistant/worker-requests.test.ts
+++ b/apps/meet/src/features/live-assistant/worker-requests.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { liveRoomCommand } from '../../../cloudflare/live/room';
+import {
+  type LiveEnvironment,
+  liveDatabase,
+} from '../../../cloudflare/live/storage';
+import type { LiveSessionClaims } from './contracts';
+
+const env = {
+  MEET_REALTIME_URL: 'https://realtime.example.test/realtime',
+  MEET_REALTIME_TOKEN_SECRET: 'test-secret',
+  NEXT_PUBLIC_SUPABASE_URL: 'https://database.example.test',
+  SUPABASE_SECRET_KEY: 'test-database-secret',
+} as LiveEnvironment;
+const claims = {
+  sessionId: 'session',
+  ownerId: '11111111-1111-4111-8111-111111111111',
+  meetingId: '22222222-2222-4222-8222-222222222222',
+  mode: 'room',
+} as LiveSessionClaims;
+const identity = {
+  workspaceId: '33333333-3333-4333-8333-333333333333',
+  isHost: true,
+  displayName: 'Test host',
+};
+afterEach(() => vi.unstubAllGlobals());
+
+it.each(['room', 'database'] as const)(
+  'uses workerd-compatible requests for %s',
+  async (target) => {
+    const fetcher = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      if (init?.redirect === 'error')
+        throw new TypeError('Unsupported redirect mode');
+      return Response.json({ ok: true });
+    });
+    vi.stubGlobal('fetch', fetcher);
+    const result =
+      target === 'room'
+        ? await liveRoomCommand(env, claims, identity, {
+            action: 'live.context',
+          })
+        : await liveDatabase(env, 'meet_ai_user_preferences');
+    expect(result).toEqual({ ok: true });
+    expect(fetcher.mock.calls[0]?.[1]?.redirect).toBe('manual');
+  }
+);
+
+it.each([301, 302, 307, 308])(
+  'rejects HTTP %s without forwarding server credentials',
+  async (status) => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(null, {
+          status,
+          headers: { Location: 'https://untrusted.example.test' },
+        })
+    );
+    vi.stubGlobal('fetch', fetcher);
+    await expect(liveRoomCommand(env, claims, identity, {})).rejects.toThrow(
+      `live_room_${status}`
+    );
+    await expect(liveDatabase(env, 'meet_ai_user_preferences')).rejects.toThrow(
+      `live_database_${status}`
+    );
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    for (const call of fetcher.mock.calls as unknown as Array<
+      [unknown, RequestInit]
+    >) {
+      expect(call[1].redirect).toBe('manual');
+    }
+  }
+);


### PR DESCRIPTION
The production Gemini Live WebSocket upgrade fails with a workerd `TypeError` because its authenticated room request uses the unsupported `redirect: 'error'` mode. The database helper uses the same mode and would also fail after connection.

Use `manual` for both server requests and retain the existing non-success status checks, so redirects are rejected without forwarding credentials. Add regression coverage for successful requests and HTTP 301/302/307/308 rejection, and document why provider-only and Next.js API tests do not prove the Worker upgrade works.

Validation: production failure reproduced with sanitized exception logging; six focused tests passed; `bun check` and `bun run build:cloudflare` passed. Signed-in production Live verification will be repeated after deployment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the production Gemini Live WebSocket upgrade failing in `workerd` because the authenticated room request used the unsupported `redirect: 'error'` mode. Switches both the room request and database helper to `redirect: 'manual'`, keeping the existing non-success status checks so redirects are rejected without forwarding credentials.

**Tests and Docs**
- Adds regression tests for successful requests and rejection of HTTP 301/302/307/308.
- Documents why provider-only and Next.js API tests don't prove the Worker upgrade works.

<sup>Written for commit 229d66a6f039b8fdd49d7308e6026f7106f07839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

