### PR TITLE
feat(calendar): automatically refresh connected calendars

### DIFF
--- a/packages/ui/src/components/ui/calendar-app/components/calendar-sync-attention-button.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/calendar-sync-attention-button.tsx
@@ -10,7 +10,10 @@ import {
   DialogTrigger,
 } from '../../dialog';
 import { CalendarConnectionsSettingsContent } from './calendar-connections-settings-content';
-import { needsCalendarSyncAttention } from './calendar-sync-recovery';
+import {
+  isCalendarSyncActive,
+  needsCalendarSyncAttention,
+} from './calendar-sync-recovery';
 import type { CalendarConnectionsManagerState } from './use-calendar-connections-manager';
 
 /** Keep recovery visible when the sidebar replaces the header calendar picker. */
@@ -20,49 +23,59 @@ export function CalendarSyncAttentionButton({
   state: CalendarConnectionsManagerState;
 }) {
   const [open, setOpen] = useState(false);
-  const syncing =
-    state.syncMutation.isPending || state.syncHealth?.currentlyRunning;
+  const syncing = isCalendarSyncActive(state);
   const needsAttention = needsCalendarSyncAttention(state);
-  if (!open && !syncing && !needsAttention) return null;
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className={
-            syncing || !needsAttention
-              ? 'gap-1.5 text-muted-foreground'
-              : 'gap-1.5 border-dynamic-orange/40 text-dynamic-orange'
-          }
-        >
-          {syncing ? (
-            <RefreshCw className="size-4 shrink-0 animate-spin" />
-          ) : needsAttention ? (
-            <AlertTriangle className="size-4 shrink-0" />
-          ) : (
-            <CalendarDays className="size-4 shrink-0" />
-          )}
-          <span role="status">
-            {state.t(
-              syncing
-                ? 'syncing_calendars'
-                : needsAttention
-                  ? 'sync_recovery.attention'
-                  : 'manage_calendar_accounts'
-            )}
-          </span>
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>{state.t('manage_calendar_accounts')}</DialogTitle>
-          <DialogDescription>
-            {state.t('manage_calendar_accounts_desc')}
-          </DialogDescription>
-        </DialogHeader>
-        <CalendarConnectionsSettingsContent state={state} />
-      </DialogContent>
-    </Dialog>
+    <>
+      <span role="status" className="sr-only">
+        {needsAttention
+          ? state.t('sync_recovery.attention')
+          : syncing
+            ? state.t('syncing_calendars')
+            : ''}
+      </span>
+      {(open || syncing || needsAttention) && (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className={
+                !needsAttention
+                  ? 'gap-1.5 text-muted-foreground'
+                  : 'gap-1.5 border-dynamic-orange/40 text-dynamic-orange'
+              }
+            >
+              {syncing && !needsAttention ? (
+                <RefreshCw className="size-4 shrink-0 animate-spin" />
+              ) : needsAttention ? (
+                <AlertTriangle className="size-4 shrink-0" />
+              ) : (
+                <CalendarDays className="size-4 shrink-0" />
+              )}
+              <span>
+                {state.t(
+                  needsAttention
+                    ? 'sync_recovery.attention'
+                    : syncing
+                      ? 'syncing_calendars'
+                      : 'manage_calendar_accounts'
+                )}
+              </span>
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle>{state.t('manage_calendar_accounts')}</DialogTitle>
+              <DialogDescription>
+                {state.t('manage_calendar_accounts_desc')}
+              </DialogDescription>
+            </DialogHeader>
+            <CalendarConnectionsSettingsContent state={state} />
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
   );
 }

--- a/packages/ui/src/components/ui/calendar-app/components/calendar-sync-attention-button.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/calendar-sync-attention-button.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, RefreshCw } from '@tuturuuu/icons';
+import { AlertTriangle, CalendarDays, RefreshCw } from '@tuturuuu/icons';
 import { useState } from 'react';
 import { Button } from '../../button';
 import {
@@ -22,7 +22,8 @@ export function CalendarSyncAttentionButton({
   const [open, setOpen] = useState(false);
   const syncing =
     state.syncMutation.isPending || state.syncHealth?.currentlyRunning;
-  if (!open && !syncing && !needsCalendarSyncAttention(state)) return null;
+  const needsAttention = needsCalendarSyncAttention(state);
+  if (!open && !syncing && !needsAttention) return null;
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -30,18 +31,26 @@ export function CalendarSyncAttentionButton({
           variant="outline"
           size="sm"
           className={
-            syncing
+            syncing || !needsAttention
               ? 'gap-1.5 text-muted-foreground'
               : 'gap-1.5 border-dynamic-orange/40 text-dynamic-orange'
           }
         >
           {syncing ? (
             <RefreshCw className="size-4 shrink-0 animate-spin" />
-          ) : (
+          ) : needsAttention ? (
             <AlertTriangle className="size-4 shrink-0" />
+          ) : (
+            <CalendarDays className="size-4 shrink-0" />
           )}
           <span role="status">
-            {state.t(syncing ? 'syncing_calendars' : 'sync_recovery.attention')}
+            {state.t(
+              syncing
+                ? 'syncing_calendars'
+                : needsAttention
+                  ? 'sync_recovery.attention'
+                  : 'manage_calendar_accounts'
+            )}
           </span>
         </Button>
       </DialogTrigger>

--- a/packages/ui/src/components/ui/calendar-app/components/calendar-sync-attention-button.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/calendar-sync-attention-button.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from '@tuturuuu/icons';
+import { AlertTriangle, RefreshCw } from '@tuturuuu/icons';
 import { useState } from 'react';
 import { Button } from '../../button';
 import {
@@ -20,17 +20,29 @@ export function CalendarSyncAttentionButton({
   state: CalendarConnectionsManagerState;
 }) {
   const [open, setOpen] = useState(false);
-  if (!open && !needsCalendarSyncAttention(state)) return null;
+  const syncing =
+    state.syncMutation.isPending || state.syncHealth?.currentlyRunning;
+  if (!open && !syncing && !needsCalendarSyncAttention(state)) return null;
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
           variant="outline"
           size="sm"
-          className="gap-1.5 border-dynamic-orange/40 text-dynamic-orange"
+          className={
+            syncing
+              ? 'gap-1.5 text-muted-foreground'
+              : 'gap-1.5 border-dynamic-orange/40 text-dynamic-orange'
+          }
         >
-          <AlertTriangle className="size-4 shrink-0" />
-          {state.t('sync_recovery.attention')}
+          {syncing ? (
+            <RefreshCw className="size-4 shrink-0 animate-spin" />
+          ) : (
+            <AlertTriangle className="size-4 shrink-0" />
+          )}
+          <span role="status">
+            {state.t(syncing ? 'syncing_calendars' : 'sync_recovery.attention')}
+          </span>
         </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">

--- a/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.test.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.test.tsx
@@ -144,3 +144,26 @@ it('keeps an open settings dialog neutral when automatic syncing finishes', () =
   expect(screen.queryByText('sync_recovery.attention')).toBeNull();
   expect(screen.queryByText('syncing_calendars')).toBeNull();
 });
+
+it('keeps reconnection warnings prominent while another calendar syncs', () => {
+  const value = state({
+    providerAccountStatuses: { google: { state: 'reconnect_required' } },
+  });
+  value.syncHealth!.state = 'syncing';
+  value.syncHealth!.currentlyRunning = true;
+  render(<CalendarSyncRecovery state={value} />);
+  expect(screen.getByRole('alert')).toBeVisible();
+  expect(screen.getByText('sync_recovery.attention')).toBeVisible();
+});
+
+it('keeps the status live region mounted before syncing starts', () => {
+  const value = state();
+  value.syncHealth!.state = 'healthy';
+  const view = render(<CalendarSyncAttentionButton state={value} />);
+  const liveRegion = screen.getByRole('status');
+  expect(liveRegion).toHaveTextContent('');
+  value.syncHealth!.currentlyRunning = true;
+  view.rerender(<CalendarSyncAttentionButton state={value} />);
+  expect(screen.getByRole('status')).toBe(liveRegion);
+  expect(liveRegion).toHaveTextContent('syncing_calendars');
+});

--- a/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.test.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.test.tsx
@@ -110,3 +110,18 @@ it('can pause an identified calendar during the retry cooldown without deleting 
   );
   expect(value.syncMutation.mutate).not.toHaveBeenCalled();
 });
+
+it('shows neutral progress for an automatic sync instead of an attention warning', () => {
+  const value = state();
+  value.syncHealth!.state = 'syncing';
+  value.syncHealth!.currentlyRunning = true;
+  value.manualSyncDisabled = true;
+  render(<CalendarSyncRecovery state={value} />);
+  expect(screen.queryByText('sync_recovery.attention')).toBeNull();
+  expect(screen.getByRole('status')).toBeVisible();
+  expect(screen.queryByRole('alert')).toBeNull();
+  expect(screen.getByText('sync_recovery.syncing_description')).toBeVisible();
+  expect(
+    screen.getByRole('button', { name: 'syncing_calendars' })
+  ).toBeDisabled();
+});

--- a/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.test.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.test.tsx
@@ -1,10 +1,15 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { CalendarSyncAttentionButton } from './calendar-sync-attention-button';
 import {
   CalendarSyncRecovery,
   needsCalendarSyncAttention,
 } from './calendar-sync-recovery';
 import type { CalendarConnectionsManagerState } from './use-calendar-connections-manager';
+
+vi.mock('./calendar-connections-settings-content', () => ({
+  CalendarConnectionsSettingsContent: () => <div>Settings</div>,
+}));
 
 function state(overrides: Partial<CalendarConnectionsManagerState> = {}) {
   return {
@@ -124,4 +129,18 @@ it('shows neutral progress for an automatic sync instead of an attention warning
   expect(
     screen.getByRole('button', { name: 'syncing_calendars' })
   ).toBeDisabled();
+});
+
+it('keeps an open settings dialog neutral when automatic syncing finishes', () => {
+  const value = state();
+  value.syncHealth!.currentlyRunning = true;
+  value.syncHealth!.state = 'syncing';
+  const view = render(<CalendarSyncAttentionButton state={value} />);
+  fireEvent.click(screen.getByRole('button', { name: 'syncing_calendars' }));
+  value.syncHealth!.currentlyRunning = false;
+  value.syncHealth!.state = 'healthy';
+  view.rerender(<CalendarSyncAttentionButton state={value} />);
+  expect(screen.getByRole('dialog')).toBeVisible();
+  expect(screen.queryByText('sync_recovery.attention')).toBeNull();
+  expect(screen.queryByText('syncing_calendars')).toBeNull();
 });

--- a/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.tsx
@@ -44,8 +44,8 @@ export function needsCalendarSyncAttention(
 
 export function CalendarSyncRecovery({ state }: { state: RecoveryState }) {
   const { t, syncHealth, syncStatusError, providerAccountStatuses } = state;
-  if (!needsCalendarSyncAttention(state) && !state.syncMutation.isPending)
-    return null;
+  const syncing = state.syncMutation.isPending || syncHealth?.currentlyRunning;
+  if (!needsCalendarSyncAttention(state) && !syncing) return null;
   const reconnectAccounts = state.accounts.filter(
     (account) =>
       providerAccountStatuses[account.id]?.state === 'reconnect_required'
@@ -92,17 +92,24 @@ export function CalendarSyncRecovery({ state }: { state: RecoveryState }) {
       reconnectProviders.add(provider);
   }
   return (
-    <Alert className="border-dynamic-orange/30 bg-dynamic-orange/5 text-foreground">
-      <AlertTriangle className="size-4 text-dynamic-orange" />
-      <AlertTitle>{t('sync_recovery.attention')}</AlertTitle>
+    <Alert
+      role={syncing ? 'status' : 'alert'}
+      className={
+        syncing
+          ? 'border-border bg-muted/30 text-foreground'
+          : 'border-dynamic-orange/30 bg-dynamic-orange/5 text-foreground'
+      }
+    >
+      {syncing ? (
+        <RefreshCw className="size-4 animate-spin" />
+      ) : (
+        <AlertTriangle className="size-4 text-dynamic-orange" />
+      )}
+      <AlertTitle>
+        {t(syncing ? 'syncing_calendars' : 'sync_recovery.attention')}
+      </AlertTitle>
       <AlertDescription className="space-y-3">
-        <p>
-          {t(
-            state.syncMutation.isPending
-              ? 'sync_recovery.syncing_description'
-              : description
-          )}
-        </p>
+        <p>{t(syncing ? 'sync_recovery.syncing_description' : description)}</p>
         <p className="text-muted-foreground text-xs">
           {t('sync_recovery.saved_events')}
         </p>
@@ -163,14 +170,10 @@ export function CalendarSyncRecovery({ state }: { state: RecoveryState }) {
                 : state.syncMutation.mutate()
             }
           >
-            <RefreshCw
-              className={
-                state.syncMutation.isPending ? 'size-4 animate-spin' : 'size-4'
-              }
-            />
+            <RefreshCw className={syncing ? 'size-4 animate-spin' : 'size-4'} />
             {syncStatusError
               ? t('sync_recovery.check_again')
-              : state.syncMutation.isPending
+              : syncing
                 ? t('syncing_calendars')
                 : t('sync_now')}
           </Button>

--- a/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/calendar-sync-recovery.tsx
@@ -42,10 +42,17 @@ export function needsCalendarSyncAttention(
   );
 }
 
+export function isCalendarSyncActive(
+  state: Pick<RecoveryState, 'syncMutation' | 'syncHealth'>
+) {
+  return !!(state.syncMutation.isPending || state.syncHealth?.currentlyRunning);
+}
+
 export function CalendarSyncRecovery({ state }: { state: RecoveryState }) {
   const { t, syncHealth, syncStatusError, providerAccountStatuses } = state;
-  const syncing = state.syncMutation.isPending || syncHealth?.currentlyRunning;
-  if (!needsCalendarSyncAttention(state) && !syncing) return null;
+  const syncing = isCalendarSyncActive(state);
+  const needsAttention = needsCalendarSyncAttention(state);
+  if (!needsAttention && !syncing) return null;
   const reconnectAccounts = state.accounts.filter(
     (account) =>
       providerAccountStatuses[account.id]?.state === 'reconnect_required'
@@ -93,23 +100,27 @@ export function CalendarSyncRecovery({ state }: { state: RecoveryState }) {
   }
   return (
     <Alert
-      role={syncing ? 'status' : 'alert'}
+      role={needsAttention ? 'alert' : 'status'}
       className={
-        syncing
-          ? 'border-border bg-muted/30 text-foreground'
-          : 'border-dynamic-orange/30 bg-dynamic-orange/5 text-foreground'
+        needsAttention
+          ? 'border-dynamic-orange/30 bg-dynamic-orange/5 text-foreground'
+          : 'border-border bg-muted/30 text-foreground'
       }
     >
-      {syncing ? (
+      {!needsAttention ? (
         <RefreshCw className="size-4 animate-spin" />
       ) : (
         <AlertTriangle className="size-4 text-dynamic-orange" />
       )}
       <AlertTitle>
-        {t(syncing ? 'syncing_calendars' : 'sync_recovery.attention')}
+        {t(needsAttention ? 'sync_recovery.attention' : 'syncing_calendars')}
       </AlertTitle>
       <AlertDescription className="space-y-3">
-        <p>{t(syncing ? 'sync_recovery.syncing_description' : description)}</p>
+        <p>
+          {t(
+            needsAttention ? description : 'sync_recovery.syncing_description'
+          )}
+        </p>
         <p className="text-muted-foreground text-xs">
           {t('sync_recovery.saved_events')}
         </p>

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
@@ -1,0 +1,230 @@
+import {
+  focusManager,
+  onlineManager,
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import {
+  getWorkspaceCalendarSyncStatus,
+  syncWorkspaceCalendar,
+} from '@tuturuuu/internal-api/calendar';
+import type { CalendarSyncStatusResponse } from '@tuturuuu/internal-api/calendar-sync';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  calendarSyncStatusQueryOptions,
+  refreshCalendarSyncStatus,
+} from './refresh-calendar-sync-status';
+
+vi.mock('@tuturuuu/internal-api/calendar', () => ({
+  getWorkspaceCalendarSyncStatus: vi.fn(),
+  syncWorkspaceCalendar: vi.fn(),
+}));
+const interval = 5 * 60_000;
+let client: QueryClient;
+let status: CalendarSyncStatusResponse;
+const getStatus = vi.mocked(getWorkspaceCalendarSyncStatus);
+const sync = vi.mocked(syncWorkspaceCalendar);
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-09-11T12:00:00Z'));
+  focusManager.setFocused(true);
+  onlineManager.setOnline(true);
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  status = {
+    health: {
+      state: 'degraded',
+      reason: 'sync_stale',
+      currentlyRunning: false,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+      retryAfterSeconds: null,
+    },
+    accountsSummary: { total: 1, google: 1, microsoft: 0 },
+    connectionsSummary: { total: 2, enabled: 2 },
+  };
+  getStatus.mockReset().mockImplementation(async () => structuredClone(status));
+  sync.mockReset().mockImplementation(async () => {
+    status.health = {
+      ...status.health,
+      state: 'healthy',
+      reason: 'ok',
+      lastSuccessAt: new Date().toISOString(),
+    };
+    return { ok: true };
+  });
+});
+afterEach(() => {
+  client.clear();
+  focusManager.setFocused(undefined);
+  onlineManager.setOnline(true);
+  vi.useRealTimers();
+});
+
+describe('automatic provider synchronization', () => {
+  it('imports stale calendars and refreshes every loaded event range without touching other workspaces', async () => {
+    client.setQueryData(['databaseCalendarEvents', 'ws', 'week'], []);
+    client.setQueryData(['databaseCalendarEvents', 'ws', 'month'], []);
+    client.setQueryData(['databaseCalendarEvents', 'other'], []);
+    const result = await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).toHaveBeenCalledExactlyOnceWith('ws');
+    expect(result.health.state).toBe('healthy');
+    expect(
+      client.getQueryState(['databaseCalendarEvents', 'ws', 'week'])
+        ?.isInvalidated
+    ).toBe(true);
+    expect(
+      client.getQueryState(['databaseCalendarEvents', 'ws', 'month'])
+        ?.isInvalidated
+    ).toBe(true);
+    expect(
+      client.getQueryState(['databaseCalendarEvents', 'other'])?.isInvalidated
+    ).toBe(false);
+  });
+
+  it.each(['paused', 'disconnected', 'syncing'] as const)(
+    'does not start a sync when %s',
+    async (state) => {
+      status.health.state = state;
+      status.health.currentlyRunning = state === 'syncing';
+      await refreshCalendarSyncStatus(client, 'ws');
+      expect(sync).not.toHaveBeenCalled();
+    }
+  );
+  it.each(['auth', 'reconnect_required', 'configuration'])(
+    'leaves %s failures for recovery',
+    async (reason) => {
+      status.health.reason = reason;
+      await refreshCalendarSyncStatus(client, 'ws');
+      expect(sync).not.toHaveBeenCalled();
+    }
+  );
+  it('honors cooldowns, disabled calendars and the active-sync switch', async () => {
+    status.health.retryAfterSeconds = 30;
+    await refreshCalendarSyncStatus(client, 'ws');
+    status.health.retryAfterSeconds = null;
+    status.connectionsSummary.enabled = 0;
+    await refreshCalendarSyncStatus(client, 'ws');
+    status.connectionsSummary.enabled = 2;
+    await refreshCalendarSyncStatus(client, 'ws', true);
+    expect(sync).not.toHaveBeenCalled();
+  });
+  it('waits for an in-flight manual sync', async () => {
+    let finish!: () => void;
+    const mutation = client.getMutationCache().build(client, {
+      mutationKey: ['calendar-provider-sync', 'ws'],
+      mutationFn: () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    });
+    const pending = mutation.execute(undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).not.toHaveBeenCalled();
+    finish();
+    await pending;
+  });
+  it('waits until healthy calendars are five minutes old', async () => {
+    status.health.state = 'healthy';
+    status.health.lastSuccessAt = new Date().toISOString();
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(interval);
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).toHaveBeenCalledOnce();
+  });
+  it('deduplicates overlapping controls while exposing neutral syncing state', async () => {
+    let finish!: () => void;
+    sync.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = () => resolve({ ok: true });
+        })
+    );
+    const first = refreshCalendarSyncStatus(client, 'ws');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(
+      client.getQueryData<CalendarSyncStatusResponse>([
+        'calendar-sync-status',
+        'ws',
+      ])?.health.currentlyRunning
+    ).toBe(true);
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).toHaveBeenCalledOnce();
+    finish();
+    await first;
+  });
+  it('backs off after partial failures and still refreshes imported events', async () => {
+    sync.mockResolvedValue({ ok: false, partialFailure: true });
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ['databaseCalendarEvents', 'ws'],
+    });
+    vi.advanceTimersByTime(interval);
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(interval);
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(interval * 2);
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).toHaveBeenCalledTimes(2);
+  });
+  it('handles network failures quietly and respects provider retry-after', async () => {
+    sync.mockRejectedValueOnce(new Error('Network unavailable'));
+    await expect(
+      refreshCalendarSyncStatus(client, 'ws')
+    ).resolves.toBeDefined();
+    vi.advanceTimersByTime(interval * 2);
+    sync.mockResolvedValueOnce({ ok: false, retryAfterSeconds: 3600 });
+    await refreshCalendarSyncStatus(client, 'ws');
+    vi.advanceTimersByTime(interval * 7);
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).toHaveBeenCalledTimes(2);
+  });
+  it('does not sync while hidden or offline', async () => {
+    focusManager.setFocused(false);
+    await refreshCalendarSyncStatus(client, 'ws');
+    focusManager.setFocused(true);
+    onlineManager.setOnline(false);
+    await refreshCalendarSyncStatus(client, 'ws');
+    expect(sync).not.toHaveBeenCalled();
+  });
+});
+
+it('polls while open and catches up on focus and reconnect without a manual click', async () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  const view = renderHook(
+    () => useQuery(calendarSyncStatusQueryOptions(client, 'ws')),
+    { wrapper }
+  );
+  await act(() => vi.advanceTimersByTimeAsync(1));
+  expect(sync).toHaveBeenCalledTimes(1);
+  await act(() => vi.advanceTimersByTimeAsync(interval));
+  expect(sync).toHaveBeenCalledTimes(2);
+  act(() => focusManager.setFocused(false));
+  await act(() => vi.advanceTimersByTimeAsync(interval * 2));
+  expect(sync).toHaveBeenCalledTimes(2);
+  await act(async () => {
+    focusManager.setFocused(true);
+    await vi.advanceTimersByTimeAsync(1);
+  });
+  expect(sync).toHaveBeenCalledTimes(3);
+  act(() => onlineManager.setOnline(false));
+  await act(() => vi.advanceTimersByTimeAsync(interval * 2));
+  expect(sync).toHaveBeenCalledTimes(3);
+  await act(async () => {
+    onlineManager.setOnline(true);
+    await vi.advanceTimersByTimeAsync(1);
+  });
+  expect(sync).toHaveBeenCalledTimes(4);
+  view.unmount();
+  await act(() => vi.advanceTimersByTimeAsync(interval * 2));
+  expect(sync).toHaveBeenCalledTimes(4);
+});

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
@@ -297,3 +297,25 @@ it('treats a healthy response with no success timestamp as stale but throttles r
   await refreshCalendarSyncStatus(client, 'ws');
   expect(sync).toHaveBeenCalledTimes(2);
 });
