### PR TITLE
fix(meet): restore workspace switching and personal app entry

### DIFF
--- a/apps/docs/platform/features/meet-calls.mdx
+++ b/apps/docs/platform/features/meet-calls.mdx
@@ -6,7 +6,7 @@ description: Run Tuturuuu Meet video calls on Cloudflare Realtime SFU, including
 
 Tuturuuu Meet calls are Google-Meet-style conferences carried by the
 **Cloudflare Realtime SFU**. This is a different product from Cloudflare Stream
-Live, which powers one-to-many broadcast and is documented separately.
+Live, which powers one-to-many broadcast. Meet opens Personal from the app launcher; use the workspace picker or direct workspace links for team meetings.
 
 Every participant holds exactly **two peer connections** to the SFU — one
 publishing, one subscribing — regardless of room size. Connection count stays

--- a/apps/meet/src/app/[locale]/[wsId]/workspace-select.tsx
+++ b/apps/meet/src/app/[locale]/[wsId]/workspace-select.tsx
@@ -2,20 +2,8 @@
 
 import { WorkspaceSelect as SharedWorkspaceSelect } from '@tuturuuu/ui/custom/workspace-select';
 import { TTR_URL } from '@/constants/common';
+import { resolveMeetWorkspacePath } from '@/lib/workspace-navigation';
 import { fetchWorkspaces } from './actions';
