### PR TITLE
fix(email): discard hidden titles and preserve report table layout

### DIFF
--- a/packages/email-service/src/providers/__tests__/base.test.ts
+++ b/packages/email-service/src/providers/__tests__/base.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { BaseEmailProvider } from '../base';
+
+class TestEmailProvider extends BaseEmailProvider {
+  name = 'test';
+  async send() {
+    return { success: true };
+  }
+  async validateCredentials() {
+    return true;
+  }
+  html(value: string) {
+    return this.sanitizeHtml(value);
+  }
+  plainText(value: string) {
+    return this.htmlToPlainText(value);
+  }
+}
+
+const provider = new TestEmailProvider();
+const report = `<!doctype html><html><head>
+<meta charset="utf-8"><title>Hidden document title</title>
+<style>.report{color:#123456}</style></head><body>
+<table><tr><td colspan="2"><h1 class="report">Monthly report</h1></td></tr>
+<tr><td rowspan="2">Lessons</td><td>Score: 93</td></tr></table>
+</body></html>`;
+
+describe('email provider document conversion', () => {
+  it('discards document titles while retaining report headings and table layout', async () => {
+    const result = await provider.html(report);
+    expect(result).not.toContain('Hidden document title');
+    expect(result).toContain('Monthly report');
+    expect(result).toContain('colspan="2"');
+    expect(result).toContain('rowspan="2"');
+    expect(result).toMatch(/color: ?#123456/);
+  });
+
+  it('omits head metadata from the plain-text alternative', () => {
+    const result = provider.plainText(report);
+    expect(result).not.toContain('Hidden document title');
+    expect(result).not.toContain('.report');
+    expect(result).toContain('Monthly report');
+    expect(result).toContain('Score: 93');
+  });
+
+  it('retains body text when a sender omits the closing head tag', () => {
+    expect(
+      provider.plainText(
+        '<head><title>Hidden</title><body><h1>Monthly report</h1>'
+      )
+    ).toBe('Monthly report');
+  });
+
+  it('preserves visible header text in plain-text email', () => {
+    expect(
+      provider.plainText('<header>Visible heading</header><p>Body</p>')
+    ).toBe('Visible headingBody');
+  });
+
+  it.each(['title', 'TiTlE'])(
+    'discards %s text from HTML fragments',
+    async (tag) => {
+      const fragment = `<${tag}>Hidden document title</${tag}><h1>Monthly report</h1>`;
+      expect(await provider.html(fragment)).not.toContain(
+        'Hidden document title'
+      );
+      expect(provider.plainText(fragment)).toBe('Monthly report');
+    }
+  );
+});

--- a/packages/email-service/src/providers/__tests__/base.test.ts
+++ b/packages/email-service/src/providers/__tests__/base.test.ts
@@ -57,6 +57,17 @@ describe('email provider document conversion', () => {
     ).toBe('Visible headingBody');
   });
 
