### PR TITLE
fix(meet): recover sources-only assistant answers

### DIFF
--- a/apps/docs/platform/features/meet-calls.mdx
+++ b/apps/docs/platform/features/meet-calls.mdx
@@ -830,10 +830,10 @@ Provider citation IDs are resolved only against their exact returned sources.
 Older unmapped references show an unavailable-reference badge rather than a guessed
 link, and the source footer is displayed as an expandable list of source cards.
 
-Source metadata is limited to eight distinct URLs and 4,000 serialized characters.
-The answer reserves space for complete source links within the 16,000-character
-saved-message limit; oversized prose stops at a complete Markdown block, or uses
-a safely escaped text prefix when the first block alone exceeds the limit.
+Source metadata is limited to eight URLs and 4,000 characters within the 16,000-character message limit; oversized prose is safely truncated.
+Empty final synthesis reuses only an available grounded public-search answer, without another paid call.
+Otherwise generation fails visibly after incurred usage is accounted for; pending approvals stay private.
+Legacy sources-only replies display an incomplete-answer notice. Sources alone never count as a completed answer.
 
 ### Fast return to ended meetings
 

--- a/apps/meet/messages/en.json
+++ b/apps/meet/messages/en.json
@@ -3827,6 +3827,7 @@
       "assistant_decision_saving": "Saving your decision…",
       "assistant_deny_actions": "Deny actions",
       "assistant_discard_draft": "Discard draft",
+      "assistant_empty_answer": "Mira did not complete this answer. Please ask again; the sources below are not a completed response.",
       "assistant_failed": "Mira could not answer. Please try again.",
       "assistant_only_you": "Only you can see this",
       "assistant_personal_workspace": "Mira · Personal workspace",

--- a/apps/meet/messages/vi.json
+++ b/apps/meet/messages/vi.json
@@ -3827,6 +3827,7 @@
       "assistant_decision_saving": "Đang lưu quyết định của bạn…",
       "assistant_deny_actions": "Từ chối thao tác",
       "assistant_discard_draft": "Bỏ bản nháp",
+      "assistant_empty_answer": "Mira chưa hoàn thành câu trả lời này. Vui lòng hỏi lại; các nguồn bên dưới không phải là câu trả lời hoàn chỉnh.",
       "assistant_failed": "Mira chưa thể trả lời. Vui lòng thử lại.",
       "assistant_only_you": "Chỉ bạn có thể xem",
       "assistant_personal_workspace": "Mira · Không gian cá nhân",

--- a/apps/meet/src/app/api/meet-call/[meetingId]/assistant/route.test.ts
+++ b/apps/meet/src/app/api/meet-call/[meetingId]/assistant/route.test.ts
@@ -268,3 +268,20 @@ it.each(['invalid JSON', JSON.stringify({ messages: [], context: {} })])(
     expect(mocks.answer).not.toHaveBeenCalled();
   }
 );
+
+it('settles usage but never publishes a blank model answer', async () => {
+  mocks.answer.mockResolvedValueOnce({
+    text: '  ',
+    costUsd: 0.001,
+    usage: { available: true, inputTokens: 100, outputTokens: 20 },
+  });
+  await expect(
+    POST(request(), { params: Promise.resolve({ meetingId: 'room' }) })
+  ).rejects.toMatchObject({ status: 503 });
+  expect(mocks.deduct).toHaveBeenCalledOnce();
+  expect(mocks.service).toHaveBeenLastCalledWith(expect.anything(), {
+    action: 'ai.finish',
+    messageId: 'message',
+    costUsd: 0.001,
+  });
+});

