### PR TITLE
fix(contacts): unify daily and periodic report status dashboards

### DIFF
--- a/apps/contacts/messages/en.json
+++ b/apps/contacts/messages/en.json
@@ -3503,6 +3503,7 @@
     "test_sent_at": "Test sent {date}",
     "title": "Reports",
     "total": "Total",
+    "total_reports": "Total reports",
     "unapproved": "Unapproved",
     "unknown_group": "Unknown group",
     "unknown_member": "Unknown member",

--- a/apps/contacts/messages/vi.json
+++ b/apps/contacts/messages/vi.json
@@ -3503,6 +3503,7 @@
     "test_sent_at": "Đã gửi thử {date}",
     "title": "Báo cáo",
     "total": "Tổng",
+    "total_reports": "Tổng báo cáo",
     "unapproved": "Chưa phê duyệt",
     "unknown_group": "Nhóm không xác định",
     "unknown_member": "Thành viên không xác định",

--- a/apps/contacts/src/app/[locale]/[wsId]/posts/status-summary.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/posts/status-summary.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { Button } from '@tuturuuu/ui/button';
-import { Card, CardContent } from '@tuturuuu/ui/card';
-import { cn } from '@tuturuuu/utils/format';
 import { useTranslations } from 'next-intl';
 import { useQueryStates } from 'nuqs';
 import type { ReactNode } from 'react';
