### PR TITLE
fix(reports): retain exact smart-search pagination totals

### DIFF
--- a/apps/tanstack-web/migration/route-overrides.json
+++ b/apps/tanstack-web/migration/route-overrides.json
@@ -2397,7 +2397,7 @@
     "api:/api/v1/workspaces/:wsId/users/reports:apps/web/src/app/api/v1/workspaces/[wsId]/users/reports/route.ts": {
       "status": "legacy-next",
       "targetOwner": "rust-backend",
-      "note": "Generation-status filter for draft reports alongside approval and delivery filters. First-class Next.js route; Rust parity pending."
+      "note": "Generation-status filter for draft reports alongside approval and delivery filters; smart search requests exact RPC counts for pagination. First-class Next.js route; Rust parity pending."
     },
     "api:/api/v1/workspaces/:wsId/users/reports/:reportId:apps/web/src/app/api/v1/workspaces/[wsId]/users/reports/[reportId]/route.ts": {
       "status": "legacy-next",

--- a/packages/users-core/src/routes/users/reports/route.ts
+++ b/packages/users-core/src/routes/users/reports/route.ts
@@ -144,14 +144,19 @@ export async function GET(request: Request, { params }: Params) {
                   p_group_ids: string[] | null;
                   p_search: string;
                   p_ws_id: string;
-                }
+                },
+                options: { count: 'exact' }
               ) => typeof fallbackSource
-            )('search_periodic_reports', {
-              p_cadence: parsed.data.cadence,
-              p_group_ids: accessibleGroupIds,
-              p_search: parsed.data.q,
-              p_ws_id: wsId,
-            })
+            )(
+              'search_periodic_reports',
+              {
+                p_cadence: parsed.data.cadence,
+                p_group_ids: accessibleGroupIds,
+                p_search: parsed.data.q,
+                p_ws_id: wsId,
+              },
+              { count: 'exact' }
+            )
           : fallbackSource;
 
       let query = source

--- a/packages/users-core/src/routes/users/reports/search-pagination.test.ts
+++ b/packages/users-core/src/routes/users/reports/search-pagination.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tuturuuu/supabase/next/server', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tuturuuu/supabase/next/server')>();
+  return {
+    ...actual,
+    createAdminClient: () => actual.createAdminClient({ noCookie: true }),
+  };
+});
+vi.mock('../../../lib/user-groups/route-auth', () => ({
+  getUserGroupRoutePermissions: async () => ({
+    containsPermission: () => true,
+  }),
+}));
+vi.mock('../../../lib/user-groups/route-helpers', () => ({
+  resolveUserGroupRouteWorkspaceId: async () => 'workspace',
+  resolveRequestActorAuthUid: async () => 'actor',
+}));
+
+import { GET } from './route';
+
+describe('smart-search pagination through the real Supabase query builder', () => {
+  beforeEach(() => {
+    vi.stubEnv('SUPABASE_SERVER_URL', 'https://reports-counts.test');
+    vi.stubEnv('SUPABASE_SECRET_KEY', 'test-only-key');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([1, 2])('retains the exact total on search page %i', async (page) => {
+    const preferences: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (url.hostname !== 'reports-counts.test')
+          throw new Error('Unexpected network target');
+        const headers = { 'Content-Type': 'application/json' };
+        if (url.pathname.endsWith('/workspaces'))
+          return new Response(
+            JSON.stringify({ id: 'workspace', timezone: 'UTC' }),
+            { headers }
+          );
+        if (url.pathname.endsWith('/rpc/get_periodic_report_counts'))
+          return new Response(JSON.stringify([{ total: 25 }]), { headers });
+        if (!url.pathname.endsWith('/rpc/search_periodic_reports'))
+          throw new Error('Unexpected query');
+        const prefer = new Headers(init?.headers).get('Prefer') ?? '';
+        preferences.push(prefer);
+        const start = Number(url.searchParams.get('offset') ?? 0);
+        const length = Math.min(20, 25 - start);
+        const rows = Array.from({ length }, (_, index) => ({
+          id: `report-${start + index}`,
+          title: 'Matching report',
+        }));
+        return new Response(JSON.stringify(rows), {
+          headers: {
+            ...headers,
+            ...(prefer.includes('count=exact')
+              ? { 'Content-Range': `${start}-${start + length - 1}/25` }
+              : {}),
+          },
+        });
+      })
+    );
+    const response = await GET(
+      new Request(
+        `https://example.com/reports?q=matching&page=${page}&pageSize=20`
+      ),
+      { params: Promise.resolve({ wsId: 'workspace' }) }
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.total).toBe(25);
+    expect(body.data).toHaveLength(page === 1 ? 20 : 5);
+    expect(preferences[0]).toContain('count=exact');
+  });
+});


### PR DESCRIPTION
Searching periodic reports could return matching rows while showing “0 matches” and hiding Load more. Request the exact count in the Supabase RPC options so search totals and pagination reflect the server result.

Validation: a regression using the real Supabase query builder reproduces total 0 before the fix and passes afterward for both pages of 25 matches. Full `bun check` and Contacts/Web production builds passed. Migration tracking is refreshed; no schema change is required.