-
-function resolveWorkspacePath({
-  currentPathname,
-  nextSlug,
-}: {
-  currentPathname: string;
-  nextSlug: string;
-}) {
-  return currentPathname.replace(
-    /^((?:\/[a-z]{2})?\/workspace)\/[^/]+/,
-    `$1/${nextSlug}`
-  );
-}
 
 export function WorkspaceSelect({
   disableCreateNewWorkspace,
@@ -35,7 +23,7 @@ export function WorkspaceSelect({
       hideLeading={hideLeading}
       platformWorkspaceSetupUrl={TTR_URL}
       standalone={standalone}
-      resolveNextPathname={resolveWorkspacePath}
+      resolveNextPathname={resolveMeetWorkspacePath}
       wsId={wsId}
     />
   );

--- a/apps/meet/src/lib/workspace-navigation.test.ts
+++ b/apps/meet/src/lib/workspace-navigation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveMeetWorkspacePath } from './workspace-navigation';
+
+vi.mock('@/i18n/routing', () => ({ supportedLocales: ['en', 'vi'] }));
+
+describe('Meet workspace switching', () => {
+  it.each([
+    ['/personal/meetings', '/internal/meetings'],
+    ['/vi/personal/meetings', '/vi/internal/meetings'],
+    ['/en/personal/plans', '/en/internal/plans'],
+    ['/workspace/personal/plans', '/internal/plans'],
+    ['/vi/workspace/personal/meetings', '/vi/internal/meetings'],
+  ])('switches %s while retaining the section and locale', (path, expected) => {
+    expect(
+      resolveMeetWorkspacePath({ currentPathname: path, nextSlug: 'internal' })
+    ).toBe(expected);
+  });
+  it('can return from a team to Personal', () => {
+    expect(
+      resolveMeetWorkspacePath({
+        currentPathname: '/internal/meetings',
+        nextSlug: 'personal',
+      })
+    ).toBe('/personal/meetings');
+  });
+});

--- a/apps/meet/src/lib/workspace-navigation.test.ts
+++ b/apps/meet/src/lib/workspace-navigation.test.ts
@@ -8,8 +8,7 @@ describe('Meet workspace switching', () => {
     ['/personal/meetings', '/internal/meetings'],
     ['/vi/personal/meetings', '/vi/internal/meetings'],
     ['/en/personal/plans', '/en/internal/plans'],
-    ['/workspace/personal/plans', '/internal/plans'],
-    ['/vi/workspace/personal/meetings', '/vi/internal/meetings'],
+    ['/en/workspace/meetings', '/en/internal/meetings'],
   ])('switches %s while retaining the section and locale', (path, expected) => {
     expect(
       resolveMeetWorkspacePath({ currentPathname: path, nextSlug: 'internal' })

--- a/apps/meet/src/lib/workspace-navigation.ts
+++ b/apps/meet/src/lib/workspace-navigation.ts
@@ -11,7 +11,6 @@ export function resolveMeetWorkspacePath({
   const index = supportedLocales.some((locale) => locale === segments[0])
     ? 1
     : 0;
-  if (segments[index] === 'workspace') segments.splice(index, 1);
   segments[index] = nextSlug;
   return `/${segments.join('/')}`;
 }

--- a/apps/meet/src/lib/workspace-navigation.ts
+++ b/apps/meet/src/lib/workspace-navigation.ts
@@ -1,0 +1,17 @@
+import { supportedLocales } from '@/i18n/routing';
+
+export function resolveMeetWorkspacePath({
+  currentPathname,
+  nextSlug,
+}: {
+  currentPathname: string;
+  nextSlug: string;
+}) {
+  const segments = currentPathname.split('/').filter(Boolean);
+  const index = supportedLocales.some((locale) => locale === segments[0])
+    ? 1
+    : 0;
+  if (segments[index] === 'workspace') segments.splice(index, 1);
+  segments[index] = nextSlug;
+  return `/${segments.join('/')}`;
+}

--- a/apps/meet/src/proxy.test.ts
+++ b/apps/meet/src/proxy.test.ts
@@ -105,6 +105,7 @@ vi.mock('next-intl/navigation', () => ({
 
 vi.mock('@/i18n/routing', () => ({
   supportedLocales: ['en', 'vi'],
+  defaultLocale: 'en',
 }));
 
 describe('Meet proxy auth handoff', () => {
@@ -206,7 +207,7 @@ describe('Meet proxy auth handoff', () => {
     expect(mocks.refreshAppSessionForRequest).not.toHaveBeenCalled();
   });
 
-  it('redirects authenticated root requests to default workspace meetings', async () => {
+  it('redirects authenticated root requests to personal workspace meetings', async () => {
     mocks.getAppSessionClaimsFromRequest.mockReturnValue({ sub: 'user-id' });
     mocks.hasWebAppSessionTokenFromRequest.mockReturnValue(true);
     mocks.getCurrentUserDefaultWorkspace.mockResolvedValue({
@@ -218,15 +219,13 @@ describe('Meet proxy auth handoff', () => {
     const response = await proxy(request);
 
     expect(response.headers.get('Location')).toBe(
-      'https://meet.tuturuuu.localhost/team-workspace/meetings'
+      'https://meet.tuturuuu.localhost/personal/meetings'
     );
-    expect(mocks.getCurrentUserDefaultWorkspace).toHaveBeenCalledWith({
-      headers: request.headers,
-    });
+    expect(mocks.getCurrentUserDefaultWorkspace).not.toHaveBeenCalled();
     expect(mocks.propagateAuthCookies).toHaveBeenCalled();
   });
 
-  it('redirects Supabase-authenticated root requests to default workspace meetings', async () => {
+  it('redirects Supabase-authenticated root requests to personal workspace meetings', async () => {
     mocks.hasSupportedSupabaseAuthCookie.mockReturnValue(true);
     mocks.getCurrentUserDefaultWorkspace.mockResolvedValue({
       id: 'team-workspace',
@@ -237,11 +236,9 @@ describe('Meet proxy auth handoff', () => {
     const response = await proxy(request);
 
     expect(response.headers.get('Location')).toBe(
-      'https://meet.tuturuuu.localhost/team-workspace/meetings'
+      'https://meet.tuturuuu.localhost/personal/meetings'
     );
-    expect(mocks.getCurrentUserDefaultWorkspace).toHaveBeenCalledWith({
-      headers: request.headers,
-    });
+    expect(mocks.getCurrentUserDefaultWorkspace).not.toHaveBeenCalled();
   });
 
   it('redirects authenticated login requests back to the normalized next path', async () => {
@@ -264,10 +261,6 @@ describe('Meet proxy auth handoff', () => {
     );
   });
   it.each([
-    [
-      '/workspace/personal?source=sidebar-apps',
-      '/personal/meetings?source=sidebar-apps',
-    ],
     ['/vi/workspace/team', '/vi/team/meetings'],
     ['/workspace/personal/plans', '/personal/plans'],
   ])(
@@ -280,6 +273,35 @@ describe('Meet proxy auth handoff', () => {
       expect(response.headers.get('Location')).toBe(
         `https://meet.tuturuuu.localhost${target}`
       );
+    }
+  );
+  it.each([
+    '/workspace/team?source=sidebar-apps',
+    '/internal/meetings?source=sidebar-apps',
+    '/vi/workspace/team?source=sidebar-apps',
+    '/00000000-0000-0000-0000-000000000000?source=sidebar-apps',
+  ])('opens Personal for implicit launcher context: %s', async (path) => {
+    const response = await proxy(
+      new NextRequest(`https://meet.tuturuuu.localhost${path}`)
+    );
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(
+      `https://meet.tuturuuu.localhost${path.startsWith('/vi/') ? '/vi' : ''}/personal/meetings`
+    );
+  });
+
+  it.each([
+    '/internal/meetings',
+    '/vi/internal/plans',
+    '/r/room-code?source=sidebar-apps',
+  ])(
+    'preserves explicit workspace and meeting destinations: %s',
+    async (path) => {
+      mocks.hasSupportedSupabaseAuthCookie.mockReturnValue(true);
+      const response = await proxy(
+        new NextRequest(`https://meet.tuturuuu.localhost${path}`)
+      );
+      expect(response.headers.get('Location')).toBeNull();
     }
   );
 });

--- a/apps/meet/src/proxy.test.ts
+++ b/apps/meet/src/proxy.test.ts
@@ -277,6 +277,8 @@ describe('Meet proxy auth handoff', () => {
   );
   it.each([
     '/workspace/team?source=sidebar-apps',
+    '/workspace/team/meetings?source=sidebar-apps',
+    '/vi/workspace/team/meetings?source=sidebar-apps',
     '/internal/meetings?source=sidebar-apps',
     '/vi/workspace/team?source=sidebar-apps',
     '/00000000-0000-0000-0000-000000000000?source=sidebar-apps',

--- a/apps/meet/src/proxy.ts
+++ b/apps/meet/src/proxy.ts
@@ -123,7 +123,8 @@ export async function proxy(req: NextRequest): Promise<NextResponse> {
     (hasWorkspaceSlug &&
       (entry.length === 1 ||
         (entry.length === 2 && entry[1] === 'meetings'))) ||
-    (entry.length === 2 && entry[0] === 'workspace');
+    (entry[0] === 'workspace' &&
+      (entry.length === 2 || (entry.length === 3 && entry[2] === 'meetings')));
   if (
     req.nextUrl.searchParams.get('source') === 'sidebar-apps' &&
     isWorkspaceEntry

--- a/apps/meet/src/proxy.ts
+++ b/apps/meet/src/proxy.ts
@@ -13,12 +13,7 @@ import {
   propagateAuthCookies,
   refreshAppSessionForRequest,
 } from '@tuturuuu/auth/proxy';
-import {
-  getCurrentUserDefaultWorkspace,
-  withForwardedInternalApiAuth,
-} from '@tuturuuu/internal-api';
 import { guardApiProxyRequest } from '@tuturuuu/utils/api-proxy-guard';
-import { ROOT_WORKSPACE_ID } from '@tuturuuu/utils/constants';
 import Negotiator from 'negotiator';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -116,6 +111,30 @@ function getLegacyPathRedirect(pathname: string): string | null {
 }
 
 export async function proxy(req: NextRequest): Promise<NextResponse> {
+  // Launcher workspace context is implicit. Explicit Meet workspace links and
+  // room/plan invitations retain their destinations.
+  const entry = getPathSegmentsWithoutLocale(req.nextUrl.pathname);
+  const hasWorkspaceSlug =
+    entry[0] === 'personal' ||
+    entry[0] === 'internal' ||
+    /^[0-9a-f-]{36}$/iu.test(entry[0] ?? '');
+  const isWorkspaceEntry =
+    entry.length === 0 ||
+    (hasWorkspaceSlug &&
+      (entry.length === 1 ||
+        (entry.length === 2 && entry[1] === 'meetings'))) ||
+    (entry.length === 2 && entry[0] === 'workspace');
+  if (
+    req.nextUrl.searchParams.get('source') === 'sidebar-apps' &&
+    isWorkspaceEntry
+  ) {
+    const url = req.nextUrl.clone();
+    const locale = getPathSegments(req.nextUrl.pathname)[0];
+    url.pathname = `${isLocaleSegment(locale) ? `/${locale}` : ''}/personal/meetings`;
+    url.searchParams.delete('source');
+    return NextResponse.redirect(url);
+  }
+
   const legacyPath = getLegacyPathRedirect(req.nextUrl.pathname);
   if (legacyPath) {
     return NextResponse.redirect(
@@ -215,23 +234,15 @@ export async function proxy(req: NextRequest): Promise<NextResponse> {
   }
 
   if (isRootPathOrLocaleRoot(req.nextUrl.pathname) && hasSatelliteSession) {
-    try {
-      const defaultWorkspace = await getCurrentUserDefaultWorkspace(
-        withForwardedInternalApiAuth(authRequestHeaders)
-      );
-      const target = defaultWorkspace?.personal
-        ? 'personal'
-        : defaultWorkspace?.id === ROOT_WORKSPACE_ID
-          ? 'internal'
-          : (defaultWorkspace?.id ?? 'personal');
-      const wsRedirect = NextResponse.redirect(
-        new URL(`/${target}/meetings`, req.nextUrl)
-      );
-      propagateAuthCookies(authRes, wsRedirect);
-      return wsRedirect;
-    } catch (error) {
-      console.error('Error handling Meet root path redirect:', error);
-    }
+    const locale = getPathSegments(req.nextUrl.pathname)[0];
+    const wsRedirect = NextResponse.redirect(
+      new URL(
+        `${isLocaleSegment(locale) ? `/${locale}` : ''}/personal/meetings`,
+        req.nextUrl
+      )
+    );
+    propagateAuthCookies(authRes, wsRedirect);
+    return wsRedirect;
   }
 
   // Continue with locale handling


### PR DESCRIPTION
Meet’s workspace picker still matched the obsolete `/workspace` prefix, so selecting another workspace left the current URL unchanged. Switch the actual workspace segment while preserving language and page section, Legacy entry URLs are normalized by the proxy.

Open authenticated Meet roots and app-launcher entries in Personal. Consume `source=sidebar-apps` for implicit workspace entry, including cached legacy redirects; explicit workspace URLs and room invites retain their destinations. Remove the default-workspace API lookup from root entry.

Validation: 24 focused navigation/proxy/invite tests passed, along with the Cloudflare build, full app tests, type checking, formatting and repository guards. Full `bun check` has one unrelated failure in `scripts/watch-blue-green-deploy.test.js:4116` (expected a trailing slash on `http://host.docker.internal:8001/`). Initial tests inherited NODE_ENV=production; rerunning without it passed React tests. No schema or shared app-launcher changes.