+import {
+  ReportStatusCard,
+  ReportStatusDashboard,
+} from '../reports/report-status-dashboard';
 import { postsSearchParamParsers } from './search-params';
 import {
   getPostReviewStageAppearance,
@@ -13,11 +15,6 @@ import {
 } from './status-meta';
 import type { PostEmailStatusSummary, PostReviewStage } from './types';
 import { DEFAULT_POST_REVIEW_STAGE } from './types';
-
-function getStatusPercentage(count: number, total: number) {
-  if (total <= 0) return 0;
-  return Math.round((count / total) * 100);
-}
 
 export function PostStatusSummary({
   activeStage,
@@ -40,139 +37,78 @@ export function PostStatusSummary({
   );
 
   return (
-    <Card className="overflow-hidden border-border/60 shadow-sm">
-      <CardContent className="p-0">
-        <div className="grid gap-6 p-6 xl:grid-cols-[minmax(0,0.72fr)_minmax(0,2.28fr)]">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <div>
-                <p className="text-muted-foreground text-sm">
-                  {t('total_recipients')}
-                </p>
-                <p className="font-bold text-4xl tracking-tight">
-                  {summary.total.toLocaleString()}
-                </p>
-              </div>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              {!isShowingAllRecipients && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    void setQueryState({
-                      page: 1,
-                      showAll: true,
-                      stage: null,
-                    })
-                  }
-                >
-                  {t('show_all_recipients')}
-                </Button>
-              )}
-              {!isDefaultActionableView && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground"
-                  onClick={() =>
-                    void setQueryState({
-                      page: 1,
-                      showAll: null,
-                      stage: DEFAULT_POST_REVIEW_STAGE,
-                    })
-                  }
-                >
-                  {t('show_actionable_queue')}
-                </Button>
-              )}
-              {hasAdvancedFilters && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground"
-                  onClick={() =>
-                    void setQueryState({
-                      approvalStatus: null,
-                      page: 1,
-                      queueStatus: null,
-                    })
-                  }
-                >
-                  {t('clear_advanced_filters')}
-                </Button>
-              )}
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
-                {POST_REVIEW_STAGE_ORDER.map((stage) => {
-                  const count = summary.stages[stage];
-                  const percentage = getStatusPercentage(count, summary.total);
-                  const appearance = getPostReviewStageAppearance(stage);
-                  const Icon = appearance.icon;
-                  const isActive = activeStage === stage;
-
-                  return (
-                    <button
-                      key={stage}
-                      type="button"
-                      onClick={() =>
-                        void setQueryState({
-                          page: 1,
-                          showAll: null,
-                          stage,
-                        })
-                      }
-                      className={cn(
-                        'group rounded-xl border bg-background px-3.5 py-3 text-left transition-all',
-                        isActive
-                          ? 'border-primary bg-primary/5 shadow-sm ring-1 ring-primary/20'
-                          : 'border-border/70 hover:border-border hover:shadow-sm'
-                      )}
-                    >
-                      <div className="flex items-start justify-between gap-2">
-                        <span
-                          className={cn(
-                            'inline-flex h-8 w-8 items-center justify-center rounded-lg border',
-                            appearance.className
-                          )}
-                        >
-                          <Icon
-                            className={cn(
-                              'h-3.5 w-3.5',
-                              appearance.iconClassName
-                            )}
-                          />
-                        </span>
-                        {percentage > 0 && (
-                          <span className="font-medium text-muted-foreground text-xs">
-                            {percentage}%
-                          </span>
-                        )}
-                      </div>
-                      <div className="mt-2.5 space-y-0.5">
-                        <p className="text-muted-foreground text-xs">
-                          {tableT(appearance.labelKey)}
-                        </p>
-                        <p className="font-bold text-lg tracking-tight">
-                          {count.toLocaleString()}
-                        </p>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        </div>
-        {toolbar ? (
-          <div className="border-border/60 border-t px-6 py-4">{toolbar}</div>
-        ) : null}
-      </CardContent>
-    </Card>
+    <ReportStatusDashboard
+      total={summary.total}
+      totalLabel={t('total_recipients')}
+      toolbar={toolbar}
+      actions={
+        <>
+          {!isShowingAllRecipients && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                void setQueryState({
+                  page: 1,
+                  showAll: true,
+                  stage: null,
+                })
+              }
+            >
+              {t('show_all_recipients')}
+            </Button>
+          )}
+          {!isDefaultActionableView && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground"
+              onClick={() =>
+                void setQueryState({
+                  page: 1,
+                  showAll: null,
+                  stage: DEFAULT_POST_REVIEW_STAGE,
+                })
+              }
+            >
+              {t('show_actionable_queue')}
+            </Button>
+          )}
+          {hasAdvancedFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground"
+              onClick={() =>
+                void setQueryState({
+                  approvalStatus: null,
+                  page: 1,
+                  queueStatus: null,
+                })
+              }
+            >
+              {t('clear_advanced_filters')}
+            </Button>
+          )}
+        </>
+      }
+    >
+      {POST_REVIEW_STAGE_ORDER.map((stage) => {
+        const appearance = getPostReviewStageAppearance(stage);
+        return (
+          <ReportStatusCard
+            key={stage}
+            label={tableT(appearance.labelKey)}
+            count={summary.stages[stage]}
+            total={summary.total}
+            active={activeStage === stage}
+            appearance={appearance}
+            onClick={() =>
+              void setQueryState({ page: 1, showAll: null, stage })
+            }
+          />
+        );
+      })}
+    </ReportStatusDashboard>
   );
 }

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-reports-loading.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-reports-loading.tsx
@@ -1,24 +1,36 @@
+'use client';
+
 import { Card, CardContent } from '@tuturuuu/ui/card';
 import { Skeleton } from '@tuturuuu/ui/skeleton';
