### PR TITLE
fix(tasks): replace empty smart columns with search recovery

### DIFF
--- a/packages/tasks-ui/src/tu-do/boards/boardId/kanban.tsx
+++ b/packages/tasks-ui/src/tu-do/boards/boardId/kanban.tsx
@@ -32,6 +32,10 @@ import type {
   SpecialTaskListPinState,
 } from '../../shared/special-task-list-pins';
 import { TaskBoardLoadingState } from '../../shared/task-board-loading-state';
+import {
+  shouldShowTaskSearchEmpty,
+  TaskSearchEmptyState,
+} from '../../shared/task-search-empty-state';
 import { BoardSelector } from '../board-selector';
 import { BulkActionsIsland } from './kanban/bulk/bulk-actions-island';
 import { BulkCustomDateDialog } from './kanban/bulk/bulk-custom-date-dialog';
@@ -165,22 +169,25 @@ export function KanbanBoard({
     readOnly ? null : boardId,
     readOnly ? null : workspaceId
   );
-  const { data: deadlineTasks = [], isPending: deadlineTasksPending } =
-    useQuery({
-      enabled: Boolean(boardId) && !readOnly,
-      queryFn: () =>
-        listKanbanDeadlineTasks({
-          boardId: boardId ?? '',
-          taskQueryOptions: deadlineTaskQueryOptions,
-          workspaceId,
-        }),
-      queryKey: getKanbanDeadlineTasksQueryKey(
+  const {
+    data: deadlineTasks = [],
+    isPending: deadlineTasksPending,
+    isError: deadlineTasksError,
+  } = useQuery({
+    enabled: Boolean(boardId) && !readOnly,
+    queryFn: () =>
+      listKanbanDeadlineTasks({
+        boardId: boardId ?? '',
+        taskQueryOptions: deadlineTaskQueryOptions,
         workspaceId,
-        boardId,
-        deadlineTaskQueryOptions
-      ),
-      staleTime: 30_000,
-    });
+      }),
+    queryKey: getKanbanDeadlineTasksQueryKey(
+      workspaceId,
+      boardId,
+      deadlineTaskQueryOptions
+    ),
+    staleTime: 30_000,
+  });
   const persistListPositions = useCallback(
     async (updates: Array<{ listId: string; newPosition: number }>) => {
       if (!boardId || updates.length === 0) return;
@@ -483,6 +490,29 @@ export function KanbanBoard({
 
   if (isLoading) {
     return <TaskBoardLoadingState />;
+  }
+
+  if (
+    shouldShowTaskSearchEmpty({
+      query: filters?.searchQuery,
+      taskCount:
+        tasks.length +
+        deadlineSections.overdue.length +
+        deadlineSections.upcoming.length,
+      pending: !readOnly && deadlineTasksPending,
+      failed: deadlineTasksError,
+    })
+  ) {
+    return (
+      <TaskSearchEmptyState
+        query={filters?.searchQuery ?? ''}
+        onClear={
+          onFiltersChange && filters
+            ? () => onFiltersChange({ ...filters, searchQuery: '' })
+            : undefined
+        }
+      />
+    );
   }
 
   return (

--- a/packages/tasks-ui/src/tu-do/shared/task-search-empty-state.test.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/task-search-empty-state.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  shouldShowTaskSearchEmpty,
+  TaskSearchEmptyState,
+} from './task-search-empty-state';
+
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+describe('task search empty state', () => {
+  it('shows no-results only after a nonblank search finishes without matches', () => {
+    const result = {
+      query: 'netflix',
+      taskCount: 0,
+      pending: false,
+      failed: false,
+    };
+    expect(shouldShowTaskSearchEmpty(result)).toBe(true);
+    expect(shouldShowTaskSearchEmpty({ ...result, query: ' ' })).toBe(false);
+    expect(shouldShowTaskSearchEmpty({ ...result, pending: true })).toBe(false);
+    expect(shouldShowTaskSearchEmpty({ ...result, failed: true })).toBe(false);
+    expect(shouldShowTaskSearchEmpty({ ...result, taskCount: 1 })).toBe(false);
+  });
+  it('keeps the searched phrase visible and offers a direct recovery action', () => {
+    const clear = vi.fn();
+    render(<TaskSearchEmptyState query="netflix" onClear={clear} />);
+    expect(screen.getByRole('status')).toHaveTextContent('netflix');
+    fireEvent.click(screen.getByRole('button', { name: 'clear_search' }));
+    expect(clear).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/tasks-ui/src/tu-do/shared/task-search-empty-state.tsx
+++ b/packages/tasks-ui/src/tu-do/shared/task-search-empty-state.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { SearchX } from '@tuturuuu/icons';
+import { Button } from '@tuturuuu/ui/button';
+import { useTranslations } from 'next-intl';
+
+export function shouldShowTaskSearchEmpty({
+  query,
+  taskCount,
+  pending,
+  failed,
+}: {
+  query?: string;
+  taskCount: number;
+  pending: boolean;
+  failed: boolean;
+}) {
+  return Boolean(query?.trim()) && taskCount === 0 && !pending && !failed;
+}
+
+export function TaskSearchEmptyState({
+  query,
+  onClear,
+}: {
+  query: string;
+  onClear?: () => void;
+}) {
+  const t = useTranslations('common');
+  return (
+    <div
+      role="status"
+      className="flex h-full min-h-48 flex-col items-center justify-center gap-3 px-6 py-10 text-center"
+    >
+      <div className="rounded-xl border bg-muted/40 p-3">
+        <SearchX aria-hidden className="size-6 text-muted-foreground" />
+      </div>
+      <div className="max-w-sm space-y-1">
+        <p className="font-medium text-sm">{t('no_results_found')}</p>
+        <p className="wrap-anywhere text-muted-foreground text-sm">
+          “{query.trim()}”
+        </p>
+      </div>
+      {onClear && (
+        <Button variant="outline" size="sm" onClick={onClear}>
+          {t('clear_search')}
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
A search with no matching tasks left empty Overdue and Upcoming columns on the board. The board now shows a compact no-results state with the searched phrase and a Clear search action, preserving other filters. It waits for both normal and deadline search requests; failures show an explicit loading error with recovery rather than claiming there are no results. Blank searches retain the normal board.

Validation: focused empty-state and board-view tests, full repository checks, and Tasks production build passed.