+
+it('refreshes event ranges after another session finishes importing, not on its pending response', async () => {
+  const invalidate = vi.spyOn(client, 'invalidateQueries');
+  sync.mockImplementationOnce(async () => {
+    status.health.state = 'syncing';
+    status.health.currentlyRunning = true;
+    return { ok: true, alreadyRunning: true };
+  });
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(invalidate).not.toHaveBeenCalled();
+  status.health.state = 'healthy';
+  status.health.currentlyRunning = false;
+  status.health.lastSuccessAt = new Date().toISOString();
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(invalidate).toHaveBeenCalledWith({
+    queryKey: ['databaseCalendarEvents', 'ws'],
+  });
+  expect(sync).toHaveBeenCalledOnce();
+  invalidate.mockClear();
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(invalidate).not.toHaveBeenCalled();
+});

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tuturuuu/internal-api/calendar';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runCalendarProviderSync } from '../../../../hooks/calendar-provider-sync';
 import {
   calendarSyncStatusQueryOptions,
   refreshCalendarSyncStatus,
@@ -227,4 +228,54 @@ it('polls while open and catches up on focus and reconnect without a manual clic
   view.unmount();
   await act(() => vi.advanceTimersByTimeAsync(interval * 2));
   expect(sync).toHaveBeenCalledTimes(4);
+});
+
+it('shares provider work with legacy/manual sync started during a health fetch', async () => {
+  let finishStatus!: (value: CalendarSyncStatusResponse) => void;
+  let finishSync!: () => void;
+  getStatus.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        finishStatus = resolve;
+      })
+  );
+  sync.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        finishSync = () => resolve({ ok: true });
+      })
+  );
+  const polling = refreshCalendarSyncStatus(client, 'ws');
+  const manual = runCalendarProviderSync(client, 'ws');
+  expect(runCalendarProviderSync(client, 'ws')).toBe(manual);
+  finishStatus(structuredClone(status));
+  await polling;
+  expect(sync).toHaveBeenCalledOnce();
+  finishSync();
+  await manual;
+  await runCalendarProviderSync(client, 'ws');
+  expect(sync).toHaveBeenCalledTimes(2);
+});
+
+it('seeds a new session cooldown from the last server failure', async () => {
+  status.health.reason = 'api_limit';
+  status.health.lastFailureAt = new Date().toISOString();
+  await refreshCalendarSyncStatus(client, 'ws');
+  vi.advanceTimersByTime(interval);
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(sync).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(interval);
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(sync).toHaveBeenCalledOnce();
+});
+
+it('checks again shortly when another session already started provider work', async () => {
+  sync.mockResolvedValueOnce({ ok: true, alreadyRunning: true });
+  await refreshCalendarSyncStatus(client, 'ws');
+  vi.advanceTimersByTime(29_999);
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(sync).toHaveBeenCalledTimes(1);
+  vi.advanceTimersByTime(1);
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(sync).toHaveBeenCalledTimes(2);
 });

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
@@ -6,11 +6,11 @@ import {
   useQuery,
 } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
