### PR TITLE
fix(tasks): preserve saved tasks and preload visible lists

### DIFF
--- a/packages/tasks-ui/src/tu-do/boards/boardId/board-column.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/board-column.tsx
@@ -52,6 +52,7 @@ import { normalizeBoardText } from './board-text-utils';
 import type { DragPreviewPosition } from './kanban/dnd/use-kanban-dnd';
 import { isKanbanColumnCollapsed } from './kanban/kanban-column-collapse';
 import { ListActions } from './list-actions';
+import { observeInitialTaskColumn } from './observe-initial-task-column';
 import { statusIcons } from './status-section';
 import type { TaskCardAssigneeMemberSource } from './task-card/task-card';
 import {
@@ -330,17 +331,7 @@ export function BoardColumn({
 
     if (!el) return;
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          loadColumnPage(0);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: '200px' } // Pre-fetch slightly before visible
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
+    return observeInitialTaskColumn(el, () => loadColumnPage(0));
   }, [listState, loadColumnPage]);
 
   useEffect(() => {

--- a/packages/tasks-ui/src/tu-do/boards/boardId/observe-initial-task-column.test.ts
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/observe-initial-task-column.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { observeInitialTaskColumn } from './observe-initial-task-column';
+
+afterEach(() => vi.unstubAllGlobals());
+describe('initial task column loading', () => {
+  it('loads page zero without IntersectionObserver', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+    const load = vi.fn().mockResolvedValue(undefined);
+    observeInitialTaskColumn(document.createElement('div'), load);
+    expect(load).toHaveBeenCalledOnce();
+  });
+  it('only loads on visibility and ignores duplicate or disposed callbacks', () => {
+    let notify: IntersectionObserverCallback;
+    const disconnect = vi.fn();
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe = vi.fn();
+        disconnect = disconnect;
+        constructor(callback: IntersectionObserverCallback) {
+          notify = callback;
+        }
+      }
+    );
+    const load = vi.fn().mockResolvedValue(undefined);
+    const cleanup = observeInitialTaskColumn(
+      document.createElement('div'),
+      load
+    );
+    const emit = (visible: boolean) =>
+      notify(
+        [{ isIntersecting: visible } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      );
+    emit(false);
+    expect(load).not.toHaveBeenCalled();
+    emit(true);
+    emit(true);
+    expect(load).toHaveBeenCalledOnce();
+    cleanup?.();
+    emit(true);
+    expect(load).toHaveBeenCalledOnce();
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/packages/tasks-ui/src/tu-do/boards/boardId/observe-initial-task-column.ts
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/observe-initial-task-column.ts
@@ -1,0 +1,28 @@
+/** Load the first page on visibility, with a fallback for unsupported browsers. */
+export function observeInitialTaskColumn(
+  element: Element,
+  load: () => Promise<unknown>
+) {
+  const request = () => {
+    void load().catch(() => {});
+  };
+  if (typeof IntersectionObserver === 'undefined') {
+    request();
+    return;
+  }
+  let active = true;
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (!active || !entry?.isIntersecting) return;
+      active = false;
+      observer.disconnect();
+      request();
+    },
+    { rootMargin: '200px' }
+  );
+  observer.observe(element);
+  return () => {
+    active = false;
+    observer.disconnect();
+  };
+}

--- a/packages/tasks-ui/src/tu-do/boards/boardId/task-list-load-more.test.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/task-list-load-more.test.tsx
@@ -1,0 +1,123 @@
+import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import type { TaskList } from '@tuturuuu/types/primitives/TaskList';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { VirtualizedTaskList } from './task-list';
+import { TaskListLoadMore } from './task-list-load-more';
+
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+
+vi.mock('@dnd-kit/core', () => ({
+  useDndMonitor: vi.fn(),
+  useDroppable: () => ({ setNodeRef: vi.fn() }),
+}));
+vi.mock('./task', () => ({ MeasuredTaskCard: () => null }));
+
+describe('task list pagination recovery', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('lets keyboard and pointer users load tasks without IntersectionObserver', () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+    const onLoadMore = vi.fn();
+    render(<TaskListLoadMore onLoadMore={onLoadMore} isLoading={false} />);
+    fireEvent.click(screen.getByRole('button', { name: 'load_more' }));
+    expect(onLoadMore).toHaveBeenCalledOnce();
+  });
+
+  it('announces loading and prevents duplicate clicks', () => {
+    const onLoadMore = vi.fn();
+    render(<TaskListLoadMore onLoadMore={onLoadMore} isLoading />);
+    const button = screen.getByRole('button', { name: 'loading_more_tasks' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    fireEvent.click(button);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+  it('keeps pagination reachable when no currently loaded tasks are visible', () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+    const onLoadMore = vi.fn();
+    render(
+      <VirtualizedTaskList
+        tasks={[]}
+        column={{ id: 'list-1' } as TaskList}
+        boardId="board-1"
+        onUpdate={vi.fn()}
+        hasMore
+        onLoadMore={onLoadMore}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'load_more' }));
+    expect(onLoadMore).toHaveBeenCalledOnce();
+  });
+  it('automatically preloads near the column viewport, once per page', () => {
+    const observers: {
+      notify: (visible: boolean) => void;
+      disconnect: ReturnType<typeof vi.fn>;
+      root: Element | Document | null | undefined;
+      margin: string | undefined;
+    }[] = [];
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        disconnect = vi.fn();
+        observe = vi.fn();
+        constructor(
+          callback: IntersectionObserverCallback,
+          options?: IntersectionObserverInit
+        ) {
+          observers.push({
+            notify: (visible) =>
+              callback(
+                [{ isIntersecting: visible } as IntersectionObserverEntry],
+                this as unknown as IntersectionObserver
+              ),
+            disconnect: this.disconnect,
+            root: options?.root,
+            margin: options?.rootMargin,
+          });
+        }
+      }
+    );
+    const onLoadMore = vi.fn();
+    const props = {
+      tasks: [],
+      column: { id: 'list-1' } as TaskList,
+      boardId: 'board-1',
+      onUpdate: vi.fn(),
+      hasMore: true,
+      onLoadMore,
+    };
+    const { container, rerender, unmount } = render(
+      <VirtualizedTaskList {...props} />
+    );
+    expect(observers).toHaveLength(1);
+    expect(observers[0]?.root).toBe(container.firstElementChild);
+    expect(observers[0]?.margin).toBe('200px 0px');
+    act(() => observers[0]?.notify(false));
+    expect(onLoadMore).not.toHaveBeenCalled();
+    act(() => {
+      observers[0]?.notify(true);
+      observers[0]?.notify(true);
+    });
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+    expect(observers[0]?.disconnect).toHaveBeenCalled();
+
+    rerender(<VirtualizedTaskList {...props} isLoadingMore />);
+    expect(observers).toHaveLength(1);
+    act(() => observers[0]?.notify(true));
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+    // A short column can still fit another page: re-observe after loading.
+    rerender(<VirtualizedTaskList {...props} isLoadingMore={false} />);
+    expect(observers).toHaveLength(2);
+    act(() => observers[1]?.notify(true));
+    expect(onLoadMore).toHaveBeenCalledTimes(2);
+    rerender(<VirtualizedTaskList {...props} hasMore={false} />);
+    expect(
+      screen.queryByRole('button', { name: 'load_more' })
+    ).not.toBeInTheDocument();
+    expect(observers[1]?.disconnect).toHaveBeenCalled();
+    unmount();
+    act(() => observers[1]?.notify(true));
+    expect(onLoadMore).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/tasks-ui/src/tu-do/boards/boardId/task-list-load-more.test.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/task-list-load-more.test.tsx
@@ -90,10 +90,14 @@ describe('task list pagination recovery', () => {
     const { container, rerender, unmount } = render(
       <VirtualizedTaskList {...props} />
     );
-    expect(observers).toHaveLength(1);
+    expect(observers).toHaveLength(2);
     expect(observers[0]?.root).toBe(container.firstElementChild);
     expect(observers[0]?.margin).toBe('200px 0px');
+    // Vertical proximity alone must not fetch a horizontally hidden column.
+    act(() => observers[0]?.notify(true));
+    expect(onLoadMore).not.toHaveBeenCalled();
     act(() => observers[0]?.notify(false));
+    act(() => observers[1]?.notify(true));
     expect(onLoadMore).not.toHaveBeenCalled();
     act(() => {
       observers[0]?.notify(true);
@@ -103,21 +107,24 @@ describe('task list pagination recovery', () => {
     expect(observers[0]?.disconnect).toHaveBeenCalled();
 
     rerender(<VirtualizedTaskList {...props} isLoadingMore />);
-    expect(observers).toHaveLength(1);
+    expect(observers).toHaveLength(2);
     act(() => observers[0]?.notify(true));
     expect(onLoadMore).toHaveBeenCalledTimes(1);
     // A short column can still fit another page: re-observe after loading.
     rerender(<VirtualizedTaskList {...props} isLoadingMore={false} />);
-    expect(observers).toHaveLength(2);
-    act(() => observers[1]?.notify(true));
+    expect(observers).toHaveLength(4);
+    act(() => observers[2]?.notify(true));
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+    act(() => observers[3]?.notify(true));
     expect(onLoadMore).toHaveBeenCalledTimes(2);
     rerender(<VirtualizedTaskList {...props} hasMore={false} />);
     expect(
       screen.queryByRole('button', { name: 'load_more' })
     ).not.toBeInTheDocument();
-    expect(observers[1]?.disconnect).toHaveBeenCalled();
+    expect(observers[2]?.disconnect).toHaveBeenCalled();
+    expect(observers[3]?.disconnect).toHaveBeenCalled();
     unmount();
-    act(() => observers[1]?.notify(true));
+    act(() => observers[2]?.notify(true));
     expect(onLoadMore).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/tasks-ui/src/tu-do/boards/boardId/task-list-load-more.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/task-list-load-more.tsx
@@ -21,21 +21,39 @@ export function TaskListLoadMore({
   useEffect(() => {
     const el = sentinelRef.current;
     if (!el || isLoading || typeof IntersectionObserver === 'undefined') return;
+    const root = scrollRootRef?.current ?? null;
     let active = true;
+    let columnVisible = !root;
+    let nearEnd = false;
+    let visibilityObserver: IntersectionObserver | undefined;
+    const requestIfVisible = () => {
+      if (!active || !columnVisible || !nearEnd) return;
+      active = false;
+      observer.disconnect();
+      visibilityObserver?.disconnect();
+      onLoadMore();
+    };
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (active && entry?.isIntersecting) {
-          active = false;
-          observer.disconnect();
-          onLoadMore();
-        }
+        nearEnd = Boolean(entry?.isIntersecting);
+        requestIfVisible();
       },
-      { root: scrollRootRef?.current ?? null, rootMargin: '200px 0px' }
+      { root, rootMargin: '200px 0px' }
     );
+    // An explicit root ignores clipping outside that root. Check the column
+    // against the browser viewport too, so horizontally hidden lists stay idle.
+    if (root) {
+      visibilityObserver = new IntersectionObserver(([entry]) => {
+        columnVisible = Boolean(entry?.isIntersecting);
+        requestIfVisible();
+      });
+      visibilityObserver.observe(root);
+    }
     observer.observe(el);
     return () => {
       active = false;
       observer.disconnect();
+      visibilityObserver?.disconnect();
     };
   }, [onLoadMore, isLoading, scrollRootRef]);
 

--- a/packages/tasks-ui/src/tu-do/boards/boardId/task-list-load-more.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/task-list-load-more.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Loader2 } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { useTranslations } from 'next-intl';
+import { type RefObject, useEffect, useRef } from 'react';
+
+/** Automatic pagination with a keyboard-accessible fallback and loading feedback. */
+export function TaskListLoadMore({
+  onLoadMore,
+  isLoading,
+  scrollRootRef,
+}: {
+  onLoadMore: () => void;
+  isLoading: boolean;
+  scrollRootRef?: RefObject<Element | null>;
+}) {
+  const t = useTranslations('common');
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || isLoading || typeof IntersectionObserver === 'undefined') return;
+    let active = true;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (active && entry?.isIntersecting) {
+          active = false;
+          observer.disconnect();
+          onLoadMore();
+        }
+      },
+      { root: scrollRootRef?.current ?? null, rootMargin: '200px 0px' }
+    );
+    observer.observe(el);
+    return () => {
+      active = false;
+      observer.disconnect();
+    };
+  }, [onLoadMore, isLoading, scrollRootRef]);
+
+  return (
+    <div
+      ref={sentinelRef}
+      className="flex justify-center py-2"
+      aria-live="polite"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="w-full text-muted-foreground"
+        disabled={isLoading}
+        aria-busy={isLoading}
+        onClick={onLoadMore}
+      >
+        {isLoading && (
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        )}
+        {t(isLoading ? 'loading_more_tasks' : 'load_more')}
+      </Button>
+    </div>
+  );
+}

--- a/packages/tasks-ui/src/tu-do/boards/boardId/task-list.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/task-list.tsx
@@ -3,7 +3,7 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { Loader2, MoveRight } from '@tuturuuu/icons';
+import { MoveRight } from '@tuturuuu/icons';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import type { TaskList } from '@tuturuuu/types/primitives/TaskList';
 import { useTranslations } from 'next-intl';
@@ -11,6 +11,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { DragPreviewPosition } from './kanban/dnd/use-kanban-dnd';
 import { MeasuredTaskCard } from './task';
 import type { TaskCardAssigneeMemberSource } from './task-card/task-card';
+import { TaskListLoadMore } from './task-list-load-more';
 
 const VIRTUALIZE_THRESHOLD = 60; // only virtualize for fairly large lists
 const ESTIMATED_ITEM_HEIGHT = 96; // px including margin (space-y-2 gap)
@@ -194,40 +195,6 @@ function TaskListContent({
         );
       })}
     </>
-  );
-}
-
-/** Sentinel element that triggers loading more items when scrolled into view */
-function LoadMoreSentinel({
-  onLoadMore,
-  isLoading,
-}: {
-  onLoadMore: () => void;
-  isLoading: boolean;
-}) {
-  const sentinelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting && !isLoading) {
-          onLoadMore();
-        }
-      },
-      { rootMargin: '200px' }
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [onLoadMore, isLoading]);
-
-  return (
-    <div ref={sentinelRef} className="flex justify-center py-2">
-      {isLoading && (
-        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-      )}
-    </div>
   );
 }
 
