### PR TITLE
fix(tasks): surface unprioritized tasks before paginating

### DIFF
--- a/apps/cms/messages/en.json
+++ b/apps/cms/messages/en.json
@@ -9792,7 +9792,11 @@
       "submit_shortcut_cmd_enter": "⌘/Ctrl + Enter",
       "submit_shortcut_description": "Choose the keyboard shortcut used to submit tasks from the quick input area and dialogs",
       "submit_shortcut_enter": "Enter",
-      "title": "Tasks"
+      "title": "Tasks",
+      "unprioritized_first": "Show first",
+      "unprioritized_last": "Show last",
+      "unprioritized_position": "Tasks without priority",
+      "unprioritized_position_description": "Choose where tasks without priority appear when sorting by priority, in either direction."
     },
     "time_tracker": {
       "active": "Active",

--- a/apps/cms/messages/vi.json
+++ b/apps/cms/messages/vi.json
@@ -9792,7 +9792,11 @@
       "submit_shortcut_cmd_enter": "⌘/Ctrl + Enter",
       "submit_shortcut_description": "Chọn phím tắt dùng để gửi tác vụ từ ô nhập nhanh và hộp thoại",
       "submit_shortcut_enter": "Enter",
-      "title": "Nhiệm vụ"
+      "title": "Nhiệm vụ",
+      "unprioritized_first": "Hiển thị đầu tiên",
+      "unprioritized_last": "Hiển thị cuối cùng",
+      "unprioritized_position": "Công việc chưa có độ ưu tiên",
+      "unprioritized_position_description": "Chọn vị trí hiển thị công việc chưa có độ ưu tiên khi sắp xếp theo độ ưu tiên theo cả hai chiều."
     },
     "time_tracker": {
       "active": "Hoạt động",

--- a/apps/contacts/messages/en.json
+++ b/apps/contacts/messages/en.json
@@ -3785,7 +3785,11 @@
       "submit_shortcut": "Submit shortcut",
       "submit_shortcut_cmd_enter": "⌘/Ctrl + Enter",
       "submit_shortcut_description": "Choose the keyboard shortcut used to submit tasks from the quick input area and dialogs",
-      "submit_shortcut_enter": "Enter"
+      "submit_shortcut_enter": "Enter",
+      "unprioritized_first": "Show first",
+      "unprioritized_last": "Show last",
+      "unprioritized_position": "Tasks without priority",
+      "unprioritized_position_description": "Choose where tasks without priority appear when sorting by priority, in either direction."
     },
     "user": {
       "profile": "Profile",

--- a/apps/contacts/messages/vi.json
+++ b/apps/contacts/messages/vi.json
@@ -3785,7 +3785,11 @@
       "submit_shortcut": "Phím tắt gửi",
       "submit_shortcut_cmd_enter": "⌘/Ctrl + Enter",
       "submit_shortcut_description": "Chọn phím tắt dùng để gửi tác vụ từ ô nhập nhanh và hộp thoại",
-      "submit_shortcut_enter": "Enter"
+      "submit_shortcut_enter": "Enter",
+      "unprioritized_first": "Hiển thị đầu tiên",
+      "unprioritized_last": "Hiển thị cuối cùng",
+      "unprioritized_position": "Công việc chưa có độ ưu tiên",
+      "unprioritized_position_description": "Chọn vị trí hiển thị công việc chưa có độ ưu tiên khi sắp xếp theo độ ưu tiên theo cả hai chiều."
     },
     "user": {
       "profile": "Hồ sơ",

--- a/apps/drive/messages/en.json
+++ b/apps/drive/messages/en.json
@@ -6990,7 +6990,11 @@
       "submit_shortcut_cmd_enter": "⌘/Ctrl + Enter",
       "submit_shortcut_description": "Choose the keyboard shortcut used to submit tasks from the quick input area and dialogs",
       "submit_shortcut_enter": "Enter",
-      "title": "Tasks"
+      "title": "Tasks",
+      "unprioritized_first": "Show first",
+      "unprioritized_last": "Show last",
+      "unprioritized_position": "Tasks without priority",
+      "unprioritized_position_description": "Choose where tasks without priority appear when sorting by priority, in either direction."
     },
     "time_tracker": {
       "active": "Active",

--- a/apps/drive/messages/vi.json
+++ b/apps/drive/messages/vi.json
@@ -6990,7 +6990,11 @@
       "submit_shortcut_cmd_enter": "⌘/Ctrl + Enter",
       "submit_shortcut_description": "Chọn phím tắt dùng để gửi tác vụ từ ô nhập nhanh và hộp thoại",
       "submit_shortcut_enter": "Enter",
-      "title": "Nhiệm vụ"
+      "title": "Nhiệm vụ",
+      "unprioritized_first": "Hiển thị đầu tiên",
+      "unprioritized_last": "Hiển thị cuối cùng",
+      "unprioritized_position": "Công việc chưa có độ ưu tiên",
+      "unprioritized_position_description": "Chọn vị trí hiển thị công việc chưa có độ ưu tiên khi sắp xếp theo độ ưu tiên theo cả hai chiều."
     },
     "time_tracker": {
       "active": "Hoạt động",

--- a/apps/forms/messages/en.json
+++ b/apps/forms/messages/en.json
@@ -4681,7 +4681,11 @@
       "submit_shortcut": "Submit shortcut",
       "submit_shortcut_cmd_enter": "⌘/Ctrl + Enter",
       "submit_shortcut_description": "Choose the keyboard shortcut used to submit tasks from the quick input area and dialogs",
-      "submit_shortcut_enter": "Enter"
+      "submit_shortcut_enter": "Enter",
+      "unprioritized_first": "Show first",
+      "unprioritized_last": "Show last",
+      "unprioritized_position": "Tasks without priority",
+      "unprioritized_position_description": "Choose where tasks without priority appear when sorting by priority, in either direction."
     },
     "user": {
       "profile": "Profile",

--- a/apps/forms/messages/vi.json
+++ b/apps/forms/messages/vi.json
@@ -4681,7 +4681,11 @@
       "submit_shortcut": "Phím tắt gửi",
       "submit_shortcut_cmd_enter": "⌘/Ctrl + Enter",
       "submit_shortcut_description": "Chọn phím tắt dùng để gửi tác vụ từ ô nhập nhanh và hộp thoại",
-      "submit_shortcut_enter": "Enter"
+      "submit_shortcut_enter": "Enter",
+      "unprioritized_first": "Hiển thị đầu tiên",
+      "unprioritized_last": "Hiển thị cuối cùng",
+      "unprioritized_position": "Công việc chưa có độ ưu tiên",
+      "unprioritized_position_description": "Chọn vị trí hiển thị công việc chưa có độ ưu tiên khi sắp xếp theo độ ưu tiên theo cả hai chiều."
     },
     "user": {
       "profile": "Hồ sơ",

--- a/apps/infrastructure/messages/en.json
+++ b/apps/infrastructure/messages/en.json
@@ -12807,6 +12807,10 @@
       "ticket_prefix_placeholder": "TEAM",
       "title": "Tasks",
       "unarchive_board": "Unarchive board",
+      "unprioritized_first": "Show first",
+      "unprioritized_last": "Show last",
+      "unprioritized_position": "Tasks without priority",
+      "unprioritized_position_description": "Choose where tasks without priority appear when sorting by priority, in either direction.",
       "use_as_default_board": "Use as default"
     },
     "time_tracker": {

--- a/apps/infrastructure/messages/vi.json
+++ b/apps/infrastructure/messages/vi.json
@@ -12807,6 +12807,10 @@
       "ticket_prefix_placeholder": "TEAM",
       "title": "Nhiệm vụ",
       "unarchive_board": "Bỏ lưu trữ bảng",
+      "unprioritized_first": "Hiển thị đầu tiên",
+      "unprioritized_last": "Hiển thị cuối cùng",
+      "unprioritized_position": "Công việc chưa có độ ưu tiên",
+      "unprioritized_position_description": "Chọn vị trí hiển thị công việc chưa có độ ưu tiên khi sắp xếp theo độ ưu tiên theo cả hai chiều.",
       "use_as_default_board": "Dùng làm mặc định"
     },
     "time_tracker": {

--- a/apps/tasks/messages/en.json
+++ b/apps/tasks/messages/en.json
@@ -7452,6 +7452,10 @@
       "templates": "Templates",
       "templates_description": "Manage reusable task board templates",
       "title": "Tasks",
+      "unprioritized_first": "Show first",
+      "unprioritized_last": "Show last",
+      "unprioritized_position": "Tasks without priority",
+      "unprioritized_position_description": "Choose where tasks without priority appear when sorting by priority, in either direction.",
       "untitled_board": "Untitled board",
       "untitled_list": "Untitled list"
     },

--- a/apps/tasks/messages/vi.json
+++ b/apps/tasks/messages/vi.json
@@ -7452,6 +7452,10 @@
       "templates": "Mẫu",
       "templates_description": "Quản lý các mẫu bảng công việc có thể tái sử dụng",
       "title": "Nhiệm vụ",
+      "unprioritized_first": "Hiển thị đầu tiên",
+      "unprioritized_last": "Hiển thị cuối cùng",
+      "unprioritized_position": "Công việc chưa có độ ưu tiên",
+      "unprioritized_position_description": "Chọn vị trí hiển thị công việc chưa có độ ưu tiên khi sắp xếp theo độ ưu tiên theo cả hai chiều.",
       "untitled_board": "Bảng chưa đặt tên",
       "untitled_list": "Danh sách chưa đặt tên"
     },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -13875,6 +13875,10 @@
       "ticket_prefix_placeholder": "TEAM",
       "title": "Tasks",
       "unarchive_board": "Unarchive board",