+import { useTranslations } from 'next-intl';
+import { ReportStatusDashboard } from './report-status-dashboard';
 
 export function PeriodicReportsLoading() {
+  const t = useTranslations('reports-hub');
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-6">
+      <ReportStatusDashboard
+        totalLabel={t('total_reports')}
+        columns={3}
+        actions={<Skeleton className="h-8 w-32" />}
+        toolbar={
+          <div className="space-y-3">
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+        }
+      >
         {Array.from({ length: 6 }, (_, index) => (
-          <Card key={`count-${index}`}>
-            <CardContent className="space-y-2 p-3 md:p-4">
-              <Skeleton className="h-3 w-20" />
-              <Skeleton className="h-7 w-16" />
-            </CardContent>
-          </Card>
+          <div
+            key={`count-${index}`}
+            className="space-y-2 rounded-xl border px-3.5 py-3"
+          >
+            <Skeleton className="size-8 rounded-lg" />
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-7 w-16" />
+          </div>
         ))}
-      </div>
-      <div className="flex gap-2">
-        <Skeleton className="h-9 min-w-0 flex-1" />
-        <Skeleton className="size-9 rounded-md" />
-        <Skeleton className="size-9 rounded-md" />
-      </div>
+      </ReportStatusDashboard>
       <Skeleton className="h-12 w-full rounded-lg" />
       <div className="space-y-2">
         {Array.from({ length: 7 }, (_, index) => (

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-reports-panel.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-reports-panel.tsx
@@ -216,73 +216,81 @@ export default function PeriodicReportsPanel({
         onChange={(approval, delivery, generation = 'all') => {
           void setFilters({ generation, approval, delivery });
         }}
-      />
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-muted-foreground text-xs">
-          {periodStart || periodEnd
-            ? t('period_scope', {
-                start: periodStart || t('all_time_start'),
-                end: periodEnd || t('all_time_end'),
-              })
-            : t('all_periods')}
-        </p>
-        <Button
-          size="sm"
-          variant="ghost"
-          disabled={isRefreshing}
-          onClick={async () => {
-            setIsRefreshing(true);
-            try {
-              await reportsQuery.refetch();
-            } finally {
-              setIsRefreshing(false);
-            }
-          }}
-        >
-          <RefreshCw
-            className={`size-3.5 ${isRefreshing ? 'animate-spin' : ''}`}
-          />
-          {t('refresh')}
-        </Button>
-      </div>
+        toolbar={
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-muted-foreground text-xs">
+                {periodStart || periodEnd
+                  ? t('period_scope', {
+                      start: periodStart || t('all_time_start'),
+                      end: periodEnd || t('all_time_end'),
+                    })
+                  : t('all_periods')}
+              </p>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={isRefreshing}
+                onClick={async () => {
+                  setIsRefreshing(true);
+                  try {
+                    await reportsQuery.refetch();
+                  } finally {
+                    setIsRefreshing(false);
+                  }
+                }}
+              >
+                <RefreshCw
+                  className={`size-3.5 ${isRefreshing ? 'animate-spin' : ''}`}
+                />
+                {t('refresh')}
+              </Button>
+            </div>
 
-      <PeriodicReportsToolbar
-        generationStatus={generationStatus}
-        approvalStatus={approvalStatus}
-        cadence={cadence}
-        deliveryStatus={deliveryStatus}
-        onApprovalStatusChange={(approval) => void setFilters({ approval })}
-        onCadenceChange={(cadence) => void setFilters({ cadence })}
-        onDeliveryStatusChange={(delivery) => void setFilters({ delivery })}
-        onQueryChange={(query) => void setFilters({ query })}
-        onReset={() => {
-          void setFilters({
-            approval: 'UNAPPROVED',
-            delivery: 'all',
-            generation: 'all',
-            start: '',
-            end: '',
-            query: '',
-            sort: 'period',
-            direction: 'desc',
-          });
-        }}
-        onSortChange={(nextSortBy, nextDirection) => {
-          void setFilters({ sort: nextSortBy, direction: nextDirection });
-        }}
-        periodStart={periodStart}
-        periodEnd={periodEnd}
-        onPeriodChange={(start, end) => void setFilters({ start, end })}
-        query={query}
-        isSearching={
-          !reportsQuery.isError &&
-          (reportsQuery.isLoading ||
-            reportsQuery.isPlaceholderData ||
-            query.trim() !== debouncedQuery)
+            <PeriodicReportsToolbar
+              generationStatus={generationStatus}
+              approvalStatus={approvalStatus}
+              cadence={cadence}
+              deliveryStatus={deliveryStatus}
+              onApprovalStatusChange={(approval) =>
+                void setFilters({ approval })
+              }
+              onCadenceChange={(cadence) => void setFilters({ cadence })}
+              onDeliveryStatusChange={(delivery) =>
+                void setFilters({ delivery })
+              }
+              onQueryChange={(query) => void setFilters({ query })}
+              onReset={() => {
+                void setFilters({
+                  approval: 'UNAPPROVED',
+                  delivery: 'all',
+                  generation: 'all',
+                  start: '',
+                  end: '',
+                  query: '',
+                  sort: 'period',
+                  direction: 'desc',
+                });
+              }}
+              onSortChange={(nextSortBy, nextDirection) => {
+                void setFilters({ sort: nextSortBy, direction: nextDirection });
+              }}
+              periodStart={periodStart}
+              periodEnd={periodEnd}
+              onPeriodChange={(start, end) => void setFilters({ start, end })}
+              query={query}
+              isSearching={
+                !reportsQuery.isError &&
+                (reportsQuery.isLoading ||
+                  reportsQuery.isPlaceholderData ||
+                  query.trim() !== debouncedQuery)
+              }
+              resultCount={totalReports}
+              sortBy={sortBy}
+              sortDirection={sortDirection}
+            />
+          </div>
         }
-        resultCount={totalReports}
-        sortBy={sortBy}
-        sortDirection={sortDirection}
       />
 
       <Accordion type="single" collapsible>

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.test.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.test.tsx
@@ -34,7 +34,28 @@ describe('monthly status filters', () => {
     expect(change).toHaveBeenLastCalledWith('all', 'sent', 'all');
     fireEvent.click(screen.getByRole('button', { name: 'drafts 4' }));
     expect(change).toHaveBeenLastCalledWith('all', 'all', 'draft');
-    fireEvent.click(screen.getByRole('button', { name: 'total 20' }));
+    fireEvent.click(screen.getByRole('button', { name: 'show_all_reports' }));
     expect(change).toHaveBeenLastCalledWith('all', 'all', 'all');
+  });
+  it('restores unapproved reports from the total view and renders its toolbar', () => {
+    const change = vi.fn();
+    render(
+      <PeriodicStatusSummary
+        approval="all"
+        delivery="all"
+        onChange={change}
+        toolbar={<button type="button">Date range</button>}
+      />
+    );
+    expect(screen.getByText('total_reports')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'show_all_reports' })
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'unapproved' }));
+    expect(change).toHaveBeenCalledWith('UNAPPROVED', 'all', 'all');
+    expect(
+      screen.getByRole('button', { name: 'Date range' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/NaN|Infinity/)).not.toBeInTheDocument();
   });
 });

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.test.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.test.tsx
@@ -47,6 +47,9 @@ describe('monthly status filters', () => {
         toolbar={<button type="button">Date range</button>}
       />
     );
+    expect(
+      screen.getByRole('region', { name: 'report_status' })
+    ).toBeInTheDocument();
     expect(screen.getByText('total_reports')).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'show_all_reports' })

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.tsx
@@ -1,20 +1,19 @@
 'use client';
 
-import {
-  Ban,
-  CheckCircle2,
-  Clock3,
-  FileText,
-  MailCheck,
-  MailX,
-} from '@tuturuuu/icons';
+import { FileText } from '@tuturuuu/icons';
 import type { PeriodicReportCounts } from '@tuturuuu/internal-api/reports';
-import { cn } from '@tuturuuu/utils/format';
+import { Button } from '@tuturuuu/ui/button';
+import { getPostReviewStageAppearance } from '@tuturuuu/users-ui/components/post-status-meta';
 import { useTranslations } from 'next-intl';
+import type { ReactNode } from 'react';
 import type {
   PeriodicApprovalFilter,
   PeriodicDeliveryFilter,
 } from './periodic-reports-toolbar';
+import {
+  ReportStatusCard,
+  ReportStatusDashboard,
+} from './report-status-dashboard';
 
 export function PeriodicStatusSummary({
   generation = 'all',
@@ -22,8 +21,10 @@ export function PeriodicStatusSummary({
   approval,
   delivery,
   onChange,
+  toolbar,
 }: {
   generation?: 'all' | 'draft';
+  toolbar?: ReactNode;
   counts?: PeriodicReportCounts;
   approval: PeriodicApprovalFilter;
   delivery: PeriodicDeliveryFilter;
@@ -36,94 +37,106 @@ export function PeriodicStatusSummary({
   const t = useTranslations('reports-hub');
   const stages = [
     {
-      label: 'total',
-      count: counts?.total,
-      approval: 'all',
-      delivery: 'all',
-      icon: FileText,
-    },
-    {
       label: 'drafts',
       count: counts?.draft,
       approval: 'all',
       delivery: 'all',
-      icon: FileText,
+      appearance: {
+        ...getPostReviewStageAppearance('missing_check'),
+        icon: FileText,
+      },
     },
     {
       label: 'unapproved',
       count: counts ? Math.max(0, counts.total - counts.approved) : undefined,
       approval: 'UNAPPROVED',
       delivery: 'all',
-      icon: Clock3,
+      appearance: getPostReviewStageAppearance('pending_approval'),
     },
     {
       label: 'approved',
       count: counts?.approved,
       approval: 'APPROVED',
       delivery: 'all',
-      icon: CheckCircle2,
+      appearance: getPostReviewStageAppearance('approved_awaiting_delivery'),
     },
     {
       label: 'status_sent',
       count: counts?.delivered,
       approval: 'all',
       delivery: 'sent',
-      icon: MailCheck,
+      appearance: getPostReviewStageAppearance('sent'),
     },
     {
       label: 'failed',
       count: counts?.failed,
       approval: 'all',
       delivery: 'failed',
-      icon: MailX,
+      appearance: getPostReviewStageAppearance('delivery_failed'),
     },
     {
       label: 'status_blocked',
       count: counts?.blocked,
       approval: 'all',
       delivery: 'blocked',
-      icon: Ban,
+      appearance: getPostReviewStageAppearance('undeliverable'),
     },
   ] as const;
+  const isShowingAll =
+    approval === 'all' && delivery === 'all' && generation === 'all';
+  const isUnapproved =
+    approval === 'UNAPPROVED' && delivery === 'all' && generation === 'all';
   return (
-    <section
-      className="grid min-w-0 grid-cols-2 gap-2 sm:grid-cols-3 2xl:grid-cols-7"
-      aria-label={t('report_status')}
+    <ReportStatusDashboard
+      label={t('report_status')}
+      total={counts?.total}
+      totalLabel={t('total_reports')}
+      columns={3}
+      toolbar={toolbar}
+      actions={
+        <>
+          {!isShowingAll && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onChange('all', 'all', 'all')}
+            >
+              {t('show_all_reports')}
+            </Button>
+          )}
+          {!isUnapproved && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground"
+              onClick={() => onChange('UNAPPROVED', 'all', 'all')}
+            >
+              {t('unapproved')}
+            </Button>
+          )}
+        </>
+      }
     >
       {stages.map((stage) => {
-        const active =
-          approval === stage.approval &&
-          delivery === stage.delivery &&
-          generation === (stage.label === 'drafts' ? 'draft' : 'all');
+        const stageGeneration = stage.label === 'drafts' ? 'draft' : 'all';
         return (
-          <button
+          <ReportStatusCard
             key={stage.label}
-            type="button"
-            aria-pressed={active}
-            onClick={() =>
-              onChange(
-                stage.approval,
-                stage.delivery,
-                stage.label === 'drafts' ? 'draft' : 'all'
-              )
+            label={t(stage.label)}
+            count={stage.count}
+            total={counts?.total}
+            active={
+              approval === stage.approval &&
+              delivery === stage.delivery &&
+              generation === stageGeneration
             }
-            className={cn(
-              'flex items-center gap-3 rounded-lg border px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              active
-                ? 'border-primary/40 bg-primary/5'
-                : 'border-border/60 bg-background hover:bg-muted/50'
-            )}
-          >
-            <stage.icon className="size-4 shrink-0 text-muted-foreground" />
-            <div className="min-w-0">
-              <p className="text-muted-foreground text-xs">{t(stage.label)}</p>
-              <p className="font-semibold text-xl tabular-nums tracking-tight">
-                {counts ? (stage.count ?? 0).toLocaleString() : '—'}
-              </p>
-            </div>
-          </button>
+            appearance={stage.appearance}
+            onClick={() =>
+              onChange(stage.approval, stage.delivery, stageGeneration)
+            }
+          />
         );
       })}
-    </section>
+    </ReportStatusDashboard>
   );
 }

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/report-status-dashboard.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/report-status-dashboard.tsx
@@ -21,7 +21,8 @@ export function ReportStatusDashboard({
 }) {
   return (
     <Card
-      aria-label={label}
+      role="region"
+      aria-label={label ?? totalLabel}
       className="min-w-0 overflow-hidden border-border/60 shadow-sm"
     >
       <CardContent className="p-0">

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/report-status-dashboard.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/report-status-dashboard.tsx
@@ -1,0 +1,115 @@
+import { Card, CardContent } from '@tuturuuu/ui/card';
+import { cn } from '@tuturuuu/utils/format';
+import type { ComponentType, ReactNode } from 'react';
+
+export function ReportStatusDashboard({
+  total,
+  totalLabel,
+  actions,
+  toolbar,
+  children,
+  columns = 5,
+  label,
+}: {
+  total?: number;
+  totalLabel: string;
+  actions: ReactNode;
+  toolbar?: ReactNode;
+  children: ReactNode;
+  columns?: 3 | 5;
+  label?: string;
+}) {
+  return (
+    <Card
+      aria-label={label}
+      className="min-w-0 overflow-hidden border-border/60 shadow-sm"
+    >
+      <CardContent className="p-0">
+        <div className="grid gap-6 p-6 xl:grid-cols-[minmax(0,0.72fr)_minmax(0,2.28fr)]">
+          <div className="min-w-0 space-y-4">
+            <div>
+              <p className="text-muted-foreground text-sm">{totalLabel}</p>
+              <p className="font-bold text-4xl tabular-nums tracking-tight">
+                {total?.toLocaleString() ?? '—'}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">{actions}</div>
+          </div>
+          <div
+            className={cn(
+              'grid min-w-0 gap-2 sm:grid-cols-2',
+              columns === 5 ? 'lg:grid-cols-5' : 'lg:grid-cols-3'
+            )}
+          >
+            {children}
+          </div>
+        </div>
+        {toolbar && (
+          <div className="border-border/60 border-t px-6 py-4">{toolbar}</div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ReportStatusCard({
+  label,
+  count,
+  total,
+  active,
+  onClick,
+  appearance,
+}: {
+  label: string;
+  count?: number;
+  total?: number;
+  active: boolean;
+  onClick: () => void;
+  appearance: {
+    icon: ComponentType<{ className?: string }>;
+    className: string;
+    iconClassName?: string;
+  };
+}) {
+  const percentage =
+    total && count !== undefined ? Math.round((count / total) * 100) : 0;
+  const Icon = appearance.icon;
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        'group min-w-0 rounded-xl border bg-background px-3.5 py-3 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        active
+          ? 'border-primary bg-primary/5 shadow-sm ring-1 ring-primary/20'
+          : 'border-border/70 hover:border-border hover:shadow-sm'
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span
+          className={cn(
+            'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border',
+            appearance.className
+          )}
+        >
+          <Icon className={cn('h-3.5 w-3.5', appearance.iconClassName)} />
+        </span>
+        {percentage > 0 && (
+          <span
+            aria-hidden="true"
+            className="font-medium text-muted-foreground text-xs tabular-nums"
+          >
+            {percentage}%
+          </span>
+        )}
+      </div>
+      <div className="mt-2.5 space-y-0.5">
+        <p className="text-muted-foreground text-xs">{label}</p>
+        <p className="font-bold text-lg tabular-nums tracking-tight">
+          {count?.toLocaleString() ?? '—'}
+        </p>
+      </div>
+    </button>
+  );
+}


### PR DESCRIPTION
Periodic reports used a separate row of plain status tiles, unlike the daily report dashboard. Both now share the same dashboard shell and status-card component: total and view controls on the left, colored icons, percentages, counts and selected states on the right, and filters in a bordered footer. Periodic loading uses the same layout.

Keep existing daily and periodic filter behavior, including the monthly Unapproved default. Periodic reports use two rows of three cards for their six existing statuses; daily keeps two rows of five. No API, delivery, or database changes.

Validation: formatting and translation sorting pass. All 28 focused daily/periodic tests, full bun check, and Contacts production build pass.

Production verification: merged and deployed at `31aea30fedf48603fe294803c7bf1d1ae20915a8`. All 9 main and 8 production workflows passed. Authenticated Easy Center checks confirmed matching dashboards, daily and periodic status filtering, and responsive periodic cards at 300% browser zoom.