+import type { CalendarSyncStatusResponse } from '@tuturuuu/internal-api/calendar';
 import {
   getWorkspaceCalendarSyncStatus,
   syncWorkspaceCalendar,
 } from '@tuturuuu/internal-api/calendar';
-import type { CalendarSyncStatusResponse } from '@tuturuuu/internal-api/calendar-sync';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.test.tsx
@@ -59,6 +59,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   client.clear();
+  vi.restoreAllMocks();
   focusManager.setFocused(undefined);
   onlineManager.setOnline(true);
   vi.useRealTimers();
@@ -276,6 +277,23 @@ it('checks again shortly when another session already started provider work', as
   await refreshCalendarSyncStatus(client, 'ws');
   expect(sync).toHaveBeenCalledTimes(1);
   vi.advanceTimersByTime(1);
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(sync).toHaveBeenCalledTimes(2);
+});
+
+it('does not sync a hidden document even when the focus manager reports focused', async () => {
+  vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(sync).not.toHaveBeenCalled();
+});
+
+it('treats a healthy response with no success timestamp as stale but throttles retries', async () => {
+  status.health.state = 'healthy';
+  sync.mockResolvedValue({ ok: true });
+  await refreshCalendarSyncStatus(client, 'ws');
+  await refreshCalendarSyncStatus(client, 'ws');
+  expect(sync).toHaveBeenCalledOnce();
+  vi.advanceTimersByTime(interval);
   await refreshCalendarSyncStatus(client, 'ws');
   expect(sync).toHaveBeenCalledTimes(2);
 });

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
@@ -5,10 +5,12 @@ import {
   queryOptions,
 } from '@tanstack/react-query';
 import type { CalendarSyncStatusResponse } from '@tuturuuu/internal-api/calendar';