+      "unprioritized_first": "Show first",
+      "unprioritized_last": "Show last",
+      "unprioritized_position": "Tasks without priority",
+      "unprioritized_position_description": "Choose where tasks without priority appear when sorting by priority, in either direction.",
       "use_as_default_board": "Use as default"
     },
     "time_tracker": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -13875,6 +13875,10 @@
       "ticket_prefix_placeholder": "TEAM",
       "title": "Nhiệm vụ",
       "unarchive_board": "Bỏ lưu trữ bảng",
+      "unprioritized_first": "Hiển thị đầu tiên",
+      "unprioritized_last": "Hiển thị cuối cùng",
+      "unprioritized_position": "Công việc chưa có độ ưu tiên",
+      "unprioritized_position_description": "Chọn vị trí hiển thị công việc chưa có độ ưu tiên khi sắp xếp theo độ ưu tiên theo cả hai chiều.",
       "use_as_default_board": "Dùng làm mặc định"
     },
     "time_tracker": {

--- a/packages/internal-api/src/task-list-options.ts
+++ b/packages/internal-api/src/task-list-options.ts
@@ -1,0 +1,63 @@
+import type { TaskPriority } from '@tuturuuu/types/primitives/Priority';
+
+export interface ListWorkspaceTasksOptions {
+  boardId?: string;
+  listId?: string;
+  listStatuses?: string[];
+  sourceScope?: TaskSourceScope;
+  sourceWorkspaceIds?: string[];
+  sourceBoardIds?: string[];
+  q?: string;
+  identifier?: string;
+  limit?: number;
+  offset?: number;
+  labelIds?: string[];
+  assigneeIds?: string[];
+  projectIds?: string[];
+  priorities?: TaskPriority[];
+  estimationMin?: number;
+  estimationMax?: number;
+  dueDateFrom?: string;
+  dueDateTo?: string;
+  assignedToMe?: boolean;
+  includeUnassigned?: boolean;
+  completed?: 'exclude' | 'only';
+  closed?: 'exclude' | 'only';
+  hasDueDate?: boolean;
+  externalIncludeDocuments?: boolean;
+  externalIncludeDoneClosed?: boolean;
+  externalSortBy?: ExternalTaskSortBy;
+  sortBy?: SortOption;
+  unprioritizedPosition?: 'first' | 'last';
+  forTimeTracking?: boolean;
+  includeRelationshipSummary?: boolean;
+  includeArchivedBoards?: boolean;
+  includeDeleted?: boolean | 'only';
+  includeCount?: boolean;
+  includeListCounts?: boolean;
+}
+
+export type ExternalTaskSortBy =
+  | 'created-desc'
+  | 'created-asc'
+  | 'due-asc'
+  | 'name-asc'
+  | 'source-asc';
+
+export type TaskSourceScope =
+  | 'all_visible'
+  | 'current_board'
+  | 'external_current_workspace'
+  | 'external_specific';
+
+export type SortOption =
+  | 'name-asc'
+  | 'name-desc'
+  | 'priority-high'
+  | 'priority-low'
+  | 'due-date-asc'
+  | 'due-date-desc'
+  | 'created-date-desc'
+  | 'created-date-asc'
+  | 'estimation-high'
+  | 'estimation-low';

--- a/packages/internal-api/src/task-priority-options.test.ts
+++ b/packages/internal-api/src/task-priority-options.test.ts
@@ -1,0 +1,27 @@
+import { expect, it, vi } from 'vitest';
+import { listWorkspaceTasks } from './tasks';
+
+it.each(['first', 'last'] as const)(
+  'sends priority placement %s with each task page',
+  async (unprioritizedPosition) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ tasks: [] }),
+    });
+    await listWorkspaceTasks(
+      'workspace',
+      { sortBy: 'priority-high', unprioritizedPosition, limit: 50, offset: 50 },
+      {
+        baseUrl: 'https://internal.example.com',
+        fetch: fetchMock as typeof fetch,
+      }
+    );
+    const url = new URL(fetchMock.mock.calls[0]![0]);
+    expect(url.searchParams.get('unprioritizedPosition')).toBe(
+      unprioritizedPosition
+    );
+    expect(url.searchParams.get('offset')).toBe('50');
+    expect(url.searchParams.get('sortBy')).toBe('priority-high');
+  }
+);