--- a/apps/meet/src/features/call/components/chat-message-body.tsx
+++ b/apps/meet/src/features/call/components/chat-message-body.tsx
@@ -36,6 +36,11 @@ export function ChatMessageBody({
     : { text: body, sources: [] };
   return (
     <div className="min-w-0 space-y-3 text-sm leading-relaxed">
+      {assistant && !text.trim() && (
+        <p role="status" className="text-muted-foreground">
+          {t('assistant_empty_answer')}
+        </p>
+      )}
       <Markdown
         text={text}
         remarkPlugins={assistant ? assistantPlugins : userPlugins}

--- a/apps/meet/src/features/call/server/assistant-generation.ts
+++ b/apps/meet/src/features/call/server/assistant-generation.ts
@@ -193,6 +193,11 @@ export async function generateMeetAssistant(
     });
     if (!charge.success)
       throw new MeetCallAccessError(503, 'AI quota accounting failed');
+    if (!answer.text.trim() && !answer.approvals?.length)
+      throw new MeetCallAccessError(
+        503,
+        'AI returned no answer. Please try again.'
+      );
     settlement = answer.privateResult
       ? {
           action: 'ai.review.save',

--- a/apps/meet/src/features/call/server/personal-assistant.test.ts
+++ b/apps/meet/src/features/call/server/personal-assistant.test.ts
@@ -203,3 +203,21 @@ it('reserves search separately, charges multiple actual queries and releases bot
     'search',
   ]);
 });
+
+it('accounts for an empty private generation and reports failure instead of saving a blank reply', async () => {
+  mocks.answer.mockResolvedValueOnce({
+    text: '',
+    searchCount: 0,
+    usage: { available: true, inputTokens: 10, outputTokens: 20 },
+  });
+  await expect(
+    answerPersonalMeetChat('requester', {
+      question: 'Public question',
+      timezone: 'UTC',
+      history: [],
+    })
+  ).rejects.toMatchObject({ status: 503 });
+  expect(mocks.deduct).toHaveBeenCalledOnce();
+  expect(mocks.service).not.toHaveBeenCalled();
+  expect(mocks.release).toHaveBeenCalled();
+});

--- a/apps/meet/src/features/call/server/personal-assistant.ts
+++ b/apps/meet/src/features/call/server/personal-assistant.ts
@@ -133,6 +133,11 @@ export async function answerPersonalMeetChat(
     });
     if (!charge.success)
       throw new MeetCallAccessError(503, 'AI quota accounting failed');
+    if (!answer.text.trim())
+      throw new MeetCallAccessError(
+        503,
+        'AI returned no answer. Please try again.'
+      );
     return { text: answer.text.slice(0, 16000) };
   } finally {
     // Keep the hold through actual deduction: releasing first opens a spending race.

--- a/packages/ai/src/meetings/chat-source-footer.test.ts
+++ b/packages/ai/src/meetings/chat-source-footer.test.ts
@@ -54,3 +54,16 @@ it('keeps a readable escaped prefix when the first paragraph alone is oversized'
   expect(answer.length).toBeGreaterThan(1000);
   expect(answer).toMatch(/\n…\n\n- \[example\.com\]/);
 });
+
+it('does not turn an empty answer into a sources-only success', () => {
+  expect(
+    formatMeetSourceAnswer('  ', [
+      {
+        sourceType: 'url',
+        id: 'ref',
+        url: 'https://example.com',
+        title: 'Source',
+      },
+    ])
+  ).toBe('');
+});

--- a/packages/ai/src/meetings/chat-source-footer.ts
+++ b/packages/ai/src/meetings/chat-source-footer.ts
@@ -46,6 +46,7 @@ export function formatMeetSourceAnswer(
   text: string,
   sources: MeetCitationSource[]
 ) {
+  if (!text.trim()) return '';
   const selected = selectMeetSources(sources);
   const footer = [
     ...new Map(selected.map((source) => [source.url, source])).values(),

--- a/packages/ai/src/meetings/chat.test.ts
+++ b/packages/ai/src/meetings/chat.test.ts
@@ -174,3 +174,91 @@ it('keeps private audience rules explicit and permits searches containing synthe
   );
   expect(mocks.generate).toHaveBeenCalledTimes(2);
 });