+import { getWorkspaceCalendarSyncStatus } from '@tuturuuu/internal-api/calendar';
+
 import {
-  getWorkspaceCalendarSyncStatus,
-  syncWorkspaceCalendar,
-} from '@tuturuuu/internal-api/calendar';
+  isCalendarProviderSyncRunning,
+  runCalendarProviderSync,
+} from '../../../../hooks/calendar-provider-sync';
 
 const SYNC_INTERVAL_MS = 5 * 60_000;
 const MAX_BACKOFF_MS = 30 * 60_000;
@@ -54,12 +56,17 @@ export async function refreshCalendarSyncStatus(
   }
   const previous = workspaceAttempts.get(wsId);
   const lastSuccess = Date.parse(health.lastSuccessAt ?? '');
+  const lastFailure = Date.parse(health.lastFailureAt ?? '');
+  const recentFailure =
+    health.state === 'degraded' && now - lastFailure < SYNC_INTERVAL_MS * 2;
   if (
     !focusManager.isFocused() ||
     !onlineManager.isOnline() ||
     (typeof document !== 'undefined' &&
       document.visibilityState === 'hidden') ||
     syncBlocked ||
+    recentFailure ||
+    isCalendarProviderSyncRunning(queryClient, wsId) ||
     queryClient.isMutating({ mutationKey: ['calendar-provider-sync', wsId] }) >
       0 ||
     previous?.running ||
@@ -86,8 +93,11 @@ export async function refreshCalendarSyncStatus(
     health: { ...health, state: 'syncing', currentlyRunning: true },
   });
   let failed = false;