+  it.each(['textarea', 'option'])(
+    'discards %s contents in both alternatives',
+    async (tag) => {
+      const fragment = `<${tag}>Hidden control text</${tag}><h1>Monthly report</h1>`;
+      expect(await provider.html(fragment)).not.toContain(
+        'Hidden control text'
+      );
+      expect(provider.plainText(fragment)).toBe('Monthly report');
+    }
+  );
+
   it.each(['title', 'TiTlE'])(
     'discards %s text from HTML fragments',
     async (tag) => {

--- a/packages/email-service/src/providers/__tests__/base.test.ts
+++ b/packages/email-service/src/providers/__tests__/base.test.ts
@@ -60,6 +60,24 @@ describe('email provider document conversion', () => {
     ).toBe('A & B &lt;tag&gt;\n\nOpen (https://example.com?a=1&b=2)');
   });
 
+  it.each([
+    'tel:+84123456789',
+    'cid:report@example.test',
+    'mailto:parent@example.test',
+    'ftp://example.test/report',
+    'custom-app://reports/1',
+  ])('preserves the %s address in plain text', (href) => {
+    expect(provider.plainText(`<a href="${href}">Open</a>`)).toBe(
+      `Open (${href})`
+    );
+  });
+
+  it('keeps the URL safety filter on rendered HTML', async () => {
+    const html = await provider.html('<a href="javascript:alert(1)">Open</a>');
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('Open');
+  });
+
   it('omits head metadata from the plain-text alternative', () => {
     const result = provider.plainText(report);
     expect(result).not.toContain('Hidden document title');

--- a/packages/email-service/src/providers/__tests__/base.test.ts
+++ b/packages/email-service/src/providers/__tests__/base.test.ts
@@ -78,6 +78,14 @@ describe('email provider document conversion', () => {
     expect(html).toContain('Open');
   });
 
+  it('discards raw xmp markup before the CSS inliner reparses it', async () => {
+    const input =
+      '<xmp><img src="x" onerror="unsafe()">Hidden raw text</xmp><h1>Monthly report</h1>';
+    const html = await provider.html(input);
+    expect(html).not.toMatch(/onerror|unsafe|Hidden raw text/);
+    expect(provider.plainText(input)).toBe('Monthly report');
+  });
+
   it('omits head metadata from the plain-text alternative', () => {
     const result = provider.plainText(report);
     expect(result).not.toContain('Hidden document title');
@@ -100,7 +108,7 @@ describe('email provider document conversion', () => {
     ).toBe('Visible headingBody');
   });
 
-  it.each(['textarea', 'option'])(
+  it.each(['textarea', 'option', 'xmp'])(
     'discards %s contents in both alternatives',
     async (tag) => {
       const fragment = `<${tag}>Hidden control text</${tag}><h1>Monthly report</h1>`;

--- a/packages/email-service/src/providers/__tests__/base.test.ts
+++ b/packages/email-service/src/providers/__tests__/base.test.ts
@@ -35,6 +35,31 @@ describe('email provider document conversion', () => {
     expect(result).toMatch(/color: ?#123456/);
   });
 
+  it.each(['title', 'textarea', 'option', 'script', 'style'])(
+    'keeps visible text after a comment mentioning %s',
+    (tag) => {
+      expect(
+        provider.plainText(
+          `<!-- <${tag}> is only an example --><h1>Monthly report</h1>`
+        )
+      ).toBe('Monthly report');
+    }
+  );
+
+  it('does not interpret attribute values as hidden blocks', () => {
+    expect(
+      provider.plainText('<p title="Example <textarea> tag">Visible report</p>')
+    ).toBe('Visible report');
+  });
+
+  it('preserves links and decodes escaped text once', () => {
+    expect(
+      provider.plainText(
+        '<p>A &amp; B &amp;lt;tag&amp;gt;</p><a href="https://example.com?a=1&amp;b=2">Open</a>'
+      )
+    ).toBe('A & B &lt;tag&gt;\n\nOpen (https://example.com?a=1&b=2)');
+  });
+
   it('omits head metadata from the plain-text alternative', () => {
     const result = provider.plainText(report);
     expect(result).not.toContain('Hidden document title');

--- a/packages/email-service/src/providers/base.ts
+++ b/packages/email-service/src/providers/base.ts
@@ -148,6 +148,9 @@ export abstract class BaseEmailProvider implements EmailProvider {
         (tag) => !NON_CONTENT_TAGS.includes(tag)
       ),
       allowedAttributes: { a: ['href'] },
+      // This intermediate markup is never rendered. Preserve href text here;
+      // sanitizeHtml separately enforces URL safety for the HTML alternative.
+      allowedSchemesAppliedToAttributes: [],
       nonTextTags: NON_CONTENT_TAGS,
     });
 

--- a/packages/email-service/src/providers/base.ts
+++ b/packages/email-service/src/providers/base.ts
@@ -12,7 +12,15 @@ import type {
   ProviderSendResult,
 } from '../types';
 
-const NON_CONTENT_TAGS = ['script', 'style', 'textarea', 'option', 'title'];
+// Keep sanitize-html's default non-text exclusions, plus document titles.
+const NON_CONTENT_TAGS = [
+  'script',
+  'style',
+  'textarea',
+  'option',
+  'xmp',
+  'title',
+];
 
 /**
  * Abstract base class for email providers.

--- a/packages/email-service/src/providers/base.ts
+++ b/packages/email-service/src/providers/base.ts
@@ -12,6 +12,8 @@ import type {
   ProviderSendResult,
 } from '../types';
 
+const NON_CONTENT_TAGS = ['script', 'style', 'textarea', 'option', 'title'];
+
 /**
  * Abstract base class for email providers.
  * Implement this class to add support for new email providers.
@@ -83,7 +85,7 @@ export abstract class BaseEmailProvider implements EmailProvider {
         'html',
       ],
       // Discard hidden document titles instead of unwrapping them into body text.
-      nonTextTags: ['script', 'style', 'textarea', 'option', 'title'],
+      nonTextTags: NON_CONTENT_TAGS,
       allowedAttributes: {
         '*': [
           'href',
@@ -134,7 +136,7 @@ export abstract class BaseEmailProvider implements EmailProvider {
   }
 
   /**
-   * Remove non-visible title, script, and style blocks safely.
+   * Remove non-content blocks consistently with HTML sanitization.
    * Uses a loop-based state machine to avoid ReDoS vulnerabilities
    * and properly handle malformed/nested tags.
    * @param html Raw HTML content
@@ -148,10 +150,9 @@ export abstract class BaseEmailProvider implements EmailProvider {
     while (i < len) {
       // Match whole tag names so similarly named elements remain intact.
       if (html[i] === '<' && i + 1 < len) {
-        const remaining = html.slice(i, i + 8).toLowerCase();
-        const tagName = ['script', 'style', 'title'].find(
+        const tagName = NON_CONTENT_TAGS.find(
           (tag) =>
-            remaining.startsWith(`<${tag}`) &&
+            html.slice(i, i + tag.length + 1).toLowerCase() === `<${tag}` &&
             /[\s/>]/u.test(html[i + tag.length + 1] ?? '')
         );
 

--- a/packages/email-service/src/providers/base.ts
+++ b/packages/email-service/src/providers/base.ts
@@ -37,7 +37,7 @@ export abstract class BaseEmailProvider implements EmailProvider {
 
   /**
    * Sanitize HTML content to prevent XSS and ensure email compatibility.
-   * Uses DOMPurify for sanitization and juice for CSS inlining.
+   * Uses sanitize-html for sanitization and juice for CSS inlining.
    * @param html Raw HTML content
    * @returns Sanitized HTML with inlined CSS
    */
@@ -82,6 +82,8 @@ export abstract class BaseEmailProvider implements EmailProvider {
         'body',
         'html',
       ],
+      // Discard hidden document titles instead of unwrapping them into body text.
+      nonTextTags: ['script', 'style', 'textarea', 'option', 'title'],
       allowedAttributes: {
         '*': [
           'href',
@@ -100,6 +102,8 @@ export abstract class BaseEmailProvider implements EmailProvider {
           'cellpadding',
           'cellspacing',
         ],
+        td: ['colspan', 'rowspan'],
+        th: ['colspan', 'rowspan'],
       },
       allowedSchemes: ['http', 'https', 'mailto', 'cid'],
       allowedSchemesByTag: {
@@ -130,24 +134,28 @@ export abstract class BaseEmailProvider implements EmailProvider {
   }
 
   /**
-   * Remove script and style blocks from HTML safely.
+   * Remove non-visible title, script, and style blocks safely.
    * Uses a loop-based state machine to avoid ReDoS vulnerabilities
    * and properly handle malformed/nested tags.
    * @param html Raw HTML content
-   * @returns HTML with script and style blocks removed
+   * @returns HTML with non-visible blocks removed
    */
-  private removeScriptAndStyleBlocks(html: string): string {
+  private removeNonContentBlocks(html: string): string {
     const result: string[] = [];
     let i = 0;
     const len = html.length;
 
     while (i < len) {
-      // Check for opening <script or <style tags (case-insensitive)
+      // Match whole tag names so similarly named elements remain intact.
       if (html[i] === '<' && i + 1 < len) {
         const remaining = html.slice(i, i + 8).toLowerCase();
+        const tagName = ['script', 'style', 'title'].find(
+          (tag) =>
+            remaining.startsWith(`<${tag}`) &&
+            /[\s/>]/u.test(html[i + tag.length + 1] ?? '')
+        );
 
-        if (remaining.startsWith('<script') || remaining.startsWith('<style')) {
-          const tagName = remaining.startsWith('<script') ? 'script' : 'style';
+        if (tagName) {
           const closeTag = `</${tagName}`;
 
           // Skip to end of opening tag
@@ -162,7 +170,10 @@ export abstract class BaseEmailProvider implements EmailProvider {
               const closeCheck = html
                 .slice(i, i + closeTag.length + 1)
                 .toLowerCase();
-              if (closeCheck.startsWith(closeTag)) {
+              if (
+                closeCheck.startsWith(closeTag) &&
+                /[\s>]/u.test(html[i + closeTag.length] ?? '')
+              ) {
                 // Skip past the closing tag
                 while (i < len && html[i] !== '>') {
                   i++;
@@ -190,9 +201,9 @@ export abstract class BaseEmailProvider implements EmailProvider {
    * @returns Plain text version
    */
   protected htmlToPlainText(html: string): string {
-    // Remove script and style blocks using safe loop-based approach
+    // Remove non-visible blocks using the bounded, loop-based approach
     // This avoids ReDoS vulnerabilities and properly handles malformed tags
-    let text = this.removeScriptAndStyleBlocks(html);
+    let text = this.removeNonContentBlocks(html);
 
     // Convert block elements to line breaks
     text = text

--- a/packages/email-service/src/providers/base.ts
+++ b/packages/email-service/src/providers/base.ts
@@ -136,75 +136,20 @@ export abstract class BaseEmailProvider implements EmailProvider {
   }
 
   /**
-   * Remove non-content blocks consistently with HTML sanitization.
-   * Uses a loop-based state machine to avoid ReDoS vulnerabilities
-   * and properly handle malformed/nested tags.
-   * @param html Raw HTML content
-   * @returns HTML with non-visible blocks removed
-   */
-  private removeNonContentBlocks(html: string): string {
-    const result: string[] = [];
-    let i = 0;
-    const len = html.length;
-
-    while (i < len) {
-      // Match whole tag names so similarly named elements remain intact.
-      if (html[i] === '<' && i + 1 < len) {
-        const tagName = NON_CONTENT_TAGS.find(
-          (tag) =>
-            html.slice(i, i + tag.length + 1).toLowerCase() === `<${tag}` &&
-            /[\s/>]/u.test(html[i + tag.length + 1] ?? '')
-        );
-
-        if (tagName) {
-          const closeTag = `</${tagName}`;
-
-          // Skip to end of opening tag
-          while (i < len && html[i] !== '>') {
-            i++;
-          }
-          i++; // Skip the '>'
-
-          // Find and skip the closing tag (case-insensitive)
-          while (i < len) {
-            if (html[i] === '<') {
-              const closeCheck = html
-                .slice(i, i + closeTag.length + 1)
-                .toLowerCase();
-              if (
-                closeCheck.startsWith(closeTag) &&
-                /[\s>]/u.test(html[i + closeTag.length] ?? '')
-              ) {
-                // Skip past the closing tag
-                while (i < len && html[i] !== '>') {
-                  i++;
-                }
-                i++; // Skip the '>'
-                break;
-              }
-            }
-            i++;
-          }
-          continue;
-        }
-      }
-
-      result.push(html[i]!);
-      i++;
-    }
-
-    return result.join('');
-  }
-
-  /**
    * Generate plain text from HTML for multipart emails.
    * @param html HTML content
    * @returns Plain text version
    */
   protected htmlToPlainText(html: string): string {
-    // Remove non-visible blocks using the bounded, loop-based approach
-    // This avoids ReDoS vulnerabilities and properly handles malformed tags
-    let text = this.removeNonContentBlocks(html);
+    // Parse comments, quoted attributes, and raw-text elements before converting
+    // visible markup. Scanning raw HTML can mistake examples for actual tags.
+    let text = sanitizeHtmlContent(html, {
+      allowedTags: sanitizeHtmlContent.defaults.allowedTags.filter(
+        (tag) => !NON_CONTENT_TAGS.includes(tag)
+      ),
+      allowedAttributes: { a: ['href'] },
+      nonTextTags: NON_CONTENT_TAGS,
+    });
 
     // Convert block elements to line breaks
     text = text


### PR DESCRIPTION
Outbound email sanitization removed `<title>` tags but retained their text, creating an unwanted duplicate title above the branded monthly report. Discard that hidden metadata in HTML and plain-text output, and preserve table cell spans so report headings retain their intended alignment.

Plain-text conversion now uses the existing HTML parser before stripping visible markup. HTML comments, quoted attributes, and hidden control contents cannot be mistaken for visible report content or swallow the report body.

Validation: all 283 email-service tests pass, with regressions for the duplicate title, real CSS inlining, table layout, fragments, mixed-case tags, malformed document heads, comments, attributes, entities, links, and raw-text exclusion safety. Full `bun check` and Web/Mail production builds pass on the final revision. The exact report fixture produces one intended visible heading through the real provider sanitizer and CSS inliner.

Production verification: merged revision `b268300d9db0d219b5c365fe5e3bd3a97928ef06` passed all 12 main and 9 production workflows. An isolated monthly report was sent to the authorized test recipient through the live report worker. Actual inbox rendering confirms the stray title is absent and the intended branded heading and report content are intact. The workspace sending gate was restored to its original disabled value; test delivery is recorded separately from the real report status.