+
+it('reuses the grounded public answer when final synthesis is empty without another paid call', async () => {
+  vi.stubEnv('GOOGLE_GENERATIVE_AI_API_KEY', 'synthetic');
+  mocks.generate
+    .mockImplementationOnce(async (input) => {
+      await input.tools.google_search.execute(
+        {},
+        { toolCallId: 'search', messages: [], context: {} }
+      );
+      return { ...result(), text: '  ' };
+    })
+    .mockResolvedValueOnce({
+      ...result(),
+      text: 'Grounded public answer',
+      sources: [
+        {
+          sourceType: 'url',
+          id: 'ref',
+          url: 'https://example.com/info',
+          title: 'Source',
+        },
+      ],
+    });
+  const answer = await answerMeetChat(
+    [],
+    900,
+    'Public organization',
+    model,
+    context
+  );
+  expect(answer.text).toContain('Grounded public answer');
+  expect(answer.text).toContain('https://example.com/info');
+  expect(mocks.generate).toHaveBeenCalledTimes(2);
+  expect(answer.usage.inputTokens).toBe(200);
+});
+it('leaves an unanswerable empty generation empty for the server error path', async () => {
+  vi.stubEnv('GOOGLE_GENERATIVE_AI_API_KEY', 'synthetic');
+  mocks.generate.mockResolvedValue({
+    ...result(),
+    text: '',
+    sources: [{ sourceType: 'url', id: 'ref', url: 'https://example.com' }],
+  });
+  expect((await answerMeetChat([], 900, 'question', model, context)).text).toBe(
+    ''
+  );
+});
+
+it('never substitutes a public search answer for a pending private approval', async () => {
+  vi.stubEnv('GOOGLE_GENERATIVE_AI_API_KEY', 'synthetic');
+  mocks.generate
+    .mockImplementationOnce(async (input) => {
+      await input.tools.google_search.execute(
+        {},
+        { toolCallId: 'search', messages: [], context: {} }
+      );
+      return {
+        ...result(),
+        text: '',
+        content: [
+          {
+            type: 'tool-approval-request',
+            approvalId: 'approve',
+            toolCall: { toolName: 'create_task', input: { name: 'Draft' } },
+          },
+        ],
+      };
+    })
+    .mockResolvedValueOnce({
+      ...result(),
+      text: 'Public answer',
+      sources: [{ sourceType: 'url', id: 'ref', url: 'https://example.com' }],
+    });
+  const answer = await answerMeetChat(
+    [],
+    900,
+    'public question',
+    model,
+    context,
+    {
+      workspaceTools: {
+        create_task: { inputSchema: {}, execute: vi.fn() },
+      } as never,
+    }
+  );
+  expect(answer.privateResult).toBe(true);
+  expect(answer.approvals).toHaveLength(1);
+  expect(answer.text).toBe('');
+});

--- a/packages/ai/src/meetings/chat.ts
+++ b/packages/ai/src/meetings/chat.ts
@@ -159,7 +159,10 @@ export async function answerMeetChat(
             messages: [...initialMessages, ...result.responseMessages],
             text: search.unavailable()
               ? 'Google did not return verified sources for this question. Please try again or ask a more specific public question.'
-              : formatMeetSourceAnswer(result.text, sources),
+              : formatMeetSourceAnswer(
+                  result.text.trim() || (!privateResult ? search.answer() : ''),
+                  sources
+                ),
             ...measureMeetGeneration(
               [
                 ...result.steps.map((step) => ({

--- a/packages/ai/src/meetings/public-chat-search.ts
+++ b/packages/ai/src/meetings/public-chat-search.ts
@@ -20,9 +20,11 @@ export function publicMeetSearch(
   const steps: MeetGenerationStep[] = [];
   const sources: MeetCitationSource[] = [];
   let searched = false;
+  let groundedAnswer = '';
   return {
     steps,
     sources,
+    answer: () => groundedAnswer,
     unavailable: () => searched && sources.length === 0,
     tool: tool({
       description:
@@ -100,8 +102,9 @@ export function publicMeetSearch(
             error:
               'Google did not return grounded sources for this question. No verified web answer is available.',
           };
+        groundedAnswer = resolveMeetCitations(result.text, sources).trim();
         return {
-          answer: resolveMeetCitations(result.text, sources),
+          answer: groundedAnswer,
           sources: [
             ...new Map(
               sources.map(({ url, title }) => [url, { url, title }])


### PR DESCRIPTION
Mira could publish source links even when Gemini returned no final answer, leaving a sources-only bubble. Reuse an existing grounded public-search answer when final synthesis is empty, without another provider call; otherwise report failure after settling incurred usage. Private approvals never use this fallback. Existing sources-only bubbles display an EN/VI incomplete-answer notice.

Validation: full `bun check` passed after repairing the worktree dependency installation; focused generation/source, server/accounting, and private-approval tests passed. Cloudflare validation/build passed in CI. This fixes empty-answer handling; the provider-specific reason for individual empty generations has not been established. Production verification remains pending deployment.