+  let alreadyRunning = false;
   try {
-    const result = await syncWorkspaceCalendar(wsId);
+    const result = await runCalendarProviderSync(queryClient, wsId);
+    alreadyRunning = !!result.alreadyRunning;
+    if (alreadyRunning) attempt.nextAt = Date.now() + 30_000;
     failed = !result.ok;
     if (result.retryAfterSeconds) {
       attempt.nextAt = Math.max(
@@ -100,15 +110,16 @@ export async function refreshCalendarSyncStatus(
     failed = true;
   } finally {
     attempt.running = false;
-    attempt.failures = failed ? attempt.failures + 1 : 0;
-    attempt.nextAt = Math.max(
-      attempt.nextAt,
-      Date.now() +
-        Math.min(
-          MAX_BACKOFF_MS,
-          SYNC_INTERVAL_MS * 2 ** Math.min(attempt.failures, 3)
-        )
-    );
+    if (!alreadyRunning) attempt.failures = failed ? attempt.failures + 1 : 0;
+    if (!alreadyRunning)
+      attempt.nextAt = Math.max(
+        attempt.nextAt,
+        Date.now() +
+          Math.min(
+            MAX_BACKOFF_MS,
+            SYNC_INTERVAL_MS * 2 ** Math.min(attempt.failures, 3)
+          )
+      );
     // Partial imports can still change events. Invalidate every loaded range.
     await Promise.all([
       queryClient.invalidateQueries({

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
@@ -1,0 +1,134 @@
+import {
+  focusManager,
+  onlineManager,
+  type QueryClient,
+  queryOptions,
+} from '@tanstack/react-query';
+import {
+  getWorkspaceCalendarSyncStatus,
+  syncWorkspaceCalendar,
+} from '@tuturuuu/internal-api/calendar';
+import type { CalendarSyncStatusResponse } from '@tuturuuu/internal-api/calendar-sync';
+
+const SYNC_INTERVAL_MS = 5 * 60_000;
+const MAX_BACKOFF_MS = 30 * 60_000;
+type Attempt = { running: boolean; nextAt: number; failures: number };
+// All calendar controls in one app share a coordinator, scoped to their session.
+const attempts = new WeakMap<QueryClient, Map<string, Attempt>>();
+
+export function calendarSyncStatusQueryOptions(
+  queryClient: QueryClient,
+  wsId: string,
+  syncBlocked = false
+) {
+  return queryOptions({
+    queryKey: ['calendar-sync-status', wsId],
+    queryFn: () => refreshCalendarSyncStatus(queryClient, wsId, syncBlocked),
+    enabled: !!wsId,
+    staleTime: 15_000,
+    refetchOnWindowFocus: 'always',
+    refetchOnReconnect: 'always',
+    refetchIntervalInBackground: false,
+    retry: 1,
+    refetchInterval: (query) =>
+      query.state.data?.health.currentlyRunning ||
+      query.state.data?.health.retryAfterSeconds
+        ? 5_000
+        : 30_000,
+  });
+}
+
+/** The foreground health poll also keeps connected providers up to date. */
+export async function refreshCalendarSyncStatus(
+  queryClient: QueryClient,
+  wsId: string,
+  syncBlocked = false
+): Promise<CalendarSyncStatusResponse> {
+  const status = await getWorkspaceCalendarSyncStatus(wsId);
+  const { health } = status;
+  const now = Date.now();
+  let workspaceAttempts = attempts.get(queryClient);
+  if (!workspaceAttempts) {
+    workspaceAttempts = new Map();
+    attempts.set(queryClient, workspaceAttempts);
+  }
+  const previous = workspaceAttempts.get(wsId);
+  const lastSuccess = Date.parse(health.lastSuccessAt ?? '');
+  if (
+    !focusManager.isFocused() ||
+    !onlineManager.isOnline() ||
+    (typeof document !== 'undefined' &&
+      document.visibilityState === 'hidden') ||
+    syncBlocked ||
+    queryClient.isMutating({ mutationKey: ['calendar-provider-sync', wsId] }) >
+      0 ||
+    previous?.running ||
+    (previous?.nextAt ?? 0) > now ||
+    !status.accountsSummary.total ||
+    !status.connectionsSummary.enabled ||
+    health.currentlyRunning ||
+    health.state === 'paused' ||
+    health.state === 'disconnected' ||
+    (health.retryAfterSeconds ?? 0) > 0 ||
+    ['auth', 'reconnect_required', 'configuration'].includes(health.reason) ||
+    (health.state === 'healthy' && now - lastSuccess < SYNC_INTERVAL_MS)
+  )
+    return status;
+
+  const attempt: Attempt = {
+    running: true,
+    nextAt: now + SYNC_INTERVAL_MS,
+    failures: previous?.failures ?? 0,
+  };
+  workspaceAttempts.set(wsId, attempt);
+  queryClient.setQueryData(['calendar-sync-status', wsId], {
+    ...status,
+    health: { ...health, state: 'syncing', currentlyRunning: true },
+  });
+  let failed = false;
+  try {
+    const result = await syncWorkspaceCalendar(wsId);
+    failed = !result.ok;
+    if (result.retryAfterSeconds) {
+      attempt.nextAt = Math.max(
+        attempt.nextAt,
+        Date.now() + result.retryAfterSeconds * 1000
+      );
+    }
+  } catch {
+    // Polling failures stay in the recovery UI; background work never spams toasts.
+    failed = true;
+  } finally {
+    attempt.running = false;
+    attempt.failures = failed ? attempt.failures + 1 : 0;
+    attempt.nextAt = Math.max(
+      attempt.nextAt,
+      Date.now() +
+        Math.min(
+          MAX_BACKOFF_MS,
+          SYNC_INTERVAL_MS * 2 ** Math.min(attempt.failures, 3)
+        )
+    );
+    // Partial imports can still change events. Invalidate every loaded range.
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ['databaseCalendarEvents', wsId],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ['provider-calendar-list', wsId],
+      }),
+    ]);
+  }
+  const refreshed = await getWorkspaceCalendarSyncStatus(wsId);
+  if (failed && refreshed.health.state === 'healthy') {
+    return {
+      ...refreshed,
+      health: {
+        ...refreshed.health,
+        state: 'degraded',
+        reason: 'last_run_failed',
+      },
+    };
+  }
+  return refreshed;
+}

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
@@ -4,11 +4,11 @@ import {
   type QueryClient,
   queryOptions,
 } from '@tanstack/react-query';
+import type { CalendarSyncStatusResponse } from '@tuturuuu/internal-api/calendar';
 import {
   getWorkspaceCalendarSyncStatus,
   syncWorkspaceCalendar,
 } from '@tuturuuu/internal-api/calendar';
-import type { CalendarSyncStatusResponse } from '@tuturuuu/internal-api/calendar-sync';
 
 const SYNC_INTERVAL_MS = 5 * 60_000;
 const MAX_BACKOFF_MS = 30 * 60_000;

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
@@ -18,6 +18,40 @@ type Attempt = { running: boolean; nextAt: number; failures: number };
 // All calendar controls in one app share a coordinator, scoped to their session.
 const attempts = new WeakMap<QueryClient, Map<string, Attempt>>();
 
+const observedHealth = new WeakMap<
+  QueryClient,
+  Map<string, CalendarSyncStatusResponse['health']>
+>();
+
+function observeSyncCompletion(
+  client: QueryClient,
+  wsId: string,
+  status: CalendarSyncStatusResponse
+) {
+  let workspaces = observedHealth.get(client);
+  if (!workspaces) {
+    workspaces = new Map();
+    observedHealth.set(client, workspaces);
+  }
+  const previous = workspaces.get(wsId);
+  const health = status.health;
+  workspaces.set(wsId, { ...health });
+  return (
+    !!previous &&
+    !health.currentlyRunning &&
+    (previous.currentlyRunning ||
+      previous.lastSuccessAt !== health.lastSuccessAt ||
+      previous.lastFailureAt !== health.lastFailureAt)
+  );
+}
+
+async function invalidateImportedEvents(client: QueryClient, wsId: string) {
+  await Promise.all([
+    client.invalidateQueries({ queryKey: ['databaseCalendarEvents', wsId] }),
+    client.invalidateQueries({ queryKey: ['provider-calendar-list', wsId] }),
+  ]);
+}
+
 export function calendarSyncStatusQueryOptions(
   queryClient: QueryClient,
   wsId: string,
@@ -48,6 +82,9 @@ export async function refreshCalendarSyncStatus(
 ): Promise<CalendarSyncStatusResponse> {
   const status = await getWorkspaceCalendarSyncStatus(wsId);
   const { health } = status;
+  if (observeSyncCompletion(queryClient, wsId, status)) {
+    await invalidateImportedEvents(queryClient, wsId);
+  }
   const now = Date.now();
   let workspaceAttempts = attempts.get(queryClient);
   if (!workspaceAttempts) {
@@ -123,17 +160,14 @@ export async function refreshCalendarSyncStatus(
             SYNC_INTERVAL_MS * 2 ** Math.min(attempt.failures, 3)
           )
       );
-    // Partial imports can still change events. Invalidate every loaded range.
-    await Promise.all([
-      queryClient.invalidateQueries({
-        queryKey: ['databaseCalendarEvents', wsId],
-      }),
-      queryClient.invalidateQueries({
-        queryKey: ['provider-calendar-list', wsId],
-      }),
-    ]);
+    // Only completed requests can have imported changes. Remote runs are
+    // observed by subsequent health polls before their ranges are invalidated.
+    if (!alreadyRunning) await invalidateImportedEvents(queryClient, wsId);
   }
   const refreshed = await getWorkspaceCalendarSyncStatus(wsId);
+  const remoteCompleted = observeSyncCompletion(queryClient, wsId, refreshed);
+  if (alreadyRunning && remoteCompleted)
+    await invalidateImportedEvents(queryClient, wsId);
   if (failed && refreshed.health.state === 'healthy') {
     return {
       ...refreshed,

--- a/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
+++ b/packages/ui/src/components/ui/calendar-app/components/refresh-calendar-sync-status.ts
@@ -78,7 +78,10 @@ export async function refreshCalendarSyncStatus(
     health.state === 'disconnected' ||
     (health.retryAfterSeconds ?? 0) > 0 ||
     ['auth', 'reconnect_required', 'configuration'].includes(health.reason) ||
-    (health.state === 'healthy' && now - lastSuccess < SYNC_INTERVAL_MS)
+    // Missing or malformed timestamps are treated as stale, with normal throttling.
+    (health.state === 'healthy' &&
+      Number.isFinite(lastSuccess) &&
+      now - lastSuccess < SYNC_INTERVAL_MS)
   )
     return status;
 

--- a/packages/ui/src/components/ui/calendar-app/components/use-calendar-connections-manager.ts
+++ b/packages/ui/src/components/ui/calendar-app/components/use-calendar-connections-manager.ts
@@ -3,7 +3,6 @@ import {
   getGoogleCalendarAuthUrl,
   getWorkspaceCalendarDefaultSource,
   getWorkspaceCalendarSyncPreferences,
-  getWorkspaceCalendarSyncStatus,
   listCalendarAccounts,
   listProviderCalendars,
   syncWorkspaceCalendar,
@@ -25,6 +24,7 @@ import {
 } from './calendar-connections-manager-helpers';
 import type { AuthResponse } from './calendar-types';
 import { mergeProviderCalendarsByAccount } from './merge-provider-calendars';
+import { calendarSyncStatusQueryOptions } from './refresh-calendar-sync-status';
 
 export type CalendarConnectionsUnifiedVariant =
   | 'compact'
@@ -57,10 +57,12 @@ export function useCalendarConnectionsManager(wsId: string) {
     updateCalendarConnection,
     setCalendarConnections,
     syncToTuturuuu,
+    isActiveSyncOn,
     isSyncing,
   } = useCalendarSync();
 
   const syncMutation = useMutation({
+    mutationKey: ['calendar-provider-sync', wsId],
     mutationFn: () => syncWorkspaceCalendar(wsId),
     onSuccess: (result) => {
       if (!result.ok) toast.error(t('sync_recovery.partial_failure'));
@@ -116,17 +118,13 @@ export function useCalendarConnectionsManager(wsId: string) {
   const accounts = accountsQuery.data?.accounts || [];
   const isLoadingAccounts = accountsQuery.isLoading;
   const hasConnectedAccounts = accounts.length > 0;
-  const syncStatusQuery = useQuery({
-    queryKey: ['calendar-sync-status', wsId],
-    queryFn: () => getWorkspaceCalendarSyncStatus(wsId),
-    staleTime: 15_000,
-    retry: 1,
-    refetchInterval: (query) =>
-      query.state.data?.health.currentlyRunning ||
-      query.state.data?.health.retryAfterSeconds
-        ? 5_000
-        : 30_000,
-  });
+  const syncStatusQuery = useQuery(
+    calendarSyncStatusQueryOptions(
+      queryClient,
+      wsId,
+      isSyncing || !isActiveSyncOn
+    )
+  );
   const syncStatusData = syncStatusQuery.data;
 
   const { data: defaultSourceData } = useQuery({

--- a/packages/ui/src/components/ui/calendar-app/components/use-calendar-connections-manager.ts
+++ b/packages/ui/src/components/ui/calendar-app/components/use-calendar-connections-manager.ts
@@ -5,7 +5,6 @@ import {
   getWorkspaceCalendarSyncPreferences,
   listCalendarAccounts,
   listProviderCalendars,
-  syncWorkspaceCalendar,
   updateCalendarConnection as updateCalendarConnectionRequest,
   updateWorkspaceCalendarDefaultSource,
   updateWorkspaceCalendarSyncPreferences,
@@ -14,6 +13,7 @@ import { createClient } from '@tuturuuu/supabase/next/client';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
+import { runCalendarProviderSync } from '../../../../hooks/calendar-provider-sync';
 import { useCalendarSync } from '../../../../hooks/use-calendar-sync';
 import { toast } from '../../sonner';
 import {
@@ -63,7 +63,7 @@ export function useCalendarConnectionsManager(wsId: string) {
 
   const syncMutation = useMutation({
     mutationKey: ['calendar-provider-sync', wsId],
-    mutationFn: () => syncWorkspaceCalendar(wsId),
+    mutationFn: () => runCalendarProviderSync(queryClient, wsId),
     onSuccess: (result) => {
       if (!result.ok) toast.error(t('sync_recovery.partial_failure'));
       else if (result.alreadyRunning) toast.info(t('syncing_calendars'));

--- a/packages/ui/src/hooks/__tests__/use-calendar-sync.test.tsx
+++ b/packages/ui/src/hooks/__tests__/use-calendar-sync.test.tsx
@@ -50,7 +50,7 @@ function renderCalendarSync({
     </QueryClientProvider>
   );
 
-  return renderHook(() => useCalendarSync(), { wrapper });
+  return { ...renderHook(() => useCalendarSync(), { wrapper }), queryClient };
 }
 
 function mockCalendarFetch(
@@ -569,4 +569,23 @@ describe('CalendarSyncProvider optimistic visible events', () => {
       ]);
     });
   });
+});
+
+it('refetches invalidated event ranges even while the local range cache is fresh', async () => {
+  const fetchMock = mockCalendarFetch([createEvent('before')]);
+  vi.stubGlobal('fetch', fetchMock);
+  const { result, queryClient } = renderCalendarSync();
+  act(() => result.current.setDates(createWeekDates('2026-06-22')));
+  await waitFor(() =>
+    expect(result.current.events.map((event) => event.id)).toEqual(['before'])
+  );
+  fetchMock.mockImplementation(mockCalendarFetch([createEvent('after')]));
+  await act(() =>
+    queryClient.invalidateQueries({
+      queryKey: ['databaseCalendarEvents', 'workspace-1'],
+    })
+  );
+  await waitFor(() =>
+    expect(result.current.events.map((event) => event.id)).toEqual(['after'])
+  );
 });

--- a/packages/ui/src/hooks/calendar-provider-sync.ts
+++ b/packages/ui/src/hooks/calendar-provider-sync.ts
@@ -1,0 +1,33 @@
+import type { QueryClient } from '@tanstack/react-query';
+import {
+  type CalendarSyncResult,
+  syncWorkspaceCalendar,
+} from '@tuturuuu/internal-api/calendar';
+
+const activeRequests = new WeakMap<
+  QueryClient,
+  Map<string, Promise<CalendarSyncResult>>
+>();
+
+export function isCalendarProviderSyncRunning(
+  client: QueryClient,
+  wsId: string
+) {
+  return activeRequests.get(client)?.has(wsId) ?? false;
+}
+
+/** Manual, legacy and automatic controls share the same in-flight request. */
+export function runCalendarProviderSync(client: QueryClient, wsId: string) {
+  let requests = activeRequests.get(client);
+  if (!requests) {
+    requests = new Map();
+    activeRequests.set(client, requests);
+  }
+  const active = requests.get(wsId);
+  if (active) return active;
+  const pending = syncWorkspaceCalendar(wsId).finally(() =>
+    requests.delete(wsId)
+  );
+  requests.set(wsId, pending);
+  return pending;
+}

--- a/packages/ui/src/hooks/use-calendar-sync.tsx
+++ b/packages/ui/src/hooks/use-calendar-sync.tsx
@@ -306,13 +306,7 @@ export const CalendarSyncProvider = ({
     const isCurrentWeek = includesCurrentWeek(dateRange);
     // 30 seconds for current week, 5 minutes for other weeks
     const staleTime = isCurrentWeek ? 30 * 1000 : 5 * 60 * 1000; // 30 seconds
-    const isStale = Date.now() - lastUpdated >= staleTime;
-
-    if (isCurrentWeek && isStale) {
-      // Current week cache is stale, forcing fresh fetch
-    }
-
-    return isStale;
+    return Date.now() - lastUpdated >= staleTime;
   };
 
   const updateCache = useCallback((cacheKey: string, update: CacheUpdate) => {
@@ -412,7 +406,12 @@ export const CalendarSyncProvider = ({
       if (
         cachedData &&
         !isCacheStaleEnhanced(cachedData.dbLastUpdated, dates) &&
-        !isForcedRef.current
+        !isForcedRef.current &&
+        !queryClient.getQueryState([
+          'databaseCalendarEvents',
+          wsId,
+          activeCacheKey,
+        ])?.isInvalidated
       ) {
         return cachedData.dbEvents;
       }

--- a/packages/ui/src/hooks/use-calendar-sync.tsx
+++ b/packages/ui/src/hooks/use-calendar-sync.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  listWorkspaceCalendars,
-  syncWorkspaceCalendar,
-} from '@tuturuuu/internal-api/calendar';
+import { listWorkspaceCalendars } from '@tuturuuu/internal-api/calendar';
 import type {
   Workspace,
   WorkspaceCalendarEvent,
@@ -24,6 +21,7 @@ import {
   useState,
 } from 'react';
 import { toast } from '../components/ui/sonner';
+import { runCalendarProviderSync } from './calendar-provider-sync';
 import {
   type CacheUpdate,
   type CalendarCache,
@@ -596,7 +594,7 @@ export const CalendarSyncProvider = ({
       });
 
       try {
-        const result = await syncWorkspaceCalendar(wsId);
+        const result = await runCalendarProviderSync(queryClient, wsId);
         // Partial imports can change events even when another calendar fails.
         refresh();
         if (!result.ok) throw new Error(result.error || 'Calendar sync failed');
@@ -640,7 +638,7 @@ export const CalendarSyncProvider = ({
         setIsSyncing(false);
       }
     },
-    [wsId, isActiveSyncOn, refresh]
+    [wsId, isActiveSyncOn, refresh, queryClient]
   );
 
   // Trigger refetch from DB when changing views (optimized to reduce load)

--- a/packages/ui/src/hooks/use-calendar.tsx
+++ b/packages/ui/src/hooks/use-calendar.tsx
@@ -5,7 +5,6 @@ import {
   type WorkspaceCalendarEventCreatePayload,
   type WorkspaceCalendarEventUpdatePayload,
 } from '@tuturuuu/internal-api';
-import { syncWorkspaceCalendar } from '@tuturuuu/internal-api/calendar';
 import { createClient } from '@tuturuuu/supabase/next/client';
 import type {
   Workspace,
@@ -16,6 +15,7 @@ import type { SupportedColor } from '@tuturuuu/types/primitives/SupportedColors'
 import { createAllDayEvent } from '@tuturuuu/utils/calendar-utils';
 import dayjs from 'dayjs';
 import moment from 'moment';
+import { runCalendarProviderSync } from './calendar-provider-sync';
 import 'moment/locale/vi';
 import {
   createContext,
@@ -1368,7 +1368,7 @@ export const CalendarProvider = ({
           });
         }
 
-        const result = await syncWorkspaceCalendar(ws.id);
+        const result = await runCalendarProviderSync(queryClient, ws.id);
         await queryClient.invalidateQueries({
           queryKey: ['databaseCalendarEvents', ws.id],
           exact: false,


### PR DESCRIPTION
Connected calendars could remain stale indefinitely while the app only polled their sync status. The foreground health poll now runs inbound provider synchronization when data is at least five minutes old, including catch-up on focus and reconnect.

Manual, legacy and automatic controls share one in-flight provider request. Automatic attempts respect paused calendars, authentication/configuration failures and server cooldowns. Failures back off up to thirty minutes, including a cooldown seeded from server failure timestamps after reload; already-running responses receive a short follow-up. Partial imports still invalidate loaded event ranges. Syncs completed in another tab refresh visible events, and explicit invalidation bypasses the local range cache.

Routine syncing uses neutral, accessible progress without background toast notifications. Reconnection and status failures retain alert priority while other calendars sync. An open settings dialog stays neutral after syncing finishes.

Validation: 56 focused calendar tests passed, covering timed polling, focus/reconnect, unmount cleanup, concurrent manual/automatic controls, paused/offline states, reload cooldowns and failure backoff. Foreground synchronization deliberately retains the existing user-session endpoint cooldown to limit provider load. Full `bun check`, all 989 shared-UI tests, and main/production CI passed. Authenticated Chrome verification confirmed that opening Calendar started synchronization automatically, preserved saved events and cleared the syncing/attention states after completion without a manual sync click.