@@ -416,8 +383,9 @@ function VirtualizedTaskListInner({
   // Infinite scroll sentinel (rendered after tasks)
   const loadMoreSentinel =
     hasMore && onLoadMore ? (
-      <LoadMoreSentinel
+      <TaskListLoadMore
         onLoadMore={onLoadMore}
+        scrollRootRef={scrollRef}
         isLoading={isLoadingMore ?? false}
       />
     ) : null;
@@ -495,7 +463,6 @@ function VirtualizedTaskListInner({
               />
             </div>
           </div>
-          {loadMoreSentinel}
         </SortableContext>
       ) : (
         <SortableContext
@@ -524,9 +491,9 @@ function VirtualizedTaskListInner({
             taskOrder={tasks}
             readOnly={readOnly}
           />
-          {loadMoreSentinel}
         </SortableContext>
       )}
+      {loadMoreSentinel}
     </div>
   );
 }

--- a/packages/tasks-ui/src/tu-do/shared/__tests__/board-client.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/__tests__/board-client.test.tsx
@@ -177,7 +177,7 @@ describe('BoardClient', () => {
     );
   });
 
-  it('refreshes loaded lists without replacing the board with a limited page', async () => {
+  it('refreshes loaded lists without issuing a board-wide fetch', async () => {
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: {
@@ -207,9 +207,6 @@ describe('BoardClient', () => {
       name: `Saved task ${index}`,
     }));
     queryClient.setQueryData(['tasks', 'board-1'], savedTasks);
-    listWorkspaceTasksMock.mockResolvedValue({
-      tasks: savedTasks.slice(0, 100),
-    });
 
     await act(async () => {
       await getActiveBoardRefresh()?.();

--- a/packages/tasks-ui/src/tu-do/shared/__tests__/board-client.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/__tests__/board-client.test.tsx
@@ -177,7 +177,7 @@ describe('BoardClient', () => {
     );
   });
 
-  it('refreshes board task cache without relationship summaries', async () => {
+  it('refreshes loaded lists without replacing the board with a limited page', async () => {
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: {
@@ -201,16 +201,23 @@ describe('BoardClient', () => {
       expect(getActiveBoardRefresh()).toBeInstanceOf(Function);
     });
 
-    await act(async () => {
-      getActiveBoardRefresh()?.();
+    const savedTasks = Array.from({ length: 120 }, (_, index) => ({
+      id: `task-${index}`,
+      list_id: 'list-1',
+      name: `Saved task ${index}`,
+    }));
+    queryClient.setQueryData(['tasks', 'board-1'], savedTasks);
+    listWorkspaceTasksMock.mockResolvedValue({
+      tasks: savedTasks.slice(0, 100),
     });
 
-    await waitFor(() => {
-      expect(listWorkspaceTasksMock).toHaveBeenCalledWith('board-ws-uuid', {
-        boardId: 'board-1',
-        includeRelationshipSummary: false,
-      });
+    await act(async () => {
+      await getActiveBoardRefresh()?.();
     });
+
+    expect(queryClient.getQueryData(['tasks', 'board-1'])).toEqual(savedTasks);
+    expect(listWorkspaceTasksMock).not.toHaveBeenCalled();
+    expect(revalidateLoadedListsMock).toHaveBeenCalled();
   });
 
   it('uses the shared task board loading state while the board query resolves', () => {

--- a/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader-hydration.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader-hydration.test.tsx
@@ -12,6 +12,7 @@ import { useProgressiveBoardLoader } from '../use-progressive-board-loader';
 
 vi.mock('@tuturuuu/internal-api/tasks', () => ({
   listWorkspaceTasks: vi.fn(),
+  getWorkspaceTask: vi.fn().mockRejectedValue(new Error('Unavailable')),
 }));
 
 const cachedPagination: Record<string, ListPaginationState> = {

--- a/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader-resume.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader-resume.test.tsx
@@ -4,7 +4,11 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
-import { listWorkspaceTasks } from '@tuturuuu/internal-api/tasks';
+import { InternalApiError } from '@tuturuuu/internal-api';
+import {
+  getWorkspaceTask,
+  listWorkspaceTasks,
+} from '@tuturuuu/internal-api/tasks';
 import type { WorkspaceTaskBoard } from '@tuturuuu/types';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import type { ReactNode } from 'react';
@@ -14,6 +18,7 @@ import { useProgressiveBoardLoader } from '../use-progressive-board-loader';
 
 vi.mock('@tuturuuu/internal-api/tasks', () => ({
   listWorkspaceTasks: vi.fn(),
+  getWorkspaceTask: vi.fn().mockRejectedValue(new Error('Unavailable')),
 }));
 
 describe('useProgressiveBoardLoader resume reconciliation', () => {
@@ -107,7 +112,7 @@ describe('useProgressiveBoardLoader resume reconciliation', () => {
     expect(result.current.pagination['list-1']?.hasMore).toBe(true);
   });
 
-  it('retries the failed next page instead of skipping saved tasks', async () => {
+  it('resets pagination after a failed load so retry uses the correct offset', async () => {
     const { result } = renderHook(
       () => useProgressiveBoardLoader('ws-1', 'board-1'),
       { wrapper }
@@ -135,5 +140,30 @@ describe('useProgressiveBoardLoader resume reconciliation', () => {
       )
     );
     expect(vi.mocked(listWorkspaceTasks).mock.lastCall?.[1]?.offset).toBe(50);
+  });
+  it('removes a confirmed deletion from a partial refresh without dropping a displaced task', async () => {
+    const deleted = { id: 'deleted', list_id: 'list-1' } as Task;
+    const displaced = { id: 'displaced', list_id: 'list-1' } as Task;
+    const { result } = renderHook(
+      () =>
+        useProgressiveBoardLoader('ws-1', 'board-1', {
+          'list-1': {
+            page: 0,
+            hasMore: true,
+            totalCount: 100,
+            isLoading: false,
+            isInitialLoad: false,
+          },
+        }),
+      { wrapper }
+    );
+    queryClient.setQueryData(['tasks', 'board-1'], [deleted, displaced]);
+    vi.mocked(listWorkspaceTasks).mockResolvedValue({ tasks: [], count: 100 });
+    vi.mocked(getWorkspaceTask).mockImplementation(async (_ws, id) => {
+      if (id === 'deleted') throw new InternalApiError('Gone', 404);
+      return { task: displaced } as never;
+    });
+    await act(() => result.current.revalidateLoadedLists());
+    expect(queryClient.getQueryData(['tasks', 'board-1'])).toEqual([displaced]);
   });
 });

--- a/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader-resume.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader-resume.test.tsx
@@ -5,9 +5,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 import { listWorkspaceTasks } from '@tuturuuu/internal-api/tasks';
+import type { WorkspaceTaskBoard } from '@tuturuuu/types';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readTaskBoardCache, writeTaskBoardCache } from '../task-board-cache';
 import { useProgressiveBoardLoader } from '../use-progressive-board-loader';
 
 vi.mock('@tuturuuu/internal-api/tasks', () => ({
@@ -21,6 +23,7 @@ describe('useProgressiveBoardLoader resume reconciliation', () => {
   );
 
   beforeEach(() => {
+    localStorage.clear();
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -61,5 +64,76 @@ describe('useProgressiveBoardLoader resume reconciliation', () => {
     } as Task;
 
     expect(await loadThenRevalidate(cachedTask, 0)).toEqual([]);
+  });
+  it('retains a persisted saved task outside the refreshed page after reload and marker expiry', async () => {
+    const savedTask = {
+      id: 'saved-at-end',
+      name: 'Saved at the end of a long list',
+      list_id: 'list-1',
+      _localMutationAt: Date.now() - 60_000,
+    } as unknown as Task;
+    const firstPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `task-${index}`,
+      list_id: 'list-1',
+      name: `Task ${index}`,
+    })) as Task[];
+    writeTaskBoardCache('ws-1', 'board-1', {
+      board: { id: 'board-1' } as WorkspaceTaskBoard,
+      pagination: {
+        'list-1': {
+          page: 0,
+          hasMore: true,
+          totalCount: 51,
+          isLoading: false,
+          isInitialLoad: false,
+        },
+      },
+      tasks: [...firstPage, savedTask],
+    });
+    const restored = readTaskBoardCache('ws-1', 'board-1')!;
+    const { result } = renderHook(
+      () => useProgressiveBoardLoader('ws-1', 'board-1', restored.pagination),
+      { wrapper }
+    );
+    queryClient.setQueryData(['tasks', 'board-1'], restored.tasks);
+    vi.mocked(listWorkspaceTasks).mockResolvedValue({
+      tasks: firstPage,
+      count: 51,
+    });
+    await act(() => result.current.revalidateLoadedLists());
+    expect(
+      queryClient.getQueryData<Task[]>(['tasks', 'board-1'])
+    ).toContainEqual(savedTask);
+    expect(result.current.pagination['list-1']?.hasMore).toBe(true);
+  });
+
+  it('retries the failed next page instead of skipping saved tasks', async () => {
+    const { result } = renderHook(
+      () => useProgressiveBoardLoader('ws-1', 'board-1'),
+      { wrapper }
+    );
+    vi.mocked(listWorkspaceTasks).mockResolvedValueOnce({
+      tasks: [],
+      count: 100,
+    });
+    await act(() => result.current.loadListPage('list-1', 0));
+    vi.mocked(listWorkspaceTasks).mockRejectedValueOnce(new Error('Offline'));
+    await act(async () => {
+      await expect(result.current.loadListPage('list-1', 1)).rejects.toThrow(
+        'Offline'
+      );
+    });
+    expect(result.current.pagination['list-1']).toMatchObject({
+      page: 0,
+      hasMore: true,
+      isLoading: false,
+    });
+    await act(() =>
+      result.current.loadListPage(
+        'list-1',
+        result.current.pagination['list-1']!.page + 1
+      )
+    );
+    expect(vi.mocked(listWorkspaceTasks).mock.lastCall?.[1]?.offset).toBe(50);
   });
 });

--- a/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/__tests__/use-progressive-board-loader.test.tsx
@@ -12,6 +12,7 @@ import { useProgressiveBoardLoader } from '../use-progressive-board-loader';
 
 vi.mock('@tuturuuu/internal-api/tasks', () => ({
   listWorkspaceTasks: vi.fn(),
+  getWorkspaceTask: vi.fn().mockRejectedValue(new Error('Unavailable')),
 }));
 
 describe('useProgressiveBoardLoader', () => {

--- a/packages/tasks-ui/src/tu-do/shared/board-client.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/board-client.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  getWorkspaceTaskBoard,
-  listWorkspaceTasks,
-} from '@tuturuuu/internal-api/tasks';
+import { getWorkspaceTaskBoard } from '@tuturuuu/internal-api/tasks';
 import { useBoardRealtime } from '@tuturuuu/tasks-ui/hooks/useBoardRealtime';
 import type {
   Workspace,
   WorkspaceProductTier,
   WorkspaceTaskBoard,
 } from '@tuturuuu/types';
+import type { Task } from '@tuturuuu/types/primitives/Task';
 import type { TaskList } from '@tuturuuu/types/primitives/TaskList';
 import { useWorkspaceLabels } from '@tuturuuu/utils/task-helper';
 import { useRouter } from 'next/navigation';
@@ -115,15 +113,21 @@ export function BoardClient({
     [board]
   );
 
+  // Progressive per-list loading
+  const progressiveLoader = useProgressiveBoardLoader(
+    boardWorkspaceId,
+    boardId,
+    cachedSnapshot?.pagination
+  );
+
   // Tasks start empty and are populated progressively per-list.
   const { data: tasks = [] } = useQuery({
     queryKey: ['tasks', boardId],
     queryFn: async () => {
-      const result = await listWorkspaceTasks(boardWorkspaceId, {
-        boardId,
-        includeRelationshipSummary: false,
-      });
-      return result.tasks;
+      // This cache contains multiple independently paginated lists. A board-wide
+      // request returns only one page and must never replace the accumulated data.
+      await progressiveLoader.revalidateLoadedLists();
+      return queryClient.getQueryData<Task[]>(['tasks', boardId]) ?? [];
     },
     gcTime: 7 * 24 * 60 * 60_000,
     initialData: cachedSnapshot?.tasks ?? [],
@@ -132,13 +136,6 @@ export function BoardClient({
     refetchOnWindowFocus: false,
     enabled: !!boardWorkspaceId,
   });
-
-  // Progressive per-list loading
-  const progressiveLoader = useProgressiveBoardLoader(
-    boardWorkspaceId,
-    boardId,
-    cachedSnapshot?.pagination
-  );
 
   useEffect(() => {
     if (!board?.id) return;
@@ -224,11 +221,13 @@ export function BoardClient({
         );
       }
 
-      refreshes.push(
-        progressiveLoader.revalidateLoadedLists().catch(() => {
-          // Best effort: direct cache broadcasts still keep the visible board moving.
-        })
-      );
+      if (!invalidateTasks) {
+        refreshes.push(
+          progressiveLoader.revalidateLoadedLists().catch(() => {
+            // Relation broadcasts remain usable while the network is unavailable.
+          })
+        );
+      }
 
       if (options?.includeLists) {
         refreshes.push(

--- a/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.test.ts
+++ b/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.test.ts
@@ -6,7 +6,9 @@ import { confirmMissingBoardTasks } from './confirm-missing-board-tasks';
 
 vi.mock('@tuturuuu/internal-api/tasks', () => ({ getWorkspaceTask: vi.fn() }));
 const task = { id: 'saved', list_id: 'list-1' } as Task;
-beforeEach(() => vi.mocked(getWorkspaceTask).mockReset());
+beforeEach(() => {
+  vi.mocked(getWorkspaceTask).mockReset();
+});
 describe('partial board page membership', () => {
   it('preserves a task displaced to a later page', async () => {
     vi.mocked(getWorkspaceTask).mockResolvedValue({ task } as never);

--- a/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.test.ts
+++ b/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.test.ts
@@ -50,4 +50,20 @@ describe('partial board page membership', () => {
     ]);
     expect(getWorkspaceTask).not.toHaveBeenCalled();
   });
+  it('bounds each refresh and lets later refreshes check the next candidates', async () => {
+    const tasks = Array.from({ length: 100 }, (_, i) => ({
+      ...task,
+      id: `task-${i}`,
+    }));
+    vi.mocked(getWorkspaceTask).mockRejectedValue(
+      new InternalApiError('Gone', 404)
+    );
+    const first = await confirmMissingBoardTasks('ws', 'list-1', tasks);
+    expect(getWorkspaceTask).toHaveBeenCalledTimes(10);
+    expect(first).toEqual(new Set(tasks.slice(0, 10).map((t) => t.id)));
+    vi.mocked(getWorkspaceTask).mockClear();
+    const next = await confirmMissingBoardTasks('ws', 'list-1', tasks, 10);
+    expect(getWorkspaceTask).toHaveBeenCalledTimes(10);
+    expect(next).toEqual(new Set(tasks.slice(10, 20).map((t) => t.id)));
+  });
 });

--- a/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.test.ts
+++ b/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.test.ts
@@ -1,0 +1,51 @@
+import { InternalApiError } from '@tuturuuu/internal-api';
+import { getWorkspaceTask } from '@tuturuuu/internal-api/tasks';
+import type { Task } from '@tuturuuu/types/primitives/Task';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { confirmMissingBoardTasks } from './confirm-missing-board-tasks';
+
+vi.mock('@tuturuuu/internal-api/tasks', () => ({ getWorkspaceTask: vi.fn() }));
+const task = { id: 'saved', list_id: 'list-1' } as Task;
+beforeEach(() => vi.mocked(getWorkspaceTask).mockReset());
+describe('partial board page membership', () => {
+  it('preserves a task displaced to a later page', async () => {
+    vi.mocked(getWorkspaceTask).mockResolvedValue({ task } as never);
+    expect(await confirmMissingBoardTasks('ws', 'list-1', [task])).toEqual(
+      new Set()
+    );
+  });
+  it('removes confirmed deleted records even when later pages remain', async () => {
+    vi.mocked(getWorkspaceTask).mockRejectedValue(
+      new InternalApiError('Gone', 404)
+    );
+    expect(await confirmMissingBoardTasks('ws', 'list-1', [task])).toEqual(
+      new Set(['saved'])
+    );
+  });
+  it('removes soft-deleted tasks and tasks moved out of the list', async () => {
+    vi.mocked(getWorkspaceTask)
+      .mockResolvedValueOnce({
+        task: { ...task, deleted_at: '2026-09-11' },
+      } as never)
+      .mockResolvedValueOnce({ task: { ...task, list_id: 'list-2' } } as never);
+    expect(await confirmMissingBoardTasks('ws', 'list-1', [task])).toEqual(
+      new Set(['saved'])
+    );
+    expect(await confirmMissingBoardTasks('ws', 'list-1', [task])).toEqual(
+      new Set(['saved'])
+    );
+  });
+  it('preserves tasks on transient errors and skips external placements', async () => {
+    vi.mocked(getWorkspaceTask).mockRejectedValue(
+      new InternalApiError('Unavailable', 503)
+    );
+    expect(await confirmMissingBoardTasks('ws', 'list-1', [task])).toEqual(
+      new Set()
+    );
+    vi.mocked(getWorkspaceTask).mockClear();
+    await confirmMissingBoardTasks('ws', 'list-1', [
+      { ...task, is_personal_external: true },
+    ]);
+    expect(getWorkspaceTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.ts
+++ b/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.ts
@@ -2,15 +2,24 @@ import { InternalApiError } from '@tuturuuu/internal-api';
 import { getWorkspaceTask } from '@tuturuuu/internal-api/tasks';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 
+export const MISSING_TASK_CHECK_LIMIT = 10;
+
 /** A partial page cannot prove deletion: check missing records by ID instead. */
 export async function confirmMissingBoardTasks(
   wsId: string,
   listId: string,
-  tasks: Task[]
+  tasks: Task[],
+  offset = 0
 ) {
   const absent = new Set<string>();
   // Personal external cards represent placements, not source-list membership.
-  const candidates = tasks.filter((task) => !task.is_personal_external);
+  const eligible = tasks.filter((task) => !task.is_personal_external);
+  // Bound work on each refresh and rotate through the remaining records later.
+  // Anything not checked stays in the cache.
+  const candidates = Array.from(
+    { length: Math.min(MISSING_TASK_CHECK_LIMIT, eligible.length) },
+    (_, index) => eligible[(offset + index) % eligible.length]!
+  );
   let next = 0;
   await Promise.all(
     Array.from({ length: Math.min(2, candidates.length) }, async () => {

--- a/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.ts
+++ b/packages/tasks-ui/src/tu-do/shared/confirm-missing-board-tasks.ts
@@ -1,0 +1,36 @@
+import { InternalApiError } from '@tuturuuu/internal-api';
+import { getWorkspaceTask } from '@tuturuuu/internal-api/tasks';
+import type { Task } from '@tuturuuu/types/primitives/Task';
+
+/** A partial page cannot prove deletion: check missing records by ID instead. */
+export async function confirmMissingBoardTasks(
+  wsId: string,
+  listId: string,
+  tasks: Task[]
+) {
+  const absent = new Set<string>();
+  // Personal external cards represent placements, not source-list membership.
+  const candidates = tasks.filter((task) => !task.is_personal_external);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(2, candidates.length) }, async () => {
+      for (;;) {
+        const task = candidates[next++];
+        if (!task) return;
+        try {
+          const result = await getWorkspaceTask(wsId, task.id);
+          if (
+            result.task &&
+            (result.task.deleted_at || result.task.list_id !== listId)
+          )
+            absent.add(task.id);
+        } catch (error) {
+          if (error instanceof InternalApiError && error.status === 404)
+            absent.add(task.id);
+          // Network/server errors are not evidence that a saved task is gone.
+        }
+      }
+    })
+  );
+  return absent;
+}

--- a/packages/tasks-ui/src/tu-do/shared/use-progressive-board-loader.ts
+++ b/packages/tasks-ui/src/tu-do/shared/use-progressive-board-loader.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { listWorkspaceTasks } from '@tuturuuu/internal-api/tasks';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { confirmMissingBoardTasks } from './confirm-missing-board-tasks';
 import type {
   ListPaginationState,
   ProgressiveLoaderValue,
@@ -263,6 +264,23 @@ export function useProgressiveBoardLoader(
           ? loadedThrough < exactCount
           : lastPageTasks.length === PAGE_SIZE;
 
+      const refreshedIds = new Set(mergedListTasks.map((task) => task.id));
+      const confirmedAbsent =
+        hasAuthoritativeCount && hasMore
+          ? await confirmMissingBoardTasks(
+              wsId,
+              listId,
+              (
+                queryClient.getQueryData<Task[]>(['tasks', boardId]) ?? []
+              ).filter(
+                (task) =>
+                  task.list_id === listId &&
+                  !refreshedIds.has(task.id) &&
+                  !hasFreshLocalMutation(task)
+              )
+            )
+          : new Set<string>();
+
       queryClient.setQueryData(
         ['tasks', boardId],
         (old: Task[] | undefined) => {
@@ -304,7 +322,7 @@ export function useProgressiveBoardLoader(
             // Tasks appended by creation/search may live beyond the loaded pages.
             if (
               !hasAuthoritativeCount ||
-              hasMore ||
+              (hasMore && !confirmedAbsent.has(task.id)) ||
               hasFreshLocalMutation(task)
             ) {
               merged.push(task);

--- a/packages/tasks-ui/src/tu-do/shared/use-progressive-board-loader.ts
+++ b/packages/tasks-ui/src/tu-do/shared/use-progressive-board-loader.ts
@@ -95,6 +95,7 @@ export function useProgressiveBoardLoader(
       page: number = 0,
       options?: ProgressiveLoadListPageOptions
     ) => {
+      const previousState = paginationRef.current[listId];
       listOptionsRef.current[listId] = options ?? {};
 
       // Guard against duplicate in-flight requests for the same page
@@ -199,7 +200,10 @@ export function useProgressiveBoardLoader(
               totalCount: 0,
               isInitialLoad: false,
             }),
+            // A failed page was never loaded; retry it instead of skipping it.
+            page: previousState?.page ?? -1,
             isLoading: false,
+            isInitialLoad: false,
           },
         }));
         throw error;
@@ -296,7 +300,13 @@ export function useProgressiveBoardLoader(
               continue;
             }
 
-            if (!hasAuthoritativeCount || hasFreshLocalMutation(task)) {
+            // A count describes list size, not membership in this partial window.
+            // Tasks appended by creation/search may live beyond the loaded pages.
+            if (
+              !hasAuthoritativeCount ||
+              hasMore ||
+              hasFreshLocalMutation(task)
+            ) {
               merged.push(task);
             }
           }

--- a/packages/tasks-ui/src/tu-do/shared/use-progressive-board-loader.ts
+++ b/packages/tasks-ui/src/tu-do/shared/use-progressive-board-loader.ts
@@ -4,7 +4,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import { listWorkspaceTasks } from '@tuturuuu/internal-api/tasks';
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { confirmMissingBoardTasks } from './confirm-missing-board-tasks';
+import {
+  confirmMissingBoardTasks,
+  MISSING_TASK_CHECK_LIMIT,
+} from './confirm-missing-board-tasks';
 import type {
   ListPaginationState,
   ProgressiveLoaderValue,
@@ -52,6 +55,7 @@ export function useProgressiveBoardLoader(
   initialPagination: Record<string, ListPaginationState> = EMPTY_PAGINATION
 ): ProgressiveLoaderValue {
   const queryClient = useQueryClient();
+  const missingCheckOffsets = useRef<Record<string, number>>({});
   const [pagination, setPagination] =
     useState<Record<string, ListPaginationState>>(initialPagination);
   const paginationRef =
@@ -265,21 +269,22 @@ export function useProgressiveBoardLoader(
           : lastPageTasks.length === PAGE_SIZE;
 
       const refreshedIds = new Set(mergedListTasks.map((task) => task.id));
+      const missingTasks = (
+        queryClient.getQueryData<Task[]>(['tasks', boardId]) ?? []
+      ).filter(
+        (task) =>
+          task.list_id === listId &&
+          !task.is_personal_external &&
+          !refreshedIds.has(task.id) &&
+          !hasFreshLocalMutation(task)
+      );
+      const offset = missingCheckOffsets.current[listId] ?? 0;
       const confirmedAbsent =
         hasAuthoritativeCount && hasMore
-          ? await confirmMissingBoardTasks(
-              wsId,
-              listId,
-              (
-                queryClient.getQueryData<Task[]>(['tasks', boardId]) ?? []
-              ).filter(
-                (task) =>
-                  task.list_id === listId &&
-                  !refreshedIds.has(task.id) &&
-                  !hasFreshLocalMutation(task)
-              )
-            )
+          ? await confirmMissingBoardTasks(wsId, listId, missingTasks, offset)
           : new Set<string>();
+      missingCheckOffsets.current[listId] =
+        (offset + MISSING_TASK_CHECK_LIMIT) % Math.max(1, missingTasks.length);
 
       queryClient.setQueryData(
         ['tasks', boardId],


### PR DESCRIPTION
Saved tasks could disappear after refreshing a board because a board-wide request replaced the accumulated cache with only 100 tasks, and per-list revalidation removed tasks beyond its first 50 records. Refresh now reconciles the loaded list pages and preserves saved tasks outside a partial response; failed page requests keep the correct retry position.

Task columns automatically preload the next page within 200 pixels of their scroll viewport. Loading continues while the column has room, stops when all pages are loaded, and ignores duplicate/stale observer callbacks. Horizontally hidden columns stay idle, and browsers without IntersectionObserver can still load the first page. An accessible Load more fallback remains available even when the currently loaded tasks are all filtered out.

Partial refreshes verify omitted tasks by ID before removing them. Checks are limited to 10 tasks per list, with two requests in flight and rotating coverage; unverified records and transient errors preserve saved tasks.

Validation:
- Reproduced both disappearing-task regressions before the fix.
- 1,287 task UI tests pass (1 skipped), including cache reload, viewport visibility, fallback loading, deleted-task reconciliation, and bounded verification.
- Full `bun check` passes after workspace setup, including tests, type-check, Biome, source-size, script, translation, and API/auth guards.
- Authenticated browser verification remains outstanding.

Merge only after checks pass, review threads are resolved, and 10 minutes pass without new review/comment activity.
