### PR TITLE
fix(colab): allow concurrent AI work across teams

### DIFF
--- a/apps/colab/scripts/verify-runtime.mjs
+++ b/apps/colab/scripts/verify-runtime.mjs
@@ -6,6 +6,7 @@ import { Miniflare } from 'miniflare';
 import { verifyDirectory } from './verify-directory.mjs';
 import { verifyLearning } from './verify-learning.mjs';
 import { verifyShowcase } from './verify-showcase.mjs';
+import { verifyTeamConcurrency } from './verify-team-concurrency.mjs';
 
 const workerDir =
   process.env.COLAB_TEST_WORKER_DIR ?? '/private/tmp/colab-worker';
@@ -126,6 +127,7 @@ try {
     maxUsers: 4,
     teamCount: 2,
   };
+  await verifyTeamConcurrency(request, owner);
   const denied = await request('/rooms', alice, create);
   assert.equal(denied.status, 403, await denied.text());
   assert.equal(

--- a/apps/colab/scripts/verify-team-concurrency.mjs
+++ b/apps/colab/scripts/verify-team-concurrency.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+
+export async function verifyTeamConcurrency(request, owner) {
+  const created = await request('/rooms', owner, {
+    title: 'Concurrent teams regression',
+    startsAt: null,
+    endsAt: null,
+    maxUsers: 12,
+    teamCount: 4,
+  });
+  assert.equal(created.status, 201, await created.clone().text());
+  const room = await created.json();
+  const path = `/rooms/${room.id}`;
+  for (const team of room.teams) {
+    const saved = await request(`${path}/action`, owner, {
+      action: 'prompt',
+      teamId: team.id,
+      revision: 0,
+      prompt:
+        'Prepare a RISE invitation using approved sources and human review.',
+    });
+    assert.equal(saved.status, 200);
+  }
+  // The fixture delays compilation, so these four jobs overlap in the DO.
+  const pending = room.teams.map((team) =>
+    request(`${path}/ai`, owner, {
+      action: 'compile',
+      teamId: team.id,
+      multiple: false,
+    })
+  );
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const duplicate = await request(`${path}/ai`, owner, {
+    action: 'compile',
+    teamId: room.teams[3].id,
+    multiple: false,
+  });
+  assert.equal(duplicate.status, 409);
+  assert.match(await duplicate.text(), /ai_busy/);
+  for (const response of await Promise.all(pending)) {
+    assert.equal(response.status, 200, await response.clone().text());
+  }
+  const final = await (await request(path, owner)).json();
+  assert.equal(final.aiCalls, 4);
+  assert.ok(
+    final.teams.every((team) => team.skills.length > 0 && team.aiCalls === 1)
+  );
+  const retry = await request(`${path}/ai`, owner, {
+    action: 'compile',
+    teamId: room.teams[3].id,
+    multiple: false,
+  });
+  assert.equal(retry.status, 200, await retry.clone().text());
+  console.log(
+    'Four concurrent teams, duplicate protection, counters and lock release passed'
+  );
+}

--- a/apps/colab/src/server/room.ts
+++ b/apps/colab/src/server/room.ts
@@ -292,10 +292,14 @@ export class ColabRoom extends DurableObject<Env> {
         429
       );
     const now = Date.now();
+    // Independent teams must not block each other's generation. Snapshot
+    // checks below still reject results if the prompt or scenario changes.
+    const jobKey =
+      body.action === 'scenario' ? 'ai-scenario' : `ai-team:${team.id}`;
     const busy = this.ctx.storage.sql
       .exec<{ expires: number }>(
         'SELECT expires FROM limits WHERE key = ?',
-        'ai-job'
+        jobKey
       )
       .toArray()[0];
     requireRule(!busy || busy.expires <= now, 'ai_busy', 409);
@@ -307,7 +311,7 @@ export class ColabRoom extends DurableObject<Env> {
         120_000;
     this.ctx.storage.sql.exec(
       'INSERT OR REPLACE INTO limits(key,count,expires) VALUES(?,1,?)',
-      'ai-job',
+      jobKey,
       job
     );
     room.aiCalls++;
@@ -480,7 +484,7 @@ export class ColabRoom extends DurableObject<Env> {
       } finally {
         this.ctx.storage.sql.exec(
           'DELETE FROM limits WHERE key = ? AND expires = ?',
-          'ai-job',
+          jobKey,
           job
         );
       }


### PR DESCRIPTION
## Summary
- Replace the workshop-wide AI lock with per-team locks and a separate scenario lock.
- Preserve duplicate-job protection, snapshot validation and sponsored usage accounting.
- Add a real Durable Object regression for four overlapping team jobs, duplicate rejection, counters and lock release.

## Verification
- Colab production build passed.
- Full browser/runtime verification passed, including the new four-team concurrency regression and three-browser showcase.
- Full bun check running.

Emergency workshop hotfix: user explicitly authorized immediate production deployment and merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the workshop-wide AI lock with per-team locks plus a separate scenario lock, so a team's AI work no longer blocks other teams. Duplicate-job protection, snapshot validation, and sponsored usage accounting are unchanged.

- Scenario AI jobs still share a single lock across teams.
- Adds a regression test for four overlapping team jobs, duplicate rejection, counters, and lock release.

<sup>Written for commit e78ae902c621aea0ba2b39bc59f43ff4485d4262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

