### PR TITLE
fix(ui): move app installation into settings

### DIFF
--- a/apps/calendar/messages/en.json
+++ b/apps/calendar/messages/en.json
@@ -6786,6 +6786,7 @@
     "cache_help": "App assets are cached for faster visits. Loaded tasks and calendar views remain available in an open app. Reopening a workspace, syncing, and saving changes require a connection.",
     "install": "Install app",
     "install_help": "Use your browser’s Install app option. On iPhone or iPad, open the Share menu and choose Add to Home Screen.",
+    "installed": "This app is installed on this device.",
     "offline_status": "You’re offline. Loaded data may be out of date. Reconnect to sync and save changes."
   },
   "qr": {

--- a/apps/calendar/messages/vi.json
+++ b/apps/calendar/messages/vi.json
@@ -6786,6 +6786,7 @@
     "cache_help": "Tài nguyên ứng dụng được lưu đệm để tải nhanh hơn. Các công việc và chế độ xem lịch đã tải vẫn có thể xem trong ứng dụng đang mở. Việc mở lại không gian làm việc, đồng bộ và lưu thay đổi cần có kết nối.",
     "install": "Cài đặt ứng dụng",
     "install_help": "Chọn Cài đặt ứng dụng trong trình duyệt. Trên iPhone hoặc iPad, mở menu Chia sẻ và chọn Thêm vào Màn hình chính.",
+    "installed": "Ứng dụng đã được cài đặt trên thiết bị này.",
     "offline_status": "Bạn đang ngoại tuyến. Dữ liệu đã tải có thể chưa cập nhật. Kết nối lại để đồng bộ và lưu thay đổi."
   },
   "qr": {

--- a/apps/calendar/src/components/settings/settings-dialog.tsx
+++ b/apps/calendar/src/components/settings/settings-dialog.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import {
   CalendarDays,
   Clock,
+  Download,
   Keyboard,
   LayoutGrid,
   Palette,
@@ -27,6 +28,7 @@ import SharedSidebarSettings from '@tuturuuu/ui/custom/settings/sidebar-settings
 import { SettingsDialogShell } from '@tuturuuu/ui/custom/settings-dialog-shell';
 import { CalendarSyncProvider } from '@tuturuuu/ui/hooks/use-calendar-sync';
 import { useUserBooleanConfig } from '@tuturuuu/ui/hooks/use-user-config';
+import { PwaStatus } from '@tuturuuu/ui/pwa-status';
 import { isExactTuturuuuDotComEmail } from '@tuturuuu/utils/email/client';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
@@ -135,6 +137,13 @@ export function SettingsDialog({
       label: t('settings.preferences.title'),
       items: [
         {
+          name: 'app_install',
+          label: t('pwa.install'),
+          icon: Download,
+          description: t('pwa.cache_help'),
+          keywords: ['Install', 'App', 'Offline'],
+        },
+        {
           name: 'appearance',
           label: t('settings.preferences.appearance'),
           icon: Palette,
@@ -215,6 +224,18 @@ export function SettingsDialog({
         <SatelliteProfileSettingsPanel user={user} />
       )}
 
+      {activeTab === 'app_install' && (
+        <PwaStatus
+          placement="settings"
+          labels={{
+            offline_status: t('pwa.offline_status'),
+            install: t('pwa.install'),
+            install_help: t('pwa.install_help'),
+            cache_help: t('pwa.cache_help'),
+            installed: t('pwa.installed'),
+          }}
+        />
+      )}
       {activeTab === 'appearance' && (
         <div className="h-full">
           <AppearanceSettings

--- a/apps/docs/platform/applications/calendar.mdx
+++ b/apps/docs/platform/applications/calendar.mdx
@@ -283,7 +283,7 @@ types only after the local schema reflects the migration.
 Calendar and Tasks serve their own `/serwist/sw.js` workers and installable
 app manifests. Client instrumentation captures the install event before hydration;
 these hosts explicitly transpile `@tuturuuu/ui` for that bootstrap entry point.
-The **Install app** control uses the browser prompt when
+The **Settings → Install app** control uses the browser prompt when
 available and gives Home Screen instructions otherwise. `/offline.html` is a
 public, bilingual fallback that bypasses authentication middleware.
 

--- a/apps/tasks/messages/en.json
+++ b/apps/tasks/messages/en.json
@@ -6897,6 +6897,7 @@
     "cache_help": "App assets are cached for faster visits. Loaded tasks and calendar views remain available in an open app. Reopening a workspace, syncing, and saving changes require a connection.",
     "install": "Install app",
     "install_help": "Use your browser’s Install app option. On iPhone or iPad, open the Share menu and choose Add to Home Screen.",
+    "installed": "This app is installed on this device.",
     "offline_status": "You’re offline. Loaded data may be out of date. Reconnect to sync and save changes."
   },
   "qr": {

--- a/apps/tasks/messages/vi.json
+++ b/apps/tasks/messages/vi.json
@@ -6897,6 +6897,7 @@
     "cache_help": "Tài nguyên ứng dụng được lưu đệm để tải nhanh hơn. Các công việc và chế độ xem lịch đã tải vẫn có thể xem trong ứng dụng đang mở. Việc mở lại không gian làm việc, đồng bộ và lưu thay đổi cần có kết nối.",
     "install": "Cài đặt ứng dụng",
     "install_help": "Chọn Cài đặt ứng dụng trong trình duyệt. Trên iPhone hoặc iPad, mở menu Chia sẻ và chọn Thêm vào Màn hình chính.",
+    "installed": "Ứng dụng đã được cài đặt trên thiết bị này.",
     "offline_status": "Bạn đang ngoại tuyến. Dữ liệu đã tải có thể chưa cập nhật. Kết nối lại để đồng bộ và lưu thay đổi."
   },
   "qr": {

--- a/apps/tasks/src/components/settings/settings-dialog.tsx
+++ b/apps/tasks/src/components/settings/settings-dialog.tsx
@@ -7,6 +7,7 @@ import {
   Brain,
   CalendarDays,
   CheckSquare,
+  Download,
   FileEdit,
   hexagons3,
   Icon,
@@ -39,6 +40,7 @@ import { LunarCalendarSettings } from '@tuturuuu/ui/custom/settings/lunar-calend
 import SharedSidebarSettings from '@tuturuuu/ui/custom/settings/sidebar-settings';
 import { SettingsDialogShell } from '@tuturuuu/ui/custom/settings-dialog-shell';
 import { useUserBooleanConfig } from '@tuturuuu/ui/hooks/use-user-config';
+import { PwaStatus } from '@tuturuuu/ui/pwa-status';
 import { isExactTuturuuuDotComEmail } from '@tuturuuu/utils/email/client';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useState } from 'react';
@@ -253,6 +255,13 @@ export function SettingsDialog({
         label: t('settings.preferences.title'),
         items: [
           {
+            name: 'app_install',
+            label: t('pwa.install'),
+            icon: Download,
+            description: t('pwa.cache_help'),
+            keywords: ['Install', 'App', 'Offline'],
+          },
+          {
             name: 'appearance',
             label: t('settings.preferences.appearance'),
             icon: Paintbrush,
@@ -387,6 +396,18 @@ export function SettingsDialog({
         <SatelliteProfileSettingsPanel user={user} />
       )}
 
+      {activeTab === 'app_install' && (
+        <PwaStatus
+          placement="settings"
+          labels={{
+            offline_status: t('pwa.offline_status'),
+            install: t('pwa.install'),
+            install_help: t('pwa.install_help'),
+            cache_help: t('pwa.cache_help'),
+            installed: t('pwa.installed'),
+          }}
+        />
+      )}
       {activeTab === 'appearance' && (
         <div className="h-full">
           <AppearanceSettings

--- a/packages/ui/src/components/ui/pwa-status.test.tsx
+++ b/packages/ui/src/components/ui/pwa-status.test.tsx
@@ -22,6 +22,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 describe('PWA status and installation', () => {
+  it('does not show a floating install button in the app', () => {
+    render(<PwaStatus labels={labels} />);
+    expect(screen.queryByRole('button', { name: 'install' })).toBeNull();
+  });
   it('shows offline limitations without offering an unavailable install', () => {
     vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
     render(<PwaStatus labels={labels} />);
@@ -29,7 +33,7 @@ describe('PWA status and installation', () => {
     expect(screen.queryByRole('button', { name: 'install' })).toBeNull();
   });
   it('provides Home Screen instructions when a browser has no install prompt', () => {
-    render(<PwaStatus labels={labels} />);
+    render(<PwaStatus placement="settings" labels={labels} />);
     fireEvent.click(screen.getByRole('button', { name: 'install' }));
     expect(screen.getByRole('dialog')).toHaveTextContent('install_help');
   });
@@ -42,7 +46,7 @@ describe('PWA status and installation', () => {
     act(() => {
       window.dispatchEvent(event);
     });
-    render(<PwaStatus labels={labels} />);
+    render(<PwaStatus placement="settings" labels={labels} />);
     expect(prompt).not.toHaveBeenCalled();
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'install' }));

--- a/packages/ui/src/components/ui/pwa-status.tsx
+++ b/packages/ui/src/components/ui/pwa-status.tsx
@@ -26,12 +26,15 @@ function subscribeOnline(callback: () => void) {
 }
 export function PwaStatus({
   labels,
+  placement = 'status',
 }: {
+  placement?: 'status' | 'settings';
   labels: {
     offline_status: string;
     install: string;
     install_help: string;
     cache_help: string;
+    installed?: string;
   };
 }) {
   const t = (key: keyof typeof labels) => labels[key];
@@ -79,7 +82,7 @@ export function PwaStatus({
   };
   return (
     <>
-      {!online && (
+      {placement === 'status' && !online && (
         <div
           role="status"
           className="fixed inset-x-3 bottom-3 z-50 mx-auto flex max-w-xl items-start gap-2 rounded-lg border bg-background p-3 text-sm shadow-lg"
@@ -88,16 +91,21 @@ export function PwaStatus({
           <p>{t('offline_status')}</p>
         </div>
       )}
-      {online && !installed && (
+      {placement === 'settings' && online && !installed && (
         <Button
           variant="outline"
           size="sm"
-          className="fixed right-3 bottom-3 z-30 gap-2 rounded-full bg-background shadow-sm"
+          className="gap-2"
           onClick={() => void install()}
         >
           <Download className="size-4" />
           {t('install')}
         </Button>
+      )}
+      {placement === 'settings' && installed && labels.installed && (
+        <p role="status" className="text-muted-foreground text-sm">
+          {labels.installed}
+        </p>
       )}
       <Dialog open={showHelp} onOpenChange={setShowHelp}>
         <DialogContent className="max-w-md">


### PR DESCRIPTION
Tasks and Calendar displayed a floating Install app button over product content. Installation now lives in each app’s Settings dialog, under Preferences → Install app. The shared status component no longer renders a floating installation action; offline notices remain available.

The settings action preserves the browser install prompt, manual installation help, and installed-device state. English and Vietnamese copy and Calendar documentation are updated.

Validation: four focused installation tests, full `bun check`, and real production builds for Tasks and Calendar passed. No app was installed on the user’s device during testing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tasks and Calendar no longer show a floating Install app button over product content, so the product UI stays unobstructed. Installation now lives in each app's Settings dialog under Preferences → Install app.

The Settings install flow keeps the browser install prompt and Home Screen manual-install help, shows an "installed on this device" message when already installed, and renders offline status inline instead of as a floating notice. English and Vietnamese copy and Calendar docs are updated. Four focused tests, `bun check`, and production builds pass.

<sup>Written for commit 17b89364510266d459e8836c92a2b39a6923c4d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutur3u/platform/pull/5327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

