### PR TITLE
fix(contacts): default periodic reports to pending approval

### DIFF
--- a/apps/contacts/messages/en.json
+++ b/apps/contacts/messages/en.json
@@ -3492,7 +3492,7 @@
     "status_cancelled": "Cancelled",
     "status_draft": "Draft",
     "status_failed": "Failed",
-    "status_pending": "Pending review",
+    "status_pending": "Pending approval",
     "status_processing": "Processing",
     "status_queued": "Queued",
     "status_rejected": "Rejected",

--- a/apps/contacts/messages/vi.json
+++ b/apps/contacts/messages/vi.json
@@ -3492,7 +3492,7 @@
     "status_cancelled": "Đã hủy",
     "status_draft": "Bản nháp",
     "status_failed": "Thất bại",
-    "status_pending": "Chờ duyệt",
+    "status_pending": "Chờ phê duyệt",
     "status_processing": "Đang xử lý",
     "status_queued": "Đang xếp hàng",
     "status_rejected": "Bị từ chối",

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-report-filters.test.ts
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-report-filters.test.ts
@@ -5,8 +5,8 @@ import {
   periodicReportFilters,
 } from './periodic-report-filters';
 
-it('defaults to unapproved monthly reports without hiding older undated reports', () => {
-  expect(periodicReportFilters.approval.defaultValue).toBe('UNAPPROVED');
+it('defaults to pending monthly reports without hiding older undated reports', () => {
+  expect(periodicReportFilters.approval.defaultValue).toBe('PENDING');
   expect(periodicReportFilters.cadence.defaultValue).toBe('monthly');
   expect(periodicReportFilters.start.defaultValue).toBe('');
   expect(periodicReportFilters.end.defaultValue).toBe('');

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-report-filters.ts
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-report-filters.ts
@@ -28,7 +28,7 @@ export const periodicReportFilters = {
     'PENDING',
     'APPROVED',
     'REJECTED',
-  ]).withDefault('UNAPPROVED'),
+  ]).withDefault('PENDING'),
   delivery: parseAsStringLiteral([
     'all',
     'draft',

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-reports-panel.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-reports-panel.tsx
@@ -262,7 +262,7 @@ export default function PeriodicReportsPanel({
               onQueryChange={(query) => void setFilters({ query })}
               onReset={() => {
                 void setFilters({
-                  approval: 'UNAPPROVED',
+                  approval: 'PENDING',
                   delivery: 'all',
                   generation: 'all',
                   start: '',

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.test.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.test.tsx
@@ -26,8 +26,8 @@ describe('monthly status filters', () => {
       'aria-pressed',
       'true'
     );
-    fireEvent.click(screen.getByRole('button', { name: 'unapproved 8' }));
-    expect(change).toHaveBeenLastCalledWith('UNAPPROVED', 'all', 'all');
+    fireEvent.click(screen.getByRole('button', { name: 'status_pending 5' }));
+    expect(change).toHaveBeenLastCalledWith('PENDING', 'all', 'all');
     fireEvent.click(screen.getByRole('button', { name: 'approved 12' }));
     expect(change).toHaveBeenLastCalledWith('APPROVED', 'all', 'all');
     fireEvent.click(screen.getByRole('button', { name: 'status_sent 8' }));
@@ -37,7 +37,7 @@ describe('monthly status filters', () => {
     fireEvent.click(screen.getByRole('button', { name: 'show_all_reports' }));
     expect(change).toHaveBeenLastCalledWith('all', 'all', 'all');
   });
-  it('restores unapproved reports from the total view and renders its toolbar', () => {
+  it('restores pending reports from the total view and renders its toolbar', () => {
     const change = vi.fn();
     render(
       <PeriodicStatusSummary
@@ -54,8 +54,8 @@ describe('monthly status filters', () => {
     expect(
       screen.queryByRole('button', { name: 'show_all_reports' })
     ).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'unapproved' }));
-    expect(change).toHaveBeenCalledWith('UNAPPROVED', 'all', 'all');
+    fireEvent.click(screen.getByRole('button', { name: 'status_pending' }));
+    expect(change).toHaveBeenCalledWith('PENDING', 'all', 'all');
     expect(
       screen.getByRole('button', { name: 'Date range' })
     ).toBeInTheDocument();

--- a/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.tsx
+++ b/apps/contacts/src/app/[locale]/[wsId]/reports/periodic-status-summary.tsx
@@ -47,9 +47,9 @@ export function PeriodicStatusSummary({
       },
     },
     {
-      label: 'unapproved',
-      count: counts ? Math.max(0, counts.total - counts.approved) : undefined,
-      approval: 'UNAPPROVED',
+      label: 'status_pending',
+      count: counts?.pendingReview,
+      approval: 'PENDING',
       delivery: 'all',
       appearance: getPostReviewStageAppearance('pending_approval'),
     },
@@ -84,8 +84,8 @@ export function PeriodicStatusSummary({
   ] as const;
   const isShowingAll =
     approval === 'all' && delivery === 'all' && generation === 'all';
-  const isUnapproved =
-    approval === 'UNAPPROVED' && delivery === 'all' && generation === 'all';
+  const isPending =
+    approval === 'PENDING' && delivery === 'all' && generation === 'all';
   return (
     <ReportStatusDashboard
       label={t('report_status')}
@@ -104,14 +104,14 @@ export function PeriodicStatusSummary({
               {t('show_all_reports')}
             </Button>
           )}
-          {!isUnapproved && (
+          {!isPending && (
             <Button
               variant="ghost"
               size="sm"
               className="text-muted-foreground"
-              onClick={() => onChange('UNAPPROVED', 'all', 'all')}
+              onClick={() => onChange('PENDING', 'all', 'all')}
             >
-              {t('unapproved')}
+              {t('status_pending')}
             </Button>
           )}
         </>


### PR DESCRIPTION
Periodic reports opened with Unapproved, which included rejected reports. Default to Pending approval, matching daily reports and hiding approved/rejected reports until explicitly filtered. Reset and dashboard shortcuts use the same pending-only filter, and the status card uses the pending count.

Validation: all 387 Contacts tests, full bun check, translation sorting, and Contacts production build passed. Regression tests cover the pending default and the pending count independently of rejected reports. No API or migration changes.

Production: deployed merge `2d58c1c2474c8e4e840a28dd1845b306e9e26feb`; all 9 main and 8 production workflows passed. Authenticated Easy Center verification confirms pending-only default, no approved/rejected rows, Show all access, and pending shortcut restoration.
