### PR TITLE
feat(ai): add metered root-sponsored Colab endpoint

### DIFF
--- a/apps/ai/src/app/v1/colab/responses/route.test.ts
+++ b/apps/ai/src/app/v1/colab/responses/route.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ auth: vi.fn(), execute: vi.fn() }));
+vi.mock('@tuturuuu/ai/studio/auth', () => ({
+  authenticateAiStudioRequest: mocks.auth,
+}));
+vi.mock('@/lib/text-execution', () => ({
+  parseTextRequest: (value: unknown) => value,
+  executeTextRequest: mocks.execute,
+}));
+vi.mock('@/lib/public-api', () => ({
+  publicApiError: (error: { status?: number }) =>
+    Response.json({ error: 'rejected' }, { status: error.status ?? 500 }),
+}));
+
+import { POST } from './route';
+
+const root = '00000000-0000-0000-0000-000000000000';
+const sponsorship = {
+  workshopId: 'room',
+  workshopTitle: 'RISE Induction Day',
+  hostId: 'host',
+  teamId: 'team-1',
+  teamName: 'Marketing',
+  participantId: 'attendee',
+  operation: 'analyze',
+  phase: 'prompt_review',
+  scenarioId: 'rise-induction-post',
+  jobId: '07a13d30-0599-4572-8d1d-159860105e10',
+  sequence: 1,
+};
+const request = (body: unknown) =>
+  new Request('https://ai.tuturuuu.com/v1/colab/responses', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+describe('Colab sponsorship boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth.mockResolvedValue({
+      workspaceId: root,
+      actorId: 'key-owner',
+      apiKey: { external_app_id: null },
+    });
+    mocks.execute.mockResolvedValue(Response.json({ choices: [] }));
+  });
+  it('charges only root credits with complete workshop evidence and bounded execution', async () => {
+    const response = await POST(
+      request({
+        sponsorship,
+        instructions: 'Review the prompt',
+        prompt: 'RISE draft',
+        model: 'google/gemini-2.5-flash',
+        tools: ['external'],
+        max_steps: 100,
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-colab-sponsor-workspace')).toBe(root);
+    const [, input, options] = mocks.execute.mock.calls[0]!;
+    expect(input).toMatchObject({
+      max_steps: 1,
+      max_output_tokens: 4096,
+      tools: [],
+      stream: false,
+    });
+    expect(options).toMatchObject({
+      requirePricedUsage: true,
+      credential: { kind: 'api-key', workspaceId: root },
+      metadata: {
+        ...sponsorship,
+        sponsor_workspace_id: root,
+        product: 'colab',
+      },
+    });
+    expect(options.metadata.description).toContain('RISE Induction Day');
+  });
+  it.each([
+    { workspaceId: 'another-workspace', external_app_id: null },
+    { workspaceId: root, external_app_id: 'colab' },
+  ])(
+    'rejects non-root or unmetered app-bound credentials: %j',
+    async (value) => {
+      mocks.auth.mockResolvedValue({
+        workspaceId: value.workspaceId,
+        actorId: 'key-owner',
+        apiKey: { external_app_id: value.external_app_id },
+      });
+      expect((await POST(request({ sponsorship }))).status).toBe(403);
+      expect(mocks.execute).not.toHaveBeenCalled();
+    }
+  );
+  it('rejects incomplete sponsorship evidence before generation', async () => {
+    expect(
+      (await POST(request({ sponsorship: { workshopId: 'room' } }))).status
+    ).toBe(400);
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+  it('does not claim sponsorship when metering fails', async () => {
+    mocks.execute.mockResolvedValue(
+      Response.json({ error: 'insufficient_credits' }, { status: 402 })
+    );
+    const response = await POST(
+      request({
+        sponsorship,
+        prompt: 'draft',
+        model: 'google/gemini-2.5-flash',
+      })
+    );
+    expect(response.status).toBe(402);
+    expect(response.headers.has('x-colab-sponsor-workspace')).toBe(false);
+  });
+});

--- a/apps/ai/src/app/v1/colab/responses/route.test.ts
+++ b/apps/ai/src/app/v1/colab/responses/route.test.ts
@@ -58,7 +58,10 @@ describe('Colab sponsorship boundary', () => {
     );
     expect(response.status).toBe(200);
     expect(response.headers.get('x-colab-sponsor-workspace')).toBe(root);
-    const [, input, options] = mocks.execute.mock.calls[0]!;
+    const [executionRequest, input, options] = mocks.execute.mock.calls[0]!;
+    expect(executionRequest.headers.get('idempotency-key')).toBe(
+      `colab:${sponsorship.jobId}:1`
+    );
     expect(input).toMatchObject({
       max_steps: 1,
       max_output_tokens: 4096,
@@ -67,6 +70,8 @@ describe('Colab sponsorship boundary', () => {
     });
     expect(options).toMatchObject({
       requirePricedUsage: true,
+      feature: 'colab_analyze',
+      responseShape: 'chat',
       credential: { kind: 'api-key', workspaceId: root },
       metadata: {
         ...sponsorship,
@@ -95,6 +100,16 @@ describe('Colab sponsorship boundary', () => {
     expect(
       (await POST(request({ sponsorship: { workshopId: 'room' } }))).status
     ).toBe(400);
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+  it('rejects malformed JSON before generation', async () => {
+    const response = await POST(
+      new Request('https://ai.tuturuuu.com/v1/colab/responses', {
+        method: 'POST',
+        body: '{broken',
+      })
+    );
+    expect(response.status).toBe(400);
     expect(mocks.execute).not.toHaveBeenCalled();
   });
   it('does not claim sponsorship when metering fails', async () => {

--- a/apps/ai/src/app/v1/colab/responses/route.ts
+++ b/apps/ai/src/app/v1/colab/responses/route.ts
@@ -49,6 +49,19 @@ export async function POST(request: Request) {
         { code: 'invalid_request_error', status: 400 }
       );
     const sponsor = parsed.data;
+    const headers = new Headers(request.headers);
+    headers.set(
+      'idempotency-key',
+      `colab:${sponsor.jobId}:${sponsor.sequence}`
+    );
+    headers.set('x-request-id', `colab:${sponsor.jobId}:${sponsor.sequence}`);
+    headers.delete('x-tuturuuu-operation');
+    headers.delete('x-tuturuuu-entity-id');
+    const executionRequest = new Request(request.url, {
+      method: 'POST',
+      headers,
+      signal: request.signal,
+    });
     // These are trusted credential identity and server policy, never caller-selected billing fields.
     const metadata = {
       ...sponsor,
@@ -58,7 +71,7 @@ export async function POST(request: Request) {
       description: `Tuturuuu sponsors ${sponsor.operation} / ${sponsor.phase} for workshop "${sponsor.workshopTitle}", team "${sponsor.teamName}" (step ${sponsor.sequence}). Attendee personal credits are not charged.`,
     };
     const response = await executeTextRequest(
-      request,
+      executionRequest,
       parseTextRequest({
         instructions: body.instructions,
         prompt: body.prompt,

--- a/apps/ai/src/app/v1/colab/responses/route.ts
+++ b/apps/ai/src/app/v1/colab/responses/route.ts
@@ -1,0 +1,94 @@
+import { authenticateAiStudioRequest } from '@tuturuuu/ai/studio/auth';
+import { AiStudioError } from '@tuturuuu/ai/studio/errors';
+import { getAiStudioRequestId } from '@tuturuuu/ai/studio/request';
+import { ROOT_WORKSPACE_ID } from '@tuturuuu/utils/constants';
+import { z } from 'zod';
+import { publicApiError } from '@/lib/public-api';
+import { executeTextRequest, parseTextRequest } from '@/lib/text-execution';
+
+const sponsorshipSchema = z
+  .object({
+    workshopId: z.string().min(1).max(128),
+    workshopTitle: z.string().min(1).max(150),
+    hostId: z.string().min(1).max(128),
+    teamId: z.string().min(1).max(128),
+    teamName: z.string().min(1).max(150),
+    participantId: z.string().min(1).max(128),
+    operation: z.enum(['compile', 'analyze', 'run', 'scenario']),
+    phase: z.enum([
+      'generation',
+      'prompt_review',
+      'agent_step',
+      'result_coaching',
+    ]),
+    scenarioId: z.string().min(1).max(128),
+    jobId: z.uuid(),
+    sequence: z.number().int().min(1).max(50),
+  })
+  .strict();
+
+/** Only an unbound root workspace key may fund Colab sponsorships. */
+export async function POST(request: Request) {
+  const requestId = getAiStudioRequestId(request);
+  try {
+    const credential = await authenticateAiStudioRequest(request);
+    if (
+      credential.workspaceId !== ROOT_WORKSPACE_ID ||
+      credential.apiKey.external_app_id
+    ) {
+      throw new AiStudioError(
+        'Colab sponsorship requires an unbound root-workspace AI key.',
+        { code: 'invalid_api_key', status: 403, type: 'authentication_error' }
+      );
+    }
+    const body = (await request.json()) as Record<string, unknown>;
+    const parsed = sponsorshipSchema.safeParse(body?.sponsorship);
+    if (!parsed.success)
+      throw new AiStudioError(
+        'A complete workshop sponsorship description is required.',
+        { code: 'invalid_request_error', status: 400 }
+      );
+    const sponsor = parsed.data;
+    // These are trusted credential identity and server policy, never caller-selected billing fields.
+    const metadata = {
+      ...sponsor,
+      sponsor: 'Tuturuuu',
+      sponsor_workspace_id: ROOT_WORKSPACE_ID,
+      product: 'colab',
+      description: `Tuturuuu sponsors ${sponsor.operation} / ${sponsor.phase} for workshop "${sponsor.workshopTitle}", team "${sponsor.teamName}" (step ${sponsor.sequence}). Attendee personal credits are not charged.`,
+    };
+    const response = await executeTextRequest(
+      request,
+      parseTextRequest({
+        instructions: body.instructions,
+        prompt: body.prompt,
+        model: body.model,
+        max_output_tokens: 4096,
+        max_steps: 1,
+        response_format: { type: 'json_object' },
+        stream: false,
+        tools: [],
+      }),
+      {
+        credential: { ...credential, kind: 'api-key' },
+        feature: `colab_${sponsor.operation}`,
+        responseShape: 'chat',
+        metadata,
+        requirePricedUsage: true,
+      }
+    );
+    if (response.ok)
+      response.headers.set('x-colab-sponsor-workspace', ROOT_WORKSPACE_ID);
+    return response;
+  } catch (error) {
+    return publicApiError(
+      error instanceof SyntaxError
+        ? new AiStudioError('Request body must be valid JSON.', {
+            code: 'invalid_request_error',
+            status: 400,
+          })
+        : error,
+      requestId
+    );
+  }
+}

--- a/apps/ai/src/lib/public-api.test.ts
+++ b/apps/ai/src/lib/public-api.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   calculateAiStudioUsageCost: vi.fn(),
   createAdminClient: vi.fn(),
   settleAiStudioRun: vi.fn(),
+  recordAiStudioRunStep: vi.fn(),
   settleExternalAiStudioRun: vi.fn(),
 }));
 
@@ -19,6 +20,7 @@ vi.mock('@tuturuuu/ai/studio/metering', () => ({
   beginExternalAiStudioRun: mocks.beginExternalAiStudioRun,
   calculateAiStudioUsageCost: mocks.calculateAiStudioUsageCost,
   settleAiStudioRun: mocks.settleAiStudioRun,
+  recordAiStudioRunStep: mocks.recordAiStudioRunStep,
   settleExternalAiStudioRun: mocks.settleExternalAiStudioRun,
 }));
 vi.mock('@tuturuuu/supabase/next/server', () => ({
@@ -28,10 +30,62 @@ vi.mock('@tuturuuu/supabase/next/server', () => ({
 import {
   describeAiStudioRuntimeError,
   prepareMeteredExecution,
+  recordMeteredExecutionStep,
   settleMeteredExecution,
 } from './public-api';
 
 describe('AI Studio billing policy', () => {
+  it('rejects unknown zero model pricing before reserving credits', async () => {
+    mocks.calculateAiStudioUsageCost.mockResolvedValueOnce({
+      billedCredits: 0,
+      providerCostUsd: 0,
+    });
+    await expect(
+      prepareMeteredExecution({
+        credential: {
+          kind: 'api-key',
+          workspaceId: 'workspace',
+          apiKey: { id: 'key' },
+        } as never,
+        feature: 'colab_compile',
+        modelId: 'model',
+        maxUsage: { inputTokens: 10, outputTokens: 100 },
+        request: new Request('https://ai.tuturuuu.com/v1/colab/responses'),
+        requirePricedUsage: true,
+      })
+    ).rejects.toThrow('known positive model pricing');
+    expect(mocks.beginAiStudioRun).not.toHaveBeenCalled();
+  });
+  it('does not record unknown step pricing as priced zero', async () => {
+    mocks.calculateAiStudioUsageCost.mockRejectedValueOnce(
+      new Error('pricing unavailable')
+    );
+    await expect(
+      recordMeteredExecutionStep(
+        {
+          credential: {
+            kind: 'api-key',
+            workspaceId: 'workspace',
+            apiKey: { id: 'key' },
+          } as never,
+          modelId: 'model',
+          requestId: 'request',
+          runId: 'run',
+          startedAt: Date.now(),
+          requirePricedUsage: true,
+        },
+        {
+          kind: 'model',
+          name: 'model',
+          sequence: 1,
+          status: 'succeeded',
+          inputTokens: 100,
+          outputTokens: 50,
+        }
+      )
+    ).rejects.toThrow('pricing unavailable');
+    expect(mocks.recordAiStudioRunStep).not.toHaveBeenCalled();
+  });
   it('does not settle unknown sponsored pricing as zero credits', async () => {
     mocks.calculateAiStudioUsageCost.mockRejectedValueOnce(
       new Error('pricing unavailable')
@@ -54,7 +108,17 @@ describe('AI Studio billing policy', () => {
         { status: 'succeeded', usage: { inputTokens: 100, outputTokens: 80 } }
       )
     ).rejects.toThrow('pricing unavailable');
-    expect(mocks.settleAiStudioRun).not.toHaveBeenCalled();
+    expect(mocks.settleAiStudioRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        actualCredits: 0,
+        errorClass: 'PricingUnavailable',
+        metadata: expect.objectContaining({
+          reconciliation_required: true,
+          pricing_status: 'unavailable',
+        }),
+      })
+    );
   });
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/ai/src/lib/public-api.test.ts
+++ b/apps/ai/src/lib/public-api.test.ts
@@ -36,20 +36,9 @@ import {
 
 describe('AI Studio billing policy', () => {
   it('only one concurrent retry claims the reserved run', async () => {
-    let reserved = true;
-    const query = {
-      update: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      maybeSingle: vi.fn(async () => {
-        const data = reserved ? { id: 'metered-run' } : null;
-        reserved = false;
-        return { data, error: null };
-      }),
-    };
-    mocks.createAdminClient.mockResolvedValue({
-      schema: () => ({ from: () => query }),
-    });
+    mocks.beginAiStudioRun
+      .mockResolvedValueOnce({ runId: 'run' })
+      .mockRejectedValueOnce({ status: 409 });
     const input = {
       credential: {
         kind: 'api-key',
@@ -72,7 +61,9 @@ describe('AI Studio billing policy', () => {
     expect(
       results.find((result) => result.status === 'rejected')
     ).toMatchObject({ reason: { status: 409 } });
-    expect(query.eq).toHaveBeenCalledWith('status', 'reserved');
+    expect(mocks.beginAiStudioRun).toHaveBeenCalledWith(
+      expect.objectContaining({ rejectExisting: true })
+    );
     expect(mocks.settleAiStudioRun).not.toHaveBeenCalled();
   });
   it('fails and releases the hold if actual pricing becomes zero', async () => {

--- a/apps/ai/src/lib/public-api.test.ts
+++ b/apps/ai/src/lib/public-api.test.ts
@@ -32,6 +32,30 @@ import {
 } from './public-api';
 
 describe('AI Studio billing policy', () => {
+  it('does not settle unknown sponsored pricing as zero credits', async () => {
+    mocks.calculateAiStudioUsageCost.mockRejectedValueOnce(
+      new Error('pricing unavailable')
+    );
+    await expect(
+      settleMeteredExecution(
+        {
+          credential: {
+            actorId: 'actor',
+            apiKey: { id: 'key' },
+            kind: 'api-key',
+            workspaceId: 'workspace',
+          } as never,
+          modelId: 'model',
+          requestId: 'request',
+          runId: 'run',
+          startedAt: Date.now(),
+          requirePricedUsage: true,
+        },
+        { status: 'succeeded', usage: { inputTokens: 100, outputTokens: 80 } }
+      )
+    ).rejects.toThrow('pricing unavailable');
+    expect(mocks.settleAiStudioRun).not.toHaveBeenCalled();
+  });
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.calculateAiStudioUsageCost.mockResolvedValue({

--- a/apps/ai/src/lib/public-api.test.ts
+++ b/apps/ai/src/lib/public-api.test.ts
@@ -35,6 +35,76 @@ import {
 } from './public-api';
 
 describe('AI Studio billing policy', () => {
+  it('only one concurrent retry claims the reserved run', async () => {
+    let reserved = true;
+    const query = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn(async () => {
+        const data = reserved ? { id: 'metered-run' } : null;
+        reserved = false;
+        return { data, error: null };
+      }),
+    };
+    mocks.createAdminClient.mockResolvedValue({
+      schema: () => ({ from: () => query }),
+    });
+    const input = {
+      credential: {
+        kind: 'api-key',
+        workspaceId: 'workspace',
+        apiKey: { id: 'key' },
+      } as never,
+      feature: 'colab_compile',
+      modelId: 'model',
+      maxUsage: { inputTokens: 10, outputTokens: 100 },
+      request: new Request('https://ai.tuturuuu.com/v1/colab/responses'),
+      requirePricedUsage: true,
+    };
+    const results = await Promise.allSettled([
+      prepareMeteredExecution(input),
+      prepareMeteredExecution(input),
+    ]);
+    expect(
+      results.filter((result) => result.status === 'fulfilled')
+    ).toHaveLength(1);
+    expect(
+      results.find((result) => result.status === 'rejected')
+    ).toMatchObject({ reason: { status: 409 } });
+    expect(query.eq).toHaveBeenCalledWith('status', 'reserved');
+    expect(mocks.settleAiStudioRun).not.toHaveBeenCalled();
+  });
+  it('fails and releases the hold if actual pricing becomes zero', async () => {
+    mocks.calculateAiStudioUsageCost.mockResolvedValueOnce({
+      billedCredits: 0,
+      providerCostUsd: 0,
+    });
+    await expect(
+      settleMeteredExecution(
+        {
+          credential: {
+            kind: 'api-key',
+            workspaceId: 'workspace',
+            apiKey: { id: 'key' },
+          } as never,
+          modelId: 'model',
+          requestId: 'request',
+          runId: 'run',
+          startedAt: Date.now(),
+          requirePricedUsage: true,
+        },
+        { status: 'succeeded', usage: { inputTokens: 100, outputTokens: 50 } }
+      )
+    ).rejects.toThrow('pricing is unavailable');
+    expect(mocks.settleAiStudioRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        actualCredits: 0,
+        metadata: expect.objectContaining({ reconciliation_required: true }),
+      })
+    );
+  });
   it('rejects unknown zero model pricing before reserving credits', async () => {
     mocks.calculateAiStudioUsageCost.mockResolvedValueOnce({
       billedCredits: 0,

--- a/apps/ai/src/lib/public-api.ts
+++ b/apps/ai/src/lib/public-api.ts
@@ -30,6 +30,7 @@ export type MeteredUsage = {
 };
 
 export type MeteredExecutionContext = {
+  requirePricedUsage?: boolean;
   credential: PublicAiCredential;
   modelId: string;
   requestId: string;
@@ -254,7 +255,7 @@ export async function settleMeteredExecution(
     status: 'aborted' | 'failed' | 'succeeded';
     usage: MeteredUsage;
   }
-): Promise<void> {
+): Promise<{ billedCredits: number; providerCostUsd: number }> {
   const cost = await calculateAiStudioUsageCost({
     imageCount: usage.imageUnits,
     inputTokens: usage.inputTokens,
@@ -267,7 +268,10 @@ export async function settleMeteredExecution(
         : Math.max(0, usage.outputTokens - (usage.reasoningTokens ?? 0)),
     reasoningTokens: usage.reasoningTokens,
     workspaceId: context.credential.workspaceId,
-  }).catch(() => ({ billedCredits: 0, providerCostUsd: 0 }));
+  }).catch((error) => {
+    if (context.requirePricedUsage) throw error;
+    return { billedCredits: 0, providerCostUsd: 0 };
+  });
 
   const settlement = {
     embeddingUnits: usage.embeddingUnits,
@@ -299,6 +303,7 @@ export async function settleMeteredExecution(
       actualCredits: cost.billedCredits,
     });
   }
+  return cost;
 }
 
 export async function recordMeteredExecutionStep(

--- a/apps/ai/src/lib/public-api.ts
+++ b/apps/ai/src/lib/public-api.ts
@@ -206,6 +206,7 @@ export async function prepareMeteredExecution({
         workspaceId: credential.workspaceId,
       })
     : await beginAiStudioRun({
+        rejectExisting: requirePricedUsage,
         actorId: credential.actorId,
         apiKeyId: apiKeyIdForMeteredRun(credential),
         feature,
@@ -216,28 +217,6 @@ export async function prepareMeteredExecution({
         reservedCredits: positiveReservation(estimatedCost.billedCredits),
         workspaceId: credential.workspaceId,
       });
-
-  if (requirePricedUsage) {
-    // Atomically claim the reserved run: retries receive the same run ID but
-    // cannot start another provider request or settle the original request.
-    const sbAdmin = await createAdminClient({ noCookie: true });
-    const { data, error } = await sbAdmin
-      .schema('private')
-      .from('ai_studio_runs')
-      .update({ status: 'running' })
-      .eq('id', reservation.runId)
-      .eq('status', 'reserved')
-      .select('id')
-      .maybeSingle();
-    if (error || !data)
-      throw new AiStudioError(
-        'This sponsored request is already running or completed.',
-        {
-          code: 'invalid_request_error',
-          status: error ? 503 : 409,
-        }
-      );
-  }
 
   return {
     requirePricedUsage,

--- a/apps/ai/src/lib/public-api.ts
+++ b/apps/ai/src/lib/public-api.ts
@@ -217,6 +217,28 @@ export async function prepareMeteredExecution({
         workspaceId: credential.workspaceId,
       });
 
+  if (requirePricedUsage) {
+    // Atomically claim the reserved run: retries receive the same run ID but
+    // cannot start another provider request or settle the original request.
+    const sbAdmin = await createAdminClient({ noCookie: true });
+    const { data, error } = await sbAdmin
+      .schema('private')
+      .from('ai_studio_runs')
+      .update({ status: 'running' })
+      .eq('id', reservation.runId)
+      .eq('status', 'reserved')
+      .select('id')
+      .maybeSingle();
+    if (error || !data)
+      throw new AiStudioError(
+        'This sponsored request is already running or completed.',
+        {
+          code: 'invalid_request_error',
+          status: error ? 503 : 409,
+        }
+      );
+  }
+
   return {
     requirePricedUsage,
     credential,
@@ -295,35 +317,47 @@ export async function settleMeteredExecution(
         : Math.max(0, usage.outputTokens - (usage.reasoningTokens ?? 0)),
     reasoningTokens: usage.reasoningTokens,
     workspaceId: context.credential.workspaceId,
-  }).catch(async (pricingError) => {
-    if (context.requirePricedUsage) {
-      // Release the hold without claiming a successful zero-cost generation.
-      // Preserve measured usage for reconciliation once pricing recovers.
-      await settleAiStudioRun({
-        runId: context.runId,
-        status: 'failed',
-        actualCredits: 0,
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
-        reasoningTokens: usage.reasoningTokens,
-        errorClass: 'PricingUnavailable',
-        errorMessage:
-          'Pricing unavailable; reservation released. Usage needs reconciliation.',
-        metadata: {
-          ...(metadata &&
-          typeof metadata === 'object' &&
-          !Array.isArray(metadata)
-            ? metadata
-            : {}),
-          pricing_status: 'unavailable',
-          reconciliation_required: true,
-        },
-      });
-      context.pricingFailureFinalized = true;
-      throw pricingError;
-    }
-    return { billedCredits: 0, providerCostUsd: 0 };
-  });
+  })
+    .then((cost) => {
+      if (
+        context.requirePricedUsage &&
+        (status === 'succeeded' ||
+          Object.values(usage).some((value) => (value ?? 0) > 0)) &&
+        !(cost.providerCostUsd > 0 && cost.billedCredits > 0)
+      ) {
+        throw new Error('Sponsored usage pricing is unavailable.');
+      }
+      return cost;
+    })
+    .catch(async (pricingError) => {
+      if (context.requirePricedUsage) {
+        // Release the hold without claiming a successful zero-cost generation.
+        // Preserve measured usage for reconciliation once pricing recovers.
+        await settleAiStudioRun({
+          runId: context.runId,
+          status: 'failed',
+          actualCredits: 0,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          reasoningTokens: usage.reasoningTokens,
+          errorClass: 'PricingUnavailable',
+          errorMessage:
+            'Pricing unavailable; reservation released. Usage needs reconciliation.',
+          metadata: {
+            ...(metadata &&
+            typeof metadata === 'object' &&
+            !Array.isArray(metadata)
+              ? metadata
+              : {}),
+            pricing_status: 'unavailable',
+            reconciliation_required: true,
+          },
+        });
+        context.pricingFailureFinalized = true;
+        throw pricingError;
+      }
+      return { billedCredits: 0, providerCostUsd: 0 };
+    });
 
   const settlement = {
     embeddingUnits: usage.embeddingUnits,
@@ -380,10 +414,20 @@ export async function recordMeteredExecutionStep(
           modelId: context.modelId,
           outputTokens: input.outputTokens,
           workspaceId: context.credential.workspaceId,
-        }).catch((error) => {
-          if (context.requirePricedUsage) throw error;
-          return { billedCredits: 0, providerCostUsd: 0 };
         })
+          .then((cost) => {
+            if (
+              context.requirePricedUsage &&
+              ((input.inputTokens ?? 0) > 0 || (input.outputTokens ?? 0) > 0) &&
+              !(cost.providerCostUsd > 0 && cost.billedCredits > 0)
+            )
+              throw new Error('Sponsored step pricing is unavailable.');
+            return cost;
+          })
+          .catch((error) => {
+            if (context.requirePricedUsage) throw error;
+            return { billedCredits: 0, providerCostUsd: 0 };
+          })
       : { billedCredits: 0, providerCostUsd: 0 };
 
   await recordAiStudioRunStep({

--- a/apps/ai/src/lib/public-api.ts
+++ b/apps/ai/src/lib/public-api.ts
@@ -31,6 +31,7 @@ export type MeteredUsage = {
 
 export type MeteredExecutionContext = {
   requirePricedUsage?: boolean;
+  pricingFailureFinalized?: boolean;
   credential: PublicAiCredential;
   modelId: string;
   requestId: string;
@@ -47,6 +48,7 @@ type ErrorDetails = {
 };
 
 type PrepareMeteredExecutionInput = {
+  requirePricedUsage?: boolean;
   feature: string;
   maxUsage: MeteredUsage;
   metadata?: Json;
@@ -150,6 +152,7 @@ export async function prepareMeteredExecution({
   metadata,
   modelId,
   request,
+  requirePricedUsage = false,
   requiredModelType,
   requiredExternalScope = EXTERNAL_AI_SCOPE,
 }: PrepareMeteredExecutionInput): Promise<MeteredExecutionContext> {
@@ -170,6 +173,19 @@ export async function prepareMeteredExecution({
   });
 
   const idempotencyKey = getIdempotencyKey(request);
+  if (
+    requirePricedUsage &&
+    !(estimatedCost.providerCostUsd > 0 && estimatedCost.billedCredits > 0)
+  ) {
+    throw new AiStudioError(
+      'Sponsored generation requires known positive model pricing.',
+      {
+        code: 'server_error',
+        status: 503,
+        type: 'server_error',
+      }
+    );
+  }
   const externalApp = externalAppAttribution(credential);
 
   // An API key with no app binding is the only credential that spends workspace
@@ -202,6 +218,7 @@ export async function prepareMeteredExecution({
       });
 
   return {
+    requirePricedUsage,
     credential,
     modelId,
     requestId,
@@ -256,6 +273,16 @@ export async function settleMeteredExecution(
     usage: MeteredUsage;
   }
 ): Promise<{ billedCredits: number; providerCostUsd: number }> {
+  if (context.pricingFailureFinalized) {
+    throw new AiStudioError(
+      'Usage pricing failed; the reservation was released.',
+      {
+        code: 'server_error',
+        status: 503,
+        type: 'server_error',
+      }
+    );
+  }
   const cost = await calculateAiStudioUsageCost({
     imageCount: usage.imageUnits,
     inputTokens: usage.inputTokens,
@@ -268,8 +295,33 @@ export async function settleMeteredExecution(
         : Math.max(0, usage.outputTokens - (usage.reasoningTokens ?? 0)),
     reasoningTokens: usage.reasoningTokens,
     workspaceId: context.credential.workspaceId,
-  }).catch((error) => {
-    if (context.requirePricedUsage) throw error;
+  }).catch(async (pricingError) => {
+    if (context.requirePricedUsage) {
+      // Release the hold without claiming a successful zero-cost generation.
+      // Preserve measured usage for reconciliation once pricing recovers.
+      await settleAiStudioRun({
+        runId: context.runId,
+        status: 'failed',
+        actualCredits: 0,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        reasoningTokens: usage.reasoningTokens,
+        errorClass: 'PricingUnavailable',
+        errorMessage:
+          'Pricing unavailable; reservation released. Usage needs reconciliation.',
+        metadata: {
+          ...(metadata &&
+          typeof metadata === 'object' &&
+          !Array.isArray(metadata)
+            ? metadata
+            : {}),
+          pricing_status: 'unavailable',
+          reconciliation_required: true,
+        },
+      });
+      context.pricingFailureFinalized = true;
+      throw pricingError;
+    }
     return { billedCredits: 0, providerCostUsd: 0 };
   });
 
@@ -328,7 +380,10 @@ export async function recordMeteredExecutionStep(
           modelId: context.modelId,
           outputTokens: input.outputTokens,
           workspaceId: context.credential.workspaceId,
-        }).catch(() => ({ billedCredits: 0, providerCostUsd: 0 }))
+        }).catch((error) => {
+          if (context.requirePricedUsage) throw error;
+          return { billedCredits: 0, providerCostUsd: 0 };
+        })
       : { billedCredits: 0, providerCostUsd: 0 };
 
   await recordAiStudioRunStep({

--- a/apps/ai/src/lib/sponsored-reservation.test.ts
+++ b/apps/ai/src/lib/sponsored-reservation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ rpc: vi.fn() }));
+vi.mock('@tuturuuu/supabase/next/server', () => ({
+  createAdminClient: async () => ({ schema: () => ({ rpc: mocks.rpc }) }),
+}));
+
+import { beginAiStudioRun } from '@tuturuuu/ai/studio/metering';
+
+const input = {
+  actorId: 'actor',
+  apiKeyId: 'key',
+  feature: 'colab_compile',
+  modelId: 'model',
+  requestId: 'request',
+  reservedCredits: 1,
+  workspaceId: 'root',
+  idempotencyKey: 'job:1',
+  rejectExisting: true,
+};
+describe('transactional sponsored reservation fencing', () => {
+  it.each([0, 100])(
+    'accepts a new reservation with %s remaining credits',
+    async (remaining) => {
+      mocks.rpc.mockResolvedValue({
+        data: [
+          {
+            success: true,
+            run_id: 'run',
+            reservation_id: 'reservation',
+            remaining_credits: remaining,
+          },
+        ],
+        error: null,
+      });
+      await expect(beginAiStudioRun(input)).resolves.toMatchObject({
+        runId: 'run',
+      });
+    }
+  );
+  it('rejects an already committed idempotent run without another database update', async () => {
+    mocks.rpc.mockResolvedValue({
+      data: [
+        {
+          success: true,
+          run_id: 'run',
+          reservation_id: 'reservation',
+          remaining_credits: null,
+        },
+      ],
+      error: null,
+    });
+    await expect(beginAiStudioRun(input)).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+  it('rejects a concurrent unique-key loser whose transaction rolls back', async () => {
+    mocks.rpc.mockResolvedValue({ data: null, error: { code: '23505' } });
+    await expect(beginAiStudioRun(input)).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+});

--- a/apps/ai/src/lib/text-execution.ts
+++ b/apps/ai/src/lib/text-execution.ts
@@ -72,10 +72,14 @@ export async function executeTextRequest(
     credential,
     feature,
     responseShape,
+    metadata,
+    requirePricedUsage = false,
   }: {
     credential?: PublicAiCredential;
     feature: string;
     responseShape: 'chat' | 'responses';
+    metadata?: Record<string, Json>;
+    requirePricedUsage?: boolean;
   }
 ): Promise<Response> {
   let context: Awaited<ReturnType<typeof prepareMeteredExecution>> | undefined;
@@ -100,6 +104,7 @@ export async function executeTextRequest(
         outputTokens: input.max_output_tokens,
       },
       metadata: {
+        ...metadata,
         max_steps: input.max_steps,
         operation: auditHeader(request, 'x-tuturuuu-operation'),
         entity_id: auditHeader(request, 'x-tuturuuu-entity-id'),
@@ -113,6 +118,7 @@ export async function executeTextRequest(
       requiredModelType: 'language',
     });
 
+    context.requirePricedUsage = requirePricedUsage;
     const observed = createObservedTextAgent({
       context,
       instructions: input.instructions,
@@ -152,8 +158,9 @@ export async function executeTextRequest(
 
       reportedUsage = usage;
       usageSource = 'provider';
-      await settleMeteredExecution(context, {
+      const cost = await settleMeteredExecution(context, {
         metadata: {
+          ...metadata,
           finish_reason: String(result.finishReason),
           step_count: result.steps.length,
           tool_call_count: result.toolCalls.length,
@@ -198,7 +205,11 @@ export async function executeTextRequest(
                 prompt_tokens: usage.inputTokens,
                 total_tokens: usage.inputTokens + usage.outputTokens,
               },
-              tuturuuu: { steps: observed.summaries() },
+              tuturuuu: {
+                steps: observed.summaries(),
+                run_id: context.runId,
+                billing: cost,
+              },
             }
           : {
               created_at: created,
@@ -220,7 +231,11 @@ export async function executeTextRequest(
                 output_tokens: usage.outputTokens,
                 total_tokens: usage.inputTokens + usage.outputTokens,
               },
-              tuturuuu: { steps: observed.summaries() },
+              tuturuuu: {
+                steps: observed.summaries(),
+                run_id: context.runId,
+                billing: cost,
+              },
             };
 
       return Response.json(body, { headers: commonHeaders(context.requestId) });
@@ -242,6 +257,7 @@ export async function executeTextRequest(
         await settleMeteredExecution(context!, {
           firstTokenLatencyMs,
           metadata: {
+            ...metadata,
             finish_reason: String(finishReason),
             step_count: steps.length,
             tool_call_count: toolCalls.length,
@@ -374,6 +390,7 @@ export async function executeTextRequest(
         status: request.signal.aborted ? 'aborted' : 'failed',
         usage: reportedUsage,
         metadata: {
+          ...metadata,
           usage_source: usageSource,
           ...(objectError
             ? { finish_reason: String(objectError.finishReason) }

--- a/apps/ai/src/lib/text-execution.ts
+++ b/apps/ai/src/lib/text-execution.ts
@@ -115,10 +115,10 @@ export async function executeTextRequest(
       },
       modelId: input.model,
       request,
+      requirePricedUsage,
       requiredModelType: 'language',
     });
 
-    context.requirePricedUsage = requirePricedUsage;
     const observed = createObservedTextAgent({
       context,
       instructions: input.instructions,

--- a/apps/docs/platform/ai/ai-studio.mdx
+++ b/apps/docs/platform/ai/ai-studio.mdx
@@ -166,6 +166,17 @@ execution are not supported.
 
 ## Local verification
 
+### Colab sponsorship accounting
+
+The Colab endpoint deduplicates billing using the validated workshop job ID
+and provider-call sequence. Sponsored models must have a positive known price
+before any reservation or generation starts. A pricing failure during settlement
+finalizes the run as failed and releases the reservation; it does not represent
+free successful usage. Inspect `pricing_status: unavailable` and
+`reconciliation_required: true` in run metadata, restore model pricing, and
+reconcile the retained token counts before treating sponsorship totals as complete.
+Step pricing failures likewise do not create misleading priced-zero steps.
+
 Apply and test the private-schema migrations before running the app:
 
 ```bash

--- a/packages/ai/src/studio/metering.ts
+++ b/packages/ai/src/studio/metering.ts
@@ -115,6 +115,7 @@ export async function calculateAiStudioUsageCost(
 }
 
 export type BeginAiStudioRunInput = {
+  rejectExisting?: boolean;
   actorId: string;
   apiKeyId: string;
   feature: string;
@@ -177,6 +178,19 @@ export async function beginAiStudioRun(
     });
 
   const result = data?.[0];
+  // The transactional RPC returns NULL remaining_credits for an existing run;
+  // a concurrent insert loses the unique idempotency constraint and rolls back.
+  // Fence before provider execution without a second, fallible claim update.
+  if (
+    input.rejectExisting &&
+    (error?.code === '23505' ||
+      (result?.success && result.remaining_credits === null))
+  ) {
+    throw new AiStudioError(
+      'This sponsored request is already running or completed.',
+      { code: 'invalid_request_error', status: 409 }
+    );
+  }
   if (error || !result?.success || !result.run_id || !result.reservation_id) {
     throw reservationError(result?.error_code ?? null);
   }


### PR DESCRIPTION
## Summary
- Add a bounded Colab AI endpoint funded only by root-workspace credits.
- Preserve workshop, team, participant and generation context in billing records.
- Reject unmetered app-bound keys and unknown pricing for sponsorship.

## Validation
- AI Studio tests, type checks and production build passed.
- Repository bun check passed.

## Stack
Foundation for the Colab RISE learning and keyless first-party integration PR. No production configuration is changed by this foundation alone. Merge bottom-up with a merge commit; honor the requested 10-minute review quiet window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metered Colab AI endpoint funded only by root-workspace credits, with workshop, team, participant, and generation context preserved in billing records.

- Bounds sponsored runs to a single step, 4096 output tokens, no tools, and JSON output.
- Rejects non-root workspaces, app-bound keys, and incomplete sponsorship evidence before any generation starts.
- Requires known positive model pricing; unknown or failed pricing fails the run instead of settling as zero credits.
- Failed pricing finalizes the run as failed, releases its reservation, and flags it for reconciliation.
- Fences retries inside the reservation transaction, returning 409 for already-committed or rolled-back duplicate runs.
- Step pricing failures propagate instead of recording priced-zero steps.
- Includes `run_id` and `billing` in the `tuturuuu` metadata of responses.
- Adds the `x-colab-sponsor-workspace` header to successful sponsored responses.

<sup>Written for commit b56e2b066e3ae6184799c457cb3086611dcd6dc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

