### PR TITLE
fix(mira): restore calendar artifacts and compact composer layout

### DIFF
--- a/apps/docs/platform/features/assistant-live.mdx
+++ b/apps/docs/platform/features/assistant-live.mdx
@@ -120,3 +120,5 @@ sizes. Component or mocked protocol checks do not prove provider audio quality,
 credit settlement, or authenticated production delivery.
 
 Artifact panels replace the dashboard’s former server-loaded task and calendar insight slots. Full-view links preserve the active language; meeting links open the Meet app. Meeting creation checks the authenticated account’s verified email and provides a retry if account lookup fails. The live panel follows measured header and composer sizes as attachments, text, and narrow layouts change.
+
+Platform forwards `/api/v1/workspaces/:wsId/calendar/events` and its event-detail path to the Calendar app. Calendar remains responsible for membership, `manage_calendar`, and event encryption. Keep these forwarding rules when changing dashboard artifacts or Live calendar tools; a missing rule returns a Platform HTML 404 before Calendar authorization runs. The empty chat reserves space for the composer, allowing welcome actions to scroll independently in compact panels.

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(dashboard)/components/mira-chat-bottom-bar.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(dashboard)/components/mira-chat-bottom-bar.tsx
@@ -13,6 +13,7 @@ interface MiraChatBottomBarProps {
   assistantName: string;
   attachedFiles: ChatFile[];
   bottomBarVisible: boolean;
+  floating: boolean;
   canUploadFiles: boolean;
   input: string;
   inputRef: RefObject<HTMLTextAreaElement | null>;
@@ -50,6 +51,7 @@ export function MiraChatBottomBar({
   assistantName,
   attachedFiles,
   bottomBarVisible,
+  floating,
   canUploadFiles,
   input,
   inputRef,
@@ -80,7 +82,8 @@ export function MiraChatBottomBar({
     <div
       ref={composerRef}
       className={cn(
-        'absolute right-0 bottom-0 left-0 z-10 flex min-w-0 max-w-full flex-col p-3 sm:p-4'
+        'z-10 flex min-w-0 max-w-full flex-col p-3 sm:p-4',
+        floating ? 'absolute right-0 bottom-0 left-0' : 'relative shrink-0'
       )}
     >
       <div

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(dashboard)/components/mira-chat-empty-state.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(dashboard)/components/mira-chat-empty-state.tsx
@@ -22,8 +22,8 @@ export function MiraChatEmptyState({
   userName,
 }: MiraChatEmptyStateProps) {
   return (
-    <div className="flex h-full w-full flex-col items-center justify-start overflow-y-auto px-4 pt-6 pb-40 sm:px-6">
-      <div className="relative mx-auto my-auto w-full max-w-xl">
+    <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-start overflow-y-auto px-4 py-4 sm:px-6">
+      <div className="relative mx-auto my-auto w-full max-w-xl shrink-0">
         <div className="relative mx-auto w-full px-2 py-5 sm:px-6 sm:py-8">
           <div className="flex flex-col items-start text-left">
             <div className="mt-4 max-w-xl space-y-2">

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/(dashboard)/components/mira-chat-panel.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/(dashboard)/components/mira-chat-panel.tsx
@@ -427,6 +427,7 @@ export default function MiraChatPanel({
               assistantName={assistantName}
               attachedFiles={attachedFiles}
               bottomBarVisible={bottomBarVisible}
+              floating={hasMessages}
               canUploadFiles={supportsFileInput}
               input={input}
               inputRef={inputRef}

--- a/apps/web/src/lib/satellite-api-rewrites.test.ts
+++ b/apps/web/src/lib/satellite-api-rewrites.test.ts
@@ -1,7 +1,37 @@
+// @vitest-environment node
+
+import {
+  getRewrittenUrl,
+  unstable_getResponseFromNextConfig,
+} from 'next/experimental/testing/server';
 import { describe, expect, it } from 'vitest';
 import { createSatelliteApiRewrites } from './satellite-api-rewrites';
 
 describe('createSatelliteApiRewrites', () => {
+  it.each([
+    '/api/v1/workspaces/workspace-1/calendar/events?start_at=2026-09-12T00%3A00%3A00Z&end_at=2026-09-19T00%3A00%3A00Z',
+    '/api/v1/workspaces/workspace-1/calendar/events/event-1',
+  ])('routes the real event request %s to Calendar', async (path) => {
+    const response = await unstable_getResponseFromNextConfig({
+      url: `https://tuturuuu.com${path}`,
+      nextConfig: {
+        async rewrites() {
+          return {
+            beforeFiles: createSatelliteApiRewrites({
+              calendarAppOrigin: 'https://calendar.example.com/',
+              infrastructureAppOrigin: 'https://infrastructure.example.com/',
+            }),
+            afterFiles: [],
+            fallback: [],
+          };
+        },
+      },
+    });
+    expect(getRewrittenUrl(response)).toBe(
+      `https://calendar.example.com${path}`
+    );
+  });
+
   it('keeps migrated dashboard dependencies available on the web origin', () => {
     expect(
       createSatelliteApiRewrites({
@@ -18,6 +48,16 @@ describe('createSatelliteApiRewrites', () => {
         source: '/api/v1/infrastructure/resolve-workspace-id',
         destination:
           'https://infrastructure.example.com/api/v1/infrastructure/resolve-workspace-id',
+      },
+      {
+        source: '/api/v1/workspaces/:wsId/calendar/events',
+        destination:
+          'https://calendar.example.com/api/v1/workspaces/:wsId/calendar/events',
+      },
+      {
+        source: '/api/v1/workspaces/:wsId/calendar/events/:eventId',
+        destination:
+          'https://calendar.example.com/api/v1/workspaces/:wsId/calendar/events/:eventId',
       },
       {
         source: '/api/v1/users/calendar-settings',

--- a/apps/web/src/lib/satellite-api-rewrites.ts
+++ b/apps/web/src/lib/satellite-api-rewrites.ts
@@ -24,6 +24,14 @@ export function createSatelliteApiRewrites({
       destination: `${infrastructureOrigin}/api/v1/infrastructure/resolve-workspace-id`,
     },
     {
+      source: '/api/v1/workspaces/:wsId/calendar/events',
+      destination: `${calendarOrigin}/api/v1/workspaces/:wsId/calendar/events`,
+    },
+    {
+      source: '/api/v1/workspaces/:wsId/calendar/events/:eventId',
+      destination: `${calendarOrigin}/api/v1/workspaces/:wsId/calendar/events/:eventId`,
+    },
+    {
       source: '/api/v1/users/calendar-settings',
       destination: `${calendarOrigin}/api/v1/users/calendar-settings`,
     },


### PR DESCRIPTION
# Description

Opening a Calendar artifact in Mira returned a Platform HTML 404 because the event API belongs to the Calendar app. In a quarter-screen empty chat, welcome actions also appeared behind the floating composer toolbar.

## What?

- Forward Calendar event collection and detail requests from Platform to the Calendar-owned API, preserving workspace/event IDs and query parameters.
- Reserve composer space in the empty chat so welcome actions scroll above it in compact layouts.

## Why?

Authenticated production verification of #5318 exposed both problems. Calendar continues to enforce workspace membership, `manage_calendar`, and event encryption.

## How?

Use the existing satellite rewrite configuration and let the empty-state composer participate in normal layout. Conversation history retains its existing floating toolbar behavior.

Validation: real Next.js rewrite-matching regressions, live-mode and meeting-form tests passed (15 tests); `bun check` passed all gates. The production Next.js build passed, and its generated routing manifest contains both Calendar event forwarding rules. Final authenticated verification follows deployment. Finance wallets and the meeting list/eligible-account form were verified on the deployed parent release.

## Screenshots for proof (must have)

Existing workspace fixture reference from #5318. This follow-up corrects data routing and compact empty-state spacing; the image is not a capture of the follow-up build.

![Workspace layout fixture](https://raw.githubusercontent.com/tutur3u/platform/d8dfa1e47def97af3bfa725c03948b905f057713/apps/docs/images/mira-workspace/grid-dark.png)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Calendar artifact requests returning a Platform HTML 404 and restores the compact empty-chat layout so welcome actions no longer sit behind the floating composer.

- Adds satellite rewrite rules forwarding Calendar event collection and detail requests to the Calendar app, keeping workspace/event IDs and query parameters intact.
- Calendar still enforces workspace membership, `manage_calendar`, and event encryption.
- Makes the composer non-floating when a conversation has no messages, letting the empty state scroll independently in compact panels.
- Conversation history keeps its existing floating composer behavior.

<sup>Written for commit 869f269d07a91b14e2d0e9ccd3ee4bf11869e3ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