--- a/packages/internal-api/src/tasks.ts
+++ b/packages/internal-api/src/tasks.ts
@@ -1,3 +1,12 @@
+import type { ListWorkspaceTasksOptions } from './task-list-options';
+
+export type {
+  ExternalTaskSortBy,
+  ListWorkspaceTasksOptions,
+  SortOption,
+  TaskSourceScope,
+} from './task-list-options';
+
 import type {
   Database,
   InternalApiWorkspaceSummary,
@@ -372,67 +381,6 @@ export interface TaskDialogHydrationOptions {
   taskWorkspacePersonal?: boolean;
   taskWorkspaceTier?: 'FREE' | 'PLUS' | 'PRO' | 'ENTERPRISE';
 }
-
-export interface ListWorkspaceTasksOptions {
-  boardId?: string;
-  listId?: string;
-  listStatuses?: string[];
-  sourceScope?: TaskSourceScope;
-  sourceWorkspaceIds?: string[];
-  sourceBoardIds?: string[];
-  q?: string;
-  identifier?: string;
-  limit?: number;
-  offset?: number;
-  labelIds?: string[];
-  assigneeIds?: string[];
-  projectIds?: string[];
-  priorities?: TaskPriority[];
-  estimationMin?: number;
-  estimationMax?: number;
-  dueDateFrom?: string;
-  dueDateTo?: string;
-  assignedToMe?: boolean;
-  includeUnassigned?: boolean;
-  completed?: 'exclude' | 'only';
-  closed?: 'exclude' | 'only';
-  hasDueDate?: boolean;
-  externalIncludeDocuments?: boolean;
-  externalIncludeDoneClosed?: boolean;
-  externalSortBy?: ExternalTaskSortBy;
-  sortBy?: SortOption;
-  forTimeTracking?: boolean;
-  includeRelationshipSummary?: boolean;
-  includeArchivedBoards?: boolean;
-  includeDeleted?: boolean | 'only';
-  includeCount?: boolean;
-  includeListCounts?: boolean;
-}
-
-export type ExternalTaskSortBy =
-  | 'created-desc'
-  | 'created-asc'
-  | 'due-asc'
-  | 'name-asc'
-  | 'source-asc';
-
-export type TaskSourceScope =
-  | 'all_visible'
-  | 'current_board'
-  | 'external_current_workspace'
-  | 'external_specific';
-
-export type SortOption =
-  | 'name-asc'
-  | 'name-desc'
-  | 'priority-high'
-  | 'priority-low'
-  | 'due-date-asc'
-  | 'due-date-desc'
-  | 'created-date-desc'
-  | 'created-date-asc'
-  | 'estimation-high'
-  | 'estimation-low';
 
 export interface WorkspaceTaskListCount {
   list_id: string;
@@ -1685,6 +1633,7 @@ export async function listWorkspaceTasks(
         externalIncludeDoneClosed: options?.externalIncludeDoneClosed,
         externalSortBy: options?.externalSortBy,
         sortBy: options?.sortBy,
+        unprioritizedPosition: options?.unprioritizedPosition,
         forTimeTracking: options?.forTimeTracking,
         includeRelationshipSummary: options?.includeRelationshipSummary,
         includeArchivedBoards: options?.includeArchivedBoards,

--- a/packages/tasks-api/src/server/tasks/load-task-source-filter-ids.test.ts
+++ b/packages/tasks-api/src/server/tasks/load-task-source-filter-ids.test.ts
@@ -1,0 +1,72 @@
+import type { TypedSupabaseClient } from '@tuturuuu/supabase/types';
+import { expect, it, vi } from 'vitest';
+import { loadTaskSourceFilterIds } from './load-task-source-filter-ids';
+
+it.each(['first', 'last'] as const)(
+  'applies %s placement before pagination using the existing RPC',
+  async (unprioritizedPosition) => {
+    const rpc = vi.fn(async (_name, args) => {
+      const ids = args.p_priorities ? ['high', 'low'] : ['high', 'low', 'none'];
+      return {
+        error: null,
+        data: ids
+          .slice(args.p_offset, args.p_offset + args.p_limit)
+          .map((task_id) => ({
+            task_id,
+            list_id: 'list',
+            total_count: ids.length,
+          })),
+      };
+    });
+    const sbAdmin = {
+      schema: vi.fn(() => ({ rpc })),
+    } as unknown as TypedSupabaseClient;
+    const result = await loadTaskSourceFilterIds({
+      sbAdmin,
+      userId: 'actor',
+      workspaceId: 'workspace',
+      boardId: 'board',
+      listId: 'list',
+      sourceScope: 'current_board',
+      sourceWorkspaceIds: [],
+      sourceBoardIds: [],
+      listStatuses: ['active'],
+      parsedIdentifier: null,
+      assignedToMe: false,
+      completedMode: null,
+      closedMode: null,
+      includeArchivedBoards: false,
+      includeDeletedMode: 'none',
+      hasDueDate: false,
+      externalSortBy: 'created-desc',
+      sortBy: 'priority-high',
+      labelIds: ['label'],
+      assigneeIds: [],
+      projectIds: [],
+      priorities: [],
+      estimationMin: null,
+      estimationMax: null,
+      dueDateFrom: null,
+      dueDateTo: null,
+      includeUnassigned: false,
+      limit: 1,
+      offset: 0,
+      unprioritizedPosition,
+    });
+    expect(result).toEqual({
+      count: 3,
+      taskIds: [unprioritizedPosition === 'first' ? 'none' : 'high'],
+    });
+    for (const [name, args] of rpc.mock.calls) {
+      expect(name).toBe('list_task_source_filter_ids');
+      expect(args).toMatchObject({
+        p_actor_id: 'actor',
+        p_workspace_id: 'workspace',
+        p_board_id: 'board',
+        p_list_id: 'list',
+        p_label_ids: ['label'],
+        p_list_statuses: ['active'],
+      });
+    }
+  }
+);

--- a/packages/tasks-api/src/server/tasks/load-task-source-filter-ids.ts
+++ b/packages/tasks-api/src/server/tasks/load-task-source-filter-ids.ts
@@ -1,0 +1,151 @@
+import type { TypedSupabaseClient } from '@tuturuuu/supabase/types';
+import type { TaskSortBy } from '@tuturuuu/utils/task-helper';
+import { loadPriorityPage } from './priority-page';
+
+export type ExternalTaskSortBy =
+  | 'created-desc'
+  | 'created-asc'
+  | 'due-asc'
+  | 'name-asc'
+  | 'source-asc';
+export type TaskSourceScope =
+  | 'all_visible'
+  | 'current_board'
+  | 'external_current_workspace'
+  | 'external_specific';
+export type ExternalSourceStatus =
+  | 'not_started'
+  | 'active'
+  | 'review'
+  | 'documents'
+  | 'done'
+  | 'closed';
+type TaskSourceFilterIdRow = {
+  list_id: string | null;
+  task_id: string | null;
+  total_count: number | string | null;
+};
+
+export async function loadTaskSourceFilterIds(
+  options: Parameters<typeof loadTaskSourceFilterIdsPage>[0] & {
+    unprioritizedPosition: 'first' | 'last';
+  }
+) {
+  return loadPriorityPage(options, (page) =>
+    loadTaskSourceFilterIdsPage({ ...options, ...page })
+  );
+}
+
+async function loadTaskSourceFilterIdsPage({
+  sbAdmin,
+  userId,
+  workspaceId,
+  boardId,
+  listId,
+  sourceScope,
+  sourceWorkspaceIds,
+  sourceBoardIds,
+  listStatuses,
+  searchQuery,
+  parsedIdentifier,
+  assignedToMe,
+  completedMode,
+  closedMode,
+  includeArchivedBoards,
+  includeDeletedMode,
+  hasDueDate,
+  externalSortBy,
+  sortBy,
+  labelIds,
+  assigneeIds,
+  projectIds,
+  priorities,
+  estimationMin,
+  estimationMax,
+  dueDateFrom,
+  dueDateTo,
+  includeUnassigned,
+  limit,
+  offset,
+}: {
+  sbAdmin: TypedSupabaseClient;
+  userId: string;
+  workspaceId: string;
+  boardId: string | null;
+  listId: string | null;
+  sourceScope: TaskSourceScope;
+  sourceWorkspaceIds: string[];
+  sourceBoardIds: string[];
+  listStatuses: ExternalSourceStatus[];
+  searchQuery?: string;
+  parsedIdentifier: {
+    displayNumber: number;
+    ticketPrefix: string | null;
+  } | null;
+  assignedToMe: boolean;
+  completedMode: string | null;
+  closedMode: string | null;
+  includeArchivedBoards: boolean;
+  includeDeletedMode: 'all' | 'none' | 'only';
+  hasDueDate: boolean;
+  externalSortBy: ExternalTaskSortBy;
+  sortBy?: TaskSortBy;
+  labelIds: string[];
+  assigneeIds: string[];
+  projectIds: string[];
+  priorities: string[];
+  estimationMin: number | null;
+  estimationMax: number | null;
+  dueDateFrom: string | null;
+  dueDateTo: string | null;
+  includeUnassigned: boolean;
+  limit: number;
+  offset: number;
+}) {
+  const { data, error } = await sbAdmin
+    .schema('private')
+    .rpc('list_task_source_filter_ids', {
+      p_actor_id: userId,
+      p_workspace_id: workspaceId,
+      p_board_id: boardId ?? undefined,
+      p_list_id: listId ?? undefined,
+      p_source_scope: sourceScope,
+      p_source_workspace_ids: sourceWorkspaceIds,
+      p_source_board_ids: sourceBoardIds,
+      p_list_statuses: listStatuses,
+      p_search: searchQuery ?? undefined,
+      p_display_number: parsedIdentifier?.displayNumber ?? undefined,
+      p_ticket_prefix: parsedIdentifier?.ticketPrefix ?? undefined,
+      p_assigned_to_me: assignedToMe,
+      p_completed_mode: completedMode ?? undefined,
+      p_closed_mode: closedMode ?? undefined,
+      p_include_archived_boards: includeArchivedBoards,
+      p_include_deleted: includeDeletedMode,
+      p_has_due_date: hasDueDate,
+      p_sort_by: sortBy ?? externalSortBy,
+      p_limit: limit,
+      p_offset: offset,
+      p_label_ids: labelIds.length > 0 ? labelIds : undefined,
+      p_assignee_ids: assigneeIds.length > 0 ? assigneeIds : undefined,
+      p_project_ids: projectIds.length > 0 ? projectIds : undefined,
+      p_priorities: priorities.length > 0 ? priorities : undefined,
+      p_estimation_min: estimationMin ?? undefined,
+      p_estimation_max: estimationMax ?? undefined,
+      p_due_date_from: dueDateFrom ?? undefined,
+      p_due_date_to: dueDateTo ?? undefined,
+      p_include_unassigned: includeUnassigned,
+    });
+
+  if (error) {
+    throw new Error('TASK_SOURCE_FILTER_RPC_FAILED', { cause: error });
+  }
+
+  const rows = ((data ?? []) as TaskSourceFilterIdRow[]).filter(
+    (row): row is TaskSourceFilterIdRow & { task_id: string } =>
+      Boolean(row.task_id)
+  );
+  const taskIds = rows.map((row) => row.task_id);
+  const count = Number(rows[0]?.total_count ?? 0);
+
+  return { count: Number.isFinite(count) ? count : 0, taskIds };
+}

--- a/packages/tasks-api/src/server/tasks/priority-page.test.ts
+++ b/packages/tasks-api/src/server/tasks/priority-page.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { loadPriorityPage } from './priority-page';
 
-const ids = ['critical', 'high', 'low', 'none-new', 'none-old'];
-const expected = ['none-new', 'none-old', 'critical', 'high', 'low'];
+const ids = ['critical', 'high', 'normal', 'low', 'none-new', 'none-old'];
+const expected = ['none-new', 'none-old', 'critical', 'high', 'normal', 'low'];
 const options = {
   priorities: [],
   sortBy: 'priority-high',
@@ -21,7 +21,7 @@ function loader(source = ids) {
       limit: number;
     }) => {
       const filtered = priorities.length
-        ? source.filter((id) => !id.startsWith('none'))
+        ? source.filter((id) => priorities.includes(id))
         : source;
       return {
         count: filtered.length,
@@ -37,7 +37,7 @@ describe('priority pagination', () => {
     async (offset) => {
       const load = loader();
       expect(await loadPriorityPage({ ...options, offset }, load)).toEqual({
-        count: 5,
+        count: 6,
         taskIds: expected.slice(offset, offset + 2),
       });
       expect(load.mock.calls.length).toBeLessThanOrEqual(4);
@@ -78,14 +78,27 @@ describe('priority pagination', () => {
       });
     }
   );
-  it('returns count-only requests without loading task pages', async () => {
-    const load = loader();
-    expect(await loadPriorityPage({ ...options, limit: 0 }, load)).toEqual({
-      count: 5,
-      taskIds: [],
-    });
-    expect(load).toHaveBeenCalledTimes(1);
-  });
+  it.each([
+    { sortBy: 'name-asc' },
+    { unprioritizedPosition: 'last' as const },
+    {},
+    { priorities: ['normal'] },
+  ])(
+    'returns count-only requests without loading task pages: %j',
+    async (overrides) => {
+      const load = loader();
+      expect(
+        await loadPriorityPage(
+          { ...options, ...overrides, offset: 500, limit: 0 },
+          load
+        )
+      ).toEqual({
+        count: 'priorities' in overrides ? 1 : 6,
+        taskIds: [],
+      });
+      expect(load).toHaveBeenCalledTimes(1);
+    }
+  );
   it('propagates database failures instead of returning a misleading empty page', async () => {
     await expect(
       loadPriorityPage(

--- a/packages/tasks-api/src/server/tasks/priority-page.test.ts
+++ b/packages/tasks-api/src/server/tasks/priority-page.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadPriorityPage } from './priority-page';
+
+const ids = ['critical', 'high', 'low', 'none-new', 'none-old'];
+const expected = ['none-new', 'none-old', 'critical', 'high', 'low'];
+const options = {
+  priorities: [],
+  sortBy: 'priority-high',
+  offset: 0,
+  limit: 2,
+};
+function loader(source = ids) {
+  return vi.fn(
+    async ({
+      priorities,
+      offset,
+      limit,
+    }: {
+      priorities: string[];
+      offset: number;
+      limit: number;
+    }) => {
+      const filtered = priorities.length
+        ? source.filter((id) => !id.startsWith('none'))
+        : source;
+      return {
+        count: filtered.length,
+        taskIds: filtered.slice(offset, offset + limit),
+      };
+    }
+  );
+}
+
+describe('priority pagination', () => {
+  it.each([0, 1, 2, 3, 4, 5, 20])(
+    'returns the correct first-placement page at offset %i',
+    async (offset) => {
+      const load = loader();
+      expect(await loadPriorityPage({ ...options, offset }, load)).toEqual({
+        count: 5,
+        taskIds: expected.slice(offset, offset + 2),
+      });
+      expect(load.mock.calls.length).toBeLessThanOrEqual(4);
+      expect(load.mock.calls.every(([page]) => page.limit <= 2)).toBe(true);
+    }
+  );
+  it('preserves low-to-high order within prioritized tasks', async () => {
+    expect(
+      (
+        await loadPriorityPage(
+          { ...options, sortBy: 'priority-low', limit: 5 },
+          loader(['low', 'high', 'critical', 'none-new', 'none-old'])
+        )
+      ).taskIds
+    ).toEqual(['none-new', 'none-old', 'low', 'high', 'critical']);
+  });
+  it.each([
+    { unprioritizedPosition: 'last' as const },
+    { sortBy: 'name-asc' },
+    { priorities: ['high'] },
+  ])(
+    'uses one unchanged query when rotation is unnecessary: %j',
+    async (overrides) => {
+      const load = loader();
+      await loadPriorityPage({ ...options, ...overrides }, load);
+      expect(load).toHaveBeenCalledExactlyOnceWith({
+        ...options,
+        ...overrides,
+      });
+    }
+  );
+  it.each([[[]], [['high']], [['none-new']]])(
+    'handles homogeneous and empty results: %j',
+    async (source) => {
+      expect(await loadPriorityPage(options, loader(source))).toEqual({
+        count: source.length,
+        taskIds: source,
+      });
+    }
+  );
+  it('returns count-only requests without loading task pages', async () => {
+    const load = loader();
+    expect(await loadPriorityPage({ ...options, limit: 0 }, load)).toEqual({
+      count: 5,
+      taskIds: [],
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+  it('propagates database failures instead of returning a misleading empty page', async () => {
+    await expect(
+      loadPriorityPage(
+        options,
+        vi.fn().mockRejectedValue(new Error('unavailable'))
+      )
+    ).rejects.toThrow('unavailable');
+  });
+});

--- a/packages/tasks-api/src/server/tasks/priority-page.ts
+++ b/packages/tasks-api/src/server/tasks/priority-page.ts
@@ -1,0 +1,49 @@
+import type { UnprioritizedPosition } from '@tuturuuu/utils/task-helper/task-sort';
+
+type Page = { count: number; taskIds: string[] };
+type PageOptions = { limit: number; offset: number; priorities: string[] };
+
+/** Rotate the existing nulls-last RPC order without loading the entire task set. */
+export async function loadPriorityPage(
+  options: PageOptions & {
+    sortBy?: string;
+    unprioritizedPosition?: UnprioritizedPosition;
+  },
+  load: (page: PageOptions) => Promise<Page>
+): Promise<Page> {
+  if (
+    options.unprioritizedPosition === 'last' ||
+    !options.sortBy?.startsWith('priority-') ||
+    options.priorities.length > 0
+  ) {
+    return load(options);
+  }
+  // Counts are read at offset zero because the RPC returns counts on task rows.
+  const total = await load({ ...options, offset: 0, limit: 1 });
+  if (total.count === 0 || options.offset >= total.count)
+    return { count: total.count, taskIds: [] };
+  if (options.limit === 0) return { count: total.count, taskIds: [] };
+  const prioritized = await load({
+    ...options,
+    offset: 0,
+    limit: 1,
+    priorities: ['critical', 'high', 'normal', 'low'],
+  });
+  const missingCount = total.count - prioritized.count;
+  if (missingCount === 0 || prioritized.count === 0) return load(options);
+  const count = Math.min(options.limit, total.count - options.offset);
+  const start =
+    options.offset < missingCount
+      ? prioritized.count + options.offset
+      : options.offset - missingCount;
+  const firstLength = Math.min(count, total.count - start);
+  const first = await load({ ...options, offset: start, limit: firstLength });
+  if (firstLength === count)
+    return { count: total.count, taskIds: first.taskIds };
+  const second = await load({
+    ...options,
+    offset: 0,
+    limit: count - firstLength,
+  });
+  return { count: total.count, taskIds: [...first.taskIds, ...second.taskIds] };
+}

--- a/packages/tasks-api/src/server/tasks/priority-page.ts
+++ b/packages/tasks-api/src/server/tasks/priority-page.ts
@@ -11,6 +11,10 @@ export async function loadPriorityPage(
   },
   load: (page: PageOptions) => Promise<Page>
 ): Promise<Page> {
+  if (options.limit === 0) {
+    const total = await load({ ...options, offset: 0, limit: 1 });
+    return { count: total.count, taskIds: [] };
+  }
   if (
     options.unprioritizedPosition === 'last' ||
     !options.sortBy?.startsWith('priority-') ||
@@ -22,7 +26,6 @@ export async function loadPriorityPage(
   const total = await load({ ...options, offset: 0, limit: 1 });
   if (total.count === 0 || options.offset >= total.count)
     return { count: total.count, taskIds: [] };
-  if (options.limit === 0) return { count: total.count, taskIds: [] };
   const prioritized = await load({
     ...options,
     offset: 0,

--- a/packages/tasks-api/src/server/tasks/route.ts
+++ b/packages/tasks-api/src/server/tasks/route.ts
@@ -18,9 +18,9 @@ import {
 import {
   getPersonalExternalStagingBoardId,
   getPersonalExternalStagingListId,
+  normalizeUnprioritizedPosition,
   parseTaskSortBy,
   sortTasksByCriterion,
-  type TaskSortBy,
 } from '@tuturuuu/utils/task-helper';
 import {
   isTaskBoardCompletedStatus,
@@ -48,6 +48,12 @@ import {
   type TaskRecord,
   type TaskRelationshipSummary,
 } from './get-tasks-helpers';
+import {
+  type ExternalSourceStatus,
+  type ExternalTaskSortBy,
+  loadTaskSourceFilterIds,
+  type TaskSourceScope,
+} from './load-task-source-filter-ids';
 import {
   applyPersonalTaskMetadata,
   loadPersonalTaskMetadata,
@@ -184,25 +190,6 @@ type TaskSchedulingSettingsRow = {
   auto_schedule: boolean | null;
 };
 
-type ExternalTaskSortBy =
-  | 'created-desc'
-  | 'created-asc'
-  | 'due-asc'
-  | 'name-asc'
-  | 'source-asc';
-type TaskSourceScope =
-  | 'all_visible'
-  | 'current_board'
-  | 'external_current_workspace'
-  | 'external_specific';
-type ExternalSourceStatus =
-  | 'not_started'
-  | 'active'
-  | 'review'
-  | 'documents'
-  | 'done'
-  | 'closed';
-
 const DEFAULT_EXTERNAL_TASK_SORT_BY: ExternalTaskSortBy = 'created-desc';
 const ACTIVE_EXTERNAL_SOURCE_STATUSES: ExternalSourceStatus[] = [
   'not_started',
@@ -223,12 +210,6 @@ const TASK_LIST_STATUSES = new Set<ExternalSourceStatus>([
 type PersonalTaskBoardExternalCountRow = {
   list_id: string | null;
   task_count: number | null;
-};
-
-type TaskSourceFilterIdRow = {
-  list_id: string | null;
-  task_id: string | null;
-  total_count: number | string | null;
 };
 
 type TaskSourceFilterListCountRow = {
@@ -652,117 +633,6 @@ function applyPersonalPlacement(
   );
 }
 
-async function loadTaskSourceFilterIds({
-  sbAdmin,
-  userId,
-  workspaceId,
-  boardId,
-  listId,
-  sourceScope,
-  sourceWorkspaceIds,
-  sourceBoardIds,
-  listStatuses,
-  searchQuery,
-  parsedIdentifier,
-  assignedToMe,
-  completedMode,
-  closedMode,
-  includeArchivedBoards,
-  includeDeletedMode,
-  hasDueDate,
-  externalSortBy,
-  sortBy,
-  labelIds,
-  assigneeIds,
-  projectIds,
-  priorities,
-  estimationMin,
-  estimationMax,
-  dueDateFrom,
-  dueDateTo,
-  includeUnassigned,
-  limit,
-  offset,
-}: {
-  sbAdmin: TypedSupabaseClient;
-  userId: string;
-  workspaceId: string;
-  boardId: string | null;
-  listId: string | null;
-  sourceScope: TaskSourceScope;
-  sourceWorkspaceIds: string[];
-  sourceBoardIds: string[];
-  listStatuses: ExternalSourceStatus[];
-  searchQuery?: string;
-  parsedIdentifier: ReturnType<typeof parseTaskIdentifierQuery> | null;
-  assignedToMe: boolean;
-  completedMode: string | null;
-  closedMode: string | null;
-  includeArchivedBoards: boolean;
-  includeDeletedMode: 'all' | 'none' | 'only';
-  hasDueDate: boolean;
-  externalSortBy: ExternalTaskSortBy;
-  sortBy?: TaskSortBy;
-  labelIds: string[];
-  assigneeIds: string[];
-  projectIds: string[];
-  priorities: string[];
-  estimationMin: number | null;
-  estimationMax: number | null;
-  dueDateFrom: string | null;
-  dueDateTo: string | null;
-  includeUnassigned: boolean;
-  limit: number;
-  offset: number;
-}) {
-  const { data, error } = await sbAdmin
-    .schema('private')
-    .rpc('list_task_source_filter_ids', {
-      p_actor_id: userId,
-      p_workspace_id: workspaceId,
-      p_board_id: boardId ?? undefined,
-      p_list_id: listId ?? undefined,
-      p_source_scope: sourceScope,
-      p_source_workspace_ids: sourceWorkspaceIds,
-      p_source_board_ids: sourceBoardIds,
-      p_list_statuses: listStatuses,
-      p_search: searchQuery ?? undefined,
-      p_display_number: parsedIdentifier?.displayNumber ?? undefined,
-      p_ticket_prefix: parsedIdentifier?.ticketPrefix ?? undefined,
-      p_assigned_to_me: assignedToMe,
-      p_completed_mode: completedMode ?? undefined,
-      p_closed_mode: closedMode ?? undefined,
-      p_include_archived_boards: includeArchivedBoards,
-      p_include_deleted: includeDeletedMode,
-      p_has_due_date: hasDueDate,
-      p_sort_by: sortBy ?? externalSortBy,
-      p_limit: limit,
-      p_offset: offset,
-      p_label_ids: labelIds.length > 0 ? labelIds : undefined,
-      p_assignee_ids: assigneeIds.length > 0 ? assigneeIds : undefined,
-      p_project_ids: projectIds.length > 0 ? projectIds : undefined,
-      p_priorities: priorities.length > 0 ? priorities : undefined,
-      p_estimation_min: estimationMin ?? undefined,
-      p_estimation_max: estimationMax ?? undefined,
-      p_due_date_from: dueDateFrom ?? undefined,
-      p_due_date_to: dueDateTo ?? undefined,
-      p_include_unassigned: includeUnassigned,
-    });
-
-  if (error) {
-    throw new Error('TASK_SOURCE_FILTER_RPC_FAILED', { cause: error });
-  }
-
-  const rows = ((data ?? []) as TaskSourceFilterIdRow[]).filter(
-    (row): row is TaskSourceFilterIdRow & { task_id: string } =>
-      Boolean(row.task_id)
-  );
-  const taskIds = rows.map((row) => row.task_id);
-  const count = Number(rows[0]?.total_count ?? 0);
-
-  return { count: Number.isFinite(count) ? count : 0, taskIds };
-}
-
 async function loadTaskSourceFilterListCounts({
   sbAdmin,
   userId,
@@ -1059,6 +929,9 @@ export async function handleTaskRouteGET(
       url.searchParams.get('externalSortBy')
     );
     const sortBy = parseTaskSortBy(url.searchParams.get('sortBy'));
+    const unprioritizedPosition = normalizeUnprioritizedPosition(
+      url.searchParams.get('unprioritizedPosition')
+    );
     const parsedIdentifier = identifierQuery
       ? parseTaskIdentifierQuery(identifierQuery)
       : null;
@@ -1454,6 +1327,7 @@ export async function handleTaskRouteGET(
           hasDueDate,
           externalSortBy,
           sortBy,
+          unprioritizedPosition,
           labelIds,
           assigneeIds,
           projectIds,
@@ -2140,7 +2014,7 @@ export async function handleTaskRouteGET(
       );
     }
 
-    tasks = sortTasksByCriterion(tasks, sortBy);
+    tasks = sortTasksByCriterion(tasks, sortBy, unprioritizedPosition);
     if (shouldMergePersonalSort) tasks = tasks.slice(offset, offset + limit);
 
     const shouldIncludeRelationshipSummary =

--- a/packages/tasks-ui/src/settings/__tests__/task-settings.test.tsx
+++ b/packages/tasks-ui/src/settings/__tests__/task-settings.test.tsx
@@ -19,6 +19,7 @@ const {
   mockUpdateUserConfigMutate: vi.fn(),
   mockConfigState: {
     dialogPresentation: 'compact',
+    priorityPosition: 'first',
     soundEffectsEnabled: true,
     soundEffectsVolume: '35',
   },
@@ -50,11 +51,13 @@ vi.mock('@tuturuuu/ui/hooks/use-user-config', () => ({
   },
   useUserConfig: (configId: string, defaultValue = '') => ({
     data:
-      configId === 'TASK_SOUND_EFFECTS_VOLUME'
-        ? mockConfigState.soundEffectsVolume
-        : configId.endsWith('_PRESENTATION')
-          ? mockConfigState.dialogPresentation
-          : defaultValue,
+      configId === 'TASK_UNPRIORITIZED_POSITION'
+        ? mockConfigState.priorityPosition
+        : configId === 'TASK_SOUND_EFFECTS_VOLUME'
+          ? mockConfigState.soundEffectsVolume
+          : configId.endsWith('_PRESENTATION')
+            ? mockConfigState.dialogPresentation
+            : defaultValue,
     isLoading: false,
   }),
   useUpdateUserConfig: () => ({
@@ -80,6 +83,7 @@ describe('task sound settings controls', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfigState.dialogPresentation = 'compact';
+    mockConfigState.priorityPosition = 'first';
     mockConfigState.soundEffectsEnabled = true;
     mockConfigState.soundEffectsVolume = '35';
     vi.stubGlobal(
@@ -106,6 +110,28 @@ describe('task sound settings controls', () => {
     fireEvent.click(screen.getByRole('switch', { name: 'sound_effects' }));
 
     expect(mockSetSoundEffectsEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('defaults unprioritized tasks first and saves last placement', async () => {
+    renderWithQueryClient(<TaskSettings />);
+    const control = await screen.findByRole('combobox', {
+      name: 'unprioritized_position',
+    });
+    expect(control).toHaveTextContent('unprioritized_first');
+    fireEvent.click(control);
+    fireEvent.click(screen.getByText('unprioritized_last'));
+    expect(mockUpdateUserConfigMutate).toHaveBeenCalledWith(
+      { configId: 'TASK_UNPRIORITIZED_POSITION', value: 'last' },
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+
+  it('restores the saved last placement when settings reopen', async () => {
+    mockConfigState.priorityPosition = 'last';
+    renderWithQueryClient(<TaskSettings />);
+    expect(
+      await screen.findByRole('combobox', { name: 'unprioritized_position' })
+    ).toHaveTextContent('unprioritized_last');
   });
 
   it('persists task creation presentation independently', async () => {

--- a/packages/tasks-ui/src/settings/task-priority-settings.tsx
+++ b/packages/tasks-ui/src/settings/task-priority-settings.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { SettingItemTab } from '@tuturuuu/ui/custom/settings-item-tab';
+import {
+  useUpdateUserConfig,
+  useUserConfig,
+} from '@tuturuuu/ui/hooks/use-user-config';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@tuturuuu/ui/select';
+import { toast } from '@tuturuuu/ui/sonner';
+import {
+  normalizeUnprioritizedPosition,
+  TASK_UNPRIORITIZED_POSITION_CONFIG_ID,
+} from '@tuturuuu/utils/task-helper/task-sort';
+import { useTranslations } from 'next-intl';
+
+export function TaskPrioritySettings() {
+  const t = useTranslations('settings.tasks');
+  const { data, isLoading } = useUserConfig(
+    TASK_UNPRIORITIZED_POSITION_CONFIG_ID,
+    'first'
+  );
+  const update = useUpdateUserConfig();
+  return (
+    <SettingItemTab
+      title={t('unprioritized_position')}
+      description={t('unprioritized_position_description')}
+    >
+      <Select
+        value={normalizeUnprioritizedPosition(data)}
+        disabled={isLoading || update.isPending}
+        onValueChange={(value) =>
+          update.mutate(
+            {
+              configId: TASK_UNPRIORITIZED_POSITION_CONFIG_ID,
+              value: normalizeUnprioritizedPosition(value),
+            },
+            {
+              onError: () => toast.error(t('settings_update_failed')),
+            }
+          )
+        }
+      >
+        <SelectTrigger
+          className="w-44"
+          aria-label={t('unprioritized_position')}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="first">{t('unprioritized_first')}</SelectItem>
+          <SelectItem value="last">{t('unprioritized_last')}</SelectItem>
+        </SelectContent>
+      </Select>
+    </SettingItemTab>
+  );
+}

--- a/packages/tasks-ui/src/settings/task-settings.tsx
+++ b/packages/tasks-ui/src/settings/task-settings.tsx
@@ -42,6 +42,7 @@ import {
   TASK_SOUND_EFFECTS_VOLUME_CONFIG_ID,
 } from '../tu-do/shared/task-sound-effects';
 import { TaskDialogPresentationSettings } from './task-dialog-presentation-settings';
+import { TaskPrioritySettings } from './task-priority-settings';
 
 interface TaskSettingsData {
   task_auto_assign_to_self: boolean;
@@ -306,6 +307,8 @@ export function TaskSettings({ workspace }: TaskSettingsProps) {
             </SelectContent>
           </Select>
         </SettingItemTab>
+        <Separator />
+        <TaskPrioritySettings />
         <Separator />
         <TaskDialogPresentationSettings />
         <Separator />

--- a/packages/tasks-ui/src/tu-do/shared/board-task-filtering.test.ts
+++ b/packages/tasks-ui/src/tu-do/shared/board-task-filtering.test.ts
@@ -1,0 +1,61 @@
+import type { Task } from '@tuturuuu/types/primitives/Task';
+import { describe, expect, it } from 'vitest';
+import { taskMatchesLocalFilters } from './board-task-filtering';
+import type { TaskFilters } from './task-filter.types';
+
+const defaults: TaskFilters = {
+  labels: [],
+  projects: [],
+  assignees: [],
+  priorities: [],
+  dueDateRange: null,
+  estimationRange: null,
+  includeMyTasks: false,
+  includeUnassigned: false,
+  sourceScope: 'all_visible',
+  sourceWorkspaceIds: [],
+  sourceBoardIds: [],
+};
+const task = (overrides: Partial<Task> = {}) =>
+  ({ id: 'task', name: 'Task', priority: null, ...overrides }) as Task;
+
+describe('local and server task filter parity', () => {
+  it.each(['labels', 'projects'] as const)(
+    'matches any selected %s instead of requiring all',
+    (field) => {
+      const filters = {
+        ...defaults,
+        [field]: [{ id: 'one' }, { id: 'two' }],
+      } as TaskFilters;
+      expect(
+        taskMatchesLocalFilters(
+          task({ [field]: [{ id: 'two' }] } as Partial<Task>),
+          filters
+        )
+      ).toBe(true);
+      expect(
+        taskMatchesLocalFilters(
+          task({ [field]: [{ id: 'other' }] } as Partial<Task>),
+          filters
+        )
+      ).toBe(false);
+      expect(taskMatchesLocalFilters(task(), filters)).toBe(false);
+    }
+  );
+  it.each([{ min: 0 }, { max: 5 }, { min: 0, max: 5 }])(
+    'excludes absent estimates from a numeric range: %j',
+    (estimationRange) => {
+      const filters = { ...defaults, estimationRange };
+      expect(
+        taskMatchesLocalFilters(task({ estimation_points: null }), filters)
+      ).toBe(false);
+      expect(taskMatchesLocalFilters(task(), filters)).toBe(false);
+      expect(
+        taskMatchesLocalFilters(task({ estimation_points: 0 }), filters)
+      ).toBe(true);
+    }
+  );
+  it('includes tasks without priority or estimation when no such filter is active', () => {
+    expect(taskMatchesLocalFilters(task(), defaults)).toBe(true);
+  });
+});

--- a/packages/tasks-ui/src/tu-do/shared/board-task-filtering.ts
+++ b/packages/tasks-ui/src/tu-do/shared/board-task-filtering.ts
@@ -1,0 +1,91 @@
+import type { Task } from '@tuturuuu/types/primitives/Task';
+import {
+  sortTasksByCriterion,
+  type UnprioritizedPosition,
+} from '@tuturuuu/utils/task-helper';
+import { taskMatchesBoardSearch } from './board-task-search';
+import type { TaskFilters } from './task-filter.types';
+
+export function taskMatchesLocalFilters(
+  task: Task,
+  filters: TaskFilters,
+  currentUserId?: string,
+  boardTicketPrefix?: string | null
+) {
+  if (!taskMatchesBoardSearch(task, filters.searchQuery, boardTicketPrefix))
+    return false;
+
+  if (
+    filters.labels.length > 0 &&
+    !filters.labels.every((label) =>
+      task.labels?.some((taskLabel) => taskLabel.id === label.id)
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    filters.projects.length > 0 &&
+    !filters.projects.every((project) =>
+      task.projects?.some((taskProject) => taskProject.id === project.id)
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    filters.priorities.length > 0 &&
+    (!task.priority || !filters.priorities.includes(task.priority))
+  ) {
+    return false;
+  }
+
+  if (filters.assignees.length > 0) {
+    const assigneeIds = new Set(
+      filters.assignees.map((assignee) => assignee.id)
+    );
+    if (!task.assignees?.some((assignee) => assigneeIds.has(assignee.id))) {
+      return false;
+    }
+  }
+
+  if (
+    filters.includeMyTasks &&
+    currentUserId &&
+    !task.assignees?.some((assignee) => assignee.id === currentUserId)
+  ) {
+    return false;
+  }
+
+  if (filters.includeUnassigned && (task.assignees?.length ?? 0) > 0) {
+    return false;
+  }
+
+  if (filters.dueDateRange?.from || filters.dueDateRange?.to) {
+    if (!task.end_date) return false;
+    const dueTime = new Date(task.end_date).getTime();
+    const fromTime = filters.dueDateRange.from?.getTime() ?? -Infinity;
+    const toTime = filters.dueDateRange.to?.getTime() ?? Infinity;
+    if (dueTime < fromTime || dueTime > toTime) return false;
+  }
+
+  if (
+    typeof filters.estimationRange?.min === 'number' ||
+    typeof filters.estimationRange?.max === 'number'
+  ) {
+    const estimate = task.estimation_points ?? 0;
+    const min = filters.estimationRange.min ?? -Infinity;
+    const max = filters.estimationRange.max ?? Infinity;
+    if (estimate < min || estimate > max) return false;
+  }
+
+  return true;
+}
+
+export function sortLocalTasks(
+  tasks: Task[],
+  sortBy: TaskFilters['sortBy'],
+  position: UnprioritizedPosition
+) {
+  return sortTasksByCriterion(tasks, sortBy, position);
+}

--- a/packages/tasks-ui/src/tu-do/shared/board-task-filtering.ts
+++ b/packages/tasks-ui/src/tu-do/shared/board-task-filtering.ts
@@ -17,7 +17,7 @@ export function taskMatchesLocalFilters(
 
   if (
     filters.labels.length > 0 &&
-    !filters.labels.every((label) =>
+    !filters.labels.some((label) =>
       task.labels?.some((taskLabel) => taskLabel.id === label.id)
     )
   ) {
@@ -26,7 +26,7 @@ export function taskMatchesLocalFilters(
 
   if (
     filters.projects.length > 0 &&
-    !filters.projects.every((project) =>
+    !filters.projects.some((project) =>
       task.projects?.some((taskProject) => taskProject.id === project.id)
     )
   ) {
@@ -73,7 +73,8 @@ export function taskMatchesLocalFilters(
     typeof filters.estimationRange?.min === 'number' ||
     typeof filters.estimationRange?.max === 'number'
   ) {
-    const estimate = task.estimation_points ?? 0;
+    const estimate = task.estimation_points;
+    if (estimate == null) return false;
     const min = filters.estimationRange.min ?? -Infinity;
     const max = filters.estimationRange.max ?? Infinity;
     if (estimate < min || estimate > max) return false;

--- a/packages/tasks-ui/src/tu-do/shared/board-views.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/board-views.tsx
@@ -26,7 +26,8 @@ import {
 } from '@tuturuuu/ui/hooks/use-user-workspace-config';
 import {
   getPersonalExternalStagingListId,
-  sortTasksByCriterion,
+  normalizeUnprioritizedPosition,
+  TASK_UNPRIORITIZED_POSITION_CONFIG_ID,
   type WorkspaceLabel,
 } from '@tuturuuu/utils/task-helper';
 import { useTranslations } from 'next-intl';
@@ -51,9 +52,12 @@ import { ListView } from '../shared/list-view';
 import { RecycleBinContent } from '../shared/recycle-bin-panel';
 import { loadBoardConfig } from './board-config-storage';
 import {
+  sortLocalTasks,
+  taskMatchesLocalFilters,
+} from './board-task-filtering';
+import {
   listBoardTaskCountsForSearch,
   listBoardTasksForSearch,
-  taskMatchesBoardSearch,
 } from './board-task-search';
 import { KanbanPresentation } from './kanban-presentation';
 import {
@@ -96,86 +100,6 @@ const DEFAULT_TASK_FILTERS: TaskFilters = {
   sourceWorkspaceIds: [],
   sourceBoardIds: [],
 };
-function taskMatchesLocalFilters(
-  task: Task,
-  filters: TaskFilters,
-  currentUserId?: string,
-  boardTicketPrefix?: string | null
-) {
-  if (!taskMatchesBoardSearch(task, filters.searchQuery, boardTicketPrefix))
-    return false;
-
-  if (
-    filters.labels.length > 0 &&
-    !filters.labels.every((label) =>
-      task.labels?.some((taskLabel) => taskLabel.id === label.id)
-    )
-  ) {
-    return false;
-  }
-
-  if (
-    filters.projects.length > 0 &&
-    !filters.projects.every((project) =>
-      task.projects?.some((taskProject) => taskProject.id === project.id)
-    )
-  ) {
-    return false;
-  }
-
-  if (
-    filters.priorities.length > 0 &&
-    (!task.priority || !filters.priorities.includes(task.priority))
-  ) {
-    return false;
-  }
-
-  if (filters.assignees.length > 0) {
-    const assigneeIds = new Set(
-      filters.assignees.map((assignee) => assignee.id)
-    );
-    if (!task.assignees?.some((assignee) => assigneeIds.has(assignee.id))) {
-      return false;
-    }
-  }
-
-  if (
-    filters.includeMyTasks &&
-    currentUserId &&
-    !task.assignees?.some((assignee) => assignee.id === currentUserId)
-  ) {
-    return false;
-  }
-
-  if (filters.includeUnassigned && (task.assignees?.length ?? 0) > 0) {
-    return false;
-  }
-
-  if (filters.dueDateRange?.from || filters.dueDateRange?.to) {
-    if (!task.end_date) return false;
-    const dueTime = new Date(task.end_date).getTime();
-    const fromTime = filters.dueDateRange.from?.getTime() ?? -Infinity;
-    const toTime = filters.dueDateRange.to?.getTime() ?? Infinity;
-    if (dueTime < fromTime || dueTime > toTime) return false;
-  }
-
-  if (
-    typeof filters.estimationRange?.min === 'number' ||
-    typeof filters.estimationRange?.max === 'number'
-  ) {
-    const estimate = task.estimation_points ?? 0;
-    const min = filters.estimationRange.min ?? -Infinity;
-    const max = filters.estimationRange.max ?? Infinity;
-    if (estimate < min || estimate > max) return false;
-  }
-
-  return true;
-}
-
-function sortLocalTasks(tasks: Task[], sortBy: TaskFilters['sortBy']) {
-  return sortTasksByCriterion(tasks, sortBy);
-}
-
 interface Props {
   workspace: Workspace;
   workspaceTier?: WorkspaceProductTier | null;
@@ -236,6 +160,13 @@ export function BoardViews({
   >(() => undefined);
   const { createTask } = useTaskDialog();
   const localTaskState = readOnly || publicView;
+  const { data: priorityPositionRaw } = useUserConfig(
+    TASK_UNPRIORITIZED_POSITION_CONFIG_ID,
+    'first',
+    { enabled: !localTaskState }
+  );
+  const unprioritizedPosition =
+    normalizeUnprioritizedPosition(priorityPositionRaw);
   const { data: quickCreateTargetListRaw } = useUserConfig(
     TASK_QUICK_CREATE_TARGET_LIST_CONFIG_ID,
     DEFAULT_TASK_QUICK_CREATE_TARGET_LIST,
@@ -355,6 +286,7 @@ export function BoardViews({
       projectIds: filters.projects.map((project) => project.id),
       q: filters.searchQuery?.trim() || undefined,
       sortBy: filters.sortBy,
+      unprioritizedPosition,
       sourceBoardIds,
       sourceScope,
       sourceWorkspaceIds,
@@ -372,6 +304,7 @@ export function BoardViews({
       filters.projects,
       filters.searchQuery,
       filters.sortBy,
+      unprioritizedPosition,
       sourceBoardIds,
       sourceScope,
       sourceWorkspaceIds,
@@ -709,9 +642,10 @@ export function BoardViews({
             board.ticket_prefix
           )
         ),
-        filters.sortBy
+        filters.sortBy,
+        unprioritizedPosition
       ),
-    [board.ticket_prefix, currentUserId, filters, tasks]
+    [board.ticket_prefix, currentUserId, filters, tasks, unprioritizedPosition]
   );
 
   const localListCounts = useMemo(() => {
@@ -832,8 +766,8 @@ export function BoardViews({
 
     tasks = tasks.filter((task) => !task.deleted_at);
 
-    return sortLocalTasks(tasks, filters.sortBy);
-  }, [filteredTasks, filters.sortBy, taskOverrides]);
+    return sortLocalTasks(tasks, filters.sortBy, unprioritizedPosition);
+  }, [filteredTasks, filters.sortBy, taskOverrides, unprioritizedPosition]);
 
   const handleTaskPartialUpdate = (taskId: string, partial: Partial<Task>) => {
     setTaskOverrides((prev) => ({

--- a/packages/tasks-ui/src/tu-do/shared/list-view-sorting.test.ts
+++ b/packages/tasks-ui/src/tu-do/shared/list-view-sorting.test.ts
@@ -19,6 +19,26 @@ function task(id: string, name: string, createdAt: string): Task {
 }
 
 describe('sortListViewTasks', () => {
+  it.each(['asc', 'desc'] as const)(
+    'honors unprioritized placement independently of direction: %s',
+    (sortOrder) => {
+      const none = task('none', 'None', '2026-01-01');
+      const high = {
+        ...task('high', 'High', '2026-01-01'),
+        priority: 'high' as const,
+      };
+      const options = { sortField: 'priority' as const, sortOrder };
+      expect(sortListViewTasks([high, none], options).map((t) => t.id)).toEqual(
+        ['none', 'high']
+      );
+      expect(
+        sortListViewTasks([high, none], {
+          ...options,
+          unprioritizedPosition: 'last',
+        }).map((t) => t.id)
+      ).toEqual(['high', 'none']);
+    }
+  );
   it('keeps parent-provided order when board-level sorting is active', () => {
     const parentSortedTasks = [
       task('task-a', 'Alpha', '2026-01-01T00:00:00.000Z'),

--- a/packages/tasks-ui/src/tu-do/shared/list-view-sorting.ts
+++ b/packages/tasks-ui/src/tu-do/shared/list-view-sorting.ts
@@ -1,5 +1,8 @@
 import type { Task } from '@tuturuuu/types/primitives/Task';
-import { priorityCompare } from '@tuturuuu/utils/task-helper';
+import {
+  priorityCompare,
+  type UnprioritizedPosition,
+} from '@tuturuuu/utils/task-helper';
 
 export type ListViewSortField =
   | 'name'
@@ -13,6 +16,7 @@ export type ListViewSortField =
 export type ListViewSortOrder = 'asc' | 'desc';
 
 interface SortListViewTasksOptions {
+  unprioritizedPosition?: UnprioritizedPosition;
   preserveTaskOrder?: boolean;
   searchQuery?: string;
   sortField: ListViewSortField;
@@ -22,6 +26,7 @@ interface SortListViewTasksOptions {
 export function sortListViewTasks(
   tasks: Task[],
   {
+    unprioritizedPosition = 'first',
     preserveTaskOrder = false,
     searchQuery,
     sortField,
@@ -42,6 +47,15 @@ export function sortListViewTasks(
       return aCompleted ? 1 : -1;
     }
 
+    if (
+      sortField === 'priority' &&
+      (a.priority == null) !== (b.priority == null)
+    ) {
+      return (
+        (a.priority == null ? -1 : 1) *
+        (unprioritizedPosition === 'first' ? 1 : -1)
+      );
+    }
     let comparison = 0;
 
     switch (sortField) {

--- a/packages/tasks-ui/src/tu-do/shared/list-view-sorting.ts
+++ b/packages/tasks-ui/src/tu-do/shared/list-view-sorting.ts
@@ -1,5 +1,6 @@
 import type { Task } from '@tuturuuu/types/primitives/Task';
 import {
+  compareUnprioritizedPlacement,
   priorityCompare,
   type UnprioritizedPosition,
 } from '@tuturuuu/utils/task-helper';
@@ -47,14 +48,13 @@ export function sortListViewTasks(
       return aCompleted ? 1 : -1;
     }
 
-    if (
-      sortField === 'priority' &&
-      (a.priority == null) !== (b.priority == null)
-    ) {
-      return (
-        (a.priority == null ? -1 : 1) *
-        (unprioritizedPosition === 'first' ? 1 : -1)
+    if (sortField === 'priority') {
+      const placement = compareUnprioritizedPlacement(
+        a.priority,
+        b.priority,
+        unprioritizedPosition
       );
+      if (placement) return placement;
     }
     let comparison = 0;
 

--- a/packages/tasks-ui/src/tu-do/shared/list-view.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/list-view.tsx
@@ -75,16 +75,13 @@ import {
 import { useTaskDialog } from '../hooks/useTaskDialog';
 import { computeAccessibleLabelStyles } from '../utils/label-colors';
 import { useBoardBroadcast } from './board-broadcast-context';
-import {
-  type ListViewSortField,
-  type ListViewSortOrder,
-  sortListViewTasks,
-} from './list-view-sorting';
+import type { ListViewSortField, ListViewSortOrder } from './list-view-sorting';
 import {
   shouldShowTaskDueDate,
   TASKS_SHOW_REVIEW_DUE_DATES_CONFIG_ID,
 } from './task-due-date-visibility';
 import { TaskRowActionsMenu } from './task-row-actions-menu';
+import { useSortedListViewTasks } from './use-sorted-list-view-tasks';
 
 interface Props {
   workspaceId: string;
@@ -142,15 +139,10 @@ function ReadOnlyListView({
     () => new Map(lists.map((list) => [list.id, list])),
     [lists]
   );
-  const sortedTasks = useMemo(
-    () =>
-      sortListViewTasks(tasks, {
-        preserveTaskOrder,
-        searchQuery,
-        sortField,
-        sortOrder,
-      }),
-    [preserveTaskOrder, searchQuery, sortField, sortOrder, tasks]
+  const sortedTasks = useSortedListViewTasks(
+    tasks,
+    { preserveTaskOrder, searchQuery, sortField, sortOrder },
+    true
   );
 
   function handleSort(field: ListViewSortField) {
@@ -459,14 +451,12 @@ function InteractiveListView({
   }, [boardId, clearSelection, queryClient, workspaceId]);
 
   // Apply sorting only (filters are handled by parent)
-  const sortedTasks = useMemo(() => {
-    return sortListViewTasks(localTasks, {
-      preserveTaskOrder,
-      searchQuery,
-      sortField,
-      sortOrder,
-    });
-  }, [localTasks, preserveTaskOrder, searchQuery, sortField, sortOrder]);
+  const sortedTasks = useSortedListViewTasks(localTasks, {
+    preserveTaskOrder,
+    searchQuery,
+    sortField,
+    sortOrder,
+  });
 
   // Display tasks with incremental rendering
   const displayedTasks = useMemo(() => {

--- a/packages/tasks-ui/src/tu-do/shared/use-sorted-list-view-tasks.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/use-sorted-list-view-tasks.test.tsx
@@ -6,14 +6,14 @@ import type { ReactNode } from 'react';
 import { expect, it, vi } from 'vitest';
 import { useSortedListViewTasks } from './use-sorted-list-view-tasks';
 
+const getConfigMock = vi.hoisted(() => vi.fn(async () => ({ value: 'first' })));
 vi.mock('@tuturuuu/internal-api/users', () => ({
-  getUserConfig: vi.fn(async () => ({ value: 'first' })),
+  getUserConfig: getConfigMock,
 }));
 
-it('immediately reorders loaded tasks when the shared saved preference changes', () => {
+it('immediately reorders loaded tasks when the shared saved preference changes', async () => {
   const queryClient = new QueryClient();
   const key = ['user-config', TASK_UNPRIORITIZED_POSITION_CONFIG_ID];
-  queryClient.setQueryData(key, 'first');
   const tasks = [
     { id: 'high', priority: 'high' },
     { id: 'none', priority: null },
@@ -32,6 +32,12 @@ it('immediately reorders loaded tasks when the shared saved preference changes',
       ),
     }
   );
+  await vi.waitFor(() => {
+    expect(getConfigMock).toHaveBeenCalledWith(
+      TASK_UNPRIORITIZED_POSITION_CONFIG_ID
+    );
+    expect(queryClient.isFetching()).toBe(0);
+  });
   expect(result.current.map((task) => task.id)).toEqual(['none', 'high']);
   act(() => {
     queryClient.setQueryData(key, 'last');

--- a/packages/tasks-ui/src/tu-do/shared/use-sorted-list-view-tasks.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/use-sorted-list-view-tasks.test.tsx
@@ -1,0 +1,43 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { Task } from '@tuturuuu/types/primitives/Task';
+import { TASK_UNPRIORITIZED_POSITION_CONFIG_ID } from '@tuturuuu/utils/task-helper';
+import type { ReactNode } from 'react';
+import { expect, it, vi } from 'vitest';
+import { useSortedListViewTasks } from './use-sorted-list-view-tasks';
+
+vi.mock('@tuturuuu/internal-api/users', () => ({
+  getUserConfig: vi.fn(async () => ({ value: 'first' })),
+}));
+
+it('immediately reorders loaded tasks when the shared saved preference changes', () => {
+  const queryClient = new QueryClient();
+  const key = ['user-config', TASK_UNPRIORITIZED_POSITION_CONFIG_ID];
+  queryClient.setQueryData(key, 'first');
+  const tasks = [
+    { id: 'high', priority: 'high' },
+    { id: 'none', priority: null },
+  ] as Task[];
+  const { result } = renderHook(
+    () =>
+      useSortedListViewTasks(tasks, {
+        sortField: 'priority',
+        sortOrder: 'desc',
+      }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    }
+  );
+  expect(result.current.map((task) => task.id)).toEqual(['none', 'high']);
+  act(() => {
+    queryClient.setQueryData(key, 'last');
+  });
+  // Query notifications are scheduled; flush before checking the reordered view.
+  return vi.waitFor(() =>
+    expect(result.current.map((task) => task.id)).toEqual(['high', 'none'])
+  );
+});

--- a/packages/tasks-ui/src/tu-do/shared/use-sorted-list-view-tasks.ts
+++ b/packages/tasks-ui/src/tu-do/shared/use-sorted-list-view-tasks.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import type { Task } from '@tuturuuu/types/primitives/Task';
+import { useUserConfig } from '@tuturuuu/ui/hooks/use-user-config';
+import {
+  normalizeUnprioritizedPosition,
+  TASK_UNPRIORITIZED_POSITION_CONFIG_ID,
+} from '@tuturuuu/utils/task-helper';
+import { useMemo } from 'react';
+import { sortListViewTasks } from './list-view-sorting';
+
+export function useSortedListViewTasks(
+  tasks: Task[],
+  options: Parameters<typeof sortListViewTasks>[1],
+  readOnly = false
+) {
+  const { data } = useUserConfig(
+    TASK_UNPRIORITIZED_POSITION_CONFIG_ID,
+    'first',
+    { enabled: !readOnly }
+  );
+  const { preserveTaskOrder, searchQuery, sortField, sortOrder } = options;
+  return useMemo(
+    () =>
+      sortListViewTasks(tasks, {
+        preserveTaskOrder,
+        searchQuery,
+        sortField,
+        sortOrder,
+        unprioritizedPosition: normalizeUnprioritizedPosition(data),
+      }),
+    [tasks, preserveTaskOrder, searchQuery, sortField, sortOrder, data]
+  );
+}

--- a/packages/utils/src/task-helper/task-sort.test.ts
+++ b/packages/utils/src/task-helper/task-sort.test.ts
@@ -22,7 +22,7 @@ describe('sortTasksByCriterion', () => {
     expect(parseTaskSortBy(null)).toBeUndefined();
   });
 
-  it('sorts every priority direction with unset priorities last', () => {
+  it('sorts every priority direction with unset priorities first by default', () => {
     const tasks = [
       task('none'),
       task('high', { priority: 'high' }),
@@ -33,11 +33,30 @@ describe('sortTasksByCriterion', () => {
 
     expect(
       sortTasksByCriterion(tasks, 'priority-high').map(({ id }) => id)
-    ).toEqual(['critical', 'high', 'normal', 'low', 'none']);
+    ).toEqual(['none', 'critical', 'high', 'normal', 'low']);
     expect(
       sortTasksByCriterion(tasks, 'priority-low').map(({ id }) => id)
-    ).toEqual(['low', 'normal', 'high', 'critical', 'none']);
+    ).toEqual(['none', 'low', 'normal', 'high', 'critical']);
   });
+
+  it.each(['priority-high', 'priority-low'] as const)(
+    'keeps null and undefined priorities last when requested: %s',
+    (sortBy) => {
+      const tasks = [
+        task('null', { priority: null }),
+        task('set', { priority: 'high' }),
+        task('undefined'),
+      ];
+      expect(
+        sortTasksByCriterion(tasks, sortBy, 'last').map((t) => t.id)
+      ).toEqual(['set', 'null', 'undefined']);
+      expect(sortTasksByCriterion(tasks, sortBy).map((t) => t.id)).toEqual([
+        'null',
+        'undefined',
+        'set',
+      ]);
+    }
+  );
 
   it('keeps missing due dates and estimations last in both directions', () => {
     const tasks = [

--- a/packages/utils/src/task-helper/task-sort.ts
+++ b/packages/utils/src/task-helper/task-sort.ts
@@ -87,20 +87,28 @@ function compareCreatedFallback(a: SortableTask, b: SortableTask) {
   return created || a.id.localeCompare(b.id);
 }
 
+export function compareUnprioritizedPlacement(
+  a: TaskPriority | null | undefined,
+  b: TaskPriority | null | undefined,
+  position: UnprioritizedPosition = 'first'
+) {
+  if ((a == null) === (b == null)) return 0;
+  return (a == null ? -1 : 1) * (position === 'first' ? 1 : -1);
+}
+
 export function compareTasksByCriterion(
   a: SortableTask,
   b: SortableTask,
   sortBy: TaskSortBy,
   unprioritizedPosition: UnprioritizedPosition = 'first'
 ) {
-  if (
-    (sortBy === 'priority-high' || sortBy === 'priority-low') &&
-    (a.priority == null) !== (b.priority == null)
-  ) {
-    return (
-      (a.priority == null ? -1 : 1) *
-      (unprioritizedPosition === 'first' ? 1 : -1)
+  if (sortBy === 'priority-high' || sortBy === 'priority-low') {
+    const placement = compareUnprioritizedPlacement(
+      a.priority,
+      b.priority,
+      unprioritizedPosition
     );
+    if (placement) return placement;
   }
   let result = 0;
 

--- a/packages/utils/src/task-helper/task-sort.ts
+++ b/packages/utils/src/task-helper/task-sort.ts
@@ -1,5 +1,14 @@
 import type { TaskPriority } from '@tuturuuu/types/primitives/Priority';
 
+export const TASK_UNPRIORITIZED_POSITION_CONFIG_ID =
+  'TASK_UNPRIORITIZED_POSITION';
+export type UnprioritizedPosition = 'first' | 'last';
+export function normalizeUnprioritizedPosition(
+  value: unknown
+): UnprioritizedPosition {
+  return value === 'last' ? 'last' : 'first';
+}
+
 export type TaskSortBy =
   | 'name-asc'
   | 'name-desc'
@@ -81,8 +90,18 @@ function compareCreatedFallback(a: SortableTask, b: SortableTask) {
 export function compareTasksByCriterion(
   a: SortableTask,
   b: SortableTask,
-  sortBy: TaskSortBy
+  sortBy: TaskSortBy,
+  unprioritizedPosition: UnprioritizedPosition = 'first'
 ) {
+  if (
+    (sortBy === 'priority-high' || sortBy === 'priority-low') &&
+    (a.priority == null) !== (b.priority == null)
+  ) {
+    return (
+      (a.priority == null ? -1 : 1) *
+      (unprioritizedPosition === 'first' ? 1 : -1)
+    );
+  }
   let result = 0;
 
   switch (sortBy) {
@@ -155,8 +174,11 @@ export function compareTasksByCriterion(
 
 export function sortTasksByCriterion<T extends SortableTask>(
   tasks: readonly T[],
-  sortBy: TaskSortBy | null | undefined
+  sortBy: TaskSortBy | null | undefined,
+  unprioritizedPosition: UnprioritizedPosition = 'first'
 ) {
   if (!sortBy) return [...tasks];
-  return [...tasks].sort((a, b) => compareTasksByCriterion(a, b, sortBy));
+  return [...tasks].sort((a, b) =>
+    compareTasksByCriterion(a, b, sortBy, unprioritizedPosition)
+  );
 }


### PR DESCRIPTION
Tasks without a priority were ordered after every prioritized task in the database, so they could be absent from the first loaded pages even though search found them. Priority sorting now shows unprioritized tasks first by default, and Settings → Tasks provides a persistent “Show first / Show last” choice for both sort directions.

The server applies the placement before pagination using bounded reads through the existing filtered RPC, preserving workspace permissions and filters. Board ordering, list column sorting, and optimistic updates share the preference; changing it also changes the server query cache key. Count-only queries preserve totals in every sort mode. Local label/project filters now use the server's any-match semantics, and numeric estimation ranges exclude unset estimates consistently. No database migration is required.

Validation: focused regression tests cover page boundaries, both priority directions, empty/all-prioritized/all-unprioritized sets, filtering, count-only queries, request serialization, and settings persistence. Full `bun check` passed, and the real Tasks app build passed with local placeholder Supabase configuration. Authenticated production inspection reproduced an unprioritized task disappearing from the rendered priority-sorted board while remaining searchable; the same task will be checked after deployment.
