### PR TITLE
fix(colab): use a permitted sponsored model

### DIFF
--- a/apps/colab/src/server/sponsored-ai.test.ts
+++ b/apps/colab/src/server/sponsored-ai.test.ts
@@ -77,6 +77,7 @@ describe('sponsored model transport', () => {
     ]);
     const [url, options] = fetcher.mock.calls[0]!;
     expect(url).toBe('https://ai.tuturuuu.com/v1/colab/responses');
+    expect(JSON.parse(options.body).model).toBe('google/gemini-3.5-flash-lite');
     expect(JSON.parse(options.body).sponsorship).toMatchObject({
       workshopId: 'room',
       participantId: 'guest:member',

--- a/apps/colab/src/server/sponsored-ai.ts
+++ b/apps/colab/src/server/sponsored-ai.ts
@@ -29,7 +29,7 @@ export async function sponsoredGeneration(
   );
   const sequence = ++context.sequence;
   const body = JSON.stringify({
-    model: env.COLAB_AI_MODEL || 'google/gemini-2.5-flash',
+    model: env.COLAB_AI_MODEL || 'google/gemini-3.5-flash-lite',
     instructions: system,
     prompt: JSON.stringify(input),
     sponsorship: {

--- a/apps/colab/wrangler.jsonc
+++ b/apps/colab/wrangler.jsonc
@@ -30,7 +30,7 @@
     "APP_ORIGIN": "https://colab.tuturuuu.com",
     "AUTH_ORIGIN": "https://tuturuuu.com",
     "COLAB_REQUIRE_SPONSORSHIP": "true",
-    "COLAB_AI_MODEL": "google/gemini-2.5-flash"
+    "COLAB_AI_MODEL": "google/gemini-3.5-flash-lite"
   },
   "secrets": { "required": ["COLAB_SESSION_SECRET"] },
   "observability": { "enabled": true, "head_sampling_rate": 0.05 }


### PR DESCRIPTION
## Summary
Production browser verification found that the platform model policy excludes Gemini 2.5 Flash. Use the permitted Gemini 3.5 Flash Lite model in both the Worker configuration and transport fallback, and assert the default in the sponsorship test.

## Verification
- 46 Colab tests passed
- Colab production build passed
- Cloudflare deployment dry run passed
- Full repository check is running

Follow-up to #5296 and #5297. User requested early merge and waived the quiet window. No production AI test operations have been used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the sponsored AI model from `google/gemini-2.5-flash` to `google/gemini-3.5-flash-lite`, since the platform model policy doesn't permit Gemini 2.5 Flash.

- Updates the `COLAB_AI_MODEL` default in the transport fallback and Worker configuration.
- Adds a test assertion that the default sponsored model is `google/gemini-3.5-flash-lite`.

<sup>Written for commit 372cd9d31a6e3690a03dc8198049f29970b1ddd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

